### PR TITLE
smb2: reject signed requests with no resolvable session (MS-SMB2 3.3.5.2.4)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1550,6 +1550,22 @@ chimera_smb_server_handle_smb2(
             }
         }
 
+        /* MS-SMB2 3.3.5.2.4 / 3.3.5.3: an SMB2 NEGOTIATE request is exchanged
+         * before any session (and therefore any signing key) exists, so it can
+         * never carry a valid signature -- a NEGOTIATE with SMB2_FLAGS_SIGNED set
+         * is malformed and MUST be failed with STATUS_INVALID_PARAMETER (answered
+         * in order, not by dropping the transport).  SMB2Model Signing cases that
+         * negotiate with the signed flag set. */
+        if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+            !received_encrypted &&
+            request->smb2_hdr.command == SMB2_NEGOTIATE) {
+            request->session_handle                      = NULL;
+            request->status                              = SMB2_STATUS_INVALID_PARAMETER;
+            request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+            compound->requests[compound->num_requests++] = request;
+            goto next_compound_request;
+        }
+
         if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
             !received_encrypted &&
             request->smb2_hdr.command != SMB2_SESSION_SETUP) {
@@ -1573,11 +1589,20 @@ chimera_smb_server_handle_smb2(
                 signing_key = conn->last_session_handle->signing_key;
             } else {
                 if (unlikely(request->session_handle == NULL)) {
+                    /* MS-SMB2 3.3.5.2.4: a signed request whose SessionId names no
+                     * session (e.g. a signed NEGOTIATE, or any signed non-
+                     * SESSION_SETUP command carrying SessionId 0 or a stale id)
+                     * cannot be signature-verified.  Answer STATUS_USER_SESSION_
+                     * DELETED in order -- the same graceful deferral the unsigned
+                     * unknown-session path uses -- rather than dropping the
+                     * transport (SMB2Model Signing InvalidIdentifier cases). */
                     chimera_smb_error("Received signed SMB2 message with missing/invalid session id %x",
                                       request->smb2_hdr.session_id);
-                    chimera_smb_request_free(thread, request);
-                    evpl_close(evpl, conn->bind);
-                    return;
+                    request->session_handle                      = NULL;
+                    request->status                              = SMB2_STATUS_USER_SESSION_DELETED;
+                    request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+                    compound->requests[compound->num_requests++] = request;
+                    goto next_compound_request;
                 }
                 signing_key = request->session_handle->signing_key;
             }

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -148,6 +148,22 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.2.4 (Verifying the Signature): a request whose SMB2 header
+    * has SMB2_FLAGS_SIGNED set is signature-verified against the session named
+    * by the header SessionId.  If that SessionId resolves to no session -- a
+    * signed first-leg SESSION_SETUP carrying SessionId 0, or any signed
+    * SESSION_SETUP whose id names no live session -- the lookup fails the
+    * request with STATUS_USER_SESSION_DELETED before authentication runs (a
+    * signed leg of an in-progress exchange resolves to its in-progress session
+    * handle and is unaffected).  SMB2Model Signing InvalidIdentifier cases. */
+    if ((request->smb2_hdr.flags & SMB2_FLAGS_SIGNED) &&
+        !request->session_handle) {
+        chimera_smb_complete_request(request, SMB2_STATUS_USER_SESSION_DELETED);
+        evpl_iovecs_release(thread->evpl, request->session_setup.input_iov,
+                            request->session_setup.input_niov);
+        return;
+    }
+
     /* MS-SMB2 3.3.5.5 step 4: a SESSION_SETUP that binds a new channel to an
      * existing session (SMB2_SESSION_FLAG_BINDING set, non-zero header
      * SessionId, dialect in the 3.x family, and the session found in the

--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -2266,21 +2266,21 @@ SigningTestCaseS0,base,skip,0,feature-off: model found case inapplicable under a
 SigningTestCaseS1010,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1022,base,green,0,
 SigningTestCaseS1034,base,green,0,
-SigningTestCaseS1107,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS1107,base,green,0,
 SigningTestCaseS1128,base,green,0,
 SigningTestCaseS1140,base,green,0,
 SigningTestCaseS1152,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1164,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1176,base,green,0,
-SigningTestCaseS1188,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1200,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1218,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1230,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1242,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1254,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1266,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS1188,base,green,0,
+SigningTestCaseS1200,base,green,0,
+SigningTestCaseS1218,base,green,0,
+SigningTestCaseS1230,base,green,0,
+SigningTestCaseS1242,base,green,0,
+SigningTestCaseS1254,base,green,0,
+SigningTestCaseS1266,base,green,0,
 SigningTestCaseS1278,base,green,0,
-SigningTestCaseS1354,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS1354,base,green,0,
 SigningTestCaseS136,base,green,0,
 SigningTestCaseS1378,base,green,0,
 SigningTestCaseS1390,base,green,0,
@@ -2288,13 +2288,13 @@ SigningTestCaseS1402,base,skip,0,feature-off: model found case inapplicable unde
 SigningTestCaseS1414,base,green,0,
 SigningTestCaseS1426,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1438,base,green,0,
-SigningTestCaseS1462,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS1462,base,green,0,
 SigningTestCaseS1499,base,green,0,
 SigningTestCaseS1511,base,green,0,
 SigningTestCaseS1523,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1535,base,green,0,
 SigningTestCaseS1547,base,skip,0,feature-off: model found case inapplicable under all tested configs
-SigningTestCaseS1559,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS1559,base,green,0,
 SigningTestCaseS1561,base,green,0,
 SigningTestCaseS1576,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1588,base,skip,0,feature-off: model found case inapplicable under all tested configs
@@ -2310,50 +2310,50 @@ SigningTestCaseS1697,base,skip,0,feature-off: model found case inapplicable unde
 SigningTestCaseS1704,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1716,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS1728,base,skip,0,feature-off: model found case inapplicable under all tested configs
-SigningTestCaseS1740,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1747,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1754,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1761,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1768,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1775,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1782,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS1789,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS193,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS1740,base,green,0,
+SigningTestCaseS1747,base,green,0,
+SigningTestCaseS1754,base,green,0,
+SigningTestCaseS1761,base,green,0,
+SigningTestCaseS1768,base,green,0,
+SigningTestCaseS1775,base,green,0,
+SigningTestCaseS1782,base,green,0,
+SigningTestCaseS1789,base,green,0,
+SigningTestCaseS193,base,green,0,
 SigningTestCaseS230,base,green,0,
 SigningTestCaseS242,base,green,0,
 SigningTestCaseS254,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS266,base,green,0,
 SigningTestCaseS278,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS290,base,green,0,
-SigningTestCaseS333,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS333,base,green,0,
 SigningTestCaseS383,base,green,0,
 SigningTestCaseS395,base,green,0,
 SigningTestCaseS407,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS419,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS431,base,green,0,
 SigningTestCaseS443,base,green,0,
-SigningTestCaseS487,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS487,base,green,0,
 SigningTestCaseS511,base,green,0,
 SigningTestCaseS523,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS535,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS547,base,green,0,
 SigningTestCaseS559,base,skip,0,feature-off: model found case inapplicable under all tested configs
-SigningTestCaseS571,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS571,base,green,0,
 SigningTestCaseS621,base,green,0,
 SigningTestCaseS664,base,green,0,
 SigningTestCaseS676,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS688,base,skip,0,feature-off: model found case inapplicable under all tested configs
 SigningTestCaseS700,base,green,0,
 SigningTestCaseS712,base,skip,0,feature-off: model found case inapplicable under all tested configs
-SigningTestCaseS724,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS765,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS821,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS833,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS845,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS857,base,xfail,0,executed but fails (candidate defect)
-SigningTestCaseS869,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS724,base,green,0,
+SigningTestCaseS765,base,green,0,
+SigningTestCaseS821,base,green,0,
+SigningTestCaseS833,base,green,0,
+SigningTestCaseS845,base,green,0,
+SigningTestCaseS857,base,green,0,
+SigningTestCaseS869,base,green,0,
 SigningTestCaseS881,base,green,0,
-SigningTestCaseS937,base,xfail,0,executed but fails (candidate defect)
+SigningTestCaseS937,base,green,0,
 SigningTestCaseS974,base,green,0,
 SigningTestCaseS986,base,green,0,
 SigningTestCaseS998,base,skip,0,feature-off: model found case inapplicable under all tested configs


### PR DESCRIPTION
## Summary

MS-SMB2 **3.3.5.2.4** (Verifying the Signature) runs for every received request: if `SMB2_FLAGS_SIGNED` is set, the server verifies the signature against the session named by the header SessionId, and if that SessionId resolves to **no session** the request is *failed with an error response* — not by tearing down the transport. chimera mishandled three corners:

- **Signed NEGOTIATE** — exchanged before any session/key exists, so it can never carry a valid signature → MUST be `STATUS_INVALID_PARAMETER`. chimera ran it through the generic signed path and **dropped the connection**.
- **Signed non-SESSION_SETUP with no session** (SessionId 0 or stale) — chimera freed the request and **closed the transport**; spec requires `STATUS_USER_SESSION_DELETED` (the same graceful deferral the unsigned unknown-session path already uses).
- **Signed SESSION_SETUP first leg** (SessionId 0) — SESSION_SETUP is exempt from dispatch-time signature verification (its key is derived while processing it), so the handler now applies the 3.3.5.2.4 lookup itself: no session → `STATUS_USER_SESSION_DELETED`, before auth runs. A signed leg of an *in-progress* exchange resolves to its in-progress handle and is unaffected.

## Test impact

Found by re-triaging the MS-SMB2Model `Signing` xfail bucket: all 31 baseline cases failed in two clusters — a signed NEGOTIATE (expecting `INVALID_PARAMETER`, chimera dropped the connection) and a signed SESSION_SETUP / no-session request (expecting `USER_SESSION_DELETED`, chimera dropped or accepted). The fixes green all 31 (promoted `xfail`→`green`); the 32 already-green baseline cases are preserved.

## Verification
- WPTS MS-SMB2Model: `Signing` base **63/63** green (single + repeated runs); no regression in `SessionMgmt` (41 pass / 8 skip) or `Negotiate` (90 pass; the 2 remaining are pre-existing unrelated `STATUS_NOT_SUPPORTED` xfail).
- WPTS MS-SMB2: session / negotiate / signing base cases green (34/34).
- smbtorture `smb2.{session,negotiate,sign,create,lease,oplock,durable,replay}` green on memfs (no transport drops on signed-no-session).
- `make syntax-check` clean.