### PR TITLE
nfs4: decline SP4_SSV state protection instead of advertising it

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -79,6 +79,17 @@ set(PYNFS_EXTRA_currentstateid nopnfs)
 set(PYNFS_SKIP_BACKENDS_WRT18  linux io_uring)
 set(PYNFS_SKIP_BACKENDS_SATT15 linux io_uring)
 
+# EID50 (st_exchange_id.testSSV) exercises SP4_SSV state protection.  Chimera
+# declines SP4_SSV in EXCHANGE_ID (returning SP4_NONE) because it cannot enforce
+# the SSV-derived RPCSEC_GSS credential -- advertising it would be a security
+# overstatement (issue #946).  testSSV unconditionally assumes the server
+# granted SSV and dereferences the (now-absent) ssv context, so it cannot pass
+# against a correctly-declining server.  Skip it on every backend, mirroring the
+# nopnfs exclusion of the pNFS-only CSID7 -- it is testing an unsupported
+# feature.  (EID50's only flag is `exchange_id`, which is isolated, so it is
+# already excluded from the combined suite; this drops the per-code entries.)
+set(PYNFS_SKIP_BACKENDS_EID50  ${PYNFS_BACKENDS})
+
 # Per-code NFSv4 lease-time override (seconds).  Delegation recall-handshake
 # tests open a file as one client, then drive a *second* client's conflicting
 # OPEN to force a CB_RECALL.  Establishing that second client (SETCLIENTID /

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -18,102 +18,6 @@
          EXCHGID4_FLAG_USE_PNFS_MDS | EXCHGID4_FLAG_USE_PNFS_DS |             \
          EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
 
