### PR TITLE
smb: batch of extra-small (1-SP) conformance fixes from the 2026-06 audit

### DIFF
--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -375,10 +375,14 @@ chimera_smb_marshal_network_open_info(
 
     chimera_smb_marshal_basic_attrs(attr, smb_attr);
 
-    smb_attr->smb_alloc_size = attr->va_space_used;
+    /* A directory's data stream has no size; report 0/0 like FileStandardInformation
+     * (MS-FSCC 2.4.40), not the backend's internal directory size. */
+    smb_attr->smb_alloc_size = ((attr->va_mode & S_IFMT) == S_IFDIR) ?
+        0 : attr->va_space_used;
     smb_attr->smb_attr_mask |= SMB_ATTR_ALLOC_SIZE;
 
-    smb_attr->smb_size       = attr->va_size;
+    smb_attr->smb_size = ((attr->va_mode & S_IFMT) == S_IFDIR) ?
+        0 : attr->va_size;
     smb_attr->smb_attr_mask |= SMB_ATTR_SIZE;
 } /* chimera_smb_marshal_network_open_info */
 

--- a/src/server/smb/smb_compress.h
+++ b/src/server/smb/smb_compress.h
@@ -17,10 +17,10 @@ struct chimera_smb_compress_ctx;
  * encryption context: a per-thread object holding reusable codec scratch (the
  * LZ77 match-finder hash table), since that scratch is not thread-safe.
  *
