### PR TITLE
smb2: SMB3 multichannel correctness & security hardening

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1302,6 +1302,7 @@ chimera_smb_server_handle_smb2(
          * MS-SMB2 §3.3.5.2.10 stale-write detection and create-context replay. */
         request->channel_sequence = (uint16_t) (request->smb2_hdr.status & 0xFFFF);
         request->is_replay        = (request->smb2_hdr.flags & SMB2_FLAGS_REPLAY_OPERATION) ? 1 : 0;
+        request->bind_sig_failed  = 0;
 
         signature_cursor = *request_cursor;
 
@@ -1506,6 +1507,49 @@ chimera_smb_server_handle_smb2(
          * verification for a successfully decrypted request.  Such inner SMB2
          * headers commonly carry SMB2_FLAGS_SIGNED with a zeroed Signature
          * field, which would otherwise fail verification. */
+        /* MS-SMB2 §3.3.5.5 step 4 / §3.3.5.2.4: a channel-binding SESSION_SETUP
+         * carries a signature over the EXISTING Session.SigningKey -- the proof
+         * that the binding connection belongs to the already-authenticated
+         * principal (without it a client that learns a victim's SessionId could
+         * hijack the session).  The generic block below skips ALL SESSION_SETUP
+         * signature verification (correct only for an initial/re-auth leg, whose
+         * key is derived while processing it), so a bind is verified here, where
+         * the on-wire bytes are still available.  But we only STASH the result --
+         * the rejection is applied in the handler AFTER its dialect/cipher/
+         * algorithm compatibility checks, whose INVALID_PARAMETER/NOT_SUPPORTED
+         * statuses MUST take precedence over ACCESS_DENIED (MS-SMB2 3.3.5.5;
+         * smb2model SessionMgmtBindSession).  The dispatcher already adopted the
+         * target session onto this connection and copied its signing key into
+         * request->session_handle->signing_key, so the key is in hand. */
+        if (request->smb2_hdr.command == SMB2_SESSION_SETUP &&
+            conn->dialect >= SMB2_DIALECT_3_0 &&
+            (request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+            !received_encrypted &&
+            request->session_handle &&
+            (request->session_handle->session->flags & CHIMERA_SMB_SESSION_AUTHORIZED)) {
+            struct evpl_iovec_cursor peek = signature_cursor;
+            uint8_t                  ss_byte = 0, ss_flags = 0;
+
+            /* SESSION_SETUP body (MS-SMB2 2.2.5): StructureSize(2), Flags(1).
+             * signature_cursor sits at the body start; peek Flags off a copy. */
+            evpl_iovec_cursor_try_get_uint8(&peek, &ss_byte);  /* StructureSize lo */
+            evpl_iovec_cursor_try_get_uint8(&peek, &ss_byte);  /* StructureSize hi */
+            evpl_iovec_cursor_try_get_uint8(&peek, &ss_flags); /* Flags */
+
+            if (ss_flags & SMB2_SESSION_FLAG_BINDING) {
+                if (request->smb2_hdr.next_command) {
+                    payload_length = request->smb2_hdr.next_command - sizeof(request->smb2_hdr);
+                } else {
+                    payload_length = left;
+                }
+
+                request->bind_sig_failed =
+                    chimera_smb_verify_signature(thread->signing_ctx, request,
+                                                 request->session_handle->signing_key,
+                                                 &signature_cursor, payload_length) != 0;
+            }
+        }
+
         if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
             !received_encrypted &&
             request->smb2_hdr.command != SMB2_SESSION_SETUP) {

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -1216,4 +1216,5 @@ struct smb_direct_hdr {
     uint32_t data_length;
 };
 
-#define SMB2_CHANNEL_RDMA_V1 0x00000001
+#define SMB2_CHANNEL_RDMA_V1            0x00000001
+#define SMB2_CHANNEL_RDMA_V1_INVALIDATE 0x00000002

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -341,6 +341,11 @@ struct chimera_smb_request {
      * the SMB2_FLAGS_REPLAY_OPERATION header flag. */
     uint16_t                           channel_sequence;
     uint8_t                            is_replay;
+    /* Set at dispatch for a channel-binding SESSION_SETUP whose signature did not
+     * verify against the established Session.SigningKey.  The rejection is
+     * applied in the handler AFTER its compatibility checks so their statuses
+     * take precedence over ACCESS_DENIED (MS-SMB2 3.3.5.5). */
+    uint8_t                            bind_sig_failed;
     struct chimera_smb_session_handle *session_handle;
     struct chimera_smb_tree           *tree;
     struct chimera_smb_compound       *compound;
@@ -2003,6 +2008,31 @@ chimera_smb_session_release(
     }
 } /* chimera_smb_session_free */
 
+/* Mark a session globally deleted: clear AUTHORIZED, set DELETED, and unlink it
+ * from the GlobalSessionTable under sessions_lock.  After this, the dispatch
+ * path answers any request that resolves to the session with
+ * USER_SESSION_DELETED on EVERY channel, and the refcnt-driven
+ * chimera_smb_session_release() will not HASH_DEL it a second time (it keys that
+ * on AUTHORIZED, now cleared).  Only acts while the session is still AUTHORIZED,
+ * so a redundant call is a no-op.  Mirrors the inline unlink in
+ * chimera_smb_session_invalidate_previous (which additionally pins a refcnt
+ * across a durable-handle park, so it keeps its own copy). */
+static inline void
+chimera_smb_session_mark_deleted(
+    struct chimera_server_smb_shared *shared,
+    struct chimera_smb_session       *session)
+{
+    pthread_mutex_lock(&shared->sessions_lock);
+
+    if (session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) {
+        session->flags |= CHIMERA_SMB_SESSION_DELETED;
+        session->flags &= ~CHIMERA_SMB_SESSION_AUTHORIZED;
+        HASH_DEL(shared->sessions, session);
+    }
+
+    pthread_mutex_unlock(&shared->sessions_lock);
+} /* chimera_smb_session_mark_deleted */
+
 /* MS-SMB2 3.3.4.4 open-preservation rule: a durable open holding byte-range
  * locks survives a disconnect only if it also holds a batch oplock or a
  * WRITE-caching lease -- otherwise the locks cannot be safely maintained across
@@ -2757,7 +2787,11 @@ chimera_smb_channel_sequence_stale(
         return mutating ? true : false;
     }
 
-    /* Equal or ahead: this becomes the new high-water sequence. */
+    /* Equal or ahead: this becomes the new high-water sequence.  The forward
+     * jump advances REGARDLESS of SMB2_FLAGS_REPLAY_OPERATION -- the Windows
+     * reference behavior (smb2.replay.channel-sequence) treats a replayed and a
+     * fresh forward jump identically, so the replay flag plays no role here
+     * (the premise of #1290 is contradicted by that conformance test). */
     open_file->channel_sequence = req_cs;
     return false;
 } /* chimera_smb_channel_sequence_stale */

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -68,6 +68,40 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
     struct chimera_smb_open_file     *open_file;
     int                               status;
 
+    /* MS-SMB2 §3.3.5.2.10: the state-modifying FSCTLs belong to the same
+     * channel-sequence-checked set as WRITE/SET_INFO.  A stale, post-failover
+     * replay of one of these must be rejected with FILE_NOT_AVAILABLE so it
+     * cannot re-apply a write the client has since superseded (e.g. re-zeroing a
+     * range a newer write refilled).  Previously ONLY the read-only
+     * CREATE_OR_GET_OBJECT_ID was guarded while the genuinely mutating FSCTLs
+     * were not (issues #1123/#1256).  Resolve the IOCTL's target handle, run the
+     * check, and release -- the per-FSCTL handlers re-resolve as needed. */
+    switch (request->ioctl.ctl_code) {
+        case SMB2_FSCTL_SET_REPARSE_POINT:
+        case SMB2_FSCTL_SET_SPARSE:
+        case SMB2_FSCTL_SET_ZERO_DATA:
+        case SMB2_FSCTL_SRV_COPYCHUNK:
+        case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
+        case SMB2_FSCTL_DUPLICATE_EXTENTS_TO_FILE:
+        case SMB2_FSCTL_OFFLOAD_WRITE:
+        case SMB2_FSCTL_SET_INTEGRITY_INFORMATION:
+            open_file = chimera_smb_open_file_resolve(request, &request->ioctl.file_id);
+            if (open_file) {
+                bool stale = chimera_smb_channel_sequence_stale(
+                    open_file, request->channel_sequence, 1);
+
+                chimera_smb_open_file_release(request, open_file);
+
+                if (stale) {
+                    chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+                    return;
+                }
+            }
+            break;
+        default:
+            break;
+    } /* state-modifying FSCTL channel-sequence guard */
+
     switch (request->ioctl.ctl_code) {
         case SMB2_FSCTL_DFS_GET_REFERRALS:
             /* No DFS support; tell the client to stop asking. */
@@ -491,17 +525,30 @@ chimera_smb_ioctl_reply(
                 evpl_iovec_cursor_append_uint16(reply_cursor, nic_info->addr.ss_family == AF_INET ? 2 :
                                                 23);                                                                    /* Windows AF_INET / AF_INET6 */
                 evpl_iovec_cursor_append_uint16(reply_cursor, 0); /* port */
+                /* The SockAddr field is a fixed 128-byte SOCKADDR_STORAGE
+                 * (MS-SMB2 2.2.32 / MS-DTYP).  family(2)+port(2) are already
+                 * written; emit the family-specific body and zero-fill the
+                 * remainder so EVERY record is exactly Next(4)+IfIndex(4)+
+                 * Capability(4)+Reserved(4)+LinkSpeed(8)+SockAddr(128) = 152
+                 * bytes -- matching the hardcoded Next and the declared
+                 * output_length.  The IPv6 form is family(2)+port(2)+
+                 * flowinfo(4)+addr(16)+scope_id(4), NOT the IPv4 layout. */
                 if (nic_info->addr.ss_family == AF_INET) {
                     evpl_iovec_cursor_append_blob(reply_cursor,
                                                   &((struct sockaddr_in *) &nic_info->addr)->sin_addr.s_addr,
-                                                  4);                                                                   /* IPv4 address */
+                                                  4);                                                                   /* sin_addr */
+                    evpl_iovec_cursor_zero(reply_cursor, 120); /* SOCKADDR_STORAGE remainder: 128 - (2+2+4) */
                 } else {
+                    evpl_iovec_cursor_append_uint32(reply_cursor,
+                                                    ((struct sockaddr_in6 *) &nic_info->addr)->sin6_flowinfo); /* sin6_flowinfo */
                     evpl_iovec_cursor_append_blob(reply_cursor,
                                                   &((struct sockaddr_in6 *) &nic_info->addr)->sin6_addr.
                                                   s6_addr,
-                                                  16);                                                                  /* IPv6 address */
+                                                  16);                                                                  /* sin6_addr */
+                    evpl_iovec_cursor_append_uint32(reply_cursor,
+                                                    ((struct sockaddr_in6 *) &nic_info->addr)->sin6_scope_id); /* sin6_scope_id */
+                    evpl_iovec_cursor_zero(reply_cursor, 100); /* SOCKADDR_STORAGE remainder: 128 - (2+2+4+16+4) */
                 }
-                evpl_iovec_cursor_zero(reply_cursor, 120); /* ifname length */
             }
             break;
         case SMB2_FSCTL_GET_REPARSE_POINT:

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -36,10 +36,10 @@
                                    SMB2_LOCKFLAG_UNLOCK)
 
 /* MS-SMB2 3.3.5.14 LockSequence replay detection.  The 32-bit LockSequence is a
- * 4-bit LockSequenceNumber (the "bucket", valid 1..64) in bits [4..7] and a 4-bit
- * LockSequenceIndex in bits [0..3]; the rest is reserved.  Replay verification is
- * performed only for a durable / persistent / resilient handle, or on an SMB 3.x
- * connection that negotiated multichannel (per the spec and Note <314>). */
+ * 28-bit LockSequenceNumber (the "bucket", valid 1..64) in bits [4..31] and a
+ * 4-bit LockSequenceIndex in bits [0..3].  Replay verification is performed only
+ * for a durable / persistent / resilient handle, or on an SMB 3.x connection
+ * that negotiated multichannel (per the spec and Note <314>). */
 static inline uint32_t
 chimera_smb_lock_seq_bucket(uint32_t lock_sequence)
 {
@@ -90,6 +90,22 @@ chimera_smb_lock_seq_record(
         open_file->lock_seq_status[b - 1] = status;
     }
 } /* chimera_smb_lock_seq_record */
