### PR TITLE
diskfs: fix spurious ENOSPC in the data reservation allocator (fio_diskfs flake)

### DIFF
--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -1443,7 +1443,7 @@ space_map_reserve_chunk(
         uint32_t          dev_id     = (start_dev + d) % sm->num_devices;
         struct sm_device *dev        = &sm->devices[dev_id];
         uint32_t          want_class = sm_ag_size_class(want);
-        uint32_t          C;
+        uint32_t          C, a, start_ag;
 
         if (dev->role != role) {
             continue;
@@ -1492,6 +1492,46 @@ space_map_reserve_chunk(
                     pthread_mutex_unlock(&ag->lock);
                 }
             }
+        }
+
+        /* Backstop: the (count, bitmap) size-class index is read with two
+         * independent relaxed loads above, so it is not a consistent snapshot --
+         * a concurrent sm_ag_mc_update on a shared word can leave a reader seeing
+         * mc_class_count[C] > 0 while maxclass_bits[C] reads 0 (the bit was
+         * cleared by one max-class transition before the re-set of the next).
+         * The fast path would then visit no AG for class C and fall through to a
+         * false ENOSPC even though space is available.  Before giving up on this
+         * device, fall back to a full linear scan that re-verifies each AG under
+         * ag->lock -- authoritative, and (like sm_pick_and_alloc's backstop) a
+         * pure correctness guarantee that finds nothing the fast path missed once
+         * the index reconciles. */
+        pthread_mutex_lock(&sm->lock);
+        start_ag = dev->ag_rotor;
+        if (++dev->ag_rotor >= dev->num_ags) {
+            dev->ag_rotor = 0;
+        }
+        pthread_mutex_unlock(&sm->lock);
+
+        for (a = 0; a < dev->num_ags; a++) {
+            uint32_t         ai = (start_ag + a) % dev->num_ags;
+            struct sm_ag    *ag = &dev->ags[ai];
+            uint64_t         base, len;
+            struct sm_claim *claim;
+
+            pthread_mutex_lock(&ag->lock);
+            if (sm_ag_try_claim_locked(ag, want, chunk, &base, &len,
+                                       &claim) == 0) {
+                pthread_mutex_unlock(&ag->lock);
+                r->device_id = dev_id;
+                r->ag_index  = ai;
+                r->base      = base;
+                r->len       = len;
+                r->cursor    = base;
+                r->claim     = claim;
+                r->valid     = 1;
+                return 0;
+            }
+            pthread_mutex_unlock(&ag->lock);
         }
     }
     return -1;      /* ENOSPC */


### PR DESCRIPTION
## Summary

Fixes the top unaddressed merge-queue flake in #733: `chimera/fio/fio_diskfs_aio_basic` and `chimera/fio/fio_diskfs_io_uring_basic` intermittently fail (Debug and Release alike) with a mid-run write returning `Input/output error`, followed by `verify: bad magic header` mismatches as the verify phase reads back partially-written data.

## Root cause

The failing write returns a spurious `ENOSPC` from the diskfs data-path block reservation allocator, even though the 1 GiB device is ~95% free at the time.

`space_map_reserve_chunk()` locates a candidate AG via the device's lock-free size-class index, reading `mc_class_count[C]` and `maxclass_bits[C]` as **two independent relaxed loads**. That pair is not a consistent snapshot: `sm_ag_mc_update()` publishes a max-class transition with separate relaxed atomics — it sets the new class's bit + count, then clears the old class's bit + count. A concurrent reader can therefore observe `mc_class_count[C] > 0` while `maxclass_bits[C]` still reads `0` (the bit was cleared by one transition before being re-set by the next). When that happens the fast path visits no AG for class `C` and — unlike the metadata allocator `sm_pick_and_alloc()`, which already carries a full linear-scan backstop — `space_map_reserve_chunk()` falls straight through to a false `ENOSPC`.

The fio engine maps any non-OK write status to `EIO`, which aborts the job; the subsequent verify phase then reads back the partially-written file and reports `bad magic header` mismatches.

This was confirmed by instrumenting the failure path: at the moment of the spurious ENOSPC the size-class index was inconsistent (`mc_class_count[17]=1` while the corresponding bitmap word read `0`), and it reconciled to a consistent state microseconds later.

## Fix

Add to `space_map_reserve_chunk()` the same linear-scan backstop the metadata allocator already has: before returning `ENOSPC`, walk every role-matched AG and re-attempt the claim under `ag->lock` via `sm_ag_try_claim_locked()` (authoritative). With a consistent index this finds nothing the fast path missed; it exists purely to close the lock-free-index race window.

## Reproduction / verification

A/B under a concurrent fio harness (16 isolated diskfs instances per batch, matching the merge-queue's parallel load):

- Before (Release): 2 spurious-ENOSPC write failures in 640 runs (~0.3%, matching the ~6 hits / 12h in #733).
- After (Release): 0 failures in 800 runs.
- After (Debug/ASan): 0 failures in 960 runs.
- `zerorange_diskfs_{aio,io_uring}`, `clone_range_test`, `statfs_mask_test`, `fio_memfs_basic` all still pass; `make syntax-check` clean.

Refs #733
