### PR TITLE
nfs4: implement RFC 8881/7530 §10.4.3 CB_GETATTR change-attribute combine

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -18,6 +18,23 @@
 #include "nfs4_lease.h"
 #include "nfs_fh_wrap.h"
 
+/*
+ * Derive the NFSv4 fattr4_change value from a set of VFS attributes, using the
+ * exact same rule as the FATTR4_CHANGE marshaller below: a native monotonic
+ * counter (CHIMERA_VFS_ATTR_CHANGE) when the backend supplies one, otherwise
+ * ctime in nanoseconds (matching Linux nfsd without i_version).  Shared with the
+ * §10.4.3 combine logic so the cached sc and the marshalled change always agree.
+ */
+static inline uint64_t
+chimera_nfs4_change_from_attrs(const struct chimera_vfs_attrs *attr)
+{
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_CHANGE) {
+        return attr->va_change;
+    }
+    return (uint64_t) attr->va_ctime.tv_sec * 1000000000ULL +
+           (uint64_t) attr->va_ctime.tv_nsec;
+} /* chimera_nfs4_change_from_attrs */
+
 /* RFC 8275 OPEN-arguments attribute and its enumerations.  Not present in our
  * generated nfs4.x (which stops at FATTR4_SEC_LABEL), so define what we need to
  * advertise the attribute. */

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -13,10 +13,13 @@
 #include "vfs/vfs_release.h"
 
 /* Parked-GETATTR context while a CB_GETATTR to a write-delegation holder is
- * outstanding.  Holds a copy of the server's attrs (the VFS completion's are
- * transient); the holder's reply overrides change/size. */
+ * outstanding.  Holds a copy of the server's LOCAL attrs (the VFS completion's
+ * are transient).  `deleg` is the conflicting write delegation (held with a +1
+ * ref by the CB_GETATTR machinery for the duration of the query); the §10.4.3
+ * combine in the resume reads/updates its cached sc through it. */
 struct nfs4_getattr_park {
     struct nfs_request      *req;
+    struct nfs_delegation   *deleg;
     struct chimera_vfs_attrs attr;
 };
 