+
+/* Complete a multi-element LOCK/UNLOCK: record the outcome in the replay cache
+ * (so a retransmit on a durable/persistent/resilient/multichannel handle returns
+ * the cached status without re-applying the ranges -- issue #1119), drop the
+ * handle, and reply.  seq_record is a no-op unless the dispatch captured a valid
+ * replay bucket, so this is also correct for non-replay-active opens. */
+static inline void
+chimera_smb_lock_multi_complete(
+    struct chimera_smb_request   *request,
+    struct chimera_smb_open_file *open_file,
+    uint32_t                      status)
+{
+    chimera_smb_lock_seq_record(request, open_file, status);
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, status);
+} /* chimera_smb_lock_multi_complete */
 
 /* Half-open byte-range overlap, mirroring chimera_vfs_range_overlap: length 0
  * is a genuine zero-byte range and the exclusive end saturates at UINT64_MAX on
@@ -627,8 +643,7 @@ chimera_smb_lock_multi(
             freelist = t;
         }
 
-        chimera_smb_open_file_release(request, open_file);
-        chimera_smb_complete_request(request, status);
+        chimera_smb_lock_multi_complete(request, open_file, status);
         return;
     }
 
@@ -639,13 +654,11 @@ chimera_smb_lock_multi(
         uint64_t len  = request->lock.elements[i].length;
 
         if (kind != SMB2_LOCKFLAG_SHARED_LOCK && kind != SMB2_LOCKFLAG_EXCLUSIVE) {
-            chimera_smb_open_file_release(request, open_file);
-            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+            chimera_smb_lock_multi_complete(request, open_file, SMB2_STATUS_INVALID_PARAMETER);
             return;
         }
         if ((__uint128_t) off + len > ((__uint128_t) 1 << 64)) {
-            chimera_smb_open_file_release(request, open_file);
-            chimera_smb_complete_request(request, SMB2_STATUS_INVALID_LOCK_RANGE);
+            chimera_smb_lock_multi_complete(request, open_file, SMB2_STATUS_INVALID_LOCK_RANGE);
             return;
         }
     }
@@ -659,9 +672,8 @@ chimera_smb_lock_multi(
                                         request->lock.elements[i].length,
                                         request->lock.elements[j].offset,
                                         request->lock.elements[j].length)) {
-                chimera_smb_open_file_release(request, open_file);
-                chimera_smb_complete_request(request,
-                                             SMB2_STATUS_INVALID_PARAMETER);
+                chimera_smb_lock_multi_complete(request, open_file,
+                                                SMB2_STATUS_INVALID_PARAMETER);
                 return;
             }
         }
@@ -682,15 +694,13 @@ chimera_smb_lock_multi(
             while (ntaken > 0) {
                 chimera_smb_lock_entry_drop(vfs_state, open_file, taken[--ntaken]);
             }
-            chimera_smb_open_file_release(request, open_file);
-            chimera_smb_complete_request(request, SMB2_STATUS_LOCK_NOT_GRANTED);
+            chimera_smb_lock_multi_complete(request, open_file, SMB2_STATUS_LOCK_NOT_GRANTED);
             return;
         }
         taken[ntaken++] = e;
     }
 
-    chimera_smb_open_file_release(request, open_file);
-    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+    chimera_smb_lock_multi_complete(request, open_file, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_lock_multi */
 
 void
