### PR TITLE
nfs3: fix a batch of SP2 NFSv3 correctness issues

### DIFF
--- a/src/server/nfs/nfs3_drc.c
+++ b/src/server/nfs/nfs3_drc.c
@@ -208,6 +208,12 @@ nfs3_drc_cache_insert_locked(
         drc->bytes -= e->len;
         free(e->buf);
         e->buf = malloc(body_len);
+        if (!e->buf) {
+            /* OOM: drop the now-empty entry rather than caching a NULL buf. */
+            HASH_DELETE(hh, drc->table, e);
+            free(e);
+            return 0;
+        }
         memcpy(e->buf, body, body_len);
         e->len      = body_len;
         e->ts       = ts;
@@ -228,9 +234,16 @@ nfs3_drc_cache_insert_locked(
         free(old);
     }
 
-    e      = calloc(1, sizeof(*e));
+    e = calloc(1, sizeof(*e));
+    if (!e) {
+        return nev;
+    }
     e->key = *key;
     e->buf = malloc(body_len);
+    if (!e->buf) {
+        free(e);
+        return nev;
+    }
     memcpy(e->buf, body, body_len);
     e->len = body_len;
     e->ts  = ts;
@@ -269,7 +282,9 @@ nfs3_drc_cache_lookup(
     if (e) {
         len = e->len;
         buf = malloc(len);
-        memcpy(buf, e->buf, len);
+        if (buf) {
+            memcpy(buf, e->buf, len);
+        }
     }
     pthread_mutex_unlock(&drc->lock);
 
@@ -376,6 +391,9 @@ nfs3_drc_capture_reply(
     }
 
     buf = malloc(total_length);
+    if (!buf) {
+        return;  /* OOM: skip caching this reply (degrade to a cache miss) */
+    }
     for (i = 0; i < niov; i++) {
         memcpy(buf + offset, iov[i].data, iov[i].length);
         offset += iov[i].length;

--- a/src/server/nfs/nfs3_proc_create.c
+++ b/src/server/nfs/nfs3_proc_create.c
@@ -171,9 +171,16 @@ chimera_nfs3_create_open_at_parent_complete(
         case EXCLUSIVE:
             flags            |= CHIMERA_VFS_OPEN_EXCLUSIVE;
             attr->va_set_mask = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
-            memcpy(&attr->va_atime.tv_sec, args->how.verf, 4);
+            /* Zero-extend the two 32-bit verifier halves into the 64-bit tv_sec
+             * via uint32 temporaries; a bare 4-byte memcpy leaves the high bytes
+             * as stale dbuf data, which breaks EXCLUSIVE-create retransmit
+             * idempotency against the uint32 read back at verify time. */
+            uint32_t verf_lo, verf_hi;
+            memcpy(&verf_lo, args->how.verf, 4);
+            memcpy(&verf_hi, args->how.verf + 4, 4);
+            attr->va_atime.tv_sec  = verf_lo;
             attr->va_atime.tv_nsec = 0;
-            memcpy(&attr->va_mtime.tv_sec, args->how.verf + 4, 4);
+            attr->va_mtime.tv_sec  = verf_hi;
             attr->va_mtime.tv_nsec = 0;
             break;
     } /* switch */

--- a/src/server/nfs/nfs3_proc_fsstat.c
+++ b/src/server/nfs/nfs3_proc_fsstat.c
@@ -115,7 +115,7 @@ chimera_nfs3_fsstat(
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                         req->fh,
                         req->fhlen,
-                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_DIRECTORY,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
                         chimera_nfs3_fsstat_open_callback,
                         req);
 } /* chimera_nfs3_fsstat */

--- a/src/server/nfs/nfs3_proc_readdir.c
+++ b/src/server/nfs/nfs3_proc_readdir.c
@@ -81,6 +81,10 @@ chimera_nfs3_readdir_complete(
         res->resok.reply.eof     = !!eof;
         res->resok.reply.entries = cursor->entries;
         memcpy(res->resok.cookieverf, &verifier, sizeof(res->resok.cookieverf));
+    } else {
+        /* The encoder serializes resfail.dir_attributes on error; initialize it
+         * so a recycled request slot does not leak stale attribute bytes. */
+        chimera_nfs3_set_post_op_attr(&res->resfail.dir_attributes, dir_attr);
     }
 
     rc = shared->nfs_v3.send_reply_NFSPROC3_READDIR(evpl, NULL, res, req->encoding);
@@ -124,7 +128,8 @@ chimera_nfs3_readdir_open_callback(
 
     } else {
         res->status = chimera_vfs_error_to_nfsstat3(error_code);
-        rc          = shared->nfs_v3.send_reply_NFSPROC3_READDIR(evpl, NULL, res, req->encoding);
+        chimera_nfs3_set_post_op_attr(&res->resfail.dir_attributes, NULL);
+        rc = shared->nfs_v3.send_reply_NFSPROC3_READDIR(evpl, NULL, res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);
     }

--- a/src/server/nfs/nfs3_proc_readdirplus.c
+++ b/src/server/nfs/nfs3_proc_readdirplus.c
@@ -111,6 +111,10 @@ chimera_nfs3_readdirplus_complete(
         memcpy(res->resok.cookieverf,
                &verifier,
                sizeof(res->resok.cookieverf));
+    } else {
+        /* Initialize the failure post-op attr so a recycled request slot does
+         * not leak stale attribute bytes on the error reply. */
+        chimera_nfs3_set_post_op_attr(&res->resfail.dir_attributes, dir_attr);
     }
 
     rc = shared->nfs_v3.send_reply_NFSPROC3_READDIRPLUS(evpl, NULL, res, req->encoding);
@@ -154,7 +158,8 @@ chimera_nfs3_readdirplus_open_callback(
 
     } else {
         res->status = chimera_vfs_error_to_nfsstat3(error_code);
-        rc          = shared->nfs_v3.send_reply_NFSPROC3_READDIRPLUS(evpl, NULL, res, req->encoding);
+        chimera_nfs3_set_post_op_attr(&res->resfail.dir_attributes, NULL);
+        rc = shared->nfs_v3.send_reply_NFSPROC3_READDIRPLUS(evpl, NULL, res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
         nfs_request_free(thread, req);
     }

--- a/src/server/nfs/nfs3_proc_readlink.c
+++ b/src/server/nfs/nfs3_proc_readlink.c
@@ -27,6 +27,16 @@ chimera_nfs3_readlink_complete(
 
     res->status = chimera_vfs_error_to_nfsstat3(error_code);
 
+    /* READLINK is only valid on a symlink (RFC 1813 §3.3.5); enforce at the
+     * protocol layer rather than relying on every backend to map a non-symlink
+     * to EINVAL.  The type comes from the attrs already fetched, so no extra
+     * round-trip. */
+    if (res->status == NFS3_OK && attr &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        (attr->va_mode & S_IFMT) != S_IFLNK) {
+        res->status = NFS3ERR_INVAL;
+    }
+
     if (res->status == NFS3_OK) {
         chimera_nfs3_set_post_op_attr(&res->resok.symlink_attributes, attr);
         res->resok.data.len = targetlen;

--- a/src/server/nfs/nfs3_proc_setattr.c
+++ b/src/server/nfs/nfs3_proc_setattr.c
@@ -84,7 +84,8 @@ chimera_nfs3_setattr_guard_callback(
         return;
     }
 
-    if (attr->va_ctime.tv_sec  != args->guard.obj_ctime.seconds ||
+    if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_CTIME) ||
+        attr->va_ctime.tv_sec  != args->guard.obj_ctime.seconds ||
         attr->va_ctime.tv_nsec != args->guard.obj_ctime.nseconds) {
         res.status = NFS3ERR_NOT_SYNC;
         chimera_nfs3_set_wcc_data(&res.resfail.obj_wcc, NULL, NULL);

--- a/src/server/nfs/nfs4_drc.c
+++ b/src/server/nfs/nfs4_drc.c
@@ -515,6 +515,9 @@ nfs4_drc_repopulate_slot(
     }
 
     slot->cached_buf = malloc(len);
+    if (!slot->cached_buf) {
+        return;  /* OOM: leave the slot uncached (degrade to a cache miss) */
+    }
     memcpy(slot->cached_buf, data, len);
     slot->cached_len = len;
     atomic_fetch_add_explicit(&session->replay_bytes_in_use, len,

--- a/src/server/nfs/nfs_mount.c
+++ b/src/server/nfs/nfs_mount.c
@@ -226,7 +226,15 @@ chimera_nfs_mount_lookup_complete(
         chimera_nfs_abort_if(rc, "Failed to allocate opaque");
         memcpy(res.mountinfo.fhandle.data, wire, wirelen);
     } else {
-        res.fhs_status = MNT3ERR_NOENT;
+        /* Map the export-root lookup failure to the matching mountstat3 rather
+         * than collapsing everything to NOENT (RFC 1813 App. I). */
+        switch (error_code) {
+            case CHIMERA_VFS_EACCES:  res.fhs_status = MNT3ERR_ACCES; break;
+            case CHIMERA_VFS_ENOTDIR: res.fhs_status = MNT3ERR_NOTDIR; break;
+            case CHIMERA_VFS_EINVAL:  res.fhs_status = MNT3ERR_INVAL; break;
+            case CHIMERA_VFS_ENOENT:  res.fhs_status = MNT3ERR_NOENT; break;
+            default:                  res.fhs_status = MNT3ERR_SERVERFAULT; break;
+        } /* switch */
     }
 
     rc = shared->mount_v3.send_reply_MOUNTPROC3_MNT(evpl, NULL, &res, req->encoding);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -1176,9 +1176,10 @@ chimera_linux_commit(
 {
     int fd = (int) request->commit.handle->vfs_private;
 
-    fsync(fd);
-
-    request->status = CHIMERA_VFS_OK;
+    /* Propagate a flush failure as NFS3ERR_IO so the client retransmits the
+     * UNSTABLE data instead of dropping it (RFC 1813 §3.3.21); discarding the
+     * fsync result turns a recoverable error into silent data loss. */
+    request->status = (fsync(fd) < 0) ? CHIMERA_VFS_EIO : CHIMERA_VFS_OK;
     request->complete(request);
 
 } /* chimera_linux_commit */

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4582,11 +4582,19 @@ memfs_readlink(
         return;
     }
 
-    request->readlink.r_target_length = inode->symlink.target->length;
+    /* Clamp to the caller-supplied buffer; a stored target longer than the
+     * provided buffer must not overrun it. */
+    uint32_t copy_len = inode->symlink.target->length;
+
+    if (copy_len > request->readlink.target_maxlength) {
+        copy_len = request->readlink.target_maxlength;
+    }
+
+    request->readlink.r_target_length = copy_len;
 
     memcpy(request->readlink.r_target,
            inode->symlink.target->data,
-           inode->symlink.target->length);
+           copy_len);
 
     memfs_map_attrs(shared, &request->readlink.r_attr, inode, request->fh);
 


### PR DESCRIPTION
Fixes a batch of NFSv3 (and shared DRC) correctness issues found in the server-side audit. One commit per issue.

- **#1047** linux: COMMIT swallowed `fsync()` errors and always reported OK — a silent data-durability hazard. Map a failed fsync to `CHIMERA_VFS_EIO`.
- **#957** nfs3: EXCLUSIVE CREATE only round-tripped part of the 8-byte `createverf3`; the high bytes were stale dbuf data, breaking retransmit idempotency. Zero-extend both 32-bit halves into atime/mtime.
- **#1140** nfs3: SETATTR `sattrguard3` now fails closed when the backend didn't return ctime, instead of comparing against uninitialized ctime.
- **#1142** nfs3: FSSTAT forced `OPEN_DIRECTORY`, failing with NFS3ERR_NOTDIR against a non-directory handle. Open as a generic handle.
- **#990** mount: MNT collapsed every failure into one generic error; map to specific `mountstat3` codes (ACCES/NOTDIR/INVAL/NOENT/SERVERFAULT).
- **#1049** memfs: READLINK copied the full stored target without bounding by `target_maxlength` — buffer overflow. Clamp the copy.
- **#1139** nfs3: READLINK against a non-symlink now returns NFS3ERR_INVAL at the protocol layer (no extra round-trip).
- **#1072** nfs3: READDIR/READDIRPLUS error replies left `resfail.dir_attributes` uninitialized, leaking stale bytes from a recycled slot. Initialize on both error paths.
- **#989** nfs: NFSv3/NFSv4 duplicate-reply caches malloc'd reply buffers without NULL checks, crashing under memory pressure. Guard every allocation; degrade to a cache miss.