### PR TITLE
server: cap default rcu_reclaim_threads to 4 to avoid liburcu EAGAIN abort

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -275,13 +275,21 @@ chimera_server_config_init(void)
     /* The VFS name (lookup) cache is on by default (common.name_cache). */
     config->name_cache_enabled = 1;
 
-    /* Number of liburcu call_rcu reclaim worker threads.  0 (the default) means
-     * one worker per CPU (create_all_cpu_call_rcu_data) to keep RCU reclaim up
-     * with per-request cache churn under heavy load.  On a many-core host that
-     * spawns hundreds of threads, which is wasteful for short-lived or
-     * lightly-loaded instances (memory, and process-teardown cost); set a small
-     * positive value (e.g. the CI test daemons) to cap the worker count. */
-    config->rcu_reclaim_threads = 0;
+    /* Number of liburcu call_rcu reclaim worker threads.  0 means one worker
+     * per CPU (create_all_cpu_call_rcu_data) to keep RCU reclaim up with
+     * per-request cache churn under heavy load.  On a many-core host that
+     * spawns hundreds of threads per server instance, which is wasteful for
+     * short-lived or lightly-loaded instances (memory, process-teardown cost)
+     * AND is a correctness hazard: liburcu's call_rcu_data_init does NOT retry
+     * pthread_create and abort()s the whole process on a transient EAGAIN
+     * ("Unrecoverable error: Resource temporarily unavailable").  Spawning
+     * hundreds of RCU threads at once -- as many in-process server instances do
+     * in parallel under a -j CI run -- makes that EAGAIN abort likely, which is
+     * the root cause of the intermittent lockf/fcntl NFS3 test flakes.  Default
+     * to a small cap (matching the chimera client default) so the common case
+     * stays well clear of the thread-exhaustion abort; a real server with a
+     * heavy workload can raise it via common.rcu_reclaim_threads. */
+    config->rcu_reclaim_threads = 4;
 
     /* Default NFSv4.1 fore-channel session slots (server cap on the number
      * of concurrent SEQUENCE requests a client may have outstanding per


### PR DESCRIPTION
## Problem

`chimera/posix/lockf_nfs3_linux` and `chimera/posix/lockf_nfs3rdma_linux_myuser` flake intermittently in the merge queue (tracked in #733): they fail once and pass on `--rerun-failed`.

Root cause (confirmed): the failure is a fast `SIGABRT` from **liburcu** at server VFS init, not the previously-suspected `evpl_thread_create` EAGAIN hang (that one is already fixed and not regressed):

```
(urcu-call-rcu-impl.h:call_rcu_data_init@448) Unrecoverable error: Resource temporarily unavailable
```

`chimera_server_config_init()` left `rcu_reclaim_threads = 0`, which means **one liburcu `call_rcu` reclaim thread per CPU** — 384 on the CI host. The in-process NFS server started by the lockf/fcntl tests never overrides it, so a single test process peaks at ~596 threads. Under a parallel `-j` CI run, many server instances cold-start at once and spawn hundreds of RCU threads simultaneously, pushing the system/cgroup thread count to the limit. When `pthread_create` then returns a transient `EAGAIN`, liburcu's `call_rcu_data_init()` does **not** retry — it `abort()`s the whole process, bypassing all the EAGAIN-hardening already present in libevpl/chimera.

The **client** default was already capped to 4 (`client.c`); the **server** default was simply missed.

## Fix

Default `rcu_reclaim_threads` to `4` in the server config, matching the client. The `common.rcu_reclaim_threads` knob still lets a heavy-workload production server opt back into per-CPU RCU.

## Verification

- Per-test peak threads: 596 → 159.
- A forced-EAGAIN window (LD_PRELOAD shim) that aborted 100% of the time before now passes with 0 urcu aborts.
- Broad parallel sweep `lockf|fcntl|cthon_lock` at `-j48` under CPU load: 6/6 rounds at 100% (was ~83%).
- Both originally-flaking tests: 10/10.

Refs #733