- * Codecs implemented so far: Plain LZ77 (MS-XCA §2.4) and the chained Pattern_V1
- * run-length payload (MS-SMB2 §2.2.42.2.2) plus the NONE chained pass-through.
- * LZ77+Huffman and LZNT1 are not yet implemented; the negotiation layer only
- * advertises the algorithms below, so a peer never selects an unimplemented one.
+ * Codecs implemented: Plain LZ77 (MS-XCA §2.4), LZ77+Huffman (MS-XCA §2.1),
+ * LZNT1 (MS-XCA §2.5), the chained Pattern_V1 run-length payload (MS-SMB2
+ * §2.2.42.2.2), and the NONE chained pass-through.  All are advertised by the
+ * negotiation layer and may be selected by a peer.
  */
 struct chimera_smb_compress_ctx *
 chimera_smb_compress_ctx_create(

--- a/src/server/smb/smb_ntlm.c
+++ b/src/server/smb/smb_ntlm.c
@@ -793,7 +793,7 @@ validate_authenticate(
     memcpy(&lm_response_len, buf + 12, 2);
     memcpy(&lm_response_offset, buf + 16, 4);
 
-    if (lm_response_offset + lm_response_len > buf_len) {
+    if ((size_t) lm_response_offset + lm_response_len > buf_len) {
         smb_ntlm_error("NTLM: Invalid LM response field");
         goto cleanup;
     }
@@ -803,7 +803,7 @@ validate_authenticate(
     memcpy(&nt_response_len, buf + 20, 2);
     memcpy(&nt_response_offset, buf + 24, 4);
 
-    if (nt_response_offset + nt_response_len > buf_len) {
+    if ((size_t) nt_response_offset + nt_response_len > buf_len) {
         smb_ntlm_error("NTLM: Invalid NT response field");
         goto cleanup;
     }

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -21,8 +21,14 @@ chimera_smb_parse_change_notify(
     uint64_t file_id_vid;
     uint32_t completion_filter;
 
-    /* StructureSize (2 bytes) already consumed by the framework */
-    int      prc = 0;
+    /* StructureSize (2 bytes) already consumed by the framework; MS-SMB2 §2.2.35
+     * requires it to equal 32, else fail with STATUS_INVALID_PARAMETER (§3.3.5.2.6). */
+    if (unlikely(request->request_struct_size != SMB2_CHANGE_NOTIFY_REQUEST_SIZE)) {
+        request->status = SMB2_STATUS_INVALID_PARAMETER;
+        return -1;
+    }
+
+    int prc = 0;
 
     prc |= evpl_iovec_cursor_try_get_uint16(request_cursor, &flags);
     prc |= evpl_iovec_cursor_try_get_uint32(request_cursor, &output_buffer_length);

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -653,7 +653,10 @@ chimera_smb_close_reply(
 {
 
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_CLOSE_REPLY_SIZE);
-    evpl_iovec_cursor_append_uint16(reply_cursor, request->close.flags);
+    /* Emit only the defined POSTQUERY_ATTRIB bit; do not reflect reserved client
+     * Flags bits (MS-SMB2 3.3.5.10 / 2.2.16). */
+    evpl_iovec_cursor_append_uint16(reply_cursor,
+                                    request->close.flags & SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB);
 
     if (request->close.flags & SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB) {
         chimera_smb_append_network_open_info(reply_cursor, &request->close.r_attrs);

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -627,8 +627,11 @@ chimera_smb_close(struct chimera_smb_request *request)
                                   chimera_smb_close_durable_delete_callback, NULL);
     }
 
-    if (request->close.flags & SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB) {
+    if ((request->close.flags & SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB) &&
+        request->close.open_file->handle) {
 
+        /* Named-pipe FIDs carry handle==NULL; fall through to the zero-attrs
+         * path rather than dereferencing NULL in getattr (MS-SMB2 3.3.5.10). */
         chimera_vfs_getattr(thread->vfs_thread,
                             &request->session_handle->session->cred,
                             request->close.open_file->handle,

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -28,14 +28,14 @@
  */
 
 /* MS-SMB2 server-side copy limits (2.2.32.1):
- *   MaxChunkCount  = 256
+ *   MaxChunkCount  = 16
  *   MaxChunkSize   = 1 MiB
  *   TotalSizeLimit = 16 MiB
  * A request that exceeds any of these is answered with STATUS_INVALID_PARAMETER
  * and a SRV_COPYCHUNK_RESPONSE whose ChunksWritten / ChunkBytesWritten /
  * TotalBytesWritten advertise these maxima so the client resubmits within them
  * (MS-SMB2 3.3.5.15.6). */
-#define CHIMERA_SMB_CC_MAX_CHUNKS    256
+#define CHIMERA_SMB_CC_MAX_CHUNKS    16
 #define CHIMERA_SMB_CC_MAX_CHUNK_LEN (1024 * 1024)
 #define CHIMERA_SMB_CC_MAX_TOTAL_LEN (16 * 1024 * 1024)
 

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -125,6 +125,13 @@ chimera_smb_copychunk_error_with_body(
     struct chimera_smb_request *request,
     uint32_t                    status)
 {
+    /* On a byte-range lock conflict the response MUST report zero chunks written
+     * (MS-SMB2 3.3.5.15.6); other error bodies (e.g. the past-EOF
+     * STATUS_INVALID_VIEW_SIZE reply) keep the partial progress recorded so far. */
+    if (status == SMB2_STATUS_FILE_LOCK_CONFLICT) {
+        request->ioctl.cc_chunks_written = 0;
+        request->ioctl.cc_total_written  = 0;
+    }
     request->ioctl.cc_limit_response = 1;
     chimera_smb_copychunk_done(request, status);
 } /* chimera_smb_copychunk_error_with_body */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -4268,6 +4268,14 @@ chimera_smb_create(struct chimera_smb_request *request)
         * An undefined high CreateOptions bit is STATUS_INVALID_PARAMETER; a
         * defined-but-unsupported one (TREE_CONNECTION / OPEN_BY_FILE_ID /
         * RESERVE_OPFILTER) is STATUS_NOT_SUPPORTED.  INVALID takes precedence. */
+        /* MS-SMB2 2.2.13: ShareAccess is built only from FILE_SHARE_READ/WRITE/
+         * DELETE; any other (reserved) bit set is STATUS_INVALID_PARAMETER. */
+        if (request->create.share_access &
+            ~(SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE)) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+
         if (request->create.create_options & SMB2_CREATE_OPTIONS_INVALID_MASK) {
             chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
             return;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -4277,6 +4277,15 @@ chimera_smb_create(struct chimera_smb_request *request)
             return;
         }
 
+        /* MS-SMB2 3.3.5.9 / MS-FSA 2.1.5.1: FILE_DIRECTORY_FILE and
+         * FILE_NON_DIRECTORY_FILE are mutually exclusive; both set together is
+         * STATUS_INVALID_PARAMETER. */
+        if ((request->create.create_options & SMB2_FILE_DIRECTORY_FILE) &&
+            (request->create.create_options & SMB2_FILE_NON_DIRECTORY_FILE)) {
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            return;
+        }
+
         /* MS-FSA 2.1.5.1 Phase 1 (MS-FSA_R2374 / R2376): a CreateOptions of
          * FILE_DIRECTORY_FILE combined with a destructive CreateDisposition is
          * a contradiction -- SUPERSEDE/OVERWRITE/OVERWRITE_IF replace the data

--- a/src/server/smb/smb_proc_flush.c
+++ b/src/server/smb/smb_proc_flush.c
@@ -34,6 +34,14 @@ chimera_smb_flush(struct chimera_smb_request *request)
         return;
     }
 
+    if (!request->flush.open_file->handle) {
+        /* Named-pipe FIDs carry no VFS handle; FLUSH on a pipe completes
+         * immediately with success (MS-SMB2 3.3.5.15) -- do not deref NULL. */
+        chimera_smb_open_file_release(request, request->flush.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
     chimera_vfs_commit(
         thread->vfs_thread,
         &request->session_handle->session->cred,

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -315,7 +315,11 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
                 if (timeout_ms == 0) {
                     timeout_ms = CHIMERA_SMB_RESILIENCY_DEFAULT_TIMEOUT_MS;
                 } else if (timeout_ms > CHIMERA_SMB_RESILIENCY_MAX_TIMEOUT_MS) {
-                    timeout_ms = CHIMERA_SMB_RESILIENCY_MAX_TIMEOUT_MS;
+                    /* MS-SMB2 3.3.5.15.9: a Timeout greater than the maximum MUST
+                     * fail with STATUS_INVALID_PARAMETER, not be silently clamped. */
+                    chimera_smb_open_file_release(request, open_file);
+                    chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+                    return;
                 }
 
                 /* Register the open in the durable registry (as a non-persistent

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -40,10 +40,13 @@
  * LockSequenceIndex in bits [0..3]; the rest is reserved.  Replay verification is
  * performed only for a durable / persistent / resilient handle, or on an SMB 3.x
  * connection that negotiated multichannel (per the spec and Note <314>). */
-static inline uint8_t
+static inline uint32_t
 chimera_smb_lock_seq_bucket(uint32_t lock_sequence)
 {
-    return (uint8_t) ((lock_sequence >> 4) & 0xFF);
+    /* The full 28-bit LockSequenceNumber (bits 4..31); the 1..64 range check at
+     * the call site rejects out-of-extent values instead of aliasing them via an
+     * 8-bit truncation (MS-SMB2 2.2.26 / 3.3.5.14). */
+    return lock_sequence >> 4;
 } /* chimera_smb_lock_seq_bucket */
 
 static inline uint8_t
@@ -732,7 +735,7 @@ chimera_smb_lock(struct chimera_smb_request *request)
     request->lock.seq_bucket = 0;
     request->lock.seq_index  = chimera_smb_lock_seq_index(request->lock.lock_sequence);
     if (chimera_smb_lock_replay_active(request, open_file)) {
-        uint8_t b = chimera_smb_lock_seq_bucket(request->lock.lock_sequence);
+        uint32_t b = chimera_smb_lock_seq_bucket(request->lock.lock_sequence);
 
         if (b >= 1 && b <= 64) {
             request->lock.seq_bucket = b;

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -112,8 +112,16 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     }
 
     if (dialect == 0) {
-        chimera_smb_error("No valid dialect found");
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        /* MS-SMB2 3.3.5.4: DialectCount == 0 (no dialects offered) MUST fail with
+         * STATUS_INVALID_PARAMETER; dialects offered but none in common is
+         * STATUS_NOT_SUPPORTED. */
+        if (request->negotiate.dialect_count == 0) {
+            chimera_smb_error("SMB2 NEGOTIATE with DialectCount 0");
+            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        } else {
+            chimera_smb_error("No common SMB2 dialect found");
+            chimera_smb_complete_request(request, SMB2_STATUS_NOT_SUPPORTED);
+        }
         return;
     }
 

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -697,8 +697,9 @@ chimera_smb_oplock_break_reply(
         evpl_iovec_cursor_append_uint16(reply_cursor,
                                         SMB2_OPLOCK_BREAK_ACK_LEASE_SIZE);
         evpl_iovec_cursor_append_uint16(reply_cursor, 0);  /* Reserved */
-        evpl_iovec_cursor_append_uint32(reply_cursor,
-                                        request->oplock_break.lease_flags);
+        /* Flags is Reserved in the lease break-ack response (MS-SMB2 2.2.25.2):
+         * the server MUST set it to zero, not echo the client's LeaseFlags. */
+        evpl_iovec_cursor_append_uint32(reply_cursor, 0);
         /* LeaseKey (16) */
         evpl_iovec_cursor_append_blob(reply_cursor,
                                       request->oplock_break.lease_key, 16);

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -115,7 +115,7 @@ chimera_smb_query_directory_readdir_callback(
 
     namelen_padded = namelen ? namelen * 2 : 2;
 
-    namelen_padded += 8 - (namelen_padded & 7);
+    namelen_padded += (8 - (namelen_padded & 7)) & 7;
 
     if ((request->query_directory.flags & SMB2_INDEX_SPECIFIED) &&
         (file_index != request->query_directory.file_index)) {

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -472,9 +472,9 @@ chimera_smb_parse_query_directory(
     request->query_directory.eof              = 1;
     request->query_directory.last_file_offset = NULL;
 
-    if (request->query_directory.pattern_length > SMB_FILENAME_MAX) {
+    if (request->query_directory.pattern_length > SMB_FILENAME_MAX * 2) {
         chimera_smb_error("Received SMB2 QUERY_DIRECTORY request with invalid name length (%u > %u)",
-                          request->query_directory.pattern_length, SMB_FILENAME_MAX);
+                          request->query_directory.pattern_length, SMB_FILENAME_MAX * 2);
         request->status = SMB2_STATUS_NAME_TOO_LONG;
         return -1;
     }

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -866,7 +866,7 @@ chimera_smb_query_info_reply(
                     break;
                 case SMB2_FILE_FS_DEVICE_INFO:
                     evpl_iovec_cursor_append_uint32(reply_cursor, 0x14); /* Network File System */
-                    evpl_iovec_cursor_append_uint32(reply_cursor, 0x20); /* Remote Device */
+                    evpl_iovec_cursor_append_uint32(reply_cursor, 0x10); /* FILE_REMOTE_DEVICE */
                     break;
                 case SMB2_FILE_FS_ATTRIBUTE_INFO:
                     evpl_iovec_cursor_append_uint32(reply_cursor,

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -521,8 +521,10 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                 case SMB2_FILE_BASIC_INFO:
                 case SMB2_FILE_NETWORK_OPEN_INFO:
                 case SMB2_FILE_ATTRIBUTE_TAG_INFO:
-                case SMB2_FILE_COMPRESSION_INFO:
                 case SMB2_FILE_ALL_INFO:
+                    /* FileCompressionInformation is intentionally NOT gated:
+                     * MS-SMB2 3.3.5.20.1's READ_ATTRIBUTES list does not include
+                     * it (the always-NONE compression state is readable). */
                     if (!(request->query_info.open_file->granted_access &
                           SMB2_FILE_READ_ATTRIBUTES)) {
                         status = SMB2_STATUS_ACCESS_DENIED;

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -900,8 +900,9 @@ chimera_smb_query_info_reply(
                     break;
                 case SMB2_FILE_FS_CONTROL_INFO:
                     /* MS-FSCC 2.5.2 FileFsControlInformation.  No quota tracking:
-                     * NO_QUOTAS state with all thresholds/limits = -1 (no limit)
-                     * and no control flags. */
+                     * the FreeSpace* quota-event byte counts are 0 (filtering
+                     * disabled), DefaultQuotaThreshold/Limit are -1 (UINT64_MAX,
+                     * no limit), and no control flags are set. */
                     evpl_iovec_cursor_append_uint64(reply_cursor, 0); /* FreeSpaceStartFiltering */
                     evpl_iovec_cursor_append_uint64(reply_cursor, 0); /* FreeSpaceThreshold */
                     evpl_iovec_cursor_append_uint64(reply_cursor, 0); /* FreeSpaceStopFiltering */

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -81,10 +81,20 @@ chimera_smb_tree_connect(struct chimera_smb_request *request)
 
         tree->tree_id = session->max_trees;
 
-        session->max_trees *= 2;
-        session->trees      = realloc(session->trees,
-                                      session->max_trees * sizeof(struct chimera_smb_tree *));
+        struct chimera_smb_tree **grown =
+            realloc(session->trees,
+                    session->max_trees * 2 * sizeof(struct chimera_smb_tree *));
 
+        if (unlikely(!grown)) {
+            /* realloc failed: the original array is intact (not freed); reject
+             * the tree connect rather than dereferencing NULL (MS-SMB2 3.3.5.7). */
+            pthread_mutex_unlock(&session->lock);
+            chimera_smb_complete_request(request, SMB2_STATUS_INSUFFICIENT_RESOURCES);
+            return;
+        }
+
+        session->max_trees           *= 2;
+        session->trees                = grown;
         session->trees[tree->tree_id] = tree;
     }
 

--- a/src/server/smb/smb_signing.c
+++ b/src/server/smb/smb_signing.c
@@ -527,7 +527,14 @@ chimera_smb_verify_signature(
         return rc;
     }
 
-    if (unlikely(memcmp(signature, calculated, sizeof(signature)) != 0)) {
+    /* Constant-time comparison to avoid a timing oracle on the MAC. */
+    uint8_t sig_diff = 0;
+
+    for (size_t i = 0; i < sizeof(signature); i++) {
+        sig_diff |= signature[i] ^ calculated[i];
+    }
+
+    if (unlikely(sig_diff != 0)) {
         format_hex(recv_sig, sizeof(recv_sig), signature, sizeof(signature));
         format_hex(calc_sig, sizeof(calc_sig), calculated, sizeof(calculated));
         chimera_smb_error("Received signature: %s does not match calculated signature: %s", recv_sig, calc_sig);


### PR DESCRIPTION
Batches the **extra-small (1-SP) SMB-area fixes** from the 2026-06 server-side conformance audit into a single PR — one self-contained commit per fix — to avoid a full merge-queue matrix run per trivial fix. Each commit references the issue it closes.

## Fixes (one commit each)
**Memory-safety / DoS hardening**
- #956 — NTLM AUTHENTICATE LM/NT bounds check: cast offsets to `size_t` (pre-auth OOB read via 32-bit wrap)
- #951 — SMB2_FLUSH on a named-pipe FID: guard the NULL VFS handle (remote DoS)
- #972 — CLOSE `POSTQUERY_ATTRIB` on a named-pipe FID: guard the NULL handle
- #1242 — TREE_CONNECT table growth: check `realloc` (NULL-deref/leak on OOM → `STATUS_INSUFFICIENT_RESOURCES`)
- #1237 — constant-time SMB2 signature comparison

**Protocol correctness**
- #1033 — no common dialect → `STATUS_NOT_SUPPORTED` (not `INVALID_PARAMETER`)
- #1244 — reject reserved `ShareAccess` bits in CREATE
- #1245 — reject `FILE_DIRECTORY_FILE` + `FILE_NON_DIRECTORY_FILE` together
- #1249 — CLOSE response emits only the defined `POSTQUERY_ATTRIB` Flags bit
- #1279 — validate CHANGE_NOTIFY `StructureSize == 32`
- #1013 — use the full 28-bit LockSequence number for the replay-cache index
- #981 — over-max resiliency `Timeout` → `INVALID_PARAMETER` (not silent clamp)
- #1257 — cap COPYCHUNK `MaxChunkCount` at 16 (MS-SMB2 2.2.32.1)
- #1025 — report 0 chunks written on a copychunk **lock-conflict** reply (scoped so the past-EOF reply still reports partial progress)
- #1277 — QUERY_DIRECTORY search-pattern length limit is bytes (510), not chars
- #1024 — fix QUERY_DIRECTORY entry over-padding when the name is already 8-aligned
- #1260 — FileNetworkOpenInformation reports 0 size for directories (agrees with FileStandardInformation)
- #1269 — FsDeviceInformation Characteristics = `FILE_REMOTE_DEVICE` (0x10), not `IS_MOUNTED` (0x20)
- #1034 — don't gate FileCompressionInformation behind `FILE_READ_ATTRIBUTES`
- #1282 — zero the Reserved Flags field in the lease break-ack response

**Comment/doc accuracy**
- #1039 — codecs (LZNT1, LZ77+Huffman) are implemented; correct the stale header comment
- #1267 — FsControlInformation comment matches the emitted FreeSpace=0 / DefaultQuota=-1 values

## Validation
Built Release; `uncrustify` + copyright-year checks clean. The full **memfs smbtorture smb2 suite set passes** (create, close, lock, ioctl incl. copychunk, getinfo, find/dir, notify, session/signing, lease, oplock, negotiate, connect, multichannel).

## Notes
- **#1235** (subject SMB2 ECHO to signing/session requirements) was investigated and **deliberately not applied**: SMB2 ECHO is used as a sessionless keepalive, and the change regressed `smb2.session.two_logoff` (`transport2: keepalive` expects `NT_STATUS_OK`, got `USER_SESSION_DELETED`). The audit finding misjudged ECHO's exemption; recommend closing #1235 as invalid.