@@ -721,17 +731,14 @@ chimera_smb_lock(struct chimera_smb_request *request)
         return;
     }
 
-    /* A multi-element request is handled synchronously (all FAIL_IMMEDIATELY). */
-    if (request->lock.lock_count > 1) {
-        chimera_smb_lock_multi(thread, request, open_file);
-        return;
-    }
-
-    /* MS-SMB2 3.3.5.14 LockSequence replay detection (single-element path).
-     * Capture the bucket for an open that performs replay verification, and if it
-     * is a replay of the last op recorded under that bucket (same index), return
-     * the cached status without re-applying the lock — making a retransmit after a
-     * lost reply idempotent. */
+    /* MS-SMB2 3.3.5.14 LockSequence replay detection.  Capture the replay bucket
+     * and short-circuit a replay BEFORE dispatching either the single- or
+     * multi-element path: the spec mandates replay verification for EVERY LOCK
+     * request on a durable/persistent/resilient/multichannel handle regardless of
+     * LockCount, and the multi path records its outcome under the same bucket
+     * (issue #1119).  On a replay of the last op recorded under this bucket (same
+     * index), return the cached status without re-applying the lock(s) — making a
+     * retransmit after a lost reply idempotent. */
     request->lock.seq_bucket = 0;
     request->lock.seq_index  = chimera_smb_lock_seq_index(request->lock.lock_sequence);
     if (chimera_smb_lock_replay_active(request, open_file)) {
@@ -747,6 +754,12 @@ chimera_smb_lock(struct chimera_smb_request *request)
                 return;
             }
         }
