### PR TITLE
smb2: constrain AppInstanceId failover force-close (MS-SMB2 3.3.5.9.7)

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -178,6 +178,29 @@ chimera_smb_app_instance_decision(
         return 0;
     }
 
+    /* The AppInstanceId force-close is a client *failover*: it replaces an open
+     * held by a DIFFERENT client (one whose ClientGuid differs from the
+     * requesting connection's).  A second open carrying the same AppInstanceId
+     * from the SAME client (same ClientGuid, different connection) is not a
+     * failover and must leave the prior open intact.  (SMB2Model AppInstanceId
+     * SameClientGuid cases; the MS-SMB2 AppInstanceVersion failover uses two
+     * distinct clients, so its ClientGuids differ and the close still applies.) */
+    if (existing->create_conn &&
+        memcmp(existing->create_conn->client_guid,
+               request->compound->conn->client_guid, 16) == 0) {
+        return 0;
+    }
+
+    /* The replacement applies to the open of the same file on the SAME share:
+     * the prior open is located by file handle, which spans share names that map
+     * to one local path, so an open under a DIFFERENT share name (even of the
+     * same underlying file) is not the failover target and is left intact.
+     * (SMB2Model AppInstanceId DifferentShare* cases.) */
+    if (!existing->tree || !request->tree ||
+        existing->tree->share != request->tree->share) {
+        return 0;
+    }
+
     /* existing.V ABSENT -> force-close (an old open with no version always
      * yields to a new AppInstanceId open). */
     if (!existing->app_version_present) {
@@ -614,8 +637,13 @@ chimera_smb_create_gen_open_file(
 
     /* Record the AppInstanceId/AppInstanceVersion this open carried so a later
      * CREATE on a different connection can match it and apply the version-gated
-     * force-close (MS-SMB2 3.3.5.9.7 / 3.3.5.9.16). */
-    if (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_APP) {
+     * force-close (MS-SMB2 3.3.5.9.7 / 3.3.5.9.16).  SMB2_CREATE_APP_INSTANCE_ID
+     * is an SMB 3.x create context: on a pre-3.x (2.0.2 / 2.1) connection the
+     * server does not process it, so no failover identity is established and it
+     * must not later match (and close) a conflicting open.  (SMB2Model
+     * AppInstanceId cases whose initial open is on an Smb2002 connection.) */
+    if ((request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_APP) &&
+        request->compound->conn->dialect >= SMB2_DIALECT_3_0) {
         memcpy(open_file->app_instance_id, request->create.app_instance_id, 16);
         open_file->ctx_present_mask   |= CHIMERA_SMB_CREATE_CTX_APP;
         open_file->app_version_high    = request->create.app_version_high;

--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -1,59 +1,59 @@
 case,home_config,status,enc_path,skip_reason
 AppInstanceIdTestCaseS0,base,green,0,
 AppInstanceIdTestCaseS100,base,green,0,
-AppInstanceIdTestCaseS108,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS108,base,green,0,
 AppInstanceIdTestCaseS122,base,green,0,
-AppInstanceIdTestCaseS130,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS138,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS149,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS160,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS171,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS179,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS187,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS195,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS203,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS130,base,green,0,
+AppInstanceIdTestCaseS138,base,green,0,
+AppInstanceIdTestCaseS149,base,green,0,
+AppInstanceIdTestCaseS160,base,green,0,
+AppInstanceIdTestCaseS171,base,green,0,
+AppInstanceIdTestCaseS179,base,green,0,
+AppInstanceIdTestCaseS187,base,green,0,
+AppInstanceIdTestCaseS195,base,green,0,
+AppInstanceIdTestCaseS203,base,green,0,
 AppInstanceIdTestCaseS217,base,green,0,
-AppInstanceIdTestCaseS225,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS233,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS225,base,green,0,
+AppInstanceIdTestCaseS233,base,green,0,
 AppInstanceIdTestCaseS241,base,green,0,
 AppInstanceIdTestCaseS249,base,green,0,
 AppInstanceIdTestCaseS26,base,green,0,
 AppInstanceIdTestCaseS260,base,green,0,
-AppInstanceIdTestCaseS268,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS273,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS281,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS289,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS297,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS308,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS316,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS324,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS332,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS340,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS348,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS353,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS361,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS369,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS377,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS385,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS393,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS401,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS409,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS417,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS425,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS433,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS441,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS449,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS457,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS268,base,green,0,
+AppInstanceIdTestCaseS273,base,green,0,
+AppInstanceIdTestCaseS281,base,green,0,
+AppInstanceIdTestCaseS289,base,green,0,
+AppInstanceIdTestCaseS297,base,green,0,
+AppInstanceIdTestCaseS308,base,green,0,
+AppInstanceIdTestCaseS316,base,green,0,
+AppInstanceIdTestCaseS324,base,green,0,
+AppInstanceIdTestCaseS332,base,green,0,
+AppInstanceIdTestCaseS340,base,green,0,
+AppInstanceIdTestCaseS348,base,green,0,
+AppInstanceIdTestCaseS353,base,green,0,
+AppInstanceIdTestCaseS361,base,green,0,
+AppInstanceIdTestCaseS369,base,green,0,
+AppInstanceIdTestCaseS377,base,green,0,
+AppInstanceIdTestCaseS385,base,green,0,
+AppInstanceIdTestCaseS393,base,green,0,
+AppInstanceIdTestCaseS401,base,green,0,
+AppInstanceIdTestCaseS409,base,green,0,
+AppInstanceIdTestCaseS417,base,green,0,
+AppInstanceIdTestCaseS425,base,green,0,
+AppInstanceIdTestCaseS433,base,green,0,
+AppInstanceIdTestCaseS441,base,green,0,
+AppInstanceIdTestCaseS449,base,green,0,
+AppInstanceIdTestCaseS457,base,green,0,
 AppInstanceIdTestCaseS46,base,green,0,
-AppInstanceIdTestCaseS465,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS473,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS465,base,green,0,
+AppInstanceIdTestCaseS473,base,green,0,
 AppInstanceIdTestCaseS484,base,green,0,
-AppInstanceIdTestCaseS492,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS500,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS492,base,green,0,
+AppInstanceIdTestCaseS500,base,green,0,
 AppInstanceIdTestCaseS508,base,green,0,
 AppInstanceIdTestCaseS516,base,green,0,
 AppInstanceIdTestCaseS524,base,green,0,
-AppInstanceIdTestCaseS532,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS532,base,green,0,
 AppInstanceIdTestCaseS54,base,green,0,
 AppInstanceIdTestCaseS540,base,green,0,
 AppInstanceIdTestCaseS548,base,green,0,
@@ -64,11 +64,11 @@ AppInstanceIdTestCaseS576,base,green,0,
 AppInstanceIdTestCaseS586,base,green,0,
 AppInstanceIdTestCaseS591,base,green,0,
 AppInstanceIdTestCaseS616,base,green,0,
-AppInstanceIdTestCaseS62,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS62,base,green,0,
 AppInstanceIdTestCaseS621,base,green,0,
 AppInstanceIdTestCaseS76,base,green,0,
-AppInstanceIdTestCaseS84,base,xfail,0,executed but fails (candidate defect)
-AppInstanceIdTestCaseS92,base,xfail,0,executed but fails (candidate defect)
+AppInstanceIdTestCaseS84,base,green,0,
+AppInstanceIdTestCaseS92,base,green,0,
 BreakReadHandleLeaseV1TestCaseS0,base,xfail,0,lease-break handle model: break not delivered as modeled
 BreakReadHandleLeaseV1TestCaseS1009,base,xfail,0,lease-break handle model: break not delivered as modeled
 BreakReadHandleLeaseV1TestCaseS1033,base,xfail,0,lease-break handle model: break not delivered as modeled


### PR DESCRIPTION
## Summary

A CREATE carrying an `SMB2_CREATE_APP_INSTANCE_ID` create context force-closes a prior open of the same file held under the same AppInstanceId — an application **failover**. chimera fired that close on AppInstanceId match alone, ignoring three conditions the rule requires, so it tore down opens it must leave intact.

Added the three constraints:

- **SMB 3.x only** — `SMB2_CREATE_APP_INSTANCE_ID` is an SMB 3.x create context; on a pre-3.x (2.0.2 / 2.1) connection the server doesn't process it, so it must not establish a failover identity. Gate the recording on `dialect >= 3.0`.
- **Different client only** — a failover replaces an open held by a *different* client (a differing ClientGuid). A second open under the same AppInstanceId from the **same** client (same ClientGuid, different connection) is not a failover and must leave the prior open intact.
- **Same share only** — the prior open is located by file handle, which spans distinct share names that map to one local path; an open under a **different** share name is not the failover target.

## Test impact

Found while re-triaging the MS-SMB2Model `xfail` "candidate defect" bucket: all 45 baseline-config `AppInstanceId` model cases shared one assertion (`expected 'OpenNotClosed', actual 'OpenClosed'`) — chimera force-closing when it shouldn't. The three constraints above green all 45 (promoted `xfail`→`green` here); the 25 already-green baseline cases are preserved.

## Verification
- WPTS MS-SMB2Model: AppInstanceId base **70/70** green (single + repeated runs).
- WPTS MS-SMB2: the suite's own AppInstanceId / AppInstanceVersion **failover** cases stay green across `base`, `multichannel`, `multichannel_persistent`, and `multichannel_persistent_encryption` — these use two distinct clients, so their ClientGuids differ and the close still correctly applies.
- smbtorture `smb2.{create,lease,oplock,durable,replay,session}` green on memfs; `durable`/`replay` green on cairn + diskfs.
- `make syntax-check` clean.