### PR TITLE
nfs4: reject bogus CLAIM_PREVIOUS reclaims with NFS4ERR_RECLAIM_BAD

### DIFF
--- a/src/server/nfs/nfs4_recovery.c
+++ b/src/server/nfs/nfs4_recovery.c
@@ -530,9 +530,8 @@ nfs_recovery_open_check(
     bool                     is_reclaim)
 {
     bool in_grace;
+    bool load_ready;
     int  ls;
-
-    (void) client;  /* not gated per-client yet; future use. */
 
     ls = atomic_load_explicit(&rec->load_state, memory_order_acquire);
 
@@ -542,7 +541,8 @@ nfs_recovery_open_check(
 
     /* While the cold-start load is still in flight, behave as in-grace so a
      * reclaim that races its record load is not refused. */
-    if (!rec->persistence_disabled && ls != NFS_REC_LOAD_READY) {
+    load_ready = rec->persistence_disabled || ls == NFS_REC_LOAD_READY;
+    if (!load_ready) {
         in_grace = true;
     }
 
@@ -552,6 +552,32 @@ nfs_recovery_open_check(
     if (!in_grace && is_reclaim) {
         return NFS4ERR_NO_GRACE;
     }
+
+    /* RFC 7530 §9.6.3.1: a CLAIM_PREVIOUS reclaim is only valid for state this
+     * client actually held before the server restart.  The to_reclaim set is
+     * the authoritative list of clients with persisted pre-reboot state; a
+     * reclaim from a client absent from it is bogus and MUST be rejected with
+     * NFS4ERR_RECLAIM_BAD rather than silently fabricating share state.
+     *
+     * Only enforced once the cold-start load is READY (to_reclaim fully
+     * populated) -- while the load is still in flight a reclaim that races its
+     * record load must not be refused (handled by the load_ready=in_grace path
+     * above, which short-circuits here only when the load has completed).  When
+     * persistence is disabled to_reclaim is empty and in_grace is never set, so
+     * this leg is unreachable on the default memkv backend. */
+    if (in_grace && is_reclaim && load_ready && client) {
+        struct nfs_recovery_record *r;
+
+        pthread_mutex_lock(&rec->lock);
+        HASH_FIND(hh, rec->to_reclaim, client->owner_string,
+                  client->owner_len, r);
+        pthread_mutex_unlock(&rec->lock);
+
+        if (!r) {
+            return NFS4ERR_RECLAIM_BAD;
+        }
+    }
+
     return NFS4_OK;
 } /* nfs_recovery_open_check */
 


### PR DESCRIPTION
## Summary

Fixes #963.

A CLAIM_PREVIOUS OPEN (reclaim after a server restart) was handled identically to CLAIM_FH. `nfs_recovery_open_check()` consulted only the server-wide `in_grace` flag and never checked whether *this client* actually held state before the reboot, so it never returned `NFS4ERR_RECLAIM_BAD`. The per-client `to_reclaim` set -- loaded from the KV store on cold start and keyed by the client owner string -- was populated but never consulted in the open-check gate (`(void) client; /* not gated per-client yet */`).

Per RFC 7530 §9.6.3.1, a reclaim is valid only for state the client held before the restart. This change, when the server is in grace and the request is a reclaim, does a `HASH_FIND` of the client's owner string in `rec->to_reclaim` and returns `NFS4ERR_RECLAIM_BAD` when the client is absent (it never held state). This mirrors the existing key usage in `nfs_recovery_reclaim_complete()`.

## Notes

- The new check is gated on the cold-start load being READY, so a reclaim that races its own record load is not wrongly refused (that case is already treated as in-grace).
- All existing legs are preserved:
  - non-reclaim opens during grace -> `NFS4ERR_GRACE`
  - reclaim outside grace -> `NFS4ERR_NO_GRACE`
  - default memkv backend (`persistence_disabled` -> `in_grace` never set) -> new leg unreachable
- The OPEN call site already passed `client` through and maps the gate status straight to `res->status`, so `NFS4ERR_RECLAIM_BAD` propagates as a distinct error from `NFS4ERR_NO_GRACE` with no further wiring.

`combined_memfs_nfs4.{0,1,2}` pass with clean teardown. With the default memkv backend the grace window does not open, so the new RECLAIM_BAD leg is not exercised by pynfs (expected); the requirement met here is no regressions plus a correct implementation.