+    }
+
+    /* A multi-element request is handled synchronously (all FAIL_IMMEDIATELY). */
+    if (request->lock.lock_count > 1) {
+        chimera_smb_lock_multi(thread, request, open_file);
+        return;
     }
 
     kind = request->lock.l_flags & SMB2_LOCKFLAG_KIND_MASK;

--- a/src/server/smb/smb_proc_logoff.c
+++ b/src/server/smb/smb_proc_logoff.c
@@ -26,9 +26,23 @@ chimera_smb_logoff(struct chimera_smb_request *request)
 
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 
-    /* MS-SMB2 3.3.5.6: LOGOFF closes the session's non-durable opens but
-     * DISASSOCIATES (preserves) any durable/persistent handle so a later
-     * session on the same transport can durably reconnect it. */
+    /* MS-SMB2 3.3.5.6: for an SMB 3.x session the server MUST remove the session
+     * from every Channel.Connection.SessionTable in Session.ChannelList and from
+     * the GlobalSessionTable -- not just from THIS connection.  A bare
+     * per-connection release only decrements the refcnt, so with sibling
+     * channels bound (num_channels>1) the session would stay live and keep
+     * serving requests on the other connections after the client logged off.
+     * Mark it DELETED + unlink it globally here so the dispatch path answers
+     * USER_SESSION_DELETED on the sibling channels (their handles are reclaimed
+     * as those connections drop).  For single-channel sessions this is
+     * equivalent to the plain release below. */
+    if (conn->dialect >= SMB2_DIALECT_3_0) {
+        chimera_smb_session_mark_deleted(thread->shared, session_handle->session);
+    }
+
+    /* LOGOFF closes the session's non-durable opens but DISASSOCIATES
+     * (preserves) any durable/persistent handle so a later session on the same
+     * transport can durably reconnect it. */
     chimera_smb_session_release(thread, thread->shared, session_handle->session, true);
 
     HASH_DELETE(hh, conn->session_handles, session_handle);

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -133,7 +133,13 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     if (dialect >= 0x210 && (shared->config.capabilities & SMB2_GLOBAL_CAP_LEASING)) {
         conn->capabilities |= SMB2_GLOBAL_CAP_LEASING;
     }
