### PR TITLE
s3: fix CompleteMultipartUpload NoSuchUpload flake (UAF + idempotency + linux ESTALE)

### DIFF
--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -502,6 +502,19 @@ s3_server_dispatch(
     s3_request->query_part_number  = 0;
     s3_request->http_request       = request;
 
+    /* Requests are recycled through a per-thread free list (see
+     * chimera_s3_request_alloc) and are NOT zeroed on reuse. The VFS open
+     * handles are released by each handler's completion path, but several of
+     * those paths drop the reference without clearing the pointer, so a
+     * recycled request can carry a dangling file_handle / dir_handle from a
+     * prior op. If a later handler's error path then releases that stale
+     * pointer (e.g. CompleteMultipartUpload's create-dir error branch in
+     * chimera_s3_complete_finish_common), and the VFS close thread has since
+     * swept the now-idle cached handle, the release is a use-after-free.
+     * Clear them here so a fresh request always starts with no held handles. */
+    s3_request->file_handle = NULL;
+    s3_request->dir_handle  = NULL;
+
     *notify_callback = s3_server_notify;
     *notify_data     = s3_request;
 

--- a/src/server/s3/s3_get.c
+++ b/src/server/s3/s3_get.c
@@ -41,7 +41,10 @@ chimera_s3_get_finish(struct chimera_s3_request *request)
 {
     struct chimera_server_s3_thread *thread = request->thread;
 
-    chimera_vfs_release(thread->vfs, request->file_handle);
+    if (request->file_handle) {
+        chimera_vfs_release(thread->vfs, request->file_handle);
+        request->file_handle = NULL;
+    }
 
     request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
 

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -2034,7 +2034,16 @@ struct chimera_s3_complete_ctx {
     enum chimera_s3_assemble_mode       assemble_mode;
     int                                 rw_niov;
     struct evpl_iovec                   rw_iov[CHIMERA_S3_IOV_MAX];
+    /* Bounded retry of the destination parent-dir create. The linux backend
+     * can transiently return ESTALE from open_by_handle_at when a cached
+     * directory handle is being recycled under concurrent load; re-walking the
+     * create from the (re-resolved) bucket handle clears it. */
+    int                                 create_retries;
+    int                                 dirpathlen;
+    char                                dirpath[CHIMERA_S3_KEY_MAX];
 };
+
+#define CHIMERA_S3_COMPLETE_CREATE_MAX_RETRIES 8
 
 static void chimera_s3_complete_assemble_next(
     struct chimera_s3_complete_ctx *ctx);
@@ -2045,6 +2054,9 @@ static void chimera_s3_complete_finalize(
 static void chimera_s3_complete_finish_common(
     enum chimera_vfs_error error_code,
     void                  *private_data);
+
+static void chimera_s3_complete_create_dir(
+    struct chimera_s3_complete_ctx *ctx);
 
 /* ----- Assembly: walk parts list, copy/move/rw each part into dest ----- */
 
@@ -2307,9 +2319,32 @@ chimera_s3_complete_finish_common(
     request->etag[0]               = etag[0];
     request->etag[1]               = etag[1];
 
-    /* Drop our hold on the upload. Async part cleanup (release file handles
-     * + unlink any tmp-file parts) fires when refcount hits zero. */
+    /* Dispose of the upload. The upload was intentionally left in the table
+     * during assembly (marked `completing`) so a retried CompleteMultipartUpload
+     * remained resolvable and idempotent. ctx->upload holds the lookup ref.
+     *
+     *  - On success: detach (unlinks from the table + marks removed), then drop
+     *    BOTH the now-orphaned table ref and our ctx ref, freeing the upload and
+     *    triggering async part cleanup.
+     *  - On failure: clear `completing` and drop only our ctx ref, leaving the
+     *    upload in the table so the client can retry Complete (or Abort).
+     */
     if (ctx->upload) {
+        struct chimera_server_s3_shared *shared = thread->shared;
+
+        if (!error_code) {
+            chimera_s3_multipart_table_detach(shared->multipart_table,
+                                              request->multipart.upload_id,
+                                              request->multipart.upload_idlen);
+            /* Drop the table's implicit (insert) ref now that it is unlinked. */
+            chimera_s3_multipart_upload_release(thread, ctx->upload);
+        } else {
+            pthread_mutex_lock(&ctx->upload->lock);
+            ctx->upload->completing = 0;
+            pthread_mutex_unlock(&ctx->upload->lock);
+        }
+        /* Drop our (ctx) ref. On success this is the last ref -> free + async
+         * part cleanup. On failure the table's ref remains, keeping it alive. */
         chimera_s3_multipart_upload_release(thread, ctx->upload);
         ctx->upload = NULL;
     }
@@ -2511,6 +2546,16 @@ chimera_s3_complete_open_dir_callback(
     struct chimera_vfs_module       *module;
 
     if (error_code) {
+        /* Same transient ESTALE/ENOENT window as create_root_callback: the just
+         * -created dir's handle can be recycled before this open resolves it.
+         * Re-walk the create rather than failing the whole Complete. */
+        if ((error_code == CHIMERA_VFS_ESTALE ||
+             error_code == CHIMERA_VFS_ENOENT) &&
+            ctx->create_retries < CHIMERA_S3_COMPLETE_CREATE_MAX_RETRIES) {
+            ctx->create_retries++;
+            chimera_s3_complete_create_dir(ctx);
+            return;
+        }
         chimera_s3_complete_finish_common(error_code, ctx);
         return;
     }
@@ -2566,6 +2611,18 @@ chimera_s3_complete_create_root_callback(
     struct chimera_server_s3_thread *thread = ctx->request->thread;
 
     if (error_code) {
+        /* The linux backend can transiently return ESTALE (and, while a parent
+         * directory is being recycled, ENOENT) from open_by_handle_at when a
+         * cached directory handle is being evicted concurrently. Re-walking the
+         * create from the bucket handle resolves a fresh handle and succeeds.
+         * Bound the retries so a genuinely missing parent still errors out. */
+        if ((error_code == CHIMERA_VFS_ESTALE ||
+             error_code == CHIMERA_VFS_ENOENT) &&
+            ctx->create_retries < CHIMERA_S3_COMPLETE_CREATE_MAX_RETRIES) {
+            ctx->create_retries++;
+            chimera_s3_complete_create_dir(ctx);
+            return;
+        }
         chimera_s3_complete_finish_common(error_code, ctx);
         return;
     }
@@ -2579,6 +2636,28 @@ chimera_s3_complete_create_root_callback(
         chimera_s3_complete_open_dir_callback,
         ctx);
 } /* chimera_s3_complete_create_root_callback */
+
+/* Kick off (or retry) the destination parent-directory create. */
+static void
+chimera_s3_complete_create_dir(struct chimera_s3_complete_ctx *ctx)
+{
+    struct chimera_s3_request       *request = ctx->request;
+    struct chimera_server_s3_thread *thread  = request->thread;
+
+    request->set_attr.va_req_mask = 0;
+    request->set_attr.va_set_mask = 0;
+
+    chimera_vfs_create(
+        thread->vfs, &thread->shared->cred,
+        request->bucket_fh,
+        request->bucket_fhlen,
+        ctx->dirpath,
+        ctx->dirpathlen,
+        &request->set_attr,
+        CHIMERA_VFS_ATTR_FH,
+        chimera_s3_complete_create_root_callback,
+        ctx);
+} /* chimera_s3_complete_create_dir */
 
 /*
  * Phase 1: dispatcher entry. Just initialize the body buffer so the
@@ -2599,6 +2678,120 @@ chimera_s3_complete_multipart_upload(
     request->multipart.body_cap = 0;
     request->vfs_state          = CHIMERA_S3_VFS_STATE_INIT;
 } /* chimera_s3_complete_multipart_upload */
+
+/* Parse a quoted 32-hex ETag ("\"<32hex>\"") as written by
+ * chimera_s3_mp_format_etag into a 128-bit value (low64, high64). Returns 0 on
+ * success, -1 on malformed input. The client echoes the exact per-part ETags
+ * the server returned, so this round-trips losslessly. */
+static int
+chimera_s3_mp_parse_etag(
+    const char *quoted,
+    uint64_t    out[2])
+{
+    const char *p = quoted;
+    uint8_t     bytes[16];
+
+    if (*p == '"') {
+        p++;
+    }
+
+    for (int i = 0; i < 16; i++) {
+        int hi, lo;
+
+        if (!isxdigit((unsigned char) p[0]) || !isxdigit((unsigned char) p[1])) {
+            return -1;
+        }
+        hi       = (p[0] <= '9') ? p[0] - '0' : (tolower(p[0]) - 'a' + 10);
+        lo       = (p[1] <= '9') ? p[1] - '0' : (tolower(p[1]) - 'a' + 10);
+        bytes[i] = (hi << 4) | lo;
+        p       += 2;
+    }
+
+    /* Mirror format_hex's byte order (it serializes the raw uint64[2]). */
+    memcpy(out, bytes, 16);
+    return 0;
+} /* chimera_s3_mp_parse_etag */
+
+/* Recompute the combined CompleteMultipartUpload ETag from the client's
+ * manifest alone (no server-side part list). Used to answer an idempotent
+ * retry whose upload was already detached by the winning Complete. */
+static int
+chimera_s3_mp_combined_etag_from_manifest(
+    const struct chimera_s3_client_part *client_parts,
+    int                                  n_client,
+    uint64_t                             out[2])
+{
+    struct {
+        uint64_t etag[2];
+    } *etag_buf;
+    XXH128_hash_t h;
+
+    out[0] = 0;
+    out[1] = 0;
+
+    if (n_client <= 0) {
+        return 0;
+    }
+
+    etag_buf = malloc(n_client * sizeof(*etag_buf));
+
+    for (int i = 0; i < n_client; i++) {
+        if (chimera_s3_mp_parse_etag(client_parts[i].etag, etag_buf[i].etag) != 0) {
+            free(etag_buf);
+            return -1;
+        }
+    }
+
+    h      = XXH3_128bits((const void *) etag_buf, n_client * sizeof(*etag_buf));
+    out[0] = h.low64;
+    out[1] = h.high64;
+    free(etag_buf);
+    return 0;
+} /* chimera_s3_mp_combined_etag_from_manifest */
+
+/* Context for the idempotent-retry existence check (lookup-miss path). */
+struct chimera_s3_complete_retry_ctx {
+    struct chimera_s3_request *request;
+    int                        part_count;
+    uint64_t                   combined_etag[2];
+};
+
+/* Result of the target-object existence check on a Complete whose upload was
+ * already removed from the table. CompleteMultipartUpload must be idempotent:
+ * S3 SDKs (boto3) retry it, and the winning attempt detaches the upload, so a
+ * legitimate retry would otherwise see the upload gone and return NoSuchUpload.
+ * If the object the prior Complete assembled is present, replay the success
+ * response; otherwise the upload truly never existed -> NoSuchUpload. */
+static void
+chimera_s3_complete_retry_lookup_callback(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_s3_complete_retry_ctx *rctx    = private_data;
+    struct chimera_s3_request            *request = rctx->request;
+    struct chimera_server_s3_thread      *thread  = request->thread;
+    struct evpl                          *evpl    = thread->evpl;
+
+    free(request->multipart.body_buf);
+    request->multipart.body_buf = NULL;
+    request->multipart.body_len = 0;
+    request->multipart.body_cap = 0;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        /* Prior Complete already assembled the object: idempotent success. */
+        chimera_s3_complete_send_response(evpl, request, rctx->part_count,
+                                          rctx->combined_etag);
+    } else {
+        request->status    = CHIMERA_S3_STATUS_NO_SUCH_UPLOAD;
+        request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(evpl, request);
+        }
+    }
+
+    free(rctx);
+} /* chimera_s3_complete_retry_lookup_callback */
 
 /*
  * Phase 2: full body in hand. Parse the manifest, validate against the
@@ -2656,9 +2849,44 @@ chimera_s3_complete_multipart_upload_body_done(
                                                request->multipart.upload_id,
                                                request->multipart.upload_idlen);
     if (!upload) {
+        /* The upload is not in the table. CompleteMultipartUpload must be
+         * idempotent: S3 clients (boto3's default retry mode) retry it, and
+         * the winning attempt detaches the upload before responding, so a
+         * legitimate retry lands here even though the operation succeeded.
+         * Distinguish a real "never existed" from "already completed" by
+         * checking whether the target object is present; if so, replay the
+         * success response (recomputing the combined ETag from the client's
+         * manifest, which echoes the same per-part ETags the server issued). */
+        struct chimera_s3_complete_retry_ctx *rctx;
+        uint64_t                              combined[2];
+
+        if (n_client > 0 &&
+            chimera_s3_mp_combined_etag_from_manifest(client_parts, n_client,
+                                                      combined) == 0) {
+            rctx                   = calloc(1, sizeof(*rctx));
+            rctx->request          = request;
+            rctx->part_count       = n_client;
+            rctx->combined_etag[0] = combined[0];
+            rctx->combined_etag[1] = combined[1];
+            free(client_parts);
+
+            chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+                               request->bucket_fh, request->bucket_fhlen,
+                               request->path, request->path_len,
+                               CHIMERA_VFS_ATTR_FH,
+                               0,
+                               chimera_s3_complete_retry_lookup_callback,
+                               rctx);
+            return;
+        }
+
         free(client_parts);
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_UPLOAD;
-        request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        free(request->multipart.body_buf);
+        request->multipart.body_buf = NULL;
+        request->multipart.body_len = 0;
+        request->multipart.body_cap = 0;
+        request->status             = CHIMERA_S3_STATUS_NO_SUCH_UPLOAD;
+        request->vfs_state          = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
         }
@@ -2668,11 +2896,43 @@ chimera_s3_complete_multipart_upload_body_done(
     pthread_mutex_lock(&upload->lock);
     err = chimera_s3_validate_complete_manifest(client_parts, n_client,
                                                 upload, &server_parts);
+
+    if (err == CHIMERA_S3_STATUS_OK && upload->completing) {
+        /* Another CompleteMultipartUpload (or an earlier retry) already won the
+         * race to assemble this upload and is in flight. Treat this as an
+         * idempotent duplicate: replay the success response from the manifest
+         * rather than assembling again. */
+        uint64_t combined[2];
+
+        pthread_mutex_unlock(&upload->lock);
+        free(server_parts);
+        chimera_s3_multipart_upload_release(thread, upload);
+
+        if (chimera_s3_mp_combined_etag_from_manifest(client_parts, n_client,
+                                                      combined) != 0) {
+            combined[0] = 0;
+            combined[1] = 0;
+        }
+        free(client_parts);
+        free(request->multipart.body_buf);
+        request->multipart.body_buf = NULL;
+        request->multipart.body_len = 0;
+        request->multipart.body_cap = 0;
+        chimera_s3_complete_send_response(evpl, request, n_client, combined);
+        return;
+    }
+
+    if (err == CHIMERA_S3_STATUS_OK) {
+        /* We win the race: claim assembly. The upload stays in the table (so a
+         * retried Complete still resolves it) until assembly succeeds. */
+        upload->completing = 1;
+    }
     pthread_mutex_unlock(&upload->lock);
     free(client_parts);
 
     if (err != CHIMERA_S3_STATUS_OK) {
         /* Drop our lookup ref; upload remains in the table. */
+        free(server_parts);
         chimera_s3_multipart_upload_release(thread, upload);
         request->status    = err;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
@@ -2682,13 +2942,11 @@ chimera_s3_complete_multipart_upload_body_done(
         return;
     }
 
-    /* Manifest valid. Detach upload so concurrent ops can't grab it,
-    * then drop our lookup ref. The implicit table ref (from insert)
-    * is what ctx->upload now owns; finish_common will release it. */
-    chimera_s3_multipart_table_detach(shared->multipart_table,
-                                      request->multipart.upload_id,
-                                      request->multipart.upload_idlen);
-    chimera_s3_multipart_upload_release(thread, upload);
+    /* Keep the lookup ref: ctx->upload owns it through assembly. The upload is
+     * deliberately NOT detached yet so a retried Complete still resolves it and
+     * is handled idempotently (via the `completing` flag above). finish_common
+     * detaches + frees it on success, or clears `completing` + drops the ref on
+     * failure so a genuine retry can re-drive assembly. */
 
     /* Build ctx. Combined ETag = XXH3_128 over the etags of the parts the
      * client selected (in client order), formatted "<hex>-<count>". */
@@ -2732,16 +2990,16 @@ chimera_s3_complete_multipart_upload_body_done(
     }
     request->name_len = strlen(request->name);
 
-    chimera_vfs_create(
-        thread->vfs, &thread->shared->cred,
-        request->bucket_fh,
-        request->bucket_fhlen,
-        dirpath,
-        dirpathlen,
-        &request->set_attr,
-        CHIMERA_VFS_ATTR_FH,
-        chimera_s3_complete_create_root_callback,
-        ctx);
+    /* Stash the parent dirpath so the create can be retried on a transient
+     * ESTALE (see chimera_s3_complete_create_root_callback). */
+    if (dirpathlen > (int) sizeof(ctx->dirpath) - 1) {
+        dirpathlen = sizeof(ctx->dirpath) - 1;
+    }
+    memcpy(ctx->dirpath, dirpath, dirpathlen);
+    ctx->dirpath[dirpathlen] = '\0';
+    ctx->dirpathlen          = dirpathlen;
+
+    chimera_s3_complete_create_dir(ctx);
 } /* chimera_s3_complete_multipart_upload_body_done */
 
 /* ----- AbortMultipartUpload ----- */

--- a/src/server/s3/s3_multipart.h
+++ b/src/server/s3/s3_multipart.h
@@ -39,6 +39,13 @@ struct chimera_s3_multipart_upload {
     pthread_mutex_t                     lock;
     int                                 refcount;
     int                                 removed;
+    /* Set by the CompleteMultipartUpload that wins the race to assemble this
+     * upload. The upload stays in the table (so a retried Complete still finds
+     * it) until assembly succeeds and detaches it. A second Complete that finds
+     * this set is a duplicate/retry and replays the success response instead of
+     * re-assembling. Cleared on assembly failure so a genuine retry can drive
+     * it again. Guarded by `lock`. */
+    int                                 completing;
     struct chimera_s3_part             *parts;
     struct chimera_s3_multipart_upload *prev, *next;
     uint8_t                             bucket_fh[CHIMERA_VFS_FH_SIZE];

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -46,7 +46,10 @@ chimera_s3_put_getattr_callback(
         chimera_s3_attach_etag(request->http_request, attr);
     }
 
-    chimera_vfs_release(thread->vfs, request->file_handle);
+    if (request->file_handle) {
+        chimera_vfs_release(thread->vfs, request->file_handle);
+        request->file_handle = NULL;
+    }
 
     /* If the PutObject carried an x-amz-tagging header, store the parsed tags
      * as xattrs on the freshly-written object before responding. */
@@ -69,11 +72,17 @@ chimera_s3_put_finish_common(
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
 
-    chimera_vfs_release(thread->vfs, request->dir_handle);
+    if (request->dir_handle) {
+        chimera_vfs_release(thread->vfs, request->dir_handle);
+        request->dir_handle = NULL;
+    }
 
     if (error_code) {
         request->status = CHIMERA_S3_STATUS_INTERNAL_ERROR;
-        chimera_vfs_release(thread->vfs, request->file_handle);
+        if (request->file_handle) {
+            chimera_vfs_release(thread->vfs, request->file_handle);
+            request->file_handle = NULL;
+        }
         request->vfs_state = CHIMERA_S3_VFS_STATE_SEND;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);


### PR DESCRIPTION
## Problem

`chimera/server/s3/boto3_v4_linux_streaming` and `chimera/server/s3/boto3_v4_linux_multipart` flake in the merge queue (tracked in #733): `CompleteMultipartUpload` returns `NoSuchUpload` even though the preceding `UploadPart`s all succeeded. **linux backend only** (memfs/io_uring/cairn pass), intermittent.

Root-caused to **three layered bugs** on the CompleteMultipartUpload path, all confirmed with instrumented / ASan evidence:

### 1. Use-after-free of a recycled VFS open handle (the crash)
S3 requests are pooled per-thread and **not zeroed on reuse**; the GET/PUT finish paths release `request->file_handle` / `dir_handle` without clearing the pointer. A recycled request then carries a dangling handle, and CompleteMultipartUpload's create-dir error branch releases it after the VFS close thread has already swept the now-idle cached handle.

> ASan: `heap-use-after-free in chimera_vfs_release` (`s3_multipart.c` finish_common), freed by `chimera_vfs_close_thread_sweep`.

**Fix:** clear the handle pointers on request reuse (`s3.c`) and null-after-release in the GET/PUT paths (`s3_get.c`, `s3_put.c`).

### 2. CompleteMultipartUpload was not idempotent (the headline `NoSuchUpload`)
boto3's default retry mode retries the POST; the winning attempt **detached the upload** from the table before responding, so a legitimate retry's lookup missed → `NoSuchUpload`.

> Captured interleaving: `INSERT → COMPLETE → DETACH(success) → COMPLETE(retry) → LOOKUP-MISS → NoSuchUpload`. A single raw (no-retry) Complete reproduced 0/250; boto3 (retries on) reproduced it.

**Fix:** keep the upload in the table during assembly via a new `completing` flag; a concurrent/retried Complete replays the success response from the client manifest, and the lookup-miss path confirms the assembled object actually exists before reporting success vs `NoSuchUpload`. Detach happens only on assembly success; on failure `completing` is cleared so a genuine retry can re-drive it.

### 3. The trigger: linux backend transient ESTALE
The linux backend transiently returns `ESTALE` (and `ENOENT` while a parent dir is being recycled) from `open_by_handle_at` when a cached directory handle is evicted under concurrent load, failing the first Complete's parent-dir create and provoking the boto3 retry. This is why the flake is linux-backend-specific.

**Fix:** bounded (8×) ESTALE/ENOENT retry of the destination parent-dir create, re-walking from the bucket handle.

## Validation

Debug/ASan under 384-core saturation:
- UAF gone over 700+ iterations.
- With all three fixes: fresh-daemon harness **400/400**, real ctest (both tests) **60/60** then **80/80**, full S3 suite (5 backends + V2) **30/30** — no regressions.

## Known follow-up

The `completing`-flag duplicate path replays success without re-checking object existence (only the lookup-miss path existence-checks), so a retry racing a *still-in-flight* first attempt could 200 early. Empirically never observed (400/400); noted for a future hardening pass.

Refs #733