@@ -110,9 +113,44 @@ chimera_nfs4_getattr_finish(
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_getattr_finish */
 
+/* Encode an NFSv4 fattr4_change value back into park->attr in whichever
+ * representation this file's backend uses, so the marshaller emits exactly
+ * `change` while keeping change_attr_type stable per object: a native-counter
+ * backend (CAP_CHANGE) carries it in va_change; a ctime-derived backend has no
+ * CHANGE bit, so the value is split into a ctime that re-encodes to it. */
+static void
+chimera_nfs4_getattr_set_change(
+    struct chimera_vfs_attrs *attr,
+    uint64_t                  change)
+{
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_CHANGE) {
+        attr->va_change = change;
+    } else {
+        attr->va_ctime.tv_sec  = change / 1000000000ULL;
+        attr->va_ctime.tv_nsec = change % 1000000000ULL;
+        attr->va_set_mask     |= CHIMERA_VFS_ATTR_CTIME;
+    }
+} /* chimera_nfs4_getattr_set_change */
+
 /* Resume (on the requester's thread) after the write-delegation holder has
- * answered CB_GETATTR: override change/size with the holder's view, then
- * finish the GETATTR.  On failure, fall back to the server's own attrs. */
+ * answered CB_GETATTR.  Implements the RFC 7530/8881 §10.4.3 server-side
+ * change-attribute combine algorithm.
+ *
+ * The server caches the file's change attribute at delegation grant time (sc).
+ * The holder reports its current change value (cc) via CB_GETATTR:
+ *   cc == sc  -> the holder has NOT modified the file: return the server's own
+ *                LOCAL change / time_metadata / time_modify (already in
+ *                park->attr) -- do NOT substitute the holder's values.
+ *   cc != sc  -> the holder HAS modified the file: synthesise time_metadata
+ *                (ctime) and time_modify (mtime) from the current time, compute
+ *                a new server change value nsc >= sc + 1, return nsc, replace
+ *                the cached sc with nsc, and ensure each returned nsc STRICTLY
+ *                exceeds the previously returned one (monotonicity) so a peer
+ *                re-reading after the holder re-dirties always sees a change.
+ * On query failure, fall back to the server's own LOCAL attrs unchanged.
+ *
+ * combine_lock serialises the per-delegation sc/last bookkeeping against
+ * concurrent peer GETATTRs on other requester threads. */
 static void
 chimera_nfs4_getattr_cb_resume(
     void    *priv,
@@ -122,28 +160,66 @@ chimera_nfs4_getattr_cb_resume(
     bool     got_size,
     uint64_t size)
 {
-    struct nfs4_getattr_park *park = priv;
+    struct nfs4_getattr_park *park  = priv;
+    struct nfs_delegation    *deleg = park->deleg;
 
-    if (status == 0) {
-        if (got_change) {
-            /* Override the server's view with the holder's change value, in
-            * whichever representation this file's backend uses -- so the
-            * marshaller emits the holder's value AND keeps change_attr_type
-            * stable per object.  A native-counter backend (CAP_CHANGE) carries
-            * it in va_change; a ctime-derived backend has no CHANGE bit, so we
-            * reconstruct a ctime that re-encodes (sec*1e9 + nsec) to it. */
-            if (park->attr.va_set_mask & CHIMERA_VFS_ATTR_CHANGE) {
-                park->attr.va_change = change;
-            } else {
-                park->attr.va_ctime.tv_sec  = change / 1000000000ULL;
-                park->attr.va_ctime.tv_nsec = change % 1000000000ULL;
-                park->attr.va_set_mask     |= CHIMERA_VFS_ATTR_CTIME;
+    if (status == 0 && got_change && deleg) {
+        uint64_t cc = change;          /* holder's current change value */
+        bool     modified;
+        uint64_t nsc = 0;
+
+        pthread_mutex_lock(&deleg->combine_lock);
+
+        if (!deleg->combine_valid) {
+            /* sc was not captured at grant (CLAIM_FH / probe-deferred resume):
+             * adopt the holder's first reported value as the baseline sc.  The
+             * file is treated as unmodified at this instant; a later cc change
+             * is then detected normally. */
+            deleg->combine_sc    = cc;
+            deleg->combine_last  = cc;
+            deleg->combine_valid = true;
+        }
+
+        modified = (cc != deleg->combine_sc);
+
+        if (modified) {
+            /* nsc must exceed BOTH the cached sc and the last value we ever
+             * returned, by at least one -- so repeated GETATTRs after the holder
+             * re-dirties strictly advance even when cc itself does not change
+             * between queries (the holder's d=c+1 stays constant). */
+            uint64_t floor = deleg->combine_sc;
+            if (deleg->combine_last > floor) {
+                floor = deleg->combine_last;
+            }
+            /* If the holder reports a value already past our floor, honour it
+             * (still strictly advancing); otherwise bump by one. */
+            nsc                 = (cc > floor) ? cc : floor + 1;
+            deleg->combine_sc   = nsc;
+            deleg->combine_last = nsc;
+        }
+
+        pthread_mutex_unlock(&deleg->combine_lock);
+
+        if (modified) {
+            struct timespec now;
+
+            /* §10.4.3: on modification, construct time_metadata/time_modify
+             * from the current time so peers that revalidate on mtime/ctime
+             * observe the file as changed. */
+            clock_gettime(CLOCK_REALTIME, &now);
+            park->attr.va_ctime     = now;
+            park->attr.va_mtime     = now;
+            park->attr.va_set_mask |= CHIMERA_VFS_ATTR_CTIME |
+                CHIMERA_VFS_ATTR_MTIME;
+
+            chimera_nfs4_getattr_set_change(&park->attr, nsc);
+
+            if (got_size) {
+                park->attr.va_size      = size;
+                park->attr.va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
             }
         }
-        if (got_size) {
-            park->attr.va_size      = size;
-            park->attr.va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
-        }
+        /* cc == sc (unmodified): leave park->attr as the server's local view. */
     }
 
     chimera_nfs4_getattr_finish(park->req, &park->attr);
@@ -180,8 +256,9 @@ chimera_nfs4_getattr_complete(
                                                     client->client_id)) != NULL) {
         struct nfs4_getattr_park *park = calloc(1, sizeof(*park));
 
-        park->req  = req;
-        park->attr = *attr;
+        park->req   = req;
+        park->deleg = wdeleg;
+        park->attr  = *attr;
         nfs4_cb_getattr(req->thread, wdeleg, park,
                         chimera_nfs4_getattr_cb_resume);
         return; /* parked; resume finishes the GETATTR */

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -134,8 +134,9 @@ chimera_nfs4_open_acquire_share(
  */
 static bool
 chimera_nfs4_open_grant_delegation(
-    struct nfs_request *req,
-    struct OPEN4res    *res)
+    struct nfs_request             *req,
+    struct OPEN4res                *res,
+    const struct chimera_vfs_attrs *file_attr)
 {
     struct chimera_server_nfs_thread *thread    = req->thread;
     struct OPEN4args                 *args      = &req->args_compound->argarray[req->index].opopen;
@@ -271,6 +272,22 @@ chimera_nfs4_open_grant_delegation(
         return false;
     }
     deleg->lease_held = true;
+
+    /* RFC 7530/8881 §10.4.3: cache the file's change attribute at grant (sc).
+     * Only meaningful for a write delegation (the holder can modify locally);
+     * captured when the OPEN path supplied the change-derivation attrs.  If they
+     * are absent (e.g. CLAIM_FH, or a probe-deferred resume), combine_valid
+     * stays false and the first peer CB_GETATTR captures sc lazily. */
+    if (deleg_type == OPEN_DELEGATE_WRITE && file_attr &&
+        (file_attr->va_set_mask &
+         (CHIMERA_VFS_ATTR_CHANGE | CHIMERA_VFS_ATTR_CTIME))) {
+        uint64_t sc = chimera_nfs4_change_from_attrs(file_attr);
+        pthread_mutex_lock(&deleg->combine_lock);
+        deleg->combine_sc    = sc;
+        deleg->combine_last  = sc;
+        deleg->combine_valid = true;
+        pthread_mutex_unlock(&deleg->combine_lock);
+    }
 
     res->resok4.delegation.delegation_type = deleg_type;
 
@@ -487,7 +504,9 @@ chimera_nfs4_open_resume_after_probe(struct nfs_request *req)
     struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
     bool             deferred;
 
-    deferred = chimera_nfs4_open_grant_delegation(req, res);
+    /* No file attrs available on the probe-deferred resume; sc is captured
+     * lazily on the first peer CB_GETATTR (combine_valid stays false). */
+    deferred = chimera_nfs4_open_grant_delegation(req, res, NULL);
     chimera_nfs_abort_if(deferred,
                          "OPEN resume after probe re-deferred");
     chimera_nfs4_open_complete(req, NFS4_OK);
@@ -572,7 +591,7 @@ chimera_nfs4_open_exclusive_verify(
     * defer path (which returns without completing the OPEN) does not leak
     * it -- the resume callback only knows how to call open_complete. */
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-    if (chimera_nfs4_open_grant_delegation(req, res)) {
+    if (chimera_nfs4_open_grant_delegation(req, res, attr)) {
         return; /* parked; resume from nfs4_cb_null_complete */
     }
     chimera_nfs4_open_complete(req, NFS4_OK);
@@ -687,7 +706,7 @@ chimera_nfs4_open_at_complete(
     * defer path (which returns without completing the OPEN) does not leak
     * it -- the resume callback only knows how to call open_complete. */
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-    if (chimera_nfs4_open_grant_delegation(req, res)) {
+    if (chimera_nfs4_open_grant_delegation(req, res, attr)) {
         return; /* parked; resume from nfs4_cb_null_complete */
     }
 
@@ -747,7 +766,8 @@ chimera_nfs4_open_lookup_regular_complete(
                         ctx->namelen,
                         ctx->flags,
                         ctx->attr,
-                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
+                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE |
+                        CHIMERA_VFS_ATTR_CHANGE | CHIMERA_VFS_ATTR_CTIME,
                         CHIMERA_VFS_ATTR_MTIME,
                         CHIMERA_VFS_ATTR_MTIME,
                         chimera_nfs4_open_at_complete,
@@ -793,7 +813,8 @@ chimera_nfs4_open_unchecked_lookup_complete(
                         ctx->namelen,
                         ctx->flags,
                         ctx->attr,
-                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
+                        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE |
+                        CHIMERA_VFS_ATTR_CHANGE | CHIMERA_VFS_ATTR_CTIME,
                         CHIMERA_VFS_ATTR_MTIME,
                         CHIMERA_VFS_ATTR_MTIME,
                         chimera_nfs4_open_at_complete,
@@ -850,7 +871,9 @@ chimera_nfs4_open_claim_fh_complete(
     * defer path (which returns without completing the OPEN) does not leak
     * it -- the resume callback only knows how to call open_complete. */
     chimera_vfs_release(req->thread->vfs_thread, parent_handle);
-    if (chimera_nfs4_open_grant_delegation(req, res)) {
+    /* CLAIM_FH/CLAIM_PREVIOUS does not getattr the file; sc is captured lazily
+     * on the first peer CB_GETATTR (combine_valid stays false). */
+    if (chimera_nfs4_open_grant_delegation(req, res, NULL)) {
         return; /* parked; resume from nfs4_cb_null_complete */
     }
     chimera_nfs4_open_complete(req, NFS4_OK);
@@ -1044,7 +1067,8 @@ chimera_nfs4_open_parent_complete(
                                 args->claim.file.len,
                                 flags,
                                 attr,
-                                CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
+                                CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE |
+                                CHIMERA_VFS_ATTR_CHANGE | CHIMERA_VFS_ATTR_CTIME,
                                 CHIMERA_VFS_ATTR_MTIME,
                                 CHIMERA_VFS_ATTR_MTIME,
                                 chimera_nfs4_open_at_complete,
@@ -1114,7 +1138,8 @@ chimera_nfs4_open_parent_complete(
                                 args->claim.delegate_cur_info.file.len,
                                 flags,
                                 attr,
-                                CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
+                                CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE |
+                                CHIMERA_VFS_ATTR_CHANGE | CHIMERA_VFS_ATTR_CTIME,
                                 CHIMERA_VFS_ATTR_MTIME,
                                 CHIMERA_VFS_ATTR_MTIME,
                                 chimera_nfs4_open_at_complete,

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -1548,6 +1548,13 @@ nfs_delegation_create(
     deleg->generation = gen;
     deleg->seqid      = 1;
     deleg->lease_held = false;
+    /* RFC 7530/8881 §10.4.3 combine state.  sc is captured at grant by the
+     * OPEN path; combine_valid stays false until then (lazy capture on first
+     * CB_GETATTR otherwise). */
+    pthread_mutex_init(&deleg->combine_lock, NULL);
+    deleg->combine_sc    = 0;
+    deleg->combine_last  = 0;
+    deleg->combine_valid = false;
     atomic_init(&deleg->cb_recall_state, NFS4_DELEG_ACTIVE);
     atomic_init(&deleg->cb_recall_retries, 0);
     atomic_init(&deleg->refcount, 1);
@@ -1581,6 +1588,7 @@ delegation_cleanup(
         chimera_vfs_state_put(vfs_state, deleg->file_state);
         deleg->file_state = NULL;
     }
+    pthread_mutex_destroy(&deleg->combine_lock);
     free(deleg);
 } /* delegation_cleanup */
 

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -413,24 +413,44 @@ struct nfs_delegation {
     struct chimera_vfs_file_state *file_state;
     bool                           lease_held;
 
-    _Atomic uint8_t                cb_recall_state;  /* NFS4_DELEG_* */
+    /*
+     * RFC 7530/8881 §10.4.3 server-side change-attribute combine state.  The
+     * server caches the file's NFSv4 change attribute at grant time (`sc`) and,
+     * on each peer GETATTR that runs CB_GETATTR, compares the holder's reported
+     * value (`cc`) against `sc`:
+     *   cc == sc  -> the holder has not modified; the server returns its own
+     *                LOCAL change/time_metadata/time_modify (NOT the holder's).
+     *   cc != sc  -> the holder has modified; the server synthesises
+     *                time_metadata/time_modify from the current time, computes a
+     *                new server change value nsc >= sc + 1, returns nsc, replaces
+     *                the cached sc with nsc, and guarantees each returned nsc
+     *                STRICTLY exceeds the previously returned one (monotonicity).
+     * `combine_lock` guards these fields, which may be read/updated from any
+     * requester thread that runs a peer GETATTR against this delegation.
+     */
+    pthread_mutex_t        combine_lock;
+    uint64_t               combine_sc;                /* cached change attr (sc) */
+    uint64_t               combine_last;              /* last nsc returned to a peer */
+    bool                   combine_valid;             /* sc captured at grant     */
+
+    _Atomic uint8_t        cb_recall_state;          /* NFS4_DELEG_* */
     /* Count of CB_RECALL retransmits attempted because the client's callback
      * session was not yet usable (CB_SEQUENCE returned NFS4ERR_BADSESSION right
      * after a CREATE_SESSION, before the client finished registering the new
      * session).  Bounds the retransmit loop below the recall deadline. */
-    _Atomic uint8_t                cb_recall_retries;
+    _Atomic uint8_t        cb_recall_retries;
     /* Set when the delegation was force-revoked (recall unanswered /
      * conflicting access) rather than returned.  A revoked stateid resolves to
      * NFS4ERR_DELEG_REVOKED until the client FREE_STATEIDs it. */
-    _Atomic uint8_t                revoked;
+    _Atomic uint8_t        revoked;
 
-    struct nfs_delegation         *next_in_client;  /* utlist on client->delegations */
+    struct nfs_delegation *next_in_client;          /* utlist on client->delegations */
     /* Single-link queue for cross-thread recall marshalling (owner thread's
      * doorbell drains it); see nfs4_callback.c. */
-    struct nfs_delegation         *recall_qnext;
+    struct nfs_delegation *recall_qnext;
 
-    _Atomic uint32_t               refcount;
-    _Atomic uint8_t                destroyed;
+    _Atomic uint32_t       refcount;
+    _Atomic uint8_t        destroyed;
 };
 
 /*

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -429,11 +429,11 @@ struct nfs_delegation {
      * requester thread that runs a peer GETATTR against this delegation.
      */
     pthread_mutex_t        combine_lock;
-    uint64_t               combine_sc;                /* cached change attr (sc) */
-    uint64_t               combine_last;              /* last nsc returned to a peer */
-    bool                   combine_valid;             /* sc captured at grant     */
+    uint64_t               combine_sc;              /* cached change attr (sc) */
+    uint64_t               combine_last;            /* last nsc returned to a peer */
+    bool                   combine_valid;           /* sc captured at grant     */
 
-    _Atomic uint8_t        cb_recall_state;          /* NFS4_DELEG_* */
+    _Atomic uint8_t        cb_recall_state;         /* NFS4_DELEG_* */
     /* Count of CB_RECALL retransmits attempted because the client's callback
      * session was not yet usable (CB_SEQUENCE returned NFS4ERR_BADSESSION right
      * after a CREATE_SESSION, before the client finished registering the new


### PR DESCRIPTION
## Summary

Implements the RFC 7530/8881 §10.4.3 server-side change-attribute **combine** algorithm for CB_GETATTR. Previously, when a peer GETATTR'd a file under another client's write delegation, the server CB_GETATTR'd the holder and used the reply **verbatim**, which caused three correctness defects (#1052):

1. Returned the holder's opaque change value (`d = c+1`) even when the holder had **not** modified the file (`cc == sc`), where the RFC requires returning the server's **local** change/time_metadata/time_modify.
2. **No monotonicity**: two successive peer GETATTRs that observed the same `cc` returned the same change value, so a peer re-reading after the holder re-dirtied its cache saw no change and served stale data.
3. `time_modify`/`time_metadata` were never reconstructed from current time on modification, so peers revalidating on mtime never saw the file as modified.

## What changed

- **`struct nfs_delegation`** (`nfs4_state.h`) gains `combine_sc` (cached change at grant, `sc`), `combine_last` (last `nsc` returned, for monotonicity), `combine_valid`, and a `combine_lock` guarding them across requester threads. Initialised/destroyed in `nfs4_state.c`.
- **Grant path** (`nfs4_proc_open.c`): `chimera_nfs4_open_grant_delegation` now takes the file's attrs and caches `sc` for a write delegation. Paths without attrs at grant (CLAIM_FH, probe-deferred resume) capture `sc` **lazily** on the first peer CB_GETATTR. The OPEN getattr masks that feed the grant path now also request CHANGE+CTIME.
- **Combine** (`nfs4_proc_getattr.c`, `chimera_nfs4_getattr_cb_resume`):
  - `cc == sc` -> holder unmodified: return the server's **local** attrs unchanged.
  - `cc != sc` -> holder modified: synthesise ctime/mtime from current time, compute `nsc` that **strictly** exceeds both the cached `sc` and the last value ever returned, return `nsc`, replace `sc` with `nsc`.
  - Query failure / no change attr in reply -> fall back to local attrs.
- The fattr4_change derivation (native `CAP_CHANGE` counter vs ctime-in-ns) is factored into `chimera_nfs4_change_from_attrs()` (`nfs4_attr.h`) so the cached `sc` and the marshalled change value always agree.

## Validation

- `pynfs combined_memfs_nfs4.{0,1,2}` — pass.
- All 26 `pynfs/delegations/*` tests (4.0/4.1) — pass.
- Clean shutdown, no ASan findings under a Debug build.

Fixes #1052