### PR TITLE
Fix two critical pre-auth memory-safety bugs (REST + SMB3 compression)

### DIFF
--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -165,6 +165,11 @@ enum chimera_rest_post_handler {
 
 #define REST_POST_MAX_BODY 65536
 
+/* evpl_iovec_ring_copyv writes one output iovec per recv-ring segment it
+ * consumes, with no capacity check.  Size the output array to this and bound
+ * each copy request (below) so the returned segment count can never exceed it. */
+#define REST_POST_MAX_IOV  256
+
 struct chimera_rest_post_ctx {
     enum chimera_rest_post_handler handler;
 };
@@ -183,8 +188,8 @@ chimera_rest_notify(
     struct chimera_rest_post_ctx *ctx    = notify_data;
     struct chimera_rest_thread   *thread = private_data;
     uint64_t                      avail;
-    struct evpl_iovec             iov;
-    int                           niov;
+    struct evpl_iovec             iov[REST_POST_MAX_IOV];
+    int                           niov, i;
     char                          body[REST_POST_MAX_BODY];
     int                           body_len = 0;
 
@@ -205,12 +210,22 @@ chimera_rest_notify(
             chunk = REST_POST_MAX_BODY - body_len;
         }
 
-        niov = evpl_http_request_get_datav(evpl, request, &iov, chunk);
+        /* Bound the request by the iovec array size: copyv emits at most one
+         * output iovec per byte (a one-byte recv segment), so a chunk no larger
+         * than REST_POST_MAX_IOV can never overflow iov[]. */
+        if (chunk > REST_POST_MAX_IOV) {
+            chunk = REST_POST_MAX_IOV;
+        }
 
-        if (niov > 0) {
-            memcpy(body + body_len, evpl_iovec_data(&iov), iov.length);
-            body_len += iov.length;
-            evpl_iovec_release(evpl, &iov);
+        niov = evpl_http_request_get_datav(evpl, request, iov, chunk);
+
+        /* Copy every segment copyv returned (it may split one chunk across
+         * several): copying only iov[0] both under-reads the body and leaves
+         * the ring accounting ahead of body_len. */
+        for (i = 0; i < niov; i++) {
+            memcpy(body + body_len, evpl_iovec_data(&iov[i]), iov[i].length);
+            body_len += iov[i].length;
+            evpl_iovec_release(evpl, &iov[i]);
         }
 
         avail = evpl_http_request_get_data_avail(request);

--- a/src/server/smb/smb_compress.c
+++ b/src/server/smb/smb_compress.c
@@ -1421,11 +1421,18 @@ chimera_smb_decompress_message(
     uint32_t segment_size = rd32(cin + 4);
     uint32_t prefix       = is_unchained ? rd32(cin + 12) : 0;
 
-    orig_size = prefix + segment_size;
-    if (orig_size < sizeof(struct smb2_header) || orig_size > SMB_COMPRESS_MAX_ORIGINAL) {
-        chimera_smb_error("Invalid SMB3 compression original size %u", orig_size);
+    /* Reconstruct the size in 64-bit: prefix + segment_size are both
+     * attacker-controlled 32-bit fields, so summing them in uint32 wraps
+     * (CWE-190) and could hide a ~4 GB prefix behind a small total, defeating
+     * the cap below.  Once bounded by SMB_COMPRESS_MAX_ORIGINAL each of prefix
+     * and segment_size is itself <= the cap. */
+    uint64_t orig_size64 = (uint64_t) prefix + segment_size;
+    if (orig_size64 < sizeof(struct smb2_header) || orig_size64 > SMB_COMPRESS_MAX_ORIGINAL) {
+        chimera_smb_error("Invalid SMB3 compression original size %lu",
+                          (unsigned long) orig_size64);
         goto out;
     }
+    orig_size = (uint32_t) orig_size64;
 
     if (evpl_iovec_alloc(evpl, orig_size, 8, 1, 0, plain_out) < 1) {
         chimera_smb_error("Failed to allocate SMB3 decompression buffer");
@@ -1440,7 +1447,10 @@ chimera_smb_decompress_message(
         uint16_t alg = rd16(cin + 8);
         int      hdr = (int) sizeof(struct smb2_compression_transform_header);
 
-        if (hdr + (int) prefix > length) {
+        /* Bound the prefix copy in 64-bit unsigned: casting prefix to int makes
+         * any value >= 0x80000000 negative, so the original signed compare could
+         * never reject it and the memcpy below would read ~4 GB out of bounds. */
+        if ((uint64_t) hdr + prefix > (uint64_t) length) {
             chimera_smb_error("Invalid SMB3 compression offset %u", prefix);
             goto release;
         }


### PR DESCRIPTION
Two critical, remotely-triggerable memory-safety bugs from the server-side security audit. One commit per issue. (The third critical, #1043, lives in the xdrzcc submodule and is handled in a separate xdrzcc PR + submodule bump.)

- **#1044 — REST POST body assembly stack overrun (pre-auth).** `chimera_rest_notify` drained the body with a single stack `evpl_iovec` but `evpl_iovec_ring_copyv` writes one output iovec per recv-ring segment it consumes (no capacity check). A body delivered as ≥2 segments in one drain window overran the single iovec — a remote pre-auth stack overflow, reachable via the public `/api/v1/auth/login` route. (It also copied only `iov[0]`, silently truncating multi-segment bodies.) Fixed with a bounded iovec array + copying every segment.

- **#1045 — SMB3 decompression integer overflow.** `orig_size = prefix + segment_size` was computed in uint32, so a wrap could hide a ~4 GB prefix behind a small total and pass the size cap; the unchained prefix guard then cast `prefix` to `int`, so any value ≥ 0x80000000 went negative and the bound could never reject it, driving a ~4 GB `memcpy` (OOB read/write). The compression transform needs no session key, so this is reachable on any SMB3.1.1 connection that negotiated compression. Fixed by computing the size in 64-bit and bounding it before allocation, and comparing the prefix offset against the message length in 64-bit unsigned.

Validated: `smb_compress_test`, `rest_user_manip`, and the WPTS `memfs_compression` validator all pass — normal-path REST and compressed traffic are unaffected.