### PR TITLE
vfs: make the name (lookup) cache optional (common.name_cache, default on)

### DIFF
--- a/src/client/client.c
+++ b/src/client/client.c
@@ -33,6 +33,7 @@ chimera_client_config_init(void)
     config->async_delegation_threads = 8;
     config->cache_ttl                = 60;
     config->attr_cache_enabled       = 1;
+    config->name_cache_enabled       = 1;
     config->rcu_reclaim_threads      = 4; /* 4 = cap RCU reclaim workers to avoid thread exhaustion on many-core hosts */
     config->max_fds                  = 1024;
 
@@ -196,6 +197,7 @@ chimera_client_init(
                                    config->kv_module,
                                    config->cache_ttl,
                                    config->attr_cache_enabled,
+                                   config->name_cache_enabled,
                                    config->rcu_reclaim_threads,
                                    metrics);
 
@@ -343,6 +345,10 @@ chimera_client_init_json(
     /* The VFS attribute cache (common.attr_cache) is a VFS-level facility shared
      * with the server; on by default. */
     config->attr_cache_enabled = chimera_common_attr_cache_enabled(root);
+
+    /* The VFS name (lookup) cache (common.name_cache) is likewise shared with
+     * the server; on by default. */
+    config->name_cache_enabled = chimera_common_name_cache_enabled(root);
 
     client = chimera_client_init(config, cred, metrics);
 

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -424,6 +424,7 @@ struct chimera_client_config {
     int                           async_delegation_threads;
     int                           cache_ttl;
     int                           attr_cache_enabled;
+    int                           name_cache_enabled;
     int                           rcu_reclaim_threads;
     int                           max_fds;
     enum chimera_tcp_flavor       tcp_flavor;

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -338,3 +338,34 @@ chimera_common_attr_cache_enabled(json_t *root)
 
     return 1;
 } /* chimera_common_attr_cache_enabled */
+
+/*
+ * Whether the VFS name (lookup) cache is enabled, from the shared "common"
+ * section's "name_cache" boolean key.  Like the attr cache it is a VFS-level
+ * facility used by both the server and the client, so this is honored
+ * identically by both.  When disabled the cache is not instantiated and nothing
+ * is inserted into, looked up from, or removed from it (the cache helpers no-op
+ * on a NULL cache).  Defaults to enabled (returns 1) when the section or key is
+ * absent; `root` may be NULL.
+ */
+static inline int
+chimera_common_name_cache_enabled(json_t *root)
+{
+    json_t *common, *val;
+
+    if (!root) {
+        return 1;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return 1;
+    }
+
+    val = json_object_get(common, "name_cache");
+    if (json_is_boolean(val)) {
+        return json_is_true(val) ? 1 : 0;
+    }
+
+    return 1;
+} /* chimera_common_name_cache_enabled */

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -418,6 +418,11 @@ main(
     chimera_server_config_set_attr_cache_enabled(server_config,
                                                  chimera_common_attr_cache_enabled(config));
 
+    /* The VFS name (lookup) cache (common.name_cache) is likewise shared with
+     * the client; on by default. */
+    chimera_server_config_set_name_cache_enabled(server_config,
+                                                 chimera_common_name_cache_enabled(config));
+
     json_value = json_object_get(server_params, "smb_persistent_handles");
     if (json_is_boolean(json_value)) {
         chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -68,6 +68,7 @@ struct chimera_server_config {
     int                                   async_delegation_threads;
     int                                   cache_ttl;
     int                                   attr_cache_enabled;
+    int                                   name_cache_enabled;
     int                                   rcu_reclaim_threads;
     int                                   nfs4_session_slots;
     int                                   nfs4_delegations;
@@ -270,6 +271,9 @@ chimera_server_config_init(void)
 
     /* The VFS attribute cache is on by default (common.attr_cache). */
     config->attr_cache_enabled = 1;
+
+    /* The VFS name (lookup) cache is on by default (common.name_cache). */
+    config->name_cache_enabled = 1;
 
     /* Number of liburcu call_rcu reclaim worker threads.  0 (the default) means
      * one worker per CPU (create_all_cpu_call_rcu_data) to keep RCU reclaim up
@@ -602,6 +606,14 @@ chimera_server_config_set_attr_cache_enabled(
 {
     config->attr_cache_enabled = enabled;
 } /* chimera_server_config_set_attr_cache_enabled */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_name_cache_enabled(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->name_cache_enabled = enabled;
+} /* chimera_server_config_set_name_cache_enabled */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_rcu_reclaim_threads(
@@ -2304,6 +2316,7 @@ chimera_server_init(
                                    config->kv_module,
                                    config->cache_ttl,
                                    config->attr_cache_enabled,
+                                   config->name_cache_enabled,
                                    config->rcu_reclaim_threads,
                                    metrics);
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -193,6 +193,11 @@ chimera_server_config_set_attr_cache_enabled(
     int                           enabled);
 
 void
+chimera_server_config_set_name_cache_enabled(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+void
 chimera_server_config_set_nfs4_session_slots(
     struct chimera_server_config *config,
     int                           slots);

--- a/src/vfs/tests/vfs_async_delegation_test.c
+++ b/src/vfs/tests/vfs_async_delegation_test.c
@@ -280,6 +280,7 @@ run_phase(
         "",
         60,
         1,                  /* attr_cache_enabled */
+        1,                  /* name_cache_enabled */
         0,                  /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);

--- a/src/vfs/tests/vfs_clone_range_test.c
+++ b/src/vfs/tests/vfs_clone_range_test.c
@@ -329,7 +329,7 @@ main(
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 1, 0, metrics);
     assert(ctx.vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);

--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -386,7 +386,7 @@ main(
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 1, 0, metrics);
     assert(ctx.vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);

--- a/src/vfs/tests/vfs_identity_test.c
+++ b/src/vfs/tests/vfs_identity_test.c
@@ -74,7 +74,7 @@ main(
     evpl = evpl_create(NULL);
     assert(evpl != NULL);
 
-    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 1, 0, metrics);
     assert(vfs != NULL);
 
     thread = chimera_vfs_thread_init(evpl, vfs);

--- a/src/vfs/tests/vfs_kv_test.c
+++ b/src/vfs/tests/vfs_kv_test.c
@@ -472,6 +472,7 @@ run_suite(
         kv_name,        /* kv_module_name */
         60,             /* cache_ttl */
         1,              /* attr_cache_enabled */
+        1,              /* name_cache_enabled */
         0,              /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);

--- a/src/vfs/tests/vfs_statfs_mask_test.c
+++ b/src/vfs/tests/vfs_statfs_mask_test.c
@@ -192,7 +192,7 @@ test_memfs_behaviour(void)
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 0, metrics);
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 1, 0, metrics);
     assert(vfs != NULL);
 
     ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, vfs);

--- a/src/vfs/tests/vfs_sync_delegation_test.c
+++ b/src/vfs/tests/vfs_sync_delegation_test.c
@@ -290,6 +290,7 @@ run_phase(
         "cairn",
         60,
         1,                 /* attr_cache_enabled */
+        1,                 /* name_cache_enabled */
         0,                 /* num_rcu_reclaim_threads: 0 = one per CPU */
         metrics);
     assert(ctx.vfs != NULL);

--- a/src/vfs/tests/vfs_zerorange_test.c
+++ b/src/vfs/tests/vfs_zerorange_test.c
@@ -382,7 +382,7 @@ main(
     ctx.evpl = evpl_create(NULL);
     assert(ctx.evpl != NULL);
 
-    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, spec.ncfg, "memkv", 60, 1, 0,
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, spec.ncfg, "memkv", 60, 1, 1, 0,
                                metrics);
     assert(ctx.vfs != NULL);
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -475,6 +475,7 @@ chimera_vfs_init(
     const char                          *kv_module_name,
     int                                  cache_ttl,
     int                                  attr_cache_enabled,
+    int                                  name_cache_enabled,
     int                                  num_rcu_reclaim_threads,
     struct prometheus_metrics           *metrics)
 {
@@ -527,7 +528,11 @@ chimera_vfs_init(
     vfs->vfs_open_file_cache = chimera_vfs_open_cache_init(CHIMERA_VFS_OPEN_ID_FILE, 10, 128 * 1024, metrics,
                                                            "file_handles");
 
-    vfs->vfs_name_cache = chimera_vfs_name_cache_create(8, 4, 2, cache_ttl, metrics);
+    /* The name (lookup) cache is optional (common.name_cache).  When off we
+     * leave it NULL; its helpers (lookup/insert/remove/destroy) are all no-ops
+     * on a NULL cache, so nothing is cached, consulted, or freed. */
+    vfs->vfs_name_cache = name_cache_enabled ?
+        chimera_vfs_name_cache_create(8, 4, 2, cache_ttl, metrics) : NULL;
     /* The attr cache is optional (common.attr_cache).  When off we leave it
      * NULL; the cache helpers (lookup/insert/refresh/destroy) are all no-ops on
      * a NULL cache, so nothing is cached, consulted, or freed. */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1568,6 +1568,7 @@ chimera_vfs_init(
     const char                          *kv_module_name,
     int                                  cache_ttl,
     int                                  attr_cache_enabled,
+    int                                  name_cache_enabled,
     int                                  num_rcu_reclaim_threads,
     struct prometheus_metrics           *metrics);
 

--- a/src/vfs/vfs_name_cache.h
+++ b/src/vfs/vfs_name_cache.h
@@ -120,6 +120,10 @@ chimera_vfs_name_cache_destroy(struct chimera_vfs_name_cache *cache)
     struct chimera_vfs_name_cache_entry *entry;
     int                                  i, j;
 
+    if (!cache) {
+        return;
+    }
+
     rcu_barrier();
 
     for (i = 0; i < cache->num_shards; i++) {
@@ -175,6 +179,10 @@ chimera_vfs_name_cache_lookup(
     uint64_t                              key = fh_hash ^ name_hash;
     int                                   rc;
     uint64_t                              now = chimera_vfs_now_ticks();
+
+    if (!cache) {
+        return -1;
+    }
 
     shard = &cache->shards[key & cache->num_shards_mask];
 
@@ -234,6 +242,10 @@ chimera_vfs_name_cache_insert(
     struct chimera_vfs_name_cache_entry **slot, **slot_end, **slot_best;
     uint64_t                              key = fh_hash ^ name_hash;
     uint64_t                              now = chimera_vfs_now_ticks();
+
+    if (!cache) {
+        return;
+    }
 
     shard = &cache->shards[key & cache->num_shards_mask];
 
@@ -345,6 +357,10 @@ chimera_vfs_name_cache_remove(
     struct chimera_vfs_name_cache_shard  *shard;
     struct chimera_vfs_name_cache_entry **slot, **slot_end;
     uint64_t                              key = fh_hash ^ name_hash;
+
+    if (!cache) {
+        return;
+    }
 
     shard = &cache->shards[key & cache->num_shards_mask];
 


### PR DESCRIPTION
Adds a `common` JSON knob, **`name_cache`** (default `true`), to enable/disable the VFS name (lookup) cache — the direct sibling of the `attr_cache` knob (#1320). The name cache is a VFS-level facility, so the knob lives in the shared `common` section and is honored identically by the **server** (daemon) and the **client**.

```json
{ "common": { "name_cache": false } }
```

**When disabled,** `chimera_vfs_init()` leaves `vfs->vfs_name_cache` NULL and never creates it. The helpers (`lookup`/`insert`/`remove`/`destroy`) all no-op on a NULL cache, so nothing is inserted, consulted, or freed — a lookup simply misses and falls through to the backend, and the create/remove paths skip the cache maintenance. (Unlike the attr cache, there is no request-widening entanglement, so disabled mode is fully correct.)

**Wiring:** `chimera_common_name_cache_enabled()` parses the key; the daemon and client read it and pass it to `chimera_vfs_init()` alongside the `attr_cache` flag and `cache_ttl`.

**Validated:** enabled (default) — vfs unit + pynfs suites green; disabled — `combined_{memfs,diskfs_io_uring}` pass 100% (full NFS-server path with the name cache off, verified by injecting `name_cache:false`).

Builds on #1320 (already merged to main); same shape.