### PR TITLE
nfs4: fix client-table teardown SEGV + land READLINK MODE hardening (#997)

### DIFF
--- a/src/server/nfs/nfs4_proc_readlink.c
+++ b/src/server/nfs/nfs4_proc_readlink.c
@@ -48,8 +48,19 @@ chimera_nfs4_readlink_getattr_complete(
         return;
     }
 
-    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
-        !S_ISLNK(attr->va_mode)) {
+    /* RFC 7530 §16.22: READLINK is valid only on a symbolic link; a
+     * non-symlink current filehandle is NFS4ERR_INVAL.  The type comes from the
+     * getattr we just issued -- if a backend completed getattr without
+     * reporting MODE we cannot prove the object is a link, so fail closed
+     * (NFS4ERR_SERVERFAULT) rather than reading a non-symlink. */
+    if (!(attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
+        res->status = NFS4ERR_SERVERFAULT;
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    if (!S_ISLNK(attr->va_mode)) {
         res->status = NFS4ERR_INVAL;
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
         chimera_nfs4_compound_complete(req, res->status);

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -102,10 +102,23 @@ nfs4_client_table_free(struct nfs4_client_table *table)
 
     /* HASH_DEL blows clangs mind so we disable this block under analyzer */
 
-    HASH_ITER(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, cur, tmp)
+    /* A client record is always present in the by-id table but only
+     * *optionally* in the by-owner table: an unconfirmed SETCLIENTID reboot
+     * record (nfs4_client_new_locked with add_to_owner=false) and a superseded
+     * record both live in by-id only.  Unhashing every by-id record from
+     * by-owner would therefore HASH_DELETE records that were never added there,
+     * corrupting the by-owner table (NULL-head deref / SEGV).  Drain by-owner
+     * with its own iterator first -- freeing nothing -- then free every record
+     * via the by-id table. */
+    HASH_ITER(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
+              cur, tmp)
     {
         HASH_DELETE(nfs4_client_hh_by_owner, table->nfs4_ct_clients_by_owner,
                     cur);
+    }
+
+    HASH_ITER(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, cur, tmp)
+    {
         HASH_DELETE(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id, cur);
         free(cur);
     }


### PR DESCRIPTION
Two related fixes. The first is a latent server crash discovered while validating the SP2 NFSv4 batch (PR #1329); the second is the #997 READLINK hardening that was held back because it deterministically exposed that crash.

## 1. Client-table teardown SEGV (latent, pre-existing)

`nfs4_client_table_free` iterated the by-id client hash and unconditionally `HASH_DELETE`d each record from the by-owner hash as well. But a client record is only *optionally* in the by-owner table — an unconfirmed SETCLIENTID reboot record (`nfs4_client_new_locked` with `add_to_owner=false`) and a superseded record both live in the by-id table only. Deleting such a record from by-owner unhashes an element that was never added there, corrupting the table and crashing at shutdown:

```
AddressSanitizer: SEGV on unknown address 0x000000000020
  #0 nfs4_client_table_free  src/server/nfs/nfs4_session.c:107
  #1 nfs_server_destroy      src/server/nfs/nfs.c:623
  #2 chimera_server_destroy  src/server/server.c:2422
```

Fix: drain the by-owner table with its own iterator first (freeing nothing), then free every record via the by-id table, so no record is ever deleted from a hash it does not belong to.

This only manifests when a by-id-only record is still live at teardown. The pynfs `combined_memfs_nfs4.0` suite leaves one when `st_readlink.testDir` doesn't clean up its client — which is exactly what the #997 change below triggered, surfacing the latent bug.

## 2. READLINK MODE hardening (#997)

READLINK's non-symlink guard was gated on `CHIMERA_VFS_ATTR_MODE` being present, so a backend that completed getattr without reporting MODE would bypass the check and read a non-symlink. Treat MODE-absent-after-success as `NFS4ERR_SERVERFAULT` (fail closed), and keep returning `NFS4ERR_INVAL` for any non-symlink (RFC 7530 §16.22; matches the pynfs `st_readlink` expectation — an earlier draft returned NFS4ERR_ISDIR for directories, which the suite rejects).

Fixes #997

Validated: pynfs `combined` memfs 4.0 (3×), 4.1, 4.2 all green; the 4.0 teardown crash and the readlink assertion are both gone.