-/*
- * SSV state-protection (SP4_SSV) algorithm tables.  Each entry is a DER-encoded
- * ASN.1 OBJECT IDENTIFIER as it appears on the wire in ssv_sp_parms4, plus (for
- * hashes) the SSV length, which is the hash's output size (RFC 8881 §2.10.9).
- */
-struct nfs4_ssv_alg {
-    const uint8_t *oid;
-    uint32_t       oid_len;
-    uint32_t       ssv_len; /* hash digest size; unused (0) for ciphers */
-};
-
-/* *INDENT-OFF* */
-/* DER-encoded OBJECT IDENTIFIERs and the column-aligned tables below confuse
- * uncrustify's alignment pass (it oscillates), so format them by hand. */
-static const uint8_t nfs4_oid_sha1[]   = { 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a };
-static const uint8_t nfs4_oid_sha224[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04 };
-static const uint8_t nfs4_oid_sha256[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01 };
-static const uint8_t nfs4_oid_sha384[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02 };
-static const uint8_t nfs4_oid_sha512[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03 };
-
-static const struct nfs4_ssv_alg nfs4_ssv_hashes[] = {
-    { nfs4_oid_sha256, sizeof(nfs4_oid_sha256), 32 },
-    { nfs4_oid_sha1,   sizeof(nfs4_oid_sha1),   20 },
-    { nfs4_oid_sha512, sizeof(nfs4_oid_sha512), 64 },
-    { nfs4_oid_sha384, sizeof(nfs4_oid_sha384), 48 },
-    { nfs4_oid_sha224, sizeof(nfs4_oid_sha224), 28 },
-};
-
-static const uint8_t nfs4_oid_aes128_cbc[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x02 };
-static const uint8_t nfs4_oid_aes192_cbc[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x16 };
-static const uint8_t nfs4_oid_aes256_cbc[] = { 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x01, 0x2a };
-
-static const struct nfs4_ssv_alg nfs4_ssv_ciphers[] = {
-    { nfs4_oid_aes256_cbc, sizeof(nfs4_oid_aes256_cbc), 0 },
-    { nfs4_oid_aes192_cbc, sizeof(nfs4_oid_aes192_cbc), 0 },
-    { nfs4_oid_aes128_cbc, sizeof(nfs4_oid_aes128_cbc), 0 },
-};
-/* *INDENT-ON* */
-
-/*
- * Walk the client's offered algorithm list in preference order and pick the
- * first entry the server recognizes.  spi_hash_alg / spi_encr_alg are returned
- * as indices into the client's list (RFC 8881 §18.35.3), so the client must
- * present at least one algorithm we know.  Returns 0 on a match.
- */
-static int
-nfs4_ssv_select(
-    const struct sec_oid4     *offered,
-    uint32_t                   num_offered,
-    const struct nfs4_ssv_alg *known,
-    size_t                     num_known,
-    uint32_t                  *out_idx,
-    uint32_t                  *out_ssv_len)
-{
-    for (uint32_t i = 0; i < num_offered; i++) {
-        for (size_t k = 0; k < num_known; k++) {
-            if (offered[i].oid.len == known[k].oid_len &&
-                memcmp(offered[i].oid.data, known[k].oid, known[k].oid_len) == 0) {
-                *out_idx = i;
-                if (out_ssv_len) {
-                    *out_ssv_len = known[k].ssv_len;
-                }
-                return 0;
-            }
-        }
-    }
-    return -1;
-} /* nfs4_ssv_select */
-
-/* Echo a state_protect_ops4 (the operations the server will enforce / allow)
- * into the reply, copying the bitmap arrays into the response dbuf. */
-static void
-nfs4_copy_protect_ops(
-    struct state_protect_ops4       *dst,
-    const struct state_protect_ops4 *src,
-    xdr_dbuf                        *dbuf)
-{
-    dst->num_spo_must_enforce = src->num_spo_must_enforce;
-    dst->spo_must_enforce     = NULL;
-    if (src->num_spo_must_enforce) {
-        size_t sz = (size_t) src->num_spo_must_enforce * sizeof(uint32_t);
-        dst->spo_must_enforce = xdr_dbuf_alloc_space(sz, dbuf);
-        chimera_nfs_abort_if(dst->spo_must_enforce == NULL, "Failed to allocate space");
-        memcpy(dst->spo_must_enforce, src->spo_must_enforce, sz);
-    }
-
-    dst->num_spo_must_allow = src->num_spo_must_allow;
-    dst->spo_must_allow     = NULL;
-    if (src->num_spo_must_allow) {
-        size_t sz = (size_t) src->num_spo_must_allow * sizeof(uint32_t);
-        dst->spo_must_allow = xdr_dbuf_alloc_space(sz, dbuf);
-        chimera_nfs_abort_if(dst->spo_must_allow == NULL, "Failed to allocate space");
-        memcpy(dst->spo_must_allow, src->spo_must_allow, sz);
-    }
-} /* nfs4_copy_protect_ops */
-
 /* State-management operations chimera enforces under SP4_MACH_CRED, as a
  * bitmap4 (RFC 8881 §2.10.8.3): BIND_CONN_TO_SESSION(41), EXCHANGE_ID(42),
  * CREATE_SESSION(43), DESTROY_SESSION(44), DESTROY_CLIENTID(57).  Bit op N is
@@ -126,9 +30,19 @@ nfs4_copy_protect_ops(
  * Build the EXCHANGE_ID reply's state-protection result (RFC 8881 §18.35.3)
  * and return the negotiated mode (stored on the client record for per-op
  * enforcement).  SP4_MACH_CRED is honored when requested: the server echoes
- * the operations it will enforce against the machine credential.  SP4_SSV is
- * honored when the client offers an SSV hash (and cipher) we support.  Any
- * case we cannot satisfy falls back to SP4_NONE.
+ * the operations it will enforce against the machine credential.
+ *
+ * SP4_SSV is declined -- we fall back to SP4_NONE.  Although the wire encoding
+ * could be negotiated, chimera does not actually enforce the SSV-derived
+ * RPCSEC_GSS credential on the spo_must_enforce state-management operations,
+ * SET_SSV does not compute the ssr_digest proof-of-knowledge, and
+ * nfs4_client_mach_cred_ok never checks an SSV credential (RFC 8881
+ * §2.10.8.3 / §18.47.3).  Advertising SP4_SSV would therefore be both a
+ * protocol lie (claiming a capability we cannot back) and a security
+ * overstatement (a client would believe its session-management operations are
+ * cryptographically bound to a shared secret when they are not).  Until real
+ * SSV enforcement is implemented we decline it.  Any case we cannot satisfy
+ * falls back to SP4_NONE.
  */
 static uint32_t
 nfs4_set_state_protect(
@@ -151,35 +65,13 @@ nfs4_set_state_protect(
         return SP4_MACH_CRED;
     }
 
+    /* SP4_SSV is declined: chimera cannot enforce SSV-derived credentials, so
+     * it falls through to the SP4_NONE result below rather than advertising a
+     * capability it does not back.  See the function comment above. */
     if (req_sp->spa_how == SP4_SSV) {
-        const struct ssv_sp_parms4 *p = &req_sp->spa_ssv_parms;
-        uint32_t                    hash_idx, encr_idx, ssv_len;
-
-        if (nfs4_ssv_select(p->ssp_hash_algs, p->num_ssp_hash_algs,
-                            nfs4_ssv_hashes,
-                            sizeof(nfs4_ssv_hashes) / sizeof(nfs4_ssv_hashes[0]),
-                            &hash_idx, &ssv_len) == 0 &&
-            nfs4_ssv_select(p->ssp_encr_algs, p->num_ssp_encr_algs,
-                            nfs4_ssv_ciphers,
-                            sizeof(nfs4_ssv_ciphers) / sizeof(nfs4_ssv_ciphers[0]),
-                            &encr_idx, NULL) == 0) {
-            struct ssv_prot_info4 *info = &res_sp->spr_ssv_info;
-
-            res_sp->spr_how = SP4_SSV;
-            nfs4_copy_protect_ops(&info->spi_ops, &p->ssp_ops, dbuf);
-            info->spi_hash_alg = hash_idx;
-            info->spi_encr_alg = encr_idx;
-            info->spi_ssv_len  = ssv_len;
-            /* ssp_window is the number of concurrent SSV versions the client
-             * wants tracked; echo it (a zero window is meaningless, so floor
-             * it at one). */
-            info->spi_window = p->ssp_window ? p->ssp_window : 1;
-            /* No GSS handles are pre-provisioned; the client gets them via the
-             * RPCSEC_GSS SSV mechanism if/when it uses SSV-secured RPC. */
-            info->spi_handles.len  = 0;
-            info->spi_handles.data = NULL;
-            return SP4_SSV;
-        }
+        chimera_nfs_debug(
+            "EXCHANGE_ID: client requested SP4_SSV; declining (not enforced), "
+            "negotiating SP4_NONE instead");
     }
 
     res_sp->spr_how = SP4_NONE;

--- a/src/server/nfs/nfs4_proc_set_ssv.c
+++ b/src/server/nfs/nfs4_proc_set_ssv.c
@@ -12,12 +12,15 @@
  * requested.  The SSV underpins the RPCSEC_GSS SSV mechanism used to integrity-
  * or privacy-protect the state-protected operations.
  *
- * chimera negotiates SP4_SSV at EXCHANGE_ID (see chimera_nfs4_exchange_id) but
- * does not yet enforce the SSV-backed GSS credential on the protected
- * operations, so SET_SSV here accepts the client's contribution and completes
- * the exchange.  ssr_digest is the server's proof-of-knowledge over the
- * SEQUENCE reply; it is returned empty until SSV-secured RPC is wired up
- * (clients that do not verify it -- e.g. pynfs EID50 -- are unaffected).
+ * chimera declines SP4_SSV at EXCHANGE_ID (see nfs4_set_state_protect, which
+ * falls back to SP4_NONE because the SSV-backed GSS credential is not
+ * enforced), so a conforming client never negotiates SSV and never reaches
+ * SET_SSV.  For any client that issues it anyway this remains a benign no-op:
+ * we accept the contribution and complete the exchange.  ssr_digest is the
+ * server's proof-of-knowledge over the SEQUENCE reply; it is returned empty
+ * because no SSV is in effect (clients that do not verify it -- e.g. pynfs
+ * EID50 -- are unaffected).  Full SSV enforcement (storing the SSV, computing
+ * the HMAC digest, binding RPCSEC_GSS credentials) is deferred.
  */
 void
 chimera_nfs4_set_ssv(

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -235,8 +235,10 @@ nfs4_principal_matches(
  * SP4_MACH_CRED enforcement (RFC 8881 §2.10.8.3): a state-management operation
  * on a client that negotiated SP4_MACH_CRED must be issued with the same
  * (machine) credential that established the client at EXCHANGE_ID.  Returns 1
- * if the operation is permitted (client absent, or SP4_NONE/SP4_SSV, or the
- * principal matches), 0 if it must be rejected with NFS4ERR_WRONG_CRED.
+ * if the operation is permitted (client absent, or SP4_NONE, or the principal
+ * matches), 0 if it must be rejected with NFS4ERR_WRONG_CRED.  SP4_SSV is never
+ * negotiated (EXCHANGE_ID declines it -- see nfs4_set_state_protect), so the
+ * only modes a client record can carry here are SP4_NONE and SP4_MACH_CRED.
  */
 SYMBOL_EXPORT int
 nfs4_client_mach_cred_ok(


### PR DESCRIPTION
## Problem

EXCHANGE_ID negotiated and advertised `SP4_SSV` to the client (in `nfs4_set_state_protect`, echoing the offered `spi_ops` and selecting a hash/cipher), but nothing downstream ever enforced it:

- `nfs4_client_mach_cred_ok` (`nfs4_session.c`) treats `SP4_SSV` identically to `SP4_NONE`, permitting every state-management operation regardless of credential.
- `SET_SSV` (`nfs4_proc_set_ssv.c`) accepts the client's secret without storing it and returns an empty `ssr_digest`.

So the server claimed a security capability it does not provide. This is both a protocol violation (RFC 8881 §2.10.8.3 / §18.47.3 require a server returning `spr_how=SP4_SSV` to enforce the SSV-derived RPCSEC_GSS credential on the `spo_must_enforce` operations and to return an HMAC proof-of-knowledge digest) and a security overstatement: a client that negotiates SSV believes its session-management operations are cryptographically bound to a shared secret when they are not.

## Fix

Per the issue's recommended simplest correct fix, stop advertising a capability we cannot back: `nfs4_set_state_protect` now declines an `SP4_SSV` request and falls back to `SP4_NONE` (`spr_how = SP4_NONE`). `SP4_NONE` and `SP4_MACH_CRED` handling are unchanged.

- Removed the now-dead SSV algorithm tables and helpers (`nfs4_ssv_select`, `nfs4_copy_protect_ops`, the OID tables).
- A conforming client no longer reaches `SET_SSV`; it is left as a documented benign no-op.
- Comments in all three files explain that `SP4_SSV` is declined and that full SSV enforcement (storing the SSV, computing the HMAC `ssr_digest`, binding RPCSEC_GSS credentials) is deferred.

Full SSV enforcement is explicitly out of scope.

Fixes #946