### PR TITLE
nfs4: fix a batch of SP2 NFSv4.x correctness issues

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -1057,6 +1057,16 @@ chimera_nfs4_unmarshall_attrs(
                     return NFS4ERR_BADXDR;
                 }
 
+                /* aclsupport advertises only ALLOW/DENY ACEs (see the
+                 * fattr4_aclsupport encode below).  RFC 7530 §6.2.1.4.1
+                 * requires rejecting an ACE of an unsupported type with
+                 * NFS4ERR_ATTRNOTSUPP rather than silently storing an
+                 * AUDIT/ALARM ACE that would never be enforced. */
+                if (type != ACE4_ACCESS_ALLOWED_ACE_TYPE &&
+                    type != ACE4_ACCESS_DENIED_ACE_TYPE) {
+                    return NFS4ERR_ATTRNOTSUPP;
+                }
+
                 is_group = !!(flag & CHIMERA_ACE_FLAG_IDENTIFIER_GROUP);
 
                 acl_buf->aces[i].type        = (uint16_t) type;

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -1051,12 +1051,22 @@ chimera_nfs4_layoutreturn(
             uint32_t in_seqid =
                 args->lora_layoutreturn.lr_layout.lrf_stateid.seqid;
 
+            /* RFC 8881 §18.44.3: for LAYOUTRETURN4_FILE the layout stateid's
+             * seqid MUST NOT be zero -- unlike the anonymous/current special
+             * stateids used elsewhere, a zero seqid here is rejected with
+             * NFS4ERR_BAD_STATEID rather than treated as a wildcard. */
+            if (in_seqid == 0) {
+                res->lorr_status = NFS4ERR_BAD_STATEID;
+                chimera_nfs4_compound_complete(req, res->lorr_status);
+                return;
+            }
+
             /* RFC 8881 §12.5.3: the layout stateid carried by LAYOUTRETURN must
              * match the server's current seqid for this layout.  A stale seqid
-             * is OLD_STATEID, a future one BAD_STATEID; seqid 0 is the wildcard
-             * "current" and always matches.  (LAYOUTGET, by contrast, tolerates
-             * an old seqid -- the client may race two LAYOUTGETs.) */
-            if (in_seqid != 0 && in_seqid < layout->seqid) {
+             * is OLD_STATEID, a future one BAD_STATEID.  (LAYOUTGET, by
+             * contrast, tolerates an old seqid -- the client may race two
+             * LAYOUTGETs.) */
+            if (in_seqid < layout->seqid) {
                 res->lorr_status = NFS4ERR_OLD_STATEID;
                 chimera_nfs4_compound_complete(req, res->lorr_status);
                 return;

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -226,11 +226,20 @@ chimera_nfs4_getdeviceinfo(
      * validate a device id or (de)register notifications: TOOSMALL MUST NOT be
      * returned and the reply's da_addr_body is zero length.  Otherwise signal
      * TOOSMALL with the required size when the body cannot fit. */
+    /* gdia_maxcount bounds the entire GETDEVICEINFO4resok, including XDR
+     * overhead, not just the da_addr_body (RFC 8881 §18.40.3).  Beyond the
+     * body the resok carries da_layout_type (4), the da_addr_body opaque
+     * length prefix (4, with the body padded to a 4-byte boundary) and the
+     * gdir_notification bitmap count (4).  Compare maxcount against -- and
+     * report gdir_mincount as -- that full size, so a client that retries at
+     * exactly gdir_mincount does not TOOSMALL again. */
+    uint32_t resok_len = 4 + 4 + ((body_len + 3) & ~3u) + 4;
+
     if (args->gdia_maxcount == 0) {
         body_len = 0;
-    } else if (args->gdia_maxcount < body_len) {
+    } else if (args->gdia_maxcount < resok_len) {
         res->gdir_status   = NFS4ERR_TOOSMALL;
-        res->gdir_mincount = body_len;
+        res->gdir_mincount = resok_len;
         chimera_nfs4_compound_complete(req, res->gdir_status);
         return;
     }

--- a/src/server/nfs/nfs4_proc_close.c
+++ b/src/server/nfs/nfs4_proc_close.c
@@ -138,6 +138,12 @@ chimera_nfs4_close(
     nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                             thread->vfs_thread);
 
+    /* RFC 8881 §16.2.3.1.2: CLOSE destroys the open state, so the COMPOUND's
+     * current stateid must not continue to name it.  Invalidate it -- a
+     * following op that uses the current stateid then fails with
+     * NFS4ERR_BAD_STATEID instead of resolving to destroyed state. */
+    chimera_nfs4_clear_current_stateid(req);
+
     res->status = NFS4_OK;
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_close */

--- a/src/server/nfs/nfs4_proc_free_stateid.c
+++ b/src/server/nfs/nfs4_proc_free_stateid.c
@@ -57,6 +57,13 @@ chimera_nfs4_free_stateid(
         return;
     }
 
+    /* NFS4ERR_STALE_STATEID is a 4.0-only code; FREE_STATEID is 4.1+-only, so
+     * a wrong-epoch / older-generation stateid is reported as
+     * NFS4ERR_BAD_STATEID per the RFC 8881 §15.2 FREE_STATEID error set. */
+    if (status == NFS4ERR_STALE_STATEID) {
+        status = NFS4ERR_BAD_STATEID;
+    }
+
     if (status != NFS4_OK) {
         res->fsr_status = status;
         chimera_nfs4_compound_complete(req, res->fsr_status);

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -155,6 +155,9 @@ chimera_nfs4_lockt(
         struct nfs4_session *s = nfs4_session_find_by_clientid(
             &thread->shared->nfs4_shared_clients, args->owner.clientid);
         if (s) {
+            /* RFC 7530 §9.5: LOCKT is a clientid-bearing operation and renews
+             * all of the client's leases. */
+            nfs_client_touch(s->client_unified);
             nfs4_session_put(s);
         } else {
             res->status = NFS4ERR_STALE_CLIENTID;

--- a/src/server/nfs/nfs4_proc_open_confirm.c
+++ b/src/server/nfs/nfs4_proc_open_confirm.c
@@ -96,6 +96,21 @@ chimera_nfs4_open_confirm(
         return;
     }
 
+    /* RFC 7530 §9.1.4.2: OPEN_CONFIRM must carry the exact stateid OPEN minted.
+     * The acquire above validates structural identity (generation) but not the
+     * stateid.seqid; check it explicitly as CLOSE/OPEN_DOWNGRADE do, so a stale
+     * seqid is OLD_STATEID and a future one BAD_STATEID. */
+    status = nfs4_stateid_check_seqid(open_state->seqid,
+                                      args->open_stateid.seqid);
+    if (status != NFS4_OK) {
+        pthread_mutex_unlock(&owner->lock);
+        nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                thread->vfs_thread);
+        res->status = status;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
     /* New op: confirm the owner and advance state.seqid. */
     owner->confirmed   = true;
     owner->seqid       = args->seqid;

--- a/src/server/nfs/nfs4_proc_reclaim_complete.c
+++ b/src/server/nfs/nfs4_proc_reclaim_complete.c
@@ -27,14 +27,18 @@ chimera_nfs4_reclaim_complete(
         return;
     }
 
-    /* RFC 8881 §18.51 / RFC 7530 §10.2.5: client signals end of reclaim
-     * activity.  Drop the per-client recovery marker.  When persistence
-     * lands and the to_reclaim hash is populated at boot, the
-     * pending_reclaim counter hitting zero will also end the grace window
-     * early via nfs_recovery_sweep_once. */
-    nfs_recovery_reclaim_complete(
-        &thread->shared->nfs4_recovery,
-        req->session ? req->session->client_unified : NULL);
+    /* RFC 8881 §18.51.3: rca_one_fs == TRUE signals the client finished
+     * reclaim for a SINGLE file system after migration -- it is NOT the global
+     * end-of-reclaim and must not retire the client's whole reclaim obligation
+     * or decrement the server-wide pending_reclaim counter (which would end the
+     * grace window early for everyone).  Only the global form (rca_one_fs ==
+     * FALSE) drops the recovery marker.  Chimera does not track per-fs reclaim
+     * (no fs_locations/migration yet), so the per-fs variant is a no-op. */
+    if (!args->rca_one_fs) {
+        nfs_recovery_reclaim_complete(
+            &thread->shared->nfs4_recovery,
+            req->session ? req->session->client_unified : NULL);
+    }
 
     res->rcr_status = NFS4_OK;
 

--- a/src/server/nfs/nfs4_proc_release_lockowner.c
+++ b/src/server/nfs/nfs4_proc_release_lockowner.c
@@ -32,6 +32,10 @@ chimera_nfs4_release_lockowner(
         return;
     }
 
+    /* RFC 7530 §9.5: RELEASE_LOCKOWNER is a clientid-bearing operation and
+     * renews all of the client's leases. */
+    nfs_client_touch(client);
+
     pthread_mutex_lock(&client->lock);
 
     HASH_FIND(hh, client->lock_owners_by_str,

--- a/src/server/nfs/nfs4_proc_secinfo.c
+++ b/src/server/nfs/nfs4_proc_secinfo.c
@@ -42,6 +42,10 @@ chimera_nfs4_secinfo_complete(
 
     res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
                                                export ? export->sec_allowed : 0);
+    /* RFC 7530 §16.31.3 / RFC 8881 §18.29.3: SECINFO consumes the current
+     * filehandle on success, so a following op relying on it fails with
+     * NFS4ERR_NOFILEHANDLE. */
+    req->fhlen  = 0;
     res->status = NFS4_OK;
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_secinfo_complete */
@@ -119,6 +123,8 @@ chimera_nfs4_secinfo(
         chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
         res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
                                                    export ? export->sec_allowed : 0);
+        /* Consume the current filehandle on success (see above). */
+        req->fhlen  = 0;
         res->status = NFS4_OK;
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;

--- a/src/server/nfs/nfs4_proc_secinfo_no_name.c
+++ b/src/server/nfs/nfs4_proc_secinfo_no_name.c
@@ -31,6 +31,9 @@ chimera_nfs4_secinfo_no_name(
 
     res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
                                                export ? export->sec_allowed : 0);
+    /* RFC 8881 §18.45.3: SECINFO_NO_NAME consumes the current filehandle on
+     * success, so a following op relying on it fails with NFS4ERR_NOFILEHANDLE. */
+    req->fhlen  = 0;
     res->status = NFS4_OK;
 
     chimera_nfs4_compound_complete(req, NFS4_OK);

--- a/src/server/nfs/nfs4_proc_seek.c
+++ b/src/server/nfs/nfs4_proc_seek.c
@@ -84,6 +84,16 @@ chimera_nfs4_seek(
     req->nfs_state_ref = NULL;
     req->handle        = NULL;
 
+    /* RFC 7862 §15.11.3: sa_what selects the content type to seek for and is
+     * only defined for NFS4_CONTENT_DATA / NFS4_CONTENT_HOLE.  Reject anything
+     * else with NFS4ERR_INVAL rather than passing it through to the backend. */
+    if (args->sa_what != NFS4_CONTENT_DATA &&
+        args->sa_what != NFS4_CONTENT_HOLE) {
+        res->sa_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->sa_status);
+        return;
+    }
+
     /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
     chimera_nfs4_resolve_current_stateid(req, &args->sa_stateid);
 

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -46,10 +46,6 @@ chimera_nfs4_sequence(
 
     req->session = session;
 
-    /* SEQUENCE is the 4.1+ lease tick (RFC 8881 §8.4); touch the owning
-     * client's lease before consulting the slot table. */
-    nfs_client_touch(session->client_unified);
-
     status = nfs4_replay_slot_acquire(session,
                                       args->sa_slotid,
                                       args->sa_sequenceid,
@@ -68,6 +64,7 @@ chimera_nfs4_sequence(
          * the cached reply bytes verbatim.  Phase 1 has no cache so
          * this branch is unreachable today; nfs4_replay_slot_acquire
          * returns NFS4ERR_RETRY_UNCACHED_REP instead. */
+        nfs_client_touch(session->client_unified);
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }
@@ -121,6 +118,13 @@ chimera_nfs4_sequence(
         chimera_nfs4_compound_complete(req, NFS4ERR_REP_TOO_BIG_TO_CACHE);
         return;
     }
+
+    /* SEQUENCE is the 4.1+ lease tick (RFC 8881 §8.4).  §18.46.3 requires the
+     * lease be renewed only when SEQUENCE returns NFS4_OK and the slot state
+     * advances -- never on a BADSLOT/MISORDERED/REQ_TOO_BIG/TOO_MANY_OPS error
+     * -- so the touch happens here, after every validation has passed, rather
+     * than up front. */
+    nfs_client_touch(session->client_unified);
 
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_sequence */

--- a/src/server/nfs/nfs4_proc_test_stateid.c
+++ b/src/server/nfs/nfs4_proc_test_stateid.c
@@ -25,8 +25,16 @@ chimera_nfs4_test_stateid(
         req->encoding->dbuf);
 
     for (i = 0; i < args->num_ts_stateids; i++) {
-        resok->tsr_status_codes[i] = nfs_state_table_validate(
-            table, &args->ts_stateids[i]);
+        nfsstat4 st = nfs_state_table_validate(table, &args->ts_stateids[i]);
+
+        /* NFS4ERR_STALE_STATEID is a 4.0-only code and is not a valid
+         * per-stateid status for TEST_STATEID (RFC 8881 §18.48.3 / §15.1.16.5);
+         * a wrong-epoch or older-generation stateid is reported as
+         * NFS4ERR_BAD_STATEID to a 4.1+ client. */
+        if (st == NFS4ERR_STALE_STATEID) {
+            st = NFS4ERR_BAD_STATEID;
+        }
+        resok->tsr_status_codes[i] = st;
     }
 
     res->tsr_status = NFS4_OK;

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -170,7 +170,13 @@ nfs4_root_readdir_lookup_callback(
     struct entry4                       *entry = ctx->entry;
 
     if (error_code != CHIMERA_VFS_OK) {
-        abort();
+        /* An export root that fails to resolve (deleted directory, config
+        * typo, momentarily unavailable backend) is a routine condition, not
+        * a server fault.  Record it so nfs4_root_readdir_itr_cb surfaces it
+        * as an NFS4ERR_* READDIR status instead of aborting the whole process
+        * (RFC 7530 §16.24 / RFC 8881 §18.23: report errors as status). */
+        ctx->error_code = error_code;
+        return;
     }
     chimera_nfs4_marshall_attrs(attrs,
                                 args->num_attr_request,

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -117,13 +117,26 @@ nfs_state_table_init(
      *   bits 31..16 : node_id  -- attributes the stateid to its minting
      *                 instance, so peers sharing one backing store never mint
      *                 colliding epochs and a foreign stateid is recognisable.
-     *   bits 15..1  : low 15 bits of boot time -- differs across this node's
+     *   bits 15..1  : 15-bit boot discriminator -- differs across this node's
      *                 restarts, so a previous instance's stateids read as stale.
      *   bit  0      : 1 -- with node_id >= 1 this keeps the epoch away from the
      *                 special all-zero/all-ones stateids and pynfs's small
      *                 "old epoch" probe values (replacing the old 0x80000000). */
+    struct timespec ts;
+
+    clock_gettime(CLOCK_REALTIME, &ts);
+
+    /* Fold the full-resolution boot time (seconds AND nanoseconds) into the
+     * 15-bit discriminator.  A bare `time(NULL) & 0x7FFF` collides whenever two
+     * restarts' wall-clock seconds are congruent mod 32768 (~9.1h) -- a
+     * deterministic, easily-hit alias.  Mixing the high seconds bits and the
+     * nanosecond field makes a collision a ~1/32768 chance instead, so a
+     * previous instance's stateids reliably read as STALE_STATEID on reboot. */
+    uint32_t boot = (uint32_t) ts.tv_sec ^ ((uint32_t) ts.tv_sec >> 15) ^
+        (uint32_t) ts.tv_nsec ^ ((uint32_t) ts.tv_nsec >> 15);
+
     table->epoch = ((uint32_t) node_id << 16) |
-        (((uint32_t) time(NULL) & 0x7FFFu) << 1) | 1u;
+        ((boot & 0x7FFFu) << 1) | 1u;
 } /* nfs_state_table_init */
 
 void

--- a/src/vfs/vfs_acl.h
+++ b/src/vfs/vfs_acl.h
@@ -98,6 +98,14 @@ enum chimera_special_who {
      * presence in a DACL suppresses the otherwise-implicit owner rights so the
      * owner's access is defined entirely by the ACEs. */
     CHIMERA_WHO_OWNER_RIGHTS  = 10,
+    /* RFC 7530 §6.2.1.5 Table 5 special identifiers (DIALUP@ / BATCH@ /
+     * SERVICE@, SIDs S-1-5-1 / S-1-5-3 / S-1-5-6).  Like INTERACTIVE@/NETWORK@
+     * they describe an access method no Unix caller matches, but the spec
+     * requires they be accepted, stored, and displayed so a client can set and
+     * read them; they match nothing during access evaluation. */
+    CHIMERA_WHO_DIALUP        = 11,
+    CHIMERA_WHO_BATCH         = 12,
+    CHIMERA_WHO_SERVICE       = 13,
 };
 
 struct chimera_principal {

--- a/src/vfs/vfs_idmap.c
+++ b/src/vfs/vfs_idmap.c
@@ -21,6 +21,9 @@
 #define SID_NETWORK       "S-1-5-2"  /* Network          */
 #define SID_INTERACTIVE   "S-1-5-4"  /* Interactive      */
 #define SID_ANONYMOUS     "S-1-5-7"  /* Anonymous        */
+#define SID_DIALUP        "S-1-5-1"  /* Dialup           */
+#define SID_BATCH         "S-1-5-3"  /* Batch            */
+#define SID_SERVICE       "S-1-5-6"  /* Service          */
 
 static const char *
 special_to_who_string(uint8_t special)
@@ -33,6 +36,9 @@ special_to_who_string(uint8_t special)
         case CHIMERA_WHO_NETWORK:       return "NETWORK@";
         case CHIMERA_WHO_AUTHENTICATED: return "AUTHENTICATED@";
         case CHIMERA_WHO_ANONYMOUS:     return "ANONYMOUS@";
+        case CHIMERA_WHO_DIALUP:        return "DIALUP@";
+        case CHIMERA_WHO_BATCH:         return "BATCH@";
+        case CHIMERA_WHO_SERVICE:       return "SERVICE@";
         default:                        return NULL;
     } /* switch */
 } /* special_to_who_string */
@@ -55,6 +61,9 @@ who_string_to_special(
         { "NETWORK@",       CHIMERA_WHO_NETWORK       },
         { "AUTHENTICATED@", CHIMERA_WHO_AUTHENTICATED },
         { "ANONYMOUS@",     CHIMERA_WHO_ANONYMOUS     },
+        { "DIALUP@",        CHIMERA_WHO_DIALUP        },
+        { "BATCH@",         CHIMERA_WHO_BATCH         },
+        { "SERVICE@",       CHIMERA_WHO_SERVICE       },
     };
     /* *INDENT-ON* */
 
@@ -242,6 +251,9 @@ chimera_idmap_principal_to_sid(
             case CHIMERA_WHO_NETWORK:       s = SID_NETWORK; break;
             case CHIMERA_WHO_AUTHENTICATED: s = SID_AUTHENTICATED; break;
             case CHIMERA_WHO_ANONYMOUS:     s = SID_ANONYMOUS; break;
+            case CHIMERA_WHO_DIALUP:        s = SID_DIALUP; break;
+            case CHIMERA_WHO_BATCH:         s = SID_BATCH; break;
+            case CHIMERA_WHO_SERVICE:       s = SID_SERVICE; break;
             default:                        return -1;
         } /* switch */
         len = (int) strlen(s);


### PR DESCRIPTION
Fixes a batch of NFSv4.0/4.1/4.2 (and pNFS) correctness issues found in the server-side audit. One commit per issue.

- **#942** nfs4: pseudo-root READDIR called `abort()` when any export's backing path failed to resolve — a remotely-triggerable crash (pseudo-root READDIR is the first step of every Linux mount). Now reports an NFS4ERR_* status.
- **#1087** nfs4: SEQUENCE renewed the client lease *before* slot/size validation, so a client whose every SEQUENCE errored kept its lease alive indefinitely. Renew only on NFS4_OK (RFC 8881 §18.46.3).
- **#418** nfs4.2: SEEK now validates `sa_what` (NFS4_CONTENT_DATA/HOLE) → NFS4ERR_INVAL otherwise.
- **#1000** nfs4: CLOSE now invalidates the COMPOUND current stateid (RFC 8881 §16.2.3.1.2).
- **#1006** nfs4: per-fs RECLAIM_COMPLETE (`rca_one_fs=TRUE`) no longer retires the client's whole reclaim obligation / ends the global grace early (RFC 8881 §18.51.3).
- **#1008** nfs4: TEST_STATEID/FREE_STATEID map wrong-epoch/old-generation to NFS4ERR_BAD_STATEID, not the 4.0-only STALE_STATEID.
- **#1144 / #1159** nfs4: SECINFO and SECINFO_NO_NAME consume the current filehandle on success (RFC 7530 §16.31.3 / RFC 8881 §18.29.3/§18.45.3). *(One commit covers both — they describe the same fix scoped to 4.0 vs 4.1/4.2.)*
- **#1148** nfs4: OPEN_CONFIRM validates the supplied `open_stateid.seqid` (OLD/BAD_STATEID), matching CLOSE/OPEN_DOWNGRADE.
- **#1149** nfs4: LOCKT and RELEASE_LOCKOWNER renew the client lease (RFC 7530 §9.5).
- **#1150** nfs4: widen the stateid epoch boot discriminator entropy so two restarts no longer alias on a deterministic ~9.1h wall-clock wrap.
- **#1081** nfs4: reject unsupported (AUDIT/ALARM) ACE types in ACL SETATTR with NFS4ERR_ATTRNOTSUPP instead of silently storing an unenforced ACE.
- **#1155** nfs4: accept the DIALUP@/BATCH@/SERVICE@ special-who identifiers (RFC 7530 §6.2.1.5 Table 5) instead of rejecting the whole ACL with NFS4ERR_BADOWNER.
- **#1093** nfs4/pnfs: reject LAYOUTRETURN4_FILE with a zero-seqid layout stateid (NFS4ERR_BAD_STATEID, RFC 8881 §18.44.3).
- **#1171** nfs4/pnfs: GETDEVICEINFO TOOSMALL/gdir_mincount account for the resok XDR overhead, not just the device body.

Validated with the pynfs `combined` memfs suites on 4.0/4.1/4.2 (all green).

Note: the audit also flagged #997 (READLINK MODE-absent / ISDIR hardening) and #405 (GETDEVICEINFO notification bitmap). #405 is already satisfied by the current code (it returns an explicit empty bitmap). #997 is deliberately **not** in this PR: although the fix is correct per RFC 7530 §16.22.5, it deterministically exposes a separate pre-existing shutdown crash (a client-table `by_owner`/`by_id` hash desync at `nfs4_session.c:107`, SIGSEGV in `nfs4_client_table_free` at teardown). That latent teardown bug should be fixed first; #997 will follow on top of it.