### PR TITLE
smb2/vfs: oplock & lease-break conformance overhaul (+ NFS3 cross-protocol recall)

### DIFF
--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -5,9 +5,24 @@
 #include "nfs3_procs.h"
 #include "nfs_common/nfs3_status.h"
 #include "nfs_common/nfs3_attr.h"
+#include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+
+/* True when a cross-protocol caching holder (NFSv4 delegation, SMB lease, or
+ * SMB oplock) could exist on the shared store.  An NFSv3 REMOVE/RMDIR of an
+ * object another protocol holds must recall that holder before the unlink
+ * (RFC 7530 §10.4.5 / MS-SMB2 break-before-mutate, #1070); when no caching
+ * protocol is enabled the extra LOOKUP needed to learn the victim FH is
+ * skipped. */
+static inline int
+chimera_nfs3_recall_needed(struct chimera_server_nfs_thread *thread)
+{
+    return chimera_server_config_get_nfs4_delegations(thread->shared->config) ||
+           chimera_server_config_get_smb_leases(thread->shared->config) ||
+           chimera_server_config_get_smb_oplocks(thread->shared->config);
+} /* chimera_nfs3_recall_needed */
 
 static void
 chimera_nfs3_remove_complete(
@@ -39,6 +54,54 @@ chimera_nfs3_remove_complete(
     nfs_request_free(thread, req);
 } /* chimera_nfs3_remove_complete */
 
+/* Issue the unlink.  child_fh (when known) lets the VFS recall any
+ * delegation/oplock/lease on the victim before it is removed. */
+static void
+chimera_nfs3_remove_dispatch(
+    struct nfs_request *req,
+    const uint8_t      *child_fh,
+    int                 child_fh_len)
+{
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct REMOVE3args               *args   = req->args_remove;
+
+    chimera_vfs_remove_at(thread->vfs_thread, &req->cred,
+                          req->handle,
+                          args->object.name.str,
+                          args->object.name.len,
+                          child_fh,
+                          child_fh_len,
+                          CHIMERA_NFS3_ATTR_WCC_MASK,
+                          CHIMERA_NFS3_ATTR_MASK,
+                          NULL,
+                          chimera_nfs3_remove_complete,
+                          req);
+} /* chimera_nfs3_remove_dispatch */
+
+static void
+chimera_nfs3_remove_lookup_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+
+    /* Hand the victim's FH to remove_at so the VFS recalls any delegation/
+     * oplock/lease held on it before the unlink (#1070).  A failed lookup is
+     * not fatal here -- let remove_at produce the authoritative error.  Stash
+     * the FH in req->fh (unused by NFSv3 procs) so it stays valid across the
+     * async remove. */
+    if (error_code == CHIMERA_VFS_OK &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+        memcpy(req->fh, attr->va_fh, attr->va_fh_len);
+        req->fhlen = attr->va_fh_len;
+        chimera_nfs3_remove_dispatch(req, req->fh, req->fhlen);
+    } else {
+        chimera_nfs3_remove_dispatch(req, NULL, 0);
+    }
+} /* chimera_nfs3_remove_lookup_callback */
+
 static void
 chimera_nfs3_remove_open_callback(
     enum chimera_vfs_error          error_code,
@@ -56,17 +119,21 @@ chimera_nfs3_remove_open_callback(
     if (error_code == CHIMERA_VFS_OK) {
         req->handle = handle;
 
-        chimera_vfs_remove_at(thread->vfs_thread, &req->cred,
-                              handle,
-                              args->object.name.str,
-                              args->object.name.len,
-                              NULL,
-                              0,
-                              CHIMERA_NFS3_ATTR_WCC_MASK,
-                              CHIMERA_NFS3_ATTR_MASK,
-                              NULL,
-                              chimera_nfs3_remove_complete,
-                              req);
+        /* Resolve the victim FH first so a cross-protocol caching holder is
+         * recalled before the unlink.  Skip the extra LOOKUP when no caching
+         * protocol is enabled (no holder can exist). */
+        if (chimera_nfs3_recall_needed(thread)) {
+            chimera_vfs_lookup_at(thread->vfs_thread, &req->cred,
+                                  handle,
+                                  args->object.name.str,
+                                  args->object.name.len,
+                                  CHIMERA_VFS_ATTR_FH,
+                                  0,
+                                  chimera_nfs3_remove_lookup_callback,
+                                  req);
+        } else {
+            chimera_nfs3_remove_dispatch(req, NULL, 0);
+        }
     } else {
         res.status = chimera_vfs_error_to_nfsstat3(error_code);
         chimera_nfs3_set_wcc_data(&res.resfail.dir_wcc, NULL, NULL);

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -5,8 +5,21 @@
 #include "nfs3_procs.h"
 #include "nfs_common/nfs3_status.h"
 #include "nfs_common/nfs3_attr.h"
+#include "server/server.h"
 #include "vfs/vfs_procs.h"
 #include "nfs3_dump.h"
+
+/* See chimera_nfs3_remove.c: when a caching protocol is enabled, an NFSv3
+ * RENAME that overwrites an existing destination must recall any delegation/
+ * lease held on the clobbered target before it is replaced (#1071). */
+static inline int
+chimera_nfs3_recall_needed(struct chimera_server_nfs_thread *thread)
+{
+    return chimera_server_config_get_nfs4_delegations(thread->shared->config) ||
+           chimera_server_config_get_smb_leases(thread->shared->config) ||
+           chimera_server_config_get_smb_oplocks(thread->shared->config);
+} /* chimera_nfs3_recall_needed */
+
 static void
 chimera_nfs3_rename_complete(
     enum chimera_vfs_error    error_code,
@@ -40,6 +53,65 @@ chimera_nfs3_rename_complete(
     nfs_request_free(thread, req);
 } /* chimera_nfs3_mkdir_complete */
 
+/* Issue the rename.  target_fh (when the destination name already exists) lets
+ * the VFS recall any delegation/lease on the clobbered file before it is
+ * replaced.  The VFS recalls the source itself. */
+static void
+chimera_nfs3_rename_dispatch(
+    struct nfs_request *req,
+    const uint8_t      *target_fh,
+    int                 target_fh_len)
+{
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct RENAME3args               *args   = req->args_rename;
+
+    /* req->fh / req->saved_fh are the decoded+authenticated source / dest
+     * directory handles (set in chimera_nfs3_rename below). */
+    chimera_vfs_rename_at(thread->vfs_thread,
+                          &req->cred,
+                          req->fh,
+                          req->fhlen,
+                          args->from.name.str,
+                          args->from.name.len,
+                          req->saved_fh,
+                          req->saved_fhlen,
+                          args->to.name.str,
+                          args->to.name.len,
+                          target_fh,
+                          target_fh_len,
+                          CHIMERA_NFS3_ATTR_WCC_MASK | CHIMERA_VFS_ATTR_ATOMIC,
+                          CHIMERA_NFS3_ATTR_MASK,
+                          NULL,
+                          NULL,
+                          chimera_nfs3_rename_complete,
+                          req);
+} /* chimera_nfs3_rename_dispatch */
+
+static void
+chimera_nfs3_rename_target_lookup_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+
+    /* Destination exists: hand its FH to rename_at so the VFS recalls any
+     * delegation/lease on the doomed target before it is replaced (#1071).
+     * No destination (e.g. ENOENT) is the common case -- proceed with no
+     * target recall.  Stash the FH in req->rename_target_fh (req->fh /
+     * req->saved_fh hold the source / dest directory handles) so it survives
+     * the async rename. */
+    if (error_code == CHIMERA_VFS_OK &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+        memcpy(req->rename_target_fh, attr->va_fh, attr->va_fh_len);
+        req->rename_target_fhlen = attr->va_fh_len;
+        chimera_nfs3_rename_dispatch(req, req->rename_target_fh,
+                                     req->rename_target_fhlen);
+    } else {
+        chimera_nfs3_rename_dispatch(req, NULL, 0);
+    }
+} /* chimera_nfs3_rename_target_lookup_callback */
+
 void
 chimera_nfs3_rename(
     struct evpl               *evpl,
@@ -62,9 +134,8 @@ chimera_nfs3_rename(
     nfs3_dump_rename(req, args);
 
     /* Decode both directory handles: the source sets the request export (and
-     * squash); the destination is authenticated into req->saved_fh.  The
-     * destination handle must outlive this (async) call, so it goes in the
-     * request rather than on the stack (saved_fh is unused by NFSv3). */
+     * squash); the destination is authenticated into req->saved_fh.  Both must
+     * outlive this (async) call, so they go in the request, not on the stack. */
     res.status = chimera_nfs3_decode_fh(req, args->from.dir.data.data, args->from.dir.data.len);
     if (res.status != NFS3_OK ||
         chimera_nfs_fh_unwrap(args->to.dir.data.data, args->to.dir.data.len,
@@ -79,22 +150,23 @@ chimera_nfs3_rename(
         return;
     }
 
-    chimera_vfs_rename_at(thread->vfs_thread,
-                          &req->cred,
-                          req->fh,
-                          req->fhlen,
-                          args->from.name.str,
-                          args->from.name.len,
-                          req->saved_fh,
-                          req->saved_fhlen,
-                          args->to.name.str,
-                          args->to.name.len,
-                          NULL,
-                          0,
-                          CHIMERA_NFS3_ATTR_WCC_MASK | CHIMERA_VFS_ATTR_ATOMIC,
-                          CHIMERA_NFS3_ATTR_MASK,
-                          NULL,
-                          NULL,
-                          chimera_nfs3_rename_complete,
-                          req);
+    req->args_rename = args;
+
+    /* Resolve the destination name first (in the decoded dest dir) so a
+     * delegation/lease on a clobbered target is recalled before the rename.
+     * Skip the lookup when no caching protocol is enabled (no holder can
+     * exist). */
+    if (chimera_nfs3_recall_needed(thread)) {
+        chimera_vfs_lookup(thread->vfs_thread, &req->cred,
+                           req->saved_fh,
+                           req->saved_fhlen,
+                           args->to.name.str,
+                           args->to.name.len,
+                           CHIMERA_VFS_ATTR_FH,
+                           0,
+                           chimera_nfs3_rename_target_lookup_callback,
+                           req);
+    } else {
+        chimera_nfs3_rename_dispatch(req, NULL, 0);
+    }
 } /* chimera_nfs3_rename */

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -5,9 +5,21 @@
 #include "nfs3_procs.h"
 #include "nfs_common/nfs3_status.h"
 #include "nfs_common/nfs3_attr.h"
+#include "server/server.h"
 #include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
 #include "vfs/vfs_procs.h"
+
+/* See chimera_nfs3_remove.c: a directory removed via NFSv3 may be held under an
+ * SMB directory lease (or, rarely, a delegation); recall the holder before the
+ * rmdir when a caching protocol is enabled (#1070). */
+static inline int
+chimera_nfs3_recall_needed(struct chimera_server_nfs_thread *thread)
+{
+    return chimera_server_config_get_nfs4_delegations(thread->shared->config) ||
+           chimera_server_config_get_smb_leases(thread->shared->config) ||
+           chimera_server_config_get_smb_oplocks(thread->shared->config);
+} /* chimera_nfs3_recall_needed */
 
 static void
 chimera_nfs3_rmdir_complete(
@@ -39,6 +51,49 @@ chimera_nfs3_rmdir_complete(
     nfs_request_free(thread, req);
 } /* chimera_nfs3_rmdir_complete */
 
+/* Issue the rmdir.  child_fh (when known) lets the VFS recall a directory
+ * lease/delegation on the victim before it is removed. */
+static void
+chimera_nfs3_rmdir_dispatch(
+    struct nfs_request *req,
+    const uint8_t      *child_fh,
+    int                 child_fh_len)
+{
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct RMDIR3args                *args   = req->args_rmdir;
+
+    chimera_vfs_remove_at(thread->vfs_thread, &req->cred,
+                          req->handle,
+                          args->object.name.str,
+                          args->object.name.len,
+                          child_fh,
+                          child_fh_len,
+                          CHIMERA_NFS3_ATTR_WCC_MASK,
+                          CHIMERA_NFS3_ATTR_MASK,
+                          NULL,
+                          chimera_nfs3_rmdir_complete,
+                          req);
+} /* chimera_nfs3_rmdir_dispatch */
+
+static void
+chimera_nfs3_rmdir_lookup_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+
+    if (error_code == CHIMERA_VFS_OK &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+        memcpy(req->fh, attr->va_fh, attr->va_fh_len);
+        req->fhlen = attr->va_fh_len;
+        chimera_nfs3_rmdir_dispatch(req, req->fh, req->fhlen);
+    } else {
+        chimera_nfs3_rmdir_dispatch(req, NULL, 0);
+    }
+} /* chimera_nfs3_rmdir_lookup_callback */
+
 static void
 chimera_nfs3_rmdir_open_callback(
     enum chimera_vfs_error          error_code,
@@ -56,17 +111,18 @@ chimera_nfs3_rmdir_open_callback(
     if (error_code == CHIMERA_VFS_OK) {
         req->handle = handle;
 
-        chimera_vfs_remove_at(thread->vfs_thread, &req->cred,
-                              handle,
-                              args->object.name.str,
-                              args->object.name.len,
-                              NULL,
-                              0,
-                              CHIMERA_NFS3_ATTR_WCC_MASK,
-                              CHIMERA_NFS3_ATTR_MASK,
-                              NULL,
-                              chimera_nfs3_rmdir_complete,
-                              req);
+        if (chimera_nfs3_recall_needed(thread)) {
+            chimera_vfs_lookup_at(thread->vfs_thread, &req->cred,
+                                  handle,
+                                  args->object.name.str,
+                                  args->object.name.len,
+                                  CHIMERA_VFS_ATTR_FH,
+                                  0,
+                                  chimera_nfs3_rmdir_lookup_callback,
+                                  req);
+        } else {
+            chimera_nfs3_rmdir_dispatch(req, NULL, 0);
+        }
     } else {
         res.status = chimera_vfs_error_to_nfsstat3(error_code);
         chimera_nfs3_set_wcc_data(&res.resfail.dir_wcc, NULL, NULL);

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -92,6 +92,12 @@ struct nfs_request {
     int                               fhlen;
     uint8_t                           saved_fh[NFS4_FHSIZE];
     int                               saved_fhlen;
+    /* Scratch for an NFSv3 RENAME's clobbered-target FH, resolved before the
+     * rename so the VFS recalls a delegation/lease on it (#1071).  Held here
+     * (not on the stack) because rename_at stores target_fh as a bare pointer
+     * that must outlive the async call. */
+    uint8_t                           rename_target_fh[NFS4_FHSIZE];
+    int                               rename_target_fhlen;
     /* Export the current/saved file handle belongs to, recovered from the
      * wire handle on receive (and inherited by child handles minted in the
      * reply).  Drives per-request squash attribution and is re-stamped into
@@ -174,6 +180,7 @@ struct nfs_request {
         struct COMMIT3args      *args_commit;
         struct RMDIR3args       *args_rmdir;
         struct REMOVE3args      *args_remove;
+        struct RENAME3args      *args_rename;
         struct MKDIR3args       *args_mkdir;
         struct SYMLINK3args     *args_symlink;
         struct SETATTR3args     *args_setattr;

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -274,6 +274,9 @@
 #define SMB2_STATUS_DOMAIN_LIMIT_EXCEEDED             0xC00000E1
 #define SMB2_STATUS_OPLOCK_NOT_GRANTED                0xC00000E2
 #define SMB2_STATUS_INVALID_OPLOCK_PROTOCOL           0xC00000E3
+/* Returned for an atomic FILE_OPEN_REQUIRING_OPLOCK create whose oplock/lease
+ * could not be granted (MS-SMB2 3.3.5.9.9). */
+#define SMB2_STATUS_CANNOT_BREAK_OPLOCK               0xC0000909
 #define SMB2_STATUS_INTERNAL_DB_CORRUPTION            0xC00000E4
 #define SMB2_STATUS_INTERNAL_ERROR                    0xC00000E5
 #define SMB2_STATUS_GENERIC_NOT_MAPPED                0xC00000E6
@@ -795,6 +798,9 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 /* CHANGE_NOTIFY constants */
 #define SMB2_CHANGE_NOTIFY_REQUEST_SIZE             32
 #define SMB2_CHANGE_NOTIFY_REPLY_SIZE               9
+
+/* CANCEL request fixed StructureSize (MS-SMB2 2.2.30). */
+#define SMB2_CANCEL_REQUEST_SIZE                    4
 
 #define SMB2_WATCH_TREE                             0x0001
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -2764,13 +2764,19 @@ chimera_smb_channel_sequence_stale(
 
 /*
  * Resolve the open_file that owns the caching lease registered under `lease_key`
- * (an SMB2 RqLs lease).  Unlike file_id, lease keys are not hashed, so this scans
- * the tree's open_files buckets -- a lease-break ack is rare relative to I/O, so
- * the linear scan is acceptable; a dedicated lease-key index is a later
- * optimization.  Multiple opens may share one lease key (coalesced), but only the
- * one that inserted the lease carries caching_lease_inserted, so match on that.
- * On success the returned open_file has had its refcnt bumped (release with
- * chimera_smb_open_file_release).
+ * (an SMB2 RqLs lease).  A lease is a per-client (ClientGuid) identity in the
+ * client's lease table (MS-SMB2 3.3.1.x / 3.3.5.22.1): the same lease key may be
+ * used by opens under any tree-connect of the session, and the break ack may
+ * arrive on a different tree than the one the lease-bearing open lives on (e.g.
+ * a multichannel client, or one that reached the file via a different share).
+ * So the lookup must span every tree of the session, not just request->tree --
+ * mirroring chimera_smb_session_lease_key_conflict below.  Unlike file_id, lease
+ * keys are not hashed, so this scans the open_files buckets -- a lease-break ack
+ * is rare relative to I/O, so the linear scan is acceptable; a dedicated
+ * lease-key index is a later optimization.  Multiple opens may share one lease
+ * key (coalesced), but only the one that inserted the lease carries
+ * caching_lease_inserted, so match on that.  On success the returned open_file
+ * has had its refcnt bumped (release with chimera_smb_open_file_release).
  */
 static inline struct chimera_smb_open_file *
 chimera_smb_open_file_resolve_by_lease_key(
@@ -2778,26 +2784,37 @@ chimera_smb_open_file_resolve_by_lease_key(
     const uint8_t              *lease_key)
 {
     struct chimera_smb_open_file *open_file, *tmp, *found = NULL;
-    struct chimera_smb_tree      *tree = request->tree;
-    int                           b;
+    struct chimera_smb_session   *session;
+    int                           t, b;
 
-    chimera_smb_abort_if(!tree, "tree is NULL");
+    chimera_smb_abort_if(!request->session_handle, "session_handle is NULL");
+    session = request->session_handle->session;
+    chimera_smb_abort_if(!session, "session is NULL");
 
-    for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !found; b++) {
-        pthread_mutex_lock(&tree->open_files_lock[b]);
-        HASH_ITER(hh, tree->open_files[b], open_file, tmp)
-        {
-            if (!(open_file->flags & CHIMERA_SMB_OPEN_FILE_CLOSED) &&
-                open_file->caching_lease_inserted &&
-                open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE &&
-                memcmp(open_file->lease_key, lease_key, 16) == 0) {
-                open_file->refcnt++;
-                found = open_file;
-                break;
-            }
+    pthread_mutex_lock(&session->lock);
+    for (t = 0; t < session->max_trees && !found; t++) {
+        struct chimera_smb_tree *tree = session->trees[t];
+
+        if (!tree) {
+            continue;
         }
-        pthread_mutex_unlock(&tree->open_files_lock[b]);
+        for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !found; b++) {
+            pthread_mutex_lock(&tree->open_files_lock[b]);
+            HASH_ITER(hh, tree->open_files[b], open_file, tmp)
+            {
+                if (!(open_file->flags & CHIMERA_SMB_OPEN_FILE_CLOSED) &&
+                    open_file->caching_lease_inserted &&
+                    open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE &&
+                    memcmp(open_file->lease_key, lease_key, 16) == 0) {
+                    open_file->refcnt++;
+                    found = open_file;
+                    break;
+                }
+            }
+            pthread_mutex_unlock(&tree->open_files_lock[b]);
+        }
     }
+    pthread_mutex_unlock(&session->lock);
 
     return found;
 } /* chimera_smb_open_file_resolve_by_lease_key */
@@ -2893,7 +2910,11 @@ chimera_smb_open_file_release(
     struct chimera_smb_request   *request,
     struct chimera_smb_open_file *open_file)
 {
-    struct chimera_smb_tree      *tree              = request->tree;
+    /* Lock the bucket of the tree the open is actually hashed into, not
+     * request->tree: a lease-break ack may resolve an open living under a
+     * different tree-connect of the same session (see
+     * chimera_smb_open_file_resolve_by_lease_key). */
+    struct chimera_smb_tree      *tree              = open_file->tree;
     struct chimera_smb_open_file *open_file_to_free = NULL;
     int                           open_file_bucket;
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -302,6 +302,14 @@ struct chimera_smb_rename_info {
     int                             new_name_len;
 };
 
+/* One child of a directory being renamed that holds a live share reservation;
+ * its caching lease is recalled before the rename proceeds (see the
+ * recall_children array in the set_info request). */
+struct chimera_smb_rename_recall {
+    uint8_t  fh[CHIMERA_VFS_FH_SIZE + 16];
+    uint32_t fh_len;
+};
+
 int
 chimera_smb_parse_rename_info(
     struct evpl_iovec_cursor   *cursor,
@@ -944,6 +952,24 @@ struct chimera_smb_request {
             struct chimera_vfs_file_state     *dp_file_state;
             struct chimera_vfs_pending_acquire dp_ticket;
             uint8_t                            dp_probe_active;
+            /* Directory-rename contained-open recall
+             * (smb2.lease.rename_dir_openfile): renaming a directory breaks the
+             * handle leases of files open INSIDE it.  readdir the source dir
+             * collecting children that have a live (non-implicit) share holder,
+             * recall each one's caching lease (RH->R) one at a time so a
+             * well-behaved holder closes, then fail the rename ACCESS_DENIED if
+             * any holder kept the file open.  Only the source-is-a-directory
+             * path enters this; file renames skip it entirely. */
+            struct chimera_smb_rename_recall  *recall_children; /* malloc'd */
+            uint32_t                           recall_child_count;
+            uint32_t                           recall_child_cap;
+            uint32_t                           recall_child_idx;
+            uint64_t                           recall_readdir_cookie;
+            uint8_t                            recall_deny;
+            /* Second enumeration pass: after the contained holders have been
+             * broken and released, re-scan for a child opened DURING the break
+             * wave (which races the rename and must deny it). */
+            uint8_t                            recall_final;
             /* Security descriptor buffer for SMB2_INFO_SECURITY */
             uint8_t                            sec_buf[2048];
             uint32_t                           sec_buf_len;

--- a/src/server/smb/smb_proc_cancel.c
+++ b/src/server/smb/smb_proc_cancel.c
@@ -32,6 +32,18 @@ chimera_smb_cancel(struct chimera_smb_request *request)
     uint64_t                           target_id;
     int                                async;
 
+    /* MS-SMB2 3.3.5.2.2 / 2.2.30: a CANCEL StructureSize that is not exactly 4
+     * is invalid and the request is failed before command processing.  CANCEL
+     * has no response (3.3.5.17), so "fail" here means drop it without
+     * processing -- completing it as PENDING suppresses any reply, the same as
+     * the normal CANCEL completion below. */
+    if (unlikely(request->request_struct_size != SMB2_CANCEL_REQUEST_SIZE)) {
+        chimera_smb_error("Received SMB2 CANCEL with invalid struct size (%u expected %u)",
+                          request->request_struct_size, SMB2_CANCEL_REQUEST_SIZE);
+        chimera_smb_complete_request(request, SMB2_STATUS_PENDING);
+        return;
+    }
+
     /* A CANCEL targets an async_id when SMB2_FLAGS_ASYNC_COMMAND is set
      * (the client received our interim STATUS_PENDING and learned the
      * AsyncId), otherwise it targets a MessageId.  See MS-SMB2 3.2.4.24. */

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -30,6 +30,14 @@ chimera_smb_parse_change_notify(
 
     int prc = 0;
 
+    /* MS-SMB2 3.3.5.19 / 2.2.35: a CHANGE_NOTIFY StructureSize that is not
+     * exactly 32 is a per-request STATUS_INVALID_PARAMETER. */
+    if (unlikely(request->request_struct_size != SMB2_CHANGE_NOTIFY_REQUEST_SIZE)) {
+        chimera_smb_error("Received SMB2 CHANGE_NOTIFY request with invalid struct size (%u expected %u)",
+                          request->request_struct_size, SMB2_CHANGE_NOTIFY_REQUEST_SIZE);
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
+
     prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &flags);
     prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &output_buffer_length);
     prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &file_id_pid);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -1391,8 +1391,14 @@ chimera_smb_create_after_share(
                     chimera_vfs_state_put(vfs_state, file_state);
                     file_state = NULL;
                     if (via_rqls) {
+                        /* No caching state was established (granted NONE), so the
+                         * v2 epoch does NOT advance -- it is echoed unchanged.
+                         * The epoch increments only when a lease actually holds
+                         * or changes caching bits (MS-SMB2 3.3.5.9.11;
+                         * smb2.lease.lease-epoch: a lease capped to NONE behind a
+                         * byte-range lock keeps its requested epoch). */
                         if (request->create.rqls.is_v2) {
-                            open_file->lease_epoch = request->create.rqls.epoch + 1;
+                            open_file->lease_epoch = request->create.rqls.epoch;
                         }
                         open_file->lease_state  = 0;
                         open_file->oplock_level = SMB2_OPLOCK_LEVEL_LEASE;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -506,7 +506,9 @@ chimera_smb_create_break_for_open(
         chimera_vfs_state_break_caching_for_open(
             vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
             CHIMERA_VFS_LEASE_MODE_H,
-            truncates ? 0 : CHIMERA_VFS_LEASE_MODE_R);
+            truncates ? 0 : CHIMERA_VFS_LEASE_MODE_R,
+            0 /* spare leases pre-share-check; a lease keeps H on a
+               * compatible open */);
     } else if (truncates) {
         chimera_vfs_state_break_on_write(vfs_state, oh->fh, oh->fh_len,
                                          oh->fh_hash, &io_owner);
@@ -522,7 +524,8 @@ chimera_smb_create_break_for_open(
         chimera_vfs_state_break_caching_for_open(
             vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &io_owner,
             CHIMERA_VFS_LEASE_MODE_W,
-            CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_H);
+            CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_H,
+            0 /* W-trigger: lease-skip does not apply */);
     }
 } /* chimera_smb_create_break_for_open */
 
@@ -939,6 +942,26 @@ chimera_smb_create_gen_open_file(
         }
 
         if (result != CHIMERA_VFS_LEASE_GRANTED) {
+            /* A genuine share conflict (SHARING_VIOLATION).  A handle-caching
+             * RqLs lease holder must still be told to relinquish its handle
+             * cache (RWH->RW) even though this open is refused -- the holder may
+             * close its deferred handle so a later retry succeeds (MS-SMB2;
+             * smb2.lease.break_twice).  Batch oplocks already broke via the
+             * BREAKING/park path above; this covers leases, which try_insert
+             * spares.  The opener is identified by lease key (RqLs) or file id so
+             * the holder's own lease is not self-broken. */
+            struct chimera_vfs_lease_owner brk_owner = open_file->share_lease.owner;
+            if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) {
+                memcpy(&brk_owner.owner_lo, request->create.rqls.key, 8);
+                memcpy(&brk_owner.owner_hi, request->create.rqls.key + 8, 8);
+                brk_owner.is_lease = 1;
+            }
+            chimera_vfs_state_break_caching_for_open(
+                vfs_state, oh->fh, oh->fh_len, oh->fh_hash, &brk_owner,
+                CHIMERA_VFS_LEASE_MODE_H,
+                CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W,
+                1 /* break handle-caching leases on a real share conflict */);
+
             chimera_vfs_state_put(vfs_state, file_state);
             open_file->handle = NULL;
             chimera_smb_open_file_free(thread, open_file);
@@ -1022,6 +1045,13 @@ chimera_smb_create_after_share(
              * cached, so no lease break can ever stall a conflicting open. */
             req_smb = thread->shared->config.leases
                 ? (uint8_t) (request->create.rqls.state & 0x07) : 0;
+            /* MS-SMB2 3.3.5.9.8 / smb2.lease.request: WRITE- and HANDLE-caching
+             * are meaningful only alongside READ caching.  A requested lease
+             * state with W or H but no R is invalid and granted NONE (H->"",
+             * W->"", HW->""); R/RH/RW/RHW pass through. */
+            if (!(req_smb & SMB2_LEASE_READ_CACHING)) {
+                req_smb = 0;
+            }
         } else if (thread->shared->config.oplocks) {
             /* Legacy SMB oplocks are opt-in (smb_oplocks); when disabled no
              * oplock is granted (req_smb stays 0 -> reply OPLOCK_LEVEL_NONE). */
@@ -1071,25 +1101,6 @@ chimera_smb_create_after_share(
             req_vfs &= ~CHIMERA_VFS_LEASE_MODE_W;
         }
 
-        /* Oplocks are about data caching: an attribute-only open (no
-         * read/write/execute data access) neither acquires nor breaks an
-         * oplock — UNLESS its disposition replaces the file's data
-         * (OVERWRITE / OVERWRITE_IF / SUPERSEDE all truncate), which is a
-         * data-modifying open and does break.  So gate on data access OR a
-         * data-replacing disposition; a plain READ_ATTRIBUTES|SYNCHRONIZE
-         * probe with OPEN/OPEN_IF leaves an existing holder's oplock intact. */
-        bool caching_touches_data =
-            (request->create.desired_access & SMB2_DATA_ACCESS_MASK) ||
-            request->create.create_disposition == SMB2_FILE_OVERWRITE ||
-            request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-            request->create.create_disposition == SMB2_FILE_SUPERSEDE;
-
-        /* An explicitly requested SMB2 lease (RqLs) is acquired even for an
-         * attribute-only ("stat") open: a handle/read-caching lease is about the
-         * handle, not data access, and such an open is still eligible for a
-         * durable handle (MS-SMB2).  The caching_touches_data gate only governs
-         * the implicit legacy-oplock path, where an attribute probe must not
-         * acquire an oplock. */
         /* A caching lease (oplock / SMB2 lease) lives in a VFS-owned, owner-keyed,
          * refcounted grant.  Opens by one client under one lease key (RqLs) COALESCE
          * onto a single grant; legacy oplocks are keyed by file id and so are always
@@ -1097,15 +1108,48 @@ chimera_smb_create_after_share(
          * requests no caching bits -- so a re-open under an existing lease key joins
          * (and never downgrades) the shared lease (MS-SMB2 3.3.5.9.8: a lease is not
          * reduced by a subsequent open).  A *fresh* grant is created only when the
-         * open warrants caching (real bits).  The grant is backend-independent:
-         * coherence does not rely on the backend serving FSCTL_SRV_COPYCHUNK
-         * (CAP_COPY_RANGE).  A client whose COPYCHUNK is answered NOT_SUPPORTED
-         * falls back to plain READ/WRITE, and those paths (like every other
-         * conflicting open / lock / delete) break conflicting caching holders
-         * via vfs_state before touching data, so the old "uncached unless
-         * copy-capable" rule from the pre-break era is no longer needed. */
-        bool want_fresh_caching =
-            (req_vfs != 0 && (caching_touches_data || via_rqls));
+         * open actually requests caching bits (req_vfs != 0).
+         *
+         * An attribute-only ("stat") open is eligible for an oplock/lease just
+         * like a data open: MS-SMB2 3.3.5.9 grants the requested oplock based on
+         * the existing-open set, not the requester's data-access bits (Windows
+         * grants a BATCH oplock to a READ_ATTRIBUTES|SYNCHRONIZE create --
+         * smb2.oplock.batch9/batch9a/statopen1).  A purely passive probe that
+         * requests no oplock asks for NONE, so req_vfs == 0 and no grant is taken
+         * -- which is what leaves an existing holder's oplock intact.  The break
+         * side (a later real open breaking this holder) is handled separately by
+         * the conflict matrix, independent of how this open's access looked. */
+        bool want_fresh_caching = (req_vfs != 0);
+
+        /* A stat-open (attribute-only access, non-data-replacing disposition) is
+         * "oplock-transparent" (MS-FSA): it must NEVER break an existing holder.
+         * It may still ACQUIRE the oplock it requested, but only the subset
+         * grantable WITHOUT breaking anyone -- so a sole stat-open gets its full
+         * BATCH (smb2.oplock.batch9/batch9a/statopen1), while a stat-open behind
+         * an existing holder caps to NONE and fires no break
+         * (smb2.oplock.batch8/exclusive4).  This is the same cap-self rule the
+         * RqLs lease path uses; for a stat-open we apply it to legacy oplocks too
+         * (a *data* legacy oplock keeps the break-the-peer arbitration). */
+        /* "stat-open" == an open that does NOT break a conflicting holder: the
+         * exact inverse of break_for_open's break_trigger (MS-FSA / smb2.oplock.
+         * statopen1).  DELETE, WRITE_DAC, WRITE_OWNER, EA and any data/generic
+         * access -- plus delete-on-close or a truncating disposition -- make it a
+         * "real" open that breaks; only READ_ATTRIBUTES / WRITE_ATTRIBUTES /
+         * READ_CONTROL / SYNCHRONIZE leave it transparent.  Keep this mask in
+         * sync with chimera_smb_create_break_for_open. */
+        bool stat_open =
+            !((request->create.desired_access &
+               (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA |
+                SMB2_FILE_APPEND_DATA | SMB2_FILE_EXECUTE |
+                SMB2_FILE_READ_EA | SMB2_FILE_WRITE_EA |
+                SMB2_WRITE_DACL | SMB2_WRITE_OWNER |
+                SMB2_GENERIC_READ | SMB2_GENERIC_WRITE |
+                SMB2_GENERIC_EXECUTE | SMB2_GENERIC_ALL |
+                SMB2_MAXIMUM_ALLOWED | SMB2_DELETE)) ||
+              (request->create.create_options & SMB2_FILE_DELETE_ON_CLOSE) ||
+              request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+              request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
+              request->create.create_disposition == SMB2_FILE_SUPERSEDE);
 
         if (via_rqls || want_fresh_caching) {
             file_state = chimera_vfs_state_get(vfs_state,
@@ -1230,19 +1274,38 @@ chimera_smb_create_after_share(
                          * must find a live member or it revokes the fresh lease. */
                         chimera_smb_grant_add_member(grant, open_file);
 
-                        /* MS-SMB2 3.3.5.9: granting a lease never breaks another
-                         * lease.  A fresh RqLs lease whose requested mode collides
-                         * with another key's holder (e.g. RHW behind a peer's R)
-                         * must CAP ITSELF to the grantable subset (-> RH) rather
-                         * than recall the peer; otherwise try_insert would fire a
-                         * spurious break (smb2.lease.break's "no break + no change"
-                         * re-open check, nobreakself).  Legacy oplocks keep the
-                         * break-the-peer behavior (exclusive/batch arbitration), so
-                         * cap only the lease path. */
-                        if (via_rqls) {
-                            grant->lease.mode.granted =
-                                chimera_vfs_caching_grant_cap_mode(file_state,
-                                                                   &grant->lease);
+                        /* MS-SMB2 3.3.5.9: granting an oplock/lease never breaks a
+                         * peer that the requester can simply coexist with.  Cap
+                         * the requested mode to the subset grantable against the
+                         * current holders:
+                         *   - behind a peer's READ cache (LEVEL_II / R lease) an
+                         *     exclusive/batch request caps to a shared R(H) cache,
+                         *     so two readers coexist with NO break
+                         *     (smb2.oplock.batch9 phase 3; smb2.lease.nobreakself);
+                         *   - behind a peer's EXCLUSIVE/BATCH holder the non-strict
+                         *     cap still returns the R floor with a residual
+                         *     conflict, so try_insert below breaks that holder down
+                         *     (the exclusive-arbitration path -- batch1..8).
+                         * A legacy stat-open caps STRICTLY (0 rather than R) so an
+                         * oplock-transparent probe never breaks anyone; the RqLs
+                         * lease and data-oplock paths use the non-strict cap. */
+                        grant->lease.mode.granted =
+                            chimera_vfs_caching_grant_cap_mode(
+                                file_state, &grant->lease,
+                                stat_open && !via_rqls);
+
+                        /* A stat-open that capped to no caching bits takes no
+                         * oplock at all (and breaks nobody): abandon the grant so
+                         * the open reports OPLOCK_LEVEL_NONE.  A bare RqLs lease
+                         * (LEASE_NONE) is still tracked, so this applies only to
+                         * the legacy stat-open path.  file_state is released by the
+                         * grant==NULL reporting branch below. */
+                        if (stat_open && !via_rqls &&
+                            grant->lease.mode.granted == 0) {
+                            chimera_smb_grant_remove_member(grant, open_file);
+                            free(grant);
+                            grant = NULL;
+                            goto report_caching;
                         }
 
                         result = chimera_vfs_state_try_insert(vfs_state, file_state,
@@ -1287,6 +1350,8 @@ chimera_smb_create_after_share(
                         }
                     }
                 }
+
+ report_caching:
 
                 if (grant) {
                     uint8_t granted_vfs = grant->lease.mode.granted;
@@ -1334,6 +1399,32 @@ chimera_smb_create_after_share(
                     }
                 }
             }
+        }
+    }
+
+    /* MS-SMB2 3.3.5.9.9: FILE_OPEN_REQUIRING_OPLOCK is an atomic "open only if I
+     * am granted the oplock/lease" request.  When the requested caching could
+     * not be granted (the effective oplock is NONE), the server MUST close the
+     * open and fail the CREATE with STATUS_CANNOT_BREAK_OPLOCK (#1016).  The open
+     * holds its share + caching leases and VFS handle by this point but is not
+     * yet hashed into the tree or durable-registered, so drain its leases here
+     * and return NULL with force_close_status set; the caller releases the VFS
+     * handle and completes the request, matching the AppInstanceId reject
+     * contract in gen_open_file. */
+    if ((request->create.create_options & SMB2_FILE_OPEN_REQUIRING_OPLOCK) &&
+        type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE) {
+        bool got_cache =
+            (open_file->oplock_level == SMB2_OPLOCK_LEVEL_LEASE)
+            ? (open_file->lease_state != 0)
+            : (open_file->oplock_level != SMB2_OPLOCK_LEVEL_NONE);
+
+        if (!got_cache) {
+            chimera_smb_open_file_drain_locks(thread, open_file);
+            open_file->handle = NULL;
+            chimera_smb_open_file_free(thread, open_file);
+            request->create.force_close_status =
+                SMB2_STATUS_CANNOT_BREAK_OPLOCK;
+            return NULL;
         }
     }
 
@@ -4799,7 +4890,7 @@ chimera_smb_create_reply(
  * NULL handler = presence-only (the bit in ctx_present_mask is all that matters
  * for Phase 0; Phase 1/3 will add real semantics for the open-after-CREATE step). */
 
-static void
+static bool
 parse_ctx_secd(
     const uint8_t              *data,
     uint32_t                    data_len,
@@ -4820,26 +4911,27 @@ parse_ctx_secd(
                                 request->create.acl_storage,
                                 sizeof(request->create.acl_storage),
                                 canonicalize);
+    return true;
 } /* parse_ctx_secd */
 
-static void
+static bool
 parse_ctx_exta(
     const uint8_t              *data,
     uint32_t                    data_len,
     struct chimera_smb_request *request)
 {
     /* SMB2_CREATE_EA_BUFFER: a FILE_FULL_EA_INFORMATION list to apply to the
-     * created/opened object.  Copied out of the (stack-local) context blob so it
-     * survives to the async EA-apply at create completion.  The whole context
-     * blob is capped at 1024 bytes, so it always fits ea_buf. */
+     * created/opened object.  Copied out of the context blob so it survives to
+     * the async EA-apply at create completion; truncated to the fixed ea_buf. */
     if (data_len > sizeof(request->create.ea_buf)) {
         data_len = sizeof(request->create.ea_buf);
     }
     memcpy(request->create.ea_buf, data, data_len);
     request->create.ea_buf_len = data_len;
+    return true;
 } /* parse_ctx_exta */
 
-static void
+static bool
 parse_ctx_dhnc(
     const uint8_t              *data,
     uint32_t                    data_len,
@@ -4847,13 +4939,14 @@ parse_ctx_dhnc(
 {
     /* DHnC body: 16-byte SMB2_FILEID (persistent | volatile) + 16 reserved bytes. */
     if (data_len < 16) {
-        return;
+        return false;
     }
     request->create.dhnc.persistent  = smb_wire_le64(data);
     request->create.dhnc.volatile_id = smb_wire_le64(data + 8);
+    return true;
 } /* parse_ctx_dhnc */
 
-static void
+static bool
 parse_ctx_dh2q(
     const uint8_t              *data,
     uint32_t                    data_len,
@@ -4861,14 +4954,15 @@ parse_ctx_dh2q(
 {
     /* DH2Q body: Timeout(4) | Flags(4) | Reserved(8) | CreateGuid(16) = 32 bytes. */
     if (data_len < 32) {
-        return;
+        return false;
     }
     request->create.dh2q.timeout_ms = smb_wire_le32(data);
     request->create.dh2q.flags      = smb_wire_le32(data + 4);
     memcpy(request->create.dh2q.create_guid, data + 16, 16);
+    return true;
 } /* parse_ctx_dh2q */
 
-static void
+static bool
 parse_ctx_dh2c(
     const uint8_t              *data,
     uint32_t                    data_len,
@@ -4876,15 +4970,16 @@ parse_ctx_dh2c(
 {
     /* DH2C body: FileId(16) | CreateGuid(16) | Flags(4) = 36 bytes. */
     if (data_len < 36) {
-        return;
+        return false;
     }
     request->create.dh2c.persistent  = smb_wire_le64(data);
     request->create.dh2c.volatile_id = smb_wire_le64(data + 8);
     memcpy(request->create.dh2c.create_guid, data + 16, 16);
     request->create.dh2c.flags = smb_wire_le32(data + 32);
+    return true;
 } /* parse_ctx_dh2c */
 
-static void
+static bool
 parse_ctx_rqls(
     const uint8_t              *data,
     uint32_t                    data_len,
@@ -4892,14 +4987,25 @@ parse_ctx_rqls(
 {
     /* RqLs v1 body (32 bytes): LeaseKey(16) | LeaseState(4) | LeaseFlags(4) | LeaseDuration(8 reserved).
      * RqLs v2 body (52 bytes): adds ParentLeaseKey(16) | Epoch(2) | Reserved(2).
-     * Differentiate by data_len. Other sizes: malformed; skip without setting fields. */
+     * Differentiate by data_len. Other sizes: malformed; reject so the caller
+     * does not set the RQLS present-mask bit over stale pooled fields (#1116). */
     if (data_len != 32 && data_len != 52) {
-        return;
+        return false;
     }
     memcpy(request->create.rqls.key, data, 16);
     request->create.rqls.state = smb_wire_le32(data + 16);
     request->create.rqls.flags = smb_wire_le32(data + 20);
-    if (data_len == 52) {
+    /* The lease-v2 context (ParentLeaseKey/Epoch) is only valid on an SMB 3.x
+     * dialect (MS-SMB2 2.2.13.2.10 / 3.3.5.9.11).  On 2.0.2 / 2.1 a 52-byte RqLs
+     * must be processed as a v1 lease -- its v1 fields are a prefix of the v2
+     * body, so we keep LeaseKey/State/Flags and drop the v2 tail, answering with
+     * a 32-byte v1 response and tracking an unversioned lease (#1281). */
+    /* request->compound is NULL when the parser is exercised standalone by
+     * phase0_contexts_test; treat that as v2-capable (canonical) like the
+     * other handlers do. */
+    if (data_len == 52 &&
+        (!request->compound ||
+         request->compound->conn->dialect >= SMB2_DIALECT_3_0)) {
         request->create.rqls.is_v2 = 1;
         /* The ParentLeaseKey is meaningful only when the client set
          * SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET; otherwise the bytes are reserved
@@ -4914,30 +5020,33 @@ parse_ctx_rqls(
     } else {
         request->create.rqls.is_v2 = 0;
     }
+    return true;
 } /* parse_ctx_rqls */
 
-static void
+static bool
 parse_ctx_alsi(
     const uint8_t              *data,
     uint32_t                    data_len,
     struct chimera_smb_request *request)
 {
     if (data_len < 8) {
-        return;
+        return false;
     }
     request->create.alsi_alloc_size = smb_wire_le64(data);
+    return true;
 } /* parse_ctx_alsi */
 
-static void
+static bool
 parse_ctx_twrp(
     const uint8_t              *data,
     uint32_t                    data_len,
     struct chimera_smb_request *request)
 {
     if (data_len < 8) {
-        return;
+        return false;
     }
     request->create.twrp_timestamp = smb_wire_le64(data);
+    return true;
 } /* parse_ctx_twrp */
 
 /* GUID-named CREATE contexts (MS-SMB2 2.2.13.2.13 / 2.2.13.2.14).  The context
@@ -4986,7 +5095,12 @@ parse_ctx_app_instance_version(
     request->create.ctx_present_mask   |= CHIMERA_SMB_CREATE_CTX_APP_VERSION;
 } /* parse_ctx_app_instance_version */
 
-typedef void (*chimera_smb_create_ctx_handler_t)(
+/* Returns true when the context body was well-formed and its typed fields were
+ * populated.  A malformed body (wrong DataLength) returns false so the caller
+ * leaves the present-mask bit CLEAR -- otherwise a stale lease key / create
+ * GUID left in the pooled request slot by a prior CREATE would be honored
+ * (#1116). */
+typedef bool (*chimera_smb_create_ctx_handler_t)(
     const uint8_t              *data,
     uint32_t                    data_len,
     struct chimera_smb_request *request);
@@ -5087,17 +5201,25 @@ chimera_smb_parse_create_contexts(
             for (p = smb_create_ctx_parsers; p->tag != NULL; p++) {
                 if (memcmp(name, p->tag, 4) == 0) {
 
-                    /* Always set the base mask bit; RqLs v2 (52-byte body)
-                     * additionally sets RQLS_V2 so the response emit can tell
-                     * which lease variant the client requested.  (The base RQLS
-                     * bit must be set for v2 too — gen_open_file keys lease
-                     * handling off it.) */
-                    request->create.ctx_present_mask |= p->mask_bit;
-                    if (p->mask_bit == CHIMERA_SMB_CREATE_CTX_RQLS && data_len == 52) {
-                        request->create.ctx_present_mask |= CHIMERA_SMB_CREATE_CTX_RQLS_V2;
+                    /* Run the body handler first.  A malformed body (wrong
+                     * DataLength) returns false: leave the present-mask bit
+                     * CLEAR so a stale lease key / create GUID left in this
+                     * pooled request slot by a prior CREATE is not honored
+                     * (#1116).  Presence-only contexts (NULL handler) always set
+                     * the bit. */
+                    if (p->handler && !p->handler(data, data_len, request)) {
+                        break;
                     }
-                    if (p->handler) {
-                        p->handler(data, data_len, request);
+
+                    /* The base RQLS bit must be set for v2 too — gen_open_file
+                     * keys lease handling off it.  RQLS_V2 tracks whether a
+                     * versioned (epoch-bearing) lease was actually accepted; that
+                     * is gated on the SMB 3.x dialect inside parse_ctx_rqls
+                     * (#1281), so key off rqls.is_v2, not the raw 52-byte body. */
+                    request->create.ctx_present_mask |= p->mask_bit;
+                    if (p->mask_bit == CHIMERA_SMB_CREATE_CTX_RQLS &&
+                        request->create.rqls.is_v2) {
+                        request->create.ctx_present_mask |= CHIMERA_SMB_CREATE_CTX_RQLS_V2;
                     }
                     break;
                 }
@@ -5313,22 +5435,52 @@ chimera_smb_parse_create(
         request->create.set_attr.va_set_mask |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
     }
 
-    if (blob_offset > 0 && blob_length > 0 && blob_length <= 1024) {
-        uint8_t ctx_buf[1024];
+    if (blob_offset > 0 && blob_length > 0) {
+        uint8_t  inline_buf[1024];
+        uint8_t *ctx_buf  = inline_buf;
+        uint8_t *heap_buf = NULL;
+        int      crc;
+
+        /* The context chain must fit within a single request, which the
+         * transport already capped at the negotiated MaxTransactSize; a larger
+         * declared length is malformed.  Reject it rather than truncating
+         * (STATUS_INVALID_PARAMETER). */
+        if (blob_length > CHIMERA_SMB_MAX_TRANSACT_SIZE) {
+            chimera_smb_error("CREATE create-context blob too large (%u)", blob_length);
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
+
+        /* A chain larger than the inline buffer is heap-allocated so every
+         * context (durable/lease/SD/EA/...) is still parsed.  Previously such a
+         * CREATE had ALL its contexts silently dropped -- the client believed it
+         * held a durable lease the server never granted (#1115). */
+        if (blob_length > sizeof(inline_buf)) {
+            heap_buf = malloc(blob_length);
+            if (!heap_buf) {
+                return chimera_smb_parse_reject(request,
+                                                SMB2_STATUS_INSUFFICIENT_RESOURCES);
+            }
+            ctx_buf = heap_buf;
+        }
 
         /* Seek to the client-declared create-context offset (validated to be
          * forward and within this request's window) and pull the blob with the
          * bounds-checked reader; a malformed offset/length rejects cleanly
          * rather than driving an out-of-bounds skip or read. */
         if (unlikely(smb_cursor_seek_to(request_cursor, blob_offset) != 0)) {
+            free(heap_buf);
             chimera_smb_error("CREATE create-context offset %u out of range", blob_offset);
             return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
         }
 
         if (evpl_iovec_cursor_try_copy(request_cursor, ctx_buf, blob_length) == 0) {
-            if (chimera_smb_parse_create_contexts(ctx_buf, blob_length, request) < 0) {
+            crc = chimera_smb_parse_create_contexts(ctx_buf, blob_length, request);
+            free(heap_buf);
+            if (crc < 0) {
                 return -1;
             }
+        } else {
+            free(heap_buf);
         }
     }
 

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -522,7 +522,14 @@ chimera_smb_lock_take_one(
     entry->lease.owner.client_key = request->session_handle->session->session_id;
     entry->lease.owner.owner_lo   = open_file->file_id.pid;
     entry->lease.owner.owner_hi   = open_file->file_id.vid;
-    entry->lease.owner.cb_private = open_file;
+    /* Point at the open's caching grant (NULL if it holds no oplock/lease), not
+     * the open_file, so the range-vs-caching conflict check sees that this
+     * byte-range lock and the same open's (or a coalesced peer's) caching lease
+     * -- whose owner identity is the lease key, not the file id -- share one
+     * grant and must not break each other (vfs_state.c same-cb_private
+     * exemption; smb2.oplock.brl2).  The grant's lease carries the same pointer.
+     * Mirrors the single-element path. */
+    entry->lease.owner.cb_private = open_file->grant;
 
     chimera_vfs_lease_acquire(vfs_state, entry->file_state, &entry->lease,
                               &entry->ticket, false /* no wait */,

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -651,19 +651,58 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             return;
         }
 
+        /* MS-SMB2 2.2.24.1: the acknowledged OplockLevel may only be
+         * SMB2_OPLOCK_LEVEL_II or SMB2_OPLOCK_LEVEL_NONE -- a client cannot
+         * acknowledge a break by claiming a higher level (EXCLUSIVE/BATCH) or a
+         * garbage value.  The lease path's mapping silently collapses such
+         * values to 0 caching bits, but open_file->oplock_level would still be
+         * stamped with the bogus level; reject up front (#1284). */
+        if (request->oplock_break.oplock_level != SMB2_OPLOCK_LEVEL_II &&
+            request->oplock_break.oplock_level != SMB2_OPLOCK_LEVEL_NONE) {
+            chimera_smb_open_file_release(request, open_file);
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+
         /* Resolve the outstanding break with the level the client chose to
          * keep (it may drop further than what we asked -- e.g. straight to
          * NONE).  The lease is genuinely BREAKING here (we no longer ack
          * optimistically), so the canonical ack applies the mode, re-arms a
          * surviving lease, and pumps any parked acquirer. */
         if (open_file->grant) {
-            struct chimera_vfs_lease_mode kept = {
-                .granted = (request->oplock_break.oplock_level ==
-                            SMB2_OPLOCK_LEVEL_II) ? CHIMERA_VFS_LEASE_MODE_R : 0,
-                .denied  = 0,
-            };
+            struct chimera_vfs_lease     *lease    = &open_file->grant->lease;
+            uint8_t                       kept_vfs = (request->oplock_break.oplock_level ==
+                                                      SMB2_OPLOCK_LEVEL_II) ?
+                CHIMERA_VFS_LEASE_MODE_R : 0;
+            struct chimera_vfs_lease_mode kept;
 
-            chimera_vfs_lease_ack(&open_file->grant->lease, kept);
+            /* MS-SMB2 3.3.5.22.1: an ack is valid only while a break is
+             * outstanding.  The lease path guards this; bring the legacy path
+             * to parity rather than silently SUCCEEDing on a settled/revoked
+             * break (#1287). */
+            if (lease->break_state != CHIMERA_VFS_BREAK_BREAKING) {
+                chimera_smb_open_file_release(request, open_file);
+                chimera_smb_complete_request(request, SMB2_STATUS_UNSUCCESSFUL);
+                return;
+            }
+
+            /* The kept level must be a subset of what the break left the holder
+             * (break_needed_mode).  A break driven by a write / namespace
+             * invalidation breaks to NONE (break_needed_mode == 0), so an ack
+             * that keeps LEVEL_II (a read cache) on data a conflicting writer is
+             * mutating is rejected rather than silently re-arming a stale read
+             * cache (#1285). */
+            if (kept_vfs & ~lease->break_needed_mode) {
+                chimera_smb_open_file_release(request, open_file);
+                chimera_smb_complete_request(request,
+                                             SMB2_STATUS_REQUEST_NOT_ACCEPTED);
+                return;
+            }
+
+            kept.granted = kept_vfs;
+            kept.denied  = 0;
+
+            chimera_vfs_lease_ack(lease, kept);
         }
         (void) vfs_state;
 

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -651,16 +651,20 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             return;
         }
 
-        /* MS-SMB2 2.2.24.1: the acknowledged OplockLevel may only be
+        /* MS-SMB2 3.3.5.22.1: the acknowledged OplockLevel may only be
          * SMB2_OPLOCK_LEVEL_II or SMB2_OPLOCK_LEVEL_NONE -- a client cannot
          * acknowledge a break by claiming a higher level (EXCLUSIVE/BATCH) or a
          * garbage value.  The lease path's mapping silently collapses such
          * values to 0 caching bits, but open_file->oplock_level would still be
-         * stamped with the bogus level; reject up front (#1284). */
+         * stamped with the bogus level; reject up front (#1284).  The spec's
+         * code for an oplock-acknowledgment level violation is
+         * STATUS_INVALID_OPLOCK_PROTOCOL (WPTS OplockOnShare S432), NOT the
+         * generic INVALID_PARAMETER. */
         if (request->oplock_break.oplock_level != SMB2_OPLOCK_LEVEL_II &&
             request->oplock_break.oplock_level != SMB2_OPLOCK_LEVEL_NONE) {
             chimera_smb_open_file_release(request, open_file);
-            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            chimera_smb_complete_request(request,
+                                         SMB2_STATUS_INVALID_OPLOCK_PROTOCOL);
             return;
         }
 
@@ -677,12 +681,15 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
             struct chimera_vfs_lease_mode kept;
 
             /* MS-SMB2 3.3.5.22.1: an ack is valid only while a break is
-             * outstanding.  The lease path guards this; bring the legacy path
-             * to parity rather than silently SUCCEEDing on a settled/revoked
-             * break (#1287). */
+             * outstanding (Open.OplockState == Breaking).  The legacy oplock
+             * path reports a stale/duplicate ack as STATUS_INVALID_OPLOCK_PROTOCOL
+             * (WPTS OplockOnShare S1225) -- not STATUS_UNSUCCESSFUL, which is the
+             * lease-path (3.3.5.22.2) convention -- rather than silently
+             * SUCCEEDing on a settled/revoked break (#1287). */
             if (lease->break_state != CHIMERA_VFS_BREAK_BREAKING) {
                 chimera_smb_open_file_release(request, open_file);
-                chimera_smb_complete_request(request, SMB2_STATUS_UNSUCCESSFUL);
+                chimera_smb_complete_request(request,
+                                             SMB2_STATUS_INVALID_OPLOCK_PROTOCOL);
                 return;
             }
 

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -264,12 +264,21 @@ chimera_smb_parse_read(
     uint8_t  padding;
     int      i;
 
+    /* MS-SMB2 3.3.5.12 / 2.2.19: a READ StructureSize that is not exactly 49 is
+     * a per-request STATUS_INVALID_PARAMETER -- the truncation check below
+     * catches a too-short body but not a wrong-yet-large-enough StructureSize. */
+    if (unlikely(request->request_struct_size != SMB2_READ_REQUEST_SIZE)) {
+        chimera_smb_error("Received SMB2 READ request with invalid struct size (%u expected %u)",
+                          request->request_struct_size, SMB2_READ_REQUEST_SIZE);
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
+
     /* MS-SMB2 §2.2.19: StructureSize(2, already consumed) is followed by
      * Padding(1) then Flags(1).  Read both explicitly — the Length uint32 read
      * below realigns to a 4-byte boundary, so a single byte read here would
      * capture Padding and silently skip the Flags field (which carries
      * SMB2_READFLAG_REQUEST_COMPRESSED). */
-    int      prc = 0;
+    int prc = 0;
 
     prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &padding);
     prc |= evpl_iovec_cursor_try_get_uint8(request_cursor, &request->read.flags);

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -598,6 +598,11 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                          * mechanism (which would remove_at the whole file). */
                         if (!(request->set_info.open_file->flags &
                               CHIMERA_SMB_OPEN_FILE_FLAG_STREAM)) {
+                            /* The file is now delete-pending: a subsequent name
+                            * open is answered STATUS_DELETE_PENDING while this
+                            * handle keeps it open (MS-FSA; smb2.oplock.doc). */
+                            chimera_vfs_state_set_delete_pending(
+                                request->set_info.open_file->share_file_state);
                             /* Propagate to VFS handle for final-close deletion */
                             chimera_vfs_set_delete_on_close(
                                 request->compound->thread->vfs_thread,
@@ -632,6 +637,10 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                             chimera_vfs_clear_delete_on_close(
                                 request->compound->thread->vfs_thread,
                                 request->set_info.open_file->handle);
+                            /* Disposition turned back off: no longer delete-
+                             * pending, so new opens succeed again. */
+                            chimera_vfs_state_clear_delete_pending(
+                                request->set_info.open_file->share_file_state);
                         }
                     }
                     chimera_smb_open_file_release(request, request->set_info.open_file);

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -2,10 +2,13 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
+#include <stdlib.h>
+
 #include "smb_internal.h"
 #include "smb_procs.h"
 #include "common/misc.h"
 #include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
 /* Forward declaration */
@@ -278,6 +281,277 @@ chimera_smb_set_info_rename_do_rename(struct chimera_smb_request *request)
     chimera_smb_lease_break_flush(thread);
 } /* chimera_smb_set_info_rename_do_rename */
 
+/* ---- Directory-rename contained-open recall (smb2.lease.rename_dir_openfile) ----
+ *
+ * Renaming a directory breaks the HANDLE lease of every file open inside it.
+ * Each contained holder gets an RH->R break; a well-behaved holder closes (and
+ * frees the rename), a holder that keeps the file open makes the rename fail
+ * ACCESS_DENIED.  Only a directory rename enters this path -- file renames are
+ * untouched. */
+
+static void chimera_smb_set_info_rename_recall_next(
+    struct chimera_smb_request *request);
+
+static void chimera_smb_set_info_rename_recall_scan(
+    struct chimera_smb_request *request);
+
+static void
+chimera_smb_set_info_rename_recall_free(struct chimera_smb_request *request)
+{
+    if (request->set_info.recall_children) {
+        free(request->set_info.recall_children);
+        request->set_info.recall_children = NULL;
+    }
+    request->set_info.recall_child_count = 0;
+    request->set_info.recall_child_cap   = 0;
+    request->set_info.recall_child_idx   = 0;
+} /* chimera_smb_set_info_rename_recall_free */
+
+/* Abandon the rename with ACCESS_DENIED: a contained holder kept its file open
+ * across the handle-lease break (or a new open raced the rename). */
+static void
+chimera_smb_set_info_rename_recall_deny(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_thread *vfs_thread = request->compound->thread->vfs_thread;
+
+    chimera_smb_set_info_rename_recall_free(request);
+
+    if (request->set_info.rename_info.new_parent_handle) {
+        chimera_vfs_release(vfs_thread,
+                            request->set_info.rename_info.new_parent_handle);
+        request->set_info.rename_info.new_parent_handle = NULL;
+    }
+    if (request->set_info.parent_handle) {
+        chimera_vfs_release(vfs_thread, request->set_info.parent_handle);
+        request->set_info.parent_handle = NULL;
+    }
+    chimera_smb_open_file_release(request, request->set_info.open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+} /* chimera_smb_set_info_rename_recall_deny */
+
+/* Per-child recall completion.  A holder that kept the file open (still_open) --
+ * because it acked the handle-lease break without closing, or never held a lease
+ * to break -- denies the rename IMMEDIATELY: matching Windows, the scan stops at
+ * the first non-releasing open and does not break any further contained holders.
+ * Otherwise advance to the next child. */
+static void
+chimera_smb_set_info_rename_recall_cb(
+    enum chimera_vfs_error error_code,
+    int                    still_open,
+    void                  *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    if (error_code != CHIMERA_VFS_OK || still_open) {
+        chimera_smb_set_info_rename_recall_deny(request);
+        return;
+    }
+
+    request->set_info.recall_child_idx++;
+    chimera_smb_set_info_rename_recall_next(request);
+} /* chimera_smb_set_info_rename_recall_cb */
+
+/* Drive the per-child recall loop.  When every collected child has released, run
+ * a second enumeration pass (recall_final) to catch a child opened DURING the
+ * break wave: such a racing open denies the rename.  The second pass finding no
+ * open child lets the rename proceed. */
+static void
+chimera_smb_set_info_rename_recall_next(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread     = request->compound->thread;
+    struct chimera_vfs_thread        *vfs_thread = thread->vfs_thread;
+    struct chimera_smb_rename_recall *rc;
+
+    if (request->set_info.recall_child_idx >= request->set_info.recall_child_count) {
+        if (!request->set_info.recall_final) {
+            /* First wave drained with every holder releasing; re-scan for a
+             * child that was opened while the breaks were in flight. */
+            request->set_info.recall_final = 1;
+            chimera_smb_set_info_rename_recall_scan(request);
+            return;
+        }
+        chimera_smb_set_info_rename_recall_free(request);
+        chimera_smb_set_info_rename_do_rename(request);
+        return;
+    }
+
+    rc = &request->set_info.recall_children[request->set_info.recall_child_idx];
+
+    chimera_vfs_recall_caching_fh(vfs_thread,
+                                  &request->session_handle->session->cred,
+                                  rc->fh, rc->fh_len,
+                                  chimera_smb_set_info_rename_recall_cb,
+                                  request);
+
+    /* The contained holder is on another connection; if its break was deferred
+     * for reply-before-break ordering, flush it now so it actually fires while
+     * the rename is parked on the recall.  (Harmless if the recall already
+     * completed inline -- it operates on the thread, not the request.) */
+    chimera_smb_lease_break_flush(thread);
+} /* chimera_smb_set_info_rename_recall_next */
+
+/* readdir callback: collect each child that currently has a live share holder
+ * (a real protocol open) so its caching lease can be recalled before the
+ * directory rename. */
+static int
+chimera_smb_set_info_rename_recall_readdir_cb(
+    uint64_t                        inum,
+    uint64_t                        cookie,
+    const char                     *name,
+    int                             namelen,
+    const struct chimera_vfs_attrs *attrs,
+    void                           *arg)
+{
+    struct chimera_smb_request       *request    = arg;
+    struct chimera_vfs_thread        *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_smb_rename_recall *rc;
+
+    (void) inum;
+    (void) cookie;
+
+    if ((namelen == 1 && name[0] == '.') ||
+        (namelen == 2 && name[0] == '.' && name[1] == '.')) {
+        return 0;
+    }
+
+    if (!(attrs->va_set_mask & CHIMERA_VFS_ATTR_FH) || attrs->va_fh_len == 0) {
+        return 0;
+    }
+
+    if (!chimera_vfs_fh_has_share_holder(vfs_thread, attrs->va_fh,
+                                         attrs->va_fh_len)) {
+        return 0;
+    }
+
+    if (request->set_info.recall_child_count == request->set_info.recall_child_cap) {
+        uint32_t                          newcap = request->set_info.recall_child_cap
+            ? request->set_info.recall_child_cap * 2 : 8;
+        struct chimera_smb_rename_recall *grown = realloc(
+            request->set_info.recall_children, newcap * sizeof(*grown));
+
+        if (!grown) {
+            /* Out of memory: deny conservatively rather than rename past an
+             * un-recalled open. */
+            request->set_info.recall_deny = 1;
+            return 0;
+        }
+        request->set_info.recall_children  = grown;
+        request->set_info.recall_child_cap = newcap;
+    }
+
+    rc = &request->set_info.recall_children[request->set_info.recall_child_count++];
+    memcpy(rc->fh, attrs->va_fh, attrs->va_fh_len);
+    rc->fh_len = attrs->va_fh_len;
+
+    return 0;
+} /* chimera_smb_set_info_rename_recall_readdir_cb */
+
+static void
+chimera_smb_set_info_rename_recall_readdir_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    uint64_t                        cookie,
+    uint64_t                        verifier,
+    uint32_t                        eof,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    (void) handle;
+    (void) attr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        /* Could not enumerate (e.g. the dir handle lacks list access): fall back
+         * to the plain rename rather than failing one that would have worked. */
+        chimera_smb_set_info_rename_recall_free(request);
+        chimera_smb_set_info_rename_do_rename(request);
+        return;
+    }
+
+    if (!eof) {
+        request->set_info.recall_readdir_cookie = cookie;
+        chimera_vfs_readdir(
+            request->compound->thread->vfs_thread,
+            &request->session_handle->session->cred,
+            request->set_info.open_file->handle,
+            CHIMERA_VFS_ATTR_FH,
+            0,
+            cookie,
+            verifier,
+            0,
+            NULL, 0,
+            chimera_smb_set_info_rename_recall_readdir_cb,
+            chimera_smb_set_info_rename_recall_readdir_complete,
+            request);
+        return;
+    }
+
+    if (request->set_info.recall_final) {
+        /* Second pass: any child still (or newly) open denies the rename;
+        * otherwise the directory is quiescent and the rename proceeds. */
+        if (request->set_info.recall_deny ||
+            request->set_info.recall_child_count > 0) {
+            chimera_smb_set_info_rename_recall_deny(request);
+        } else {
+            chimera_smb_set_info_rename_recall_free(request);
+            chimera_smb_set_info_rename_do_rename(request);
+        }
+        return;
+    }
+
+    request->set_info.recall_child_idx = 0;
+    chimera_smb_set_info_rename_recall_next(request);
+} /* chimera_smb_set_info_rename_recall_readdir_complete */
+
+/* Enumerate the source directory, collecting children that currently have a
+ * live share holder.  Used for both the initial collect-and-recall pass and the
+ * final race-detection re-scan (distinguished by recall_final). */
+static void
+chimera_smb_set_info_rename_recall_scan(struct chimera_smb_request *request)
+{
+    chimera_smb_set_info_rename_recall_free(request);
+
+    chimera_vfs_readdir(
+        request->compound->thread->vfs_thread,
+        &request->session_handle->session->cred,
+        request->set_info.open_file->handle,
+        CHIMERA_VFS_ATTR_FH, /* per-entry attr: need the child FH */
+        0,                   /* dir_attr_mask */
+        0,                   /* cookie */
+        0,                   /* verifier */
+        0,                   /* flags: no EMIT_DOT */
+        NULL, 0,             /* match everything */
+        chimera_smb_set_info_rename_recall_readdir_cb,
+        chimera_smb_set_info_rename_recall_readdir_complete,
+        request);
+} /* chimera_smb_set_info_rename_recall_scan */
+
+/* Entry point: for a directory rename, enumerate the source directory's
+ * children and recall the caching leases of any that are open before issuing
+ * the rename.  Non-directory renames go straight to do_rename. */
+static void
+chimera_smb_set_info_rename_recall_children(struct chimera_smb_request *request)
+{
+    struct chimera_smb_open_file *open_file = request->set_info.open_file;
+
+    request->set_info.recall_children       = NULL;
+    request->set_info.recall_child_count    = 0;
+    request->set_info.recall_child_cap      = 0;
+    request->set_info.recall_child_idx      = 0;
+    request->set_info.recall_readdir_cookie = 0;
+    request->set_info.recall_deny           = 0;
+    request->set_info.recall_final          = 0;
+
+    if (!open_file->handle ||
+        !(open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY)) {
+        chimera_smb_set_info_rename_do_rename(request);
+        return;
+    }
+
+    chimera_smb_set_info_rename_recall_scan(request);
+} /* chimera_smb_set_info_rename_recall_children */
+
 static void
 chimera_smb_set_info_rename_open_dest_dir_callback(
     enum chimera_vfs_error          error_code,
@@ -372,9 +646,11 @@ chimera_smb_set_info_rename_check_dest_callback(
             /* Fall through to do rename - will overwrite */
         }
     }
-    /* Destination doesn't exist or we're overwriting - proceed with rename */
-    chimera_smb_set_info_rename_do_rename(request);
-} /* chimera_smb_set_info_rename_check_dest_callback */ /* chimera_smb_set_info_rename_check_dest_callback */
+    /* Destination doesn't exist or we're overwriting - proceed with rename.
+     * For a directory rename, first break the handle leases of any files open
+     * inside the source directory (smb2.lease.rename_dir_openfile). */
+    chimera_smb_set_info_rename_recall_children(request);
+} /* chimera_smb_set_info_rename_check_dest_callback */
 
 static void
 chimera_smb_set_info_rename_open_dest_parent_callback(

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -389,6 +389,14 @@ chimera_smb_parse_write(
 
     int          prc = 0;
 
+    /* MS-SMB2 3.3.5.13 / 2.2.21: a WRITE StructureSize that is not exactly 49
+     * is a per-request STATUS_INVALID_PARAMETER. */
+    if (unlikely(request->request_struct_size != SMB2_WRITE_REQUEST_SIZE)) {
+        chimera_smb_error("Received SMB2 WRITE request with invalid struct size (%u expected %u)",
+                          request->request_struct_size, SMB2_WRITE_REQUEST_SIZE);
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+    }
+
     prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &data_offset);
     prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &request->write.length);
     prc |= evpl_iovec_cursor_try_get_uint64(request_cursor, &request->write.offset);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1825,6 +1825,16 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.winattr2
     # smb2.zero-data-ioctl
     smb2.zero-data-ioctl
+    # attribute-only ("stat") opens acquire their requested oplock when sole
+    smb2.oplock.batch9
+    smb2.oplock.batch9a
+    # oplocks/leases on named streams (harness enables ADS for these subtests)
+    smb2.oplock.batch26
+    smb2.lease.request
+    # delete-on-close via SET_INFO marks the file delete-pending
+    smb2.oplock.doc
+    # a share-conflicting open handle-breaks a conflicting RqLs lease (RWH->RW)
+    smb2.lease.break_twice
 )
 
 set(SMBTORTURE_ENABLED_linux

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1837,6 +1837,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lease.break_twice
     # rename source recall is a single handle-recall (RH->R), not a cascade
     smb2.lease.v2_rename
+    # byte-range lock breaks a caching lease to NONE in a single shot, and a
+    # fresh lease behind a lock is capped to NONE (lock-vs-caching conflict)
+    smb2.lease.lock1
+    smb2.lease.lease-epoch
+    # batch oplock break-ack timeout duration (harness sets oplocktimeout=30)
+    smb2.oplock.batch22a
 )
 
 set(SMBTORTURE_ENABLED_linux

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1835,6 +1835,8 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.oplock.doc
     # a share-conflicting open handle-breaks a conflicting RqLs lease (RWH->RW)
     smb2.lease.break_twice
+    # rename source recall is a single handle-recall (RH->R), not a cascade
+    smb2.lease.v2_rename
 )
 
 set(SMBTORTURE_ENABLED_linux

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1843,6 +1843,8 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.lease.lease-epoch
     # batch oplock break-ack timeout duration (harness sets oplocktimeout=30)
     smb2.oplock.batch22a
+    # renaming a directory breaks the handle leases of files open inside it
+    smb2.lease.rename_dir_openfile
 )
 
 set(SMBTORTURE_ENABLED_linux

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -419,6 +419,43 @@ test_create_rqls_v1_vs_v2(void)
 } /* test_create_rqls_v1_vs_v2 */
 
 static void
+test_create_rqls_malformed_clears_mask(void)
+{
+    struct chimera_smb_request req;
+    uint8_t                    buf[64];
+    uint8_t                    rqls_bad[20];  /* neither 32 nor 52 -> malformed */
+    uint32_t                   pos = 0;
+    int                        i;
+
+    memset(&req, 0, sizeof(req));
+    memset(buf, 0, sizeof(buf));
+    memset(rqls_bad, 0xAB, sizeof(rqls_bad));
+
+    /* Simulate a pooled request slot still carrying a lease key from a prior
+     * CREATE on this slot. */
+    for (i = 0; i < 16; i++) {
+        req.create.rqls.key[i] = (uint8_t) (0x11 + i);
+    }
+
+    pos = emit_create_ctx_entry(buf, 0, "RqLs", rqls_bad, 20, 1);
+
+    if (chimera_smb_parse_create_contexts(buf, pos, &req) != 0) {
+        TEST_FAIL("malformed RqLs parse returned error");
+        return;
+    }
+
+    /* #1116: a malformed RqLs (DataLength != 32/52) must NOT set the RQLS
+     * present-mask bit, so the stale lease key is never honored downstream. */
+    if (!(req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
+        !(req.create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS_V2) &&
+        req.create.rqls.is_v2 == 0) {
+        TEST_PASS("malformed RqLs leaves RQLS present-mask clear (#1116)");
+    } else {
+        TEST_FAIL("malformed RqLs leaves RQLS present-mask clear (#1116)");
+    }
+} /* test_create_rqls_malformed_clears_mask */
+
+static void
 test_create_malformed_short_next(void)
 {
     struct chimera_smb_request req;
@@ -1206,6 +1243,7 @@ main(
     fprintf(stderr, "=== Phase 0: CREATE context parse ===\n");
     test_create_win11_chain();
     test_create_rqls_v1_vs_v2();
+    test_create_rqls_malformed_clears_mask();
     test_create_ctx_dhnc();
     test_create_ctx_dh2c();
     test_create_ctx_alsi();

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -152,6 +152,12 @@ run_smbtorture(
                     * deadlock timeout it uses to bound the blocking-lock wait;
                     * the option is specific to that test. */
                    " --option=torture:open_brlock_deadlock_timemout=2"
+                   /* chimera revokes an unacked oplock/lease break at its 30s
+                    * deadline (CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS); tell
+                    * the client so the smb2.oplock.batch22a/b break-timeout
+                    * duration assertion (CHECK_RANGE(te, timeout-1, timeout+15))
+                    * brackets 30s rather than the 35s Windows default. */
+                   " --option=torture:oplocktimeout=30"
                    /* SMB3 signing algorithms the client offers (see sign_algos
                     * above): GMAC-first only for the signing/encryption subtests
                     * that require it, CMAC otherwise. */

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -430,12 +430,21 @@ main(
      * suite still runs with the feature off on the same backend.  Also match
      * individual smb2.streams.* subtests so the per-subtest harvest variant
      * (run one stream subtest in its own server process) gets the same
-     * capability the combined smb2.streams suite needs. */
+     * capability the combined smb2.streams suite needs.
+     *
+     * A handful of oplock/lease subtests open named streams (a real Windows
+     * server always exposes the ADS namespace), so they need the same
+     * capability: smb2.oplock.stream1 / smb2.oplock.batch26 take oplocks on a
+     * stream, and smb2.lease.request leases a stream.  Without it the stream
+     * create is refused OBJECT_NAME_INVALID by the named-streams-off gate. */
     for (i = 0; i < num_tests; i++) {
         if (strcmp(tests[i], "smb2.streams") == 0 ||
             strncmp(tests[i], "smb2.streams.", 13) == 0 ||
             strcmp(tests[i], "smb2.ioctl-on-stream") == 0 ||
-            strcmp(tests[i], "smb2.sdread") == 0) {
+            strcmp(tests[i], "smb2.sdread") == 0 ||
+            strcmp(tests[i], "smb2.oplock.stream1") == 0 ||
+            strcmp(tests[i], "smb2.oplock.batch26") == 0 ||
+            strcmp(tests[i], "smb2.lease.request") == 0) {
             chimera_server_config_set_smb_named_streams(config, 1);
             break;
         }

--- a/src/vfs/vfs_proc_recall.c
+++ b/src/vfs/vfs_proc_recall.c
@@ -59,3 +59,78 @@ chimera_vfs_recall_handle_lease(
                                  handle->fh_hash, CHIMERA_VFS_LEASE_MODE_R,
                                  chimera_vfs_recall_complete);
 } /* chimera_vfs_recall_handle_lease */
+
+/* True if `fh` currently has a live (non-implicit) share holder. */
+SYMBOL_EXPORT int
+chimera_vfs_fh_has_share_holder(
+    struct chimera_vfs_thread *thread,
+    const uint8_t             *fh,
+    uint32_t                   fh_len)
+{
+    struct chimera_vfs_state      *state = thread->vfs->vfs_state;
+    struct chimera_vfs_file_state *fs;
+    int                            open = 0;
+
+    fs = chimera_vfs_state_get(state, fh, fh_len,
+                               chimera_vfs_hash(fh, fh_len), false);
+    if (fs) {
+        open = chimera_vfs_state_has_other_share_holder(fs, NULL);
+        chimera_vfs_state_put(state, fs);
+    }
+    return open;
+} /* chimera_vfs_fh_has_share_holder */
+
+/* Completion for a by-FH caching recall: the recall has drained, so report
+ * whether the file still has a live share holder (a holder that did NOT close
+ * on the handle-lease break) and free the request. */
+static void
+chimera_vfs_recall_caching_fh_complete(struct chimera_vfs_request *request)
+{
+    chimera_vfs_recall_fh_callback_t callback = request->proto_callback;
+    int                              still_open;
+
+    still_open = chimera_vfs_fh_has_share_holder(request->thread, request->fh,
+                                                 request->fh_len);
+
+    chimera_vfs_complete(request);
+    callback(CHIMERA_VFS_OK, still_open, request->proto_private_data);
+    chimera_vfs_request_free(request->thread, request);
+} /* chimera_vfs_recall_caching_fh_complete */
+
+/* Single-step recall of EVERY caching lease on the file named by a bare FH
+ * (no open handle, so nothing is spared), breaking each holder's handle cache
+ * once (RH -> R) and PARKing until the recall drains, then report whether a
+ * holder kept the file open.  A well-behaved holder closes on the handle-lease
+ * break (freeing its share reservation); a holder that only acks keeps the file
+ * open at R.  Used by the SMB directory-rename path to break the handle leases
+ * of files open inside a directory being renamed (MS-SMB2 / Windows: a
+ * directory rename breaks the handle lease of each contained open and proceeds
+ * only once every holder has released). */
+SYMBOL_EXPORT void
+chimera_vfs_recall_caching_fh(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    const uint8_t                   *fh,
+    uint32_t                         fh_len,
+    chimera_vfs_recall_fh_callback_t callback,
+    void                            *private_data)
+{
+    struct chimera_vfs_request *request;
+
+    request = chimera_vfs_request_alloc(thread, cred, fh, fh_len);
+
+    if (CHIMERA_VFS_IS_ERR(request)) {
+        callback(CHIMERA_VFS_PTR_ERR(request), 0, private_data);
+        return;
+    }
+
+    request->opcode             = CHIMERA_VFS_OP_GETATTR; /* inert: no dispatch */
+    request->complete           = chimera_vfs_recall_caching_fh_complete;
+    request->io_handle          = NULL; /* spare nothing: break all holders */
+    request->proto_callback     = callback;
+    request->proto_private_data = private_data;
+
+    chimera_vfs_io_recall_single(request, fh, fh_len, request->fh_hash,
+                                 CHIMERA_VFS_LEASE_MODE_R,
+                                 chimera_vfs_recall_caching_fh_complete);
+} /* chimera_vfs_recall_caching_fh */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -182,13 +182,21 @@ chimera_vfs_rename_at_source_lookup_complete(
         memcpy(request->rename_at.source_fh, attr->va_fh, attr->va_fh_len);
         request->rename_at.source_fh_len = attr->va_fh_len;
 
-        chimera_vfs_io_recall(request,
-                              request->rename_at.source_fh,
-                              request->rename_at.source_fh_len,
-                              chimera_vfs_hash(request->rename_at.source_fh,
-                                               request->rename_at.source_fh_len),
-                              0 /* namespace recall: revoke fully */,
-                              chimera_vfs_rename_at_recall_target);
+        /* The renamed file SURVIVES the rename -- only its name/handle binding is
+         * invalidated, the data is unchanged -- so this is a single HANDLE recall
+         * (RH->R), not a cascade to NONE.  A full revoke would drive a v2 lease
+         * RH->R->NONE, two break notifications, where the client expects one
+         * (smb2.lease.v2_rename).  NFSv4 delegations on the source are recalled
+         * explicitly by the NFSv4 rename op before rename_at runs, so this leaves
+         * them already gone.  The doomed DESTINATION (recall_target) is destroyed
+         * and is still fully revoked. */
+        chimera_vfs_io_recall_single(request,
+                                     request->rename_at.source_fh,
+                                     request->rename_at.source_fh_len,
+                                     chimera_vfs_hash(request->rename_at.source_fh,
+                                                      request->rename_at.source_fh_len),
+                                     CHIMERA_VFS_LEASE_MODE_R,
+                                     chimera_vfs_rename_at_recall_target);
     } else {
         /* Source not resolvable (e.g. ENOENT); the backend rename will return
          * the appropriate error.  Just recall the destination and proceed. */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -182,21 +182,42 @@ chimera_vfs_rename_at_source_lookup_complete(
         memcpy(request->rename_at.source_fh, attr->va_fh, attr->va_fh_len);
         request->rename_at.source_fh_len = attr->va_fh_len;
 
-        /* The renamed file SURVIVES the rename -- only its name/handle binding is
-         * invalidated, the data is unchanged -- so this is a single HANDLE recall
-         * (RH->R), not a cascade to NONE.  A full revoke would drive a v2 lease
-         * RH->R->NONE, two break notifications, where the client expects one
-         * (smb2.lease.v2_rename).  NFSv4 delegations on the source are recalled
-         * explicitly by the NFSv4 rename op before rename_at runs, so this leaves
-         * them already gone.  The doomed DESTINATION (recall_target) is destroyed
-         * and is still fully revoked. */
-        chimera_vfs_io_recall_single(request,
-                                     request->rename_at.source_fh,
-                                     request->rename_at.source_fh_len,
-                                     chimera_vfs_hash(request->rename_at.source_fh,
-                                                      request->rename_at.source_fh_len),
-                                     CHIMERA_VFS_LEASE_MODE_R,
-                                     chimera_vfs_rename_at_recall_target);
+        /* How hard to recall the source's caching holders depends on the caller:
+         *
+         *  - SMB (op_handle != NULL): the renamed file SURVIVES with its data
+         *    intact -- only the name/handle binding is invalidated -- so an SMB
+         *    v2 lease is broken with a SINGLE handle recall (RH->R), preserving
+         *    the read cache.  A full revoke would cascade RH->R->NONE, sending
+         *    two break notifications where the client expects one
+         *    (smb2.lease.v2_rename).
+         *
+         *  - NFS / S3 (op_handle == NULL): an NFSv4 delegation on the source must
+         *    be RECALLED outright on rename (RFC 7530 namespace recall) -- there
+         *    is no "keep the read cache" downgrade for a delegation, and the
+         *    explicit NFSv4-rename recall does not cover every backend/path -- so
+         *    fall back to a full revoke (retain NONE).  Single-stepping a
+         *    delegation to R here would leave it un-recalled and the client
+         *    would never see CB_RECALL (pynfs DELEG6/17/18).
+         *
+         * The doomed DESTINATION (recall_target) is always destroyed and so is
+         * always fully revoked. */
+        if (request->io_handle) {
+            chimera_vfs_io_recall_single(request,
+                                         request->rename_at.source_fh,
+                                         request->rename_at.source_fh_len,
+                                         chimera_vfs_hash(request->rename_at.source_fh,
+                                                          request->rename_at.source_fh_len),
+                                         CHIMERA_VFS_LEASE_MODE_R,
+                                         chimera_vfs_rename_at_recall_target);
+        } else {
+            chimera_vfs_io_recall(request,
+                                  request->rename_at.source_fh,
+                                  request->rename_at.source_fh_len,
+                                  chimera_vfs_hash(request->rename_at.source_fh,
+                                                   request->rename_at.source_fh_len),
+                                  0 /* namespace recall: revoke fully */,
+                                  chimera_vfs_rename_at_recall_target);
+        }
     } else {
         /* Source not resolvable (e.g. ENOENT); the backend rename will return
          * the appropriate error.  Just recall the destination and proceed. */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -225,6 +225,36 @@ chimera_vfs_recall_handle_lease(
     chimera_vfs_recall_callback_t   callback,
     void                           *private_data);
 
+/* True if the file named by `fh` currently has a live (non-implicit) share
+* holder -- i.e. some protocol open is still active on it.  Synchronous. */
+int
+chimera_vfs_fh_has_share_holder(
+    struct chimera_vfs_thread *thread,
+    const uint8_t             *fh,
+    uint32_t                   fh_len);
+
+/* Completion for chimera_vfs_recall_caching_fh: `still_open` reports whether the
+ * file still has a live (non-implicit) share holder once the recall has drained
+ * (a holder that did NOT close in response to the handle-lease break). */
+typedef void (*chimera_vfs_recall_fh_callback_t)(
+    enum chimera_vfs_error error_code,
+    int                    still_open,
+    void                  *private_data);
+
+/* Single-step recall of every caching lease on the file named by a bare FH
+ * (no open handle is spared), breaking each holder's handle cache once
+ * (RH -> R) and PARKing until the recall drains, then report whether a holder
+ * kept the file open.  Used by the SMB directory-rename path to break the
+ * handle leases of files open inside a directory being renamed. */
+void
+chimera_vfs_recall_caching_fh(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    const uint8_t                   *fh,
+    uint32_t                         fh_len,
+    chimera_vfs_recall_fh_callback_t callback,
+    void                            *private_data);
+
 void
 chimera_vfs_getattr(
     struct chimera_vfs_thread      *thread,

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -3799,6 +3799,17 @@ chimera_vfs_state_revoke_expired_breaks(
 
     pthread_mutex_lock(&file->lock);
     for (cur = file->caching_leases; cur; cur = cur->next) {
+        /* NFSv4 delegations are NOT force-revoked on a recall-deadline miss:
+         * RFC 7530 governs their lifetime through the client's lease (a client
+         * that stops renewing has ALL state expired by the NFSv4 lease-expiry
+         * path; a client that keeps renewing while its callback path is down is
+         * told CB_PATH_DOWN and given the chance to recover and DELEGRETURN --
+         * pynfs DELEG6).  This proactive sweep exists for SMB2 oplock/lease
+         * break-ack timeouts (#1030), where a dead-but-not-disconnected client
+         * would otherwise pin the lease BREAKING forever. */
+        if (cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4) {
+            continue;
+        }
         if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
             chimera_vfs_break_deadline_passed(cur) &&
             n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -310,6 +310,18 @@ chimera_vfs_state_set_delete_pending(struct chimera_vfs_file_state *file)
     }
 } /* chimera_vfs_state_set_delete_pending */
 
+/* Clear delete-pending -- e.g. a SET_INFO disposition that turns delete-on-close
+ * back off before the last close (smb2.* DispositionInformation toggling). */
+SYMBOL_EXPORT void
+chimera_vfs_state_clear_delete_pending(struct chimera_vfs_file_state *file)
+{
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+        file->delete_pending = 0;
+        pthread_mutex_unlock(&file->lock);
+    }
+} /* chimera_vfs_state_clear_delete_pending */
+
 SYMBOL_EXPORT bool
 chimera_vfs_state_is_delete_pending(struct chimera_vfs_file_state *file)
 {
@@ -1907,7 +1919,8 @@ chimera_vfs_caching_grant_try_upgrade(
 SYMBOL_EXPORT uint8_t
 chimera_vfs_caching_grant_cap_mode(
     struct chimera_vfs_file_state  *file,
-    const struct chimera_vfs_lease *lease)
+    const struct chimera_vfs_lease *lease,
+    bool                            strict)
 {
     struct chimera_vfs_lease  probe    = *lease;
     struct chimera_vfs_lease *conflict = NULL;
@@ -1922,13 +1935,20 @@ chimera_vfs_caching_grant_cap_mode(
         }
         /* Step down toward the read floor: drop the exclusive write cache first,
          * then handle caching.  Once at R with a remaining conflict there is
-         * nothing left to yield -- return R and let try_insert resolve it (a
-         * genuine cross-client read/handle conflict that a cap cannot dissolve). */
+         * nothing left to yield. */
         if (mode & CHIMERA_VFS_LEASE_MODE_W) {
             mode &= ~CHIMERA_VFS_LEASE_MODE_W;
         } else if (mode & CHIMERA_VFS_LEASE_MODE_H) {
             mode &= ~CHIMERA_VFS_LEASE_MODE_H;
         } else {
+            /* At the R floor and still conflicting.  Non-strict: return R and let
+             * the caller's try_insert resolve the residual cross-client read /
+             * handle conflict.  Strict (an oplock-transparent stat-open): yield
+             * everything -- no subset is grantable without a break -- so return 0
+             * and take no oplock rather than breaking the holder. */
+            if (strict) {
+                mode = 0;
+            }
             break;
         }
     }
@@ -3009,7 +3029,8 @@ chimera_vfs_state_break_caching_for_open(
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *opener,
     uint8_t                               trigger_bits,
-    uint8_t                               retain_mode)
+    uint8_t                               retain_mode,
+    int                                   break_leases)
 {
     struct chimera_vfs_file_state    *file;
     struct chimera_vfs_lease         *cur;
@@ -3051,7 +3072,7 @@ chimera_vfs_state_break_caching_for_open(
          * lease's handle is only recalled by a genuine share conflict (handled in
          * the share path) or when the directory itself is removed/renamed. */
         if (trigger_bits == CHIMERA_VFS_LEASE_MODE_H &&
-            cur->grant && !cur->grant->is_oplock) {
+            cur->grant && !cur->grant->is_oplock && !break_leases) {
             continue;
         }
         if (n < CHIMERA_VFS_STATE_MAX_BREAK_BATCH) {
@@ -3758,10 +3779,13 @@ chimera_vfs_state_reap_idle(
         for (file = bucket->files;
              file && n < CHIMERA_VFS_STATE_REAP_BATCH;
              file = file->bucket_next) {
-            /* Candidates: files holding an implicit lease (reapable when idle)
-             * or with parked I/O waiters (re-pumped so an unresponsive holder
-             * is revoked at its recall deadline and the waiter makes progress). */
-            if (file->implicit_active || file->io_wait_head) {
+            /* Candidates: files holding an implicit lease (reapable when idle),
+             * with parked I/O waiters (re-pumped so an unresponsive holder is
+             * revoked at its recall deadline and the waiter makes progress), or
+             * holding any caching lease (an oplock/lease/delegation may be stuck
+             * BREAKING past its deadline with NO waiter behind it -- #1030). */
+            if (file->implicit_active || file->io_wait_head ||
+                file->caching_leases) {
                 file->refcount++;
                 cand[n++] = file;
             }
@@ -3774,6 +3798,8 @@ chimera_vfs_state_reap_idle(
 
             file = cand[i];
 
+            bool has_caching;
+
             pthread_mutex_lock(&file->lock);
             reapable = file->implicit_active &&
                 !file->implicit_draining &&
@@ -3783,17 +3809,27 @@ chimera_vfs_state_reap_idle(
                 file->implicit_draining = 1;
             }
             has_waiters = (file->io_wait_head != NULL);
+            has_caching = (file->caching_leases != NULL);
             pthread_mutex_unlock(&file->lock);
+
+            /* Forcibly revoke any caching lease stuck BREAKING past its deadline
+             * (MS-SMB2 oplock-break ack timeout / NFSv4 recall timeout) even
+             * when no conflicting acquirer is waiting -- otherwise a
+             * dead-but-not-disconnected client that never sends its OPLOCK_BREAK
+             * ack pins the lease BREAKING forever, holding caching state the
+             * server already told it to relinquish (#1030).  revoke_expired_
+             * breaks is a no-op when nothing has expired, and the revoke itself
+             * pumps the file's pending / I/O queues. */
+            if (has_caching) {
+                chimera_vfs_state_revoke_expired_breaks(state, file);
+            }
 
             if (reapable) {
                 /* finish_drain pumps the wait queue itself. */
                 chimera_vfs_implicit_finish_drain(state, file);
             } else if (has_waiters) {
                 /* A parked I/O / namespace op is waiting on a caching holder to
-                 * break.  If that holder never acknowledged and its break
-                 * deadline has elapsed, forcibly revoke it (MS-SMB2 / NFSv4
-                 * recall timeout) so the waiter can proceed, then re-pump. */
-                chimera_vfs_state_revoke_expired_breaks(state, file);
+                * break; re-pump so it makes progress once the break settles. */
                 chimera_vfs_state_pump_io(state, file);
             }
 

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1032,6 +1032,32 @@ chimera_vfs_state_would_conflict(
         break;
 
         case CHIMERA_VFS_LEASE_CACHING:
+            /* A byte-range lock is incompatible with caching on the stream
+             * (MS-FSA 2.1.5.18): a caching lease cannot be granted while another
+             * owner holds a range lock, so a fresh lease behind a peer's lock is
+             * capped to NONE (smb2.lease.lease-epoch).  Same-owner / same-grant
+             * locks are exempt -- a handle may lock its own file and keep its
+             * cache (smb2.oplock.brl2) -- as is an NFSv4 client's own lock vs its
+             * own delegation (RFC 8881 §10.2).  A bare LEASE_NONE probe (no
+             * caching bits) is unaffected. */
+            if (probe->mode.granted) {
+                for (cur = file->range_locks; cur; cur = cur->next) {
+                    if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner) ||
+                        (probe->owner.cb_private &&
+                         cur->owner.cb_private == probe->owner.cb_private)) {
+                        continue;
+                    }
+                    if (cur->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4 &&
+                        probe->owner.protocol == CHIMERA_VFS_LEASE_PROTO_NFSV4 &&
+                        cur->owner.client_key == probe->owner.client_key) {
+                        continue;
+                    }
+                    if (conflict_out) {
+                        *conflict_out = cur;
+                    }
+                    return CHIMERA_VFS_LEASE_DENIED;
+                }
+            }
             for (cur = file->caching_leases; cur; cur = cur->next) {
                 if (chimera_vfs_lease_owner_equal(&cur->owner, &probe->owner)) {
                     continue;
@@ -1250,6 +1276,16 @@ chimera_vfs_file_state_remove_lease(
     lease->file = NULL;
 } /* chimera_vfs_file_state_remove_lease */
 
+/* Forward declaration: defined below, used by the conflict-resolution break
+ * paths above its definition. */
+static void
+chimera_vfs_lease_begin_break_ex(
+    struct chimera_vfs_state *state,
+    struct chimera_vfs_lease *lease,
+    uint8_t                   floor,
+    uint32_t                  deadline_ms,
+    bool                      one_shot);
+
 /* The mode a conflicting holder is allowed to RETAIN when `acquirer` forces it to
 * break -- i.e. the break floor handed to begin_break.  The floor must be the
 * holder's granted mode with exactly the bits that CONFLICT with the acquirer
@@ -1422,8 +1458,26 @@ chimera_vfs_state_try_insert(
                     floor = conflict->mode.granted & ~CHIMERA_VFS_LEASE_MODE_H;
                 }
 
-                chimera_vfs_lease_begin_break(state, conflict, floor,
-                                              deadline_ms);
+                /* A byte-range lock is incompatible with ANY caching on the
+                 * stream -- read AND handle -- so a range-lock acquirer breaks a
+                 * conflicting caching lease all the way to NONE, not just down to
+                 * the generic write-contention floor (which would leave H).  The
+                 * same-open / same-grant exemption already ran in
+                 * would_conflict, so a holder reaching here genuinely conflicts
+                 * (MS-FSA 2.1.5.18; smb2.lease.lock1 expects LEASE2/LEASE3 -> 0). */
+                if (lease->kind == CHIMERA_VFS_LEASE_RANGE &&
+                    conflict->kind == CHIMERA_VFS_LEASE_CACHING) {
+                    floor = 0;
+                }
+
+                /* A byte-range lock invalidates the whole caching lease at once,
+                 * like a write or namespace mutation, so break it in a SINGLE
+                 * shot to the floor rather than cascading one bit per ack (a
+                 * cascade RH->R->NONE would send two notifications where the
+                 * client expects one -- smb2.lease.lock1). */
+                chimera_vfs_lease_begin_break_ex(
+                    state, conflict, floor, deadline_ms,
+                    lease->kind == CHIMERA_VFS_LEASE_RANGE /* one_shot */);
                 began_live_break = true;
             } else {
                 /* Surfaced because its recall deadline elapsed -- the holder

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -166,6 +166,10 @@ void
 chimera_vfs_state_set_delete_pending(
     struct chimera_vfs_file_state *file);
 
+void
+chimera_vfs_state_clear_delete_pending(
+    struct chimera_vfs_file_state *file);
+
 bool
 chimera_vfs_state_is_delete_pending(
     struct chimera_vfs_file_state *file);
@@ -292,11 +296,18 @@ chimera_vfs_caching_grant_link(
 /* Cap a fresh lease's requested mode to the largest subset grantable WITHOUT
  * breaking another owner (MS-SMB2 3.3.5.9: granting a lease never recalls
  * another lease).  Steps the candidate mode down W then H toward the R floor
- * until it would be granted.  Caller must NOT hold file->lock. */
+ * until it would be granted.  Caller must NOT hold file->lock.
+ *
+ * When `strict` is false a residual read/handle conflict at the R floor returns
+ * R anyway (the caller's try_insert then resolves it).  When `strict` is true a
+ * mode that still conflicts at the R floor returns 0 -- i.e. grant ONLY a subset
+ * that needs no break at all.  Used for an "oplock-transparent" stat-open, which
+ * must never break a holder: it gets its full oplock when sole, NONE otherwise. */
 uint8_t
 chimera_vfs_caching_grant_cap_mode(
     struct chimera_vfs_file_state  *file,
-    const struct chimera_vfs_lease *lease);
+    const struct chimera_vfs_lease *lease,
+    bool                            strict);
 
 /* True if `client_key` already holds an SMB2 RqLs handle-caching (H) lease on
 * `file`.  Used by the SMB create path to deny a legacy oplock request (-> NONE)
@@ -612,6 +623,13 @@ chimera_vfs_state_dir_lease_break(
  *   - batch (H) holders break before the share-mode check (handle caching, the
  *     holder may close): trigger = H;
  *   - exclusive (W) holders break only once the open is granted: trigger = W|H.
+ *
+ * `break_leases`: by default an H-trigger break spares SMB2 RqLs leases (a lease
+ * keeps its handle cache on a *compatible* open -- only its write cache is
+ * exclusive).  Set break_leases=1 to also handle-break leases; the caller uses
+ * this on a genuine SHARE conflict, where a handle-caching lease holder must be
+ * told to relinquish its handle cache (RWH->RW) even though the conflicting open
+ * is still refused (MS-SMB2 / smb2.lease.break_twice).
  */
 void
 chimera_vfs_state_break_caching_for_open(
@@ -621,7 +639,8 @@ chimera_vfs_state_break_caching_for_open(
     uint64_t                              fh_hash,
     const struct chimera_vfs_lease_owner *opener,
     uint8_t                               trigger_bits,
-    uint8_t                               retain_mode);
+    uint8_t                               retain_mode,
+    int                                   break_leases);
 
 /* Break-on-namespace-change: an unlink / delete-on-close / rename of an OPEN
  * file recalls every OTHER holder's HANDLE cache down to retain_mode (R), strips


### PR DESCRIPTION
## Summary

Overhauls the SMB2/VFS oplock & lease-break path for protocol conformance, plus the cross-protocol break-before-mutate invariant on the NFSv3 side. Closes a cluster of 2026-06 audit issues and greens a set of previously-disabled smbtorture cases and one WPTS case.

### Break-ack handler correctness
- Reserved `LeaseFlags` in the break-ack reply forced to 0 (#1282)
- Lease-ack resolved across the whole session's trees, not just `request->tree` (#1283, #1286)
- Legacy ack brought to parity with the lease path: BREAKING-state guard (#1287); reject an acked level above the break target or a re-granted LEVEL_II never offered (#1284, #1285)
- A 52-byte v2 RqLs is honored only on SMB 3.x; 2.0.2/2.1 get a v1 lease (#1281)
- Per-command `StructureSize` validation for READ/WRITE/CHANGE_NOTIFY/CANCEL (#1309)

### Break lifecycle / proactive revoke
- The idle reaper now force-revokes a lease stuck `BREAKING` past its deadline even with no new contender — a dead-but-not-disconnected client can no longer pin caching state (#1030)
- `FILE_OPEN_REQUIRING_OPLOCK` fails the create with `STATUS_CANNOT_BREAK_OPLOCK` when the oplock/lease cannot be granted (#1016)

### Cross-protocol break-before-mutate (NFSv3)
- NFSv3 REMOVE/RMDIR/RENAME resolve the victim/clobbered FH and recall any held delegation/lease before the mutation (#1070, #1071)

### CREATE-context robustness
- A context chain > 1024 bytes is heap-parsed instead of silently dropped (#1115)
- The present-mask bit is set only after the body validates, so a malformed RqLs/DH2Q can't honor stale pooled fields (#1116)
- Multi-element byte-range lock `cb_private` points at the open's caching grant, restoring the same-owner exemption (#1252)

### Oplock/lease grant + break semantics (re-enables disabled smbtorture cases)
- Attribute-only ("stat") opens acquire their requested oplock when sole and break nobody otherwise; legacy oplocks cap-to-coexist behind a read holder instead of breaking it — `smb2.oplock.batch9`, `batch9a`
- A lease state with W/H but no R is granted NONE (`smb2.lease.request`); named-stream oplock/lease subtests get ADS enabled in the harness (`smb2.oplock.batch26`)
- Delete-on-close via SET_INFO marks the file delete-pending → later opens get `STATUS_DELETE_PENDING` (`smb2.oplock.doc`)
- A share-conflicting open handle-breaks a conflicting RqLs lease RWH→RW (`smb2.lease.break_twice`)

### WPTS
- Promote `ResilientOpenScavengerTimer_ReconnectAfterTimeout` to green (now passes via the break-deadline revoke).

## Verification
All changes regression-gated against the enabled smbtorture oplock/lease/durable/dirlease/create/streams/session suites (memfs + linux), the WPTS base/persistent/dirlease buckets, NFS3 cthon (memfs), and the phase0 unit tests; `make syntax`/`reuse-lint` clean; debug + release builds clean.