-    if (dialect >= 0x300 && (shared->config.capabilities & SMB2_GLOBAL_CAP_MULTI_CHANNEL)) {
+    /* Only advertise MULTI_CHANNEL when at least one network interface is
+     * actually configured (MS-SMB2 §3.3.5.4): the capability is meaningless
+     * without interfaces to return from FSCTL_QUERY_NETWORK_INTERFACE_INFO, and
+     * advertising it with an empty interface list invites the client to attempt
+     * a second channel it can never discover an endpoint for. */
+    if (dialect >= 0x300 && (shared->config.capabilities & SMB2_GLOBAL_CAP_MULTI_CHANNEL) &&
+        shared->config.num_nic_info > 0) {
         conn->capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
     }
     if (dialect >= 0x300 && shared->config.persistent_handles) {

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -10,6 +10,40 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_state.h"
 
+/*
+ * Completion for one SMB2_CHANNEL_RDMA_V1 read transfer (RDMA Write to a client
+ * buffer descriptor).  evpl invokes this once per evpl_rdma_write issued by
+ * chimera_smb_read_callback.  The SMB2 READ response must not be sent until all
+ * descriptors have been written -- otherwise the client is told SUCCESS while
+ * data is still in flight (MS-SMB2 3.3.5.12) -- so the request is held until the
+ * last write completes here.  The data iovecs were handed to evpl with
+ * EVPL_RDMA_FLAG_TAKE_REF, so the library owns and releases them; this callback
+ * only accounts for completion.
+ */
+static void
+chimera_smb_rdma_write_callback(
+    int   status,
+    void *private_data)
+{
+    struct chimera_smb_request *request = private_data;
+
+    chimera_smb_abort_if(request->read.pending_rdma_writes == 0,
+                         "Pending RDMA writes is 0");
+
+    if (status) {
+        request->read.r_rdma_status = status;
+    }
+
+    request->read.pending_rdma_writes--;
+
+    if (request->read.pending_rdma_writes == 0) {
+        chimera_smb_complete_request(request,
+                                     request->read.r_rdma_status ?
+                                     SMB2_STATUS_INTERNAL_ERROR :
+                                     SMB2_STATUS_SUCCESS);
+    }
+} /* chimera_smb_rdma_write_callback */
+
 static void
 chimera_smb_read_callback(
     enum chimera_vfs_error    error_code,
@@ -61,7 +95,8 @@ chimera_smb_read_callback(
         return;
     }
 
-    if (request->read.channel == SMB2_CHANNEL_RDMA_V1) {
+    if (request->read.channel == SMB2_CHANNEL_RDMA_V1 &&
+        request->read.num_rdma_elements > 0) {
 
         request->read.pending_rdma_writes = request->read.num_rdma_elements;
         request->read.r_rdma_status       = 0;
@@ -70,21 +105,30 @@ chimera_smb_read_callback(
 
         for (i = 0; i < request->read.num_rdma_elements; i++) {
 
-            chunk_niov = evpl_iovec_cursor_move(&cursor, chunk_iov, 64, request->read.rdma_elements[0].length, 0);
+            /* Each descriptor gets its OWN slice of the read data and its OWN
+             * remote token/offset -- index [i], not [0].  Writing every chunk
+             * to rdma_elements[0] corrupts/overruns the first registration and
+             * leaves the rest empty (issue #950). */
+            chunk_niov = evpl_iovec_cursor_move(&cursor, chunk_iov, 64,
+                                                request->read.rdma_elements[i].length, 0);
 
             evpl_rdma_write(
                 evpl,
                 request->compound->conn->bind,
-                request->read.rdma_elements[0].token,
-                request->read.rdma_elements[0].offset,
+                request->read.rdma_elements[i].token,
+                request->read.rdma_elements[i].offset,
                 chunk_iov,
                 chunk_niov,
                 EVPL_RDMA_FLAG_TAKE_REF,
-                NULL,
-                NULL);
+                chimera_smb_rdma_write_callback,
+                request);
 
             chunk_iov += chunk_niov;
         }
+
+        /* SUCCESS is sent from chimera_smb_rdma_write_callback once the final
+         * descriptor's RDMA Write completes, not here. */
+        return;
     }
 
     chimera_smb_complete_request(private_data, SMB2_STATUS_SUCCESS);
@@ -202,6 +246,20 @@ chimera_smb_read(struct chimera_smb_request *request)
     if (request->read.offset > 0x7FFFFFFFFFFFFFFFULL ||
         request->read.offset + request->read.length > 0x7FFFFFFFFFFFFFFFULL ||
         request->read.length > (8 * 1024 * 1024)) {
+        chimera_smb_open_file_release(request, request->read.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    /* MS-SMB2 §3.3.5.12: an RDMA channel is only valid when the connection was
+     * established over an RDMA transport.  The Channel field is fully
+     * client-controlled, so a plain-TCP client can request RDMA_V1 and supply a
+     * parseable descriptor list; dispatching that to evpl_rdma_write on a
+     * non-RDMA bind would call through a NULL rdma op and crash the thread.
+     * Reject before issuing the read. */
+    if ((request->read.channel == SMB2_CHANNEL_RDMA_V1 ||
+         request->read.channel == SMB2_CHANNEL_RDMA_V1_INVALIDATE) &&
+        !evpl_bind_is_rdma(request->compound->conn->bind)) {
         chimera_smb_open_file_release(request, request->read.open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -228,6 +228,20 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                                 request->session_setup.input_niov);
             return;
         }
+
+        /* MS-SMB2 3.3.5.5 / 3.3.5.2.4: the bind request's signature, verified at
+         * dispatch against the established Session.SigningKey, must hold.  Applied
+         * HERE -- after the dialect/cipher/algorithm compatibility checks above --
+         * so those statuses (INVALID_PARAMETER / NOT_SUPPORTED) take precedence
+         * over the ACCESS_DENIED a signature failure yields, and so a bind that
+         * resolves to no session is answered USER_SESSION_DELETED rather than
+         * ACCESS_DENIED (smb2model SessionMgmtBindSession S268/S431). */
+        if (request->bind_sig_failed) {
+            chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+            evpl_iovecs_release(thread->evpl, request->session_setup.input_iov,
+                                request->session_setup.input_niov);
+            return;
+        }
     }
 
     /* A non-binding SESSION_SETUP that names an established session which has
@@ -390,13 +404,30 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             int over_limit = 0;
 
             /* MS-SMB2 3.3.5.5.3: the binding user MUST be the user the session
-            * was established by; a successful authentication as a DIFFERENT
-            * principal is rejected with STATUS_ACCESS_DENIED and the session
-            * (and its channels) survive (smb2.session.bind_different_user). */
-            if (mech == SMB_AUTH_MECH_NTLM &&
-                smb_ntlm_get_uid(&conn->ntlm_ctx) != session->cred.uid) {
-                chimera_smb_error("Channel bind rejected: user mismatch (uid %u != session uid %u)",
-                                  smb_ntlm_get_uid(&conn->ntlm_ctx), session->cred.uid);
+             * was established by; a successful authentication as a DIFFERENT
+             * principal is rejected with STATUS_ACCESS_DENIED and the session
+             * (and its channels) survive (smb2.session.bind_different_user).
+             * NTLM matches on the resolved uid; Kerberos matches on the
+             * establishing principal captured at session setup -- without this a
+             * service ticket for ANY principal could bind a channel onto a
+             * victim's session (cross-user session hijack). */
+            int bind_user_mismatch = 0;
+
+            if (mech == SMB_AUTH_MECH_NTLM) {
+                bind_user_mismatch =
+                    smb_ntlm_get_uid(&conn->ntlm_ctx) != session->cred.uid;
+            } else if (mech == SMB_AUTH_MECH_KERBEROS) {
+                const char *bind_principal =
+                    smb_gssapi_get_principal(&conn->gssapi_ctx);
+
+                bind_user_mismatch =
+                    !bind_principal || session->principal[0] == '\0' ||
+                    strcmp(bind_principal, session->principal) != 0;
+            }
+
+            if (bind_user_mismatch) {
+                chimera_smb_error("Channel bind rejected: binding user does not match session owner (%s)",
+                                  smb_auth_mech_name(mech));
                 chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
                 evpl_iovecs_release(thread->evpl,
                                     request->session_setup.input_iov,
@@ -507,6 +538,14 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
 
             chimera_smb_info("Kerberos auth complete: principal=%s uid=%u gid=%u sid=%s",
                              principal, uid, gid, sid ? sid : "none");
+
+            /* Record the establishing principal so a later multichannel bind can
+             * verify the binding connection authenticated as the SAME principal
+             * (MS-SMB2 3.3.5.5.3).  Only on the authorizing leg -- a bind/re-auth
+             * must not move the session's owning identity. */
+            if (!(session->flags & CHIMERA_SMB_SESSION_AUTHORIZED) && principal) {
+                snprintf(session->principal, sizeof(session->principal), "%s", principal);
+            }
         }
 
         // Cache AD users in VFS user cache (non-pinned, will expire)
@@ -521,8 +560,13 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             chimera_smb_debug("Cached AD user '%s' in VFS user cache", username);
         }
 
-        // Set session credentials
-        chimera_vfs_cred_init_attr(&session->cred, uid, gid, ngids, gids);
+        /* Set session credentials.  A binding leg must NOT replace the session's
+         * credentials: the binding user was already verified to match the
+         * session owner, and overwriting here would let a bind move the owning
+         * identity.  Re-authentication does refresh the security context. */
+        if (!is_binding) {
+            chimera_vfs_cred_init_attr(&session->cred, uid, gid, ngids, gids);
+        }
 
         /* SMB3 transport encryption: derive per-session keys from the raw
          * session key.

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -280,6 +280,19 @@ chimera_smb_write(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 §3.3.5.13: an RDMA channel is only valid over an RDMA transport.
+    * The Channel field is client-controlled; honoring RDMA_V1 on a plain-TCP
+    * connection would dispatch evpl_rdma_read on a non-RDMA bind.  Reject with
+    * INVALID_PARAMETER (the spec-required status) before touching the data. */
+    if ((request->write.channel == SMB2_CHANNEL_RDMA_V1 ||
+         request->write.channel == SMB2_CHANNEL_RDMA_V1_INVALIDATE) &&
+        !evpl_bind_is_rdma(request->compound->conn->bind)) {
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
     /* MS-SMB2 §3.3.5.2.10: a WRITE carrying a stale ChannelSequence (the client
      * has since failed over to a higher sequence) must be rejected with
      * FILE_NOT_AVAILABLE so a delayed retry cannot clobber newer data. */

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -389,6 +389,13 @@ struct chimera_smb_session {
     _Atomic uint64_t            enc_nonce_counter;
 
     struct chimera_vfs_cred     cred;
+
+    /* Kerberos principal that ESTABLISHED the session, captured on the first
+     * (authorizing) leg.  A multichannel bind over Kerberos compares the binding
+     * connection's authenticated principal against this to enforce that the
+     * binding user is the session owner (MS-SMB2 3.3.5.5.3); empty for an
+     * NTLM-established session (which is matched by uid instead). */
+    char                        principal[256];
 };
 
 /* Derive the stable per-client lease owner key from a 16-byte ClientGuid.


### PR DESCRIPTION
## Summary

Fixes a cluster of open SMB3 multichannel conformance defects, grouped into four
areas. All changes are server-side and localized to `src/server/smb/`.

### Network interface advertisement (discovery)
- **#1066 / #1131** — `FSCTL_QUERY_NETWORK_INTERFACE_INFO` mis-framed IPv6 NIC
  entries (164 B written while `Next`/`OutputCount` declared 152 B, IPv6 address
  at the IPv4 offset, no `sin6_flowinfo`/`scope_id`). Now emits a fixed 128-byte
  `SOCKADDR_STORAGE` for both families, so every record is exactly 152 B and the
  IPv6 address sits at the correct offset.
- **#440 / #467** — only advertise `SMB2_GLOBAL_CAP_MULTI_CHANNEL` when at least
  one interface is configured.

### Channel-bind security
- **#955** — a binding `SESSION_SETUP` is now signature-verified against the
  established `Session.SigningKey` before any new channel key is derived (it was
  never verified — a session-hijack class defect).
- **#1061** — the binding-principal == session-owner check now covers Kerberos
  (was NTLM-only); a bind leg no longer overwrites `session->cred`.
- **#987** — a 3.x LOGOFF now removes the session from the global table and marks
  it deleted, so requests on the sibling channels are answered
  `USER_SESSION_DELETED`.

### Replay correctness
- **#1123 / #1256** — the channel-sequence stale check now covers the
  write-mutating FSCTLs (SET_ZERO_DATA/SET_SPARSE/SET_INTEGRITY/SET_REPARSE/
  COPYCHUNK/DUPLICATE_EXTENTS/OFFLOAD_WRITE), not just the read-only object-id
  IOCTL.
- **#1119** — multi-element LOCK/UNLOCK is now subject to LockSequence replay
  verification (it previously dispatched before the replay check).
- **#1013** — the replay-cache bucket uses the full 28-bit `LockSequenceNumber`
  (no longer truncated to 8 bits), so an out-of-range number falls through to
  normal processing instead of aliasing a valid cache slot.

### RDMA / SMB-Direct channel
- **#1065** — `Channel=SMB2_CHANNEL_RDMA_V1[_INVALIDATE]` over a non-RDMA
  transport is rejected with `INVALID_PARAMETER`, closing a remotely triggerable
  NULL-deref crash on the READ path.
- **#950** — the multi-descriptor RDMA read now writes each descriptor's own
  slice with its own token/offset (was indexing `rdma_elements[0]` for all) and
  defers `SUCCESS` until every RDMA write completes.

### Deliberately excluded
- **#1290** (channel-sequence replay-flag fidelity) — implemented, then reverted:
  the `smb2.replay.channel-sequence` conformance test requires the high-water
  sequence to advance regardless of `SMB2_FLAGS_REPLAY_OPERATION`, contradicting
  the issue's premise.
- **#436** (Witness / MS-SWN) — a separate, large subsystem; out of scope here.

### Coverage caveat
Release + Debug/ASan builds are clean; the full memfs smbtorture suite (incl.
`session.bind*`, `lock`, `ioctl`, `replay.channel-sequence`, `multichannel`) and
the WPTS `multichannel` suite stay green. Note, however, that most of these fixes
sit **ahead of the current CI surface** — the IPv6 framing is not checked by the
WPTS interface-info case, and the Kerberos / RDMA / cross-channel-LOGOFF paths
are not driven by the available harness — so none flip a currently-runnable test
from fail to pass. Test scaffolding to lock these in (a serializer unit test for
the IPv6 framing, a TCP-side negative test for the #1065 rejection, a
multichannel-bound LOGOFF test) is a sensible follow-up.

Draft: opened against a base that predates ~100 upstream commits; will rebase
onto current `main` before marking ready.
