### PR TITLE
diskfs: free raw extent range in dealloc (don't round up) — fixes shared edge-block over-free / silent corruption

### DIFF
--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -3230,10 +3230,18 @@ diskfs_dealloc_process(struct chimera_vfs_request *request)
     }
 
     if (es >= hole_start && ee <= hole_end) {
-        /* Completely inside the hole: free + remove, then advance. */
+        /* Completely inside the hole: free + remove, then advance.  Pass the raw
+         * extent range (not block-rounded-up): an extent can end mid-block when a
+         * sub-block-unaligned DEALLOCATE left a kept sibling extent in the same
+         * 4 KiB block (e.g. written | unwritten fragments from a prior punch).
+         * space_map_free frees only whole blocks strictly contained, so the raw
+         * range never frees that shared edge block.  Rounding the length UP would
+         * free the partial trailing block out from under the kept sibling, which
+         * is then re-allocated to a later write -> the sibling reads back the new
+         * writer's data (silent cross-extent corruption). */
         diskfs_thread_free_space(thread, p->txn, p->ext_iter.device_id,
                                  p->ext_iter.device_offset,
-                                 SM_ALIGN_UP(p->ext_iter.length));
+                                 p->ext_iter.length);
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_remove_async(op, thread, p->txn, p->inode_stash[0], es,
                                     diskfs_dealloc_modify_advance_cb, request)) {


### PR DESCRIPTION
## Problem

`chimera/vfs/zerorange_diskfs_aio` flakes intermittently in the merge queue (tracked in #733). The symptom is a read returning **another op's write data** (`MISMATCH ... expected 0xAA got 0xBB`), occasionally a spurious `ENOSPC` from the same space-map mis-accounting. This is **silent data corruption**, not just a test artifact.

## Root cause (confirmed)

In `diskfs_dealloc_process()` (`src/vfs/diskfs/diskfs_io.c`), the "extent completely inside the hole" case freed the extent's backing with `SM_ALIGN_UP(p->ext_iter.length)` — rounding the free length **up** to a 4 KiB block boundary.

A sub-block-unaligned `DEALLOCATE` (punch-hole) can leave two extents sharing a single 4 KiB block: a written fragment plus a kept sibling extent — exactly the fragmented edge-block state this test is built to create. Rounding the free length up then frees the partial trailing block that the kept sibling **still occupies**. That physical block is re-allocated to a later write, and reading the kept sibling returns the new writer's bytes.

Traced concretely (instrumentation since removed): for one failing seed, a punch freed device `[0x4de9000,0x4dec000)` via `SM_ALIGN_UP(0x2086)=0x3000` for an extent that only owned `[0x4de9000,0x4deb086)`; the over-freed block `0x4deb000` was still owned by a kept extent; a later op re-allocated and overwrote it.

## Fix

Pass the **raw** extent length, matching the three sibling cases (spans / overlap-start / overlap-end) which already free raw ranges and rely on `space_map_free` to free only whole blocks strictly contained — so a sub-block edge shared with a kept piece is never freed. The "completely inside" case was the lone outlier using `SM_ALIGN_UP`.

```c
-                                 SM_ALIGN_UP(p->ext_iter.length));
+                                 p->ext_iter.length);
```
(plus an explanatory comment).

## Validation

- Two op sequences that failed 10/10 before now pass 3/3 each.
- 500 distinct random op sequences under load: 0 failures (measurable rate before).
- Default CI seed under load avg ~1000: 1000/1000 pass.
- All four `zerorange` cases (memfs, diskfs_aio, diskfs_io_uring, cairn): pass.

Refs #733