### PR TITLE
nfs/nlm: blocking-lock NLM4_BLOCKED + outbound NLM_GRANTED callback (#971)

### DIFF
--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -205,11 +205,20 @@ done
 # Build the test command to run inside the VM
 # Build mount options based on NFS version
 NFS_MOUNT_OPTS="vers=${NFS_VERSION},tcp,nconnect=16"
+NLM_PREP=""
 if [ "$NFS_VERSION" = "3" ]; then
-    NFS_MOUNT_OPTS="${NFS_MOUNT_OPTS},nolock"
+    if [ -n "${NFS_ENABLE_NLM:-}" ]; then
+        # NLM locking over NFSv3 needs the kernel client's NSM (rpc.statd) and a
+        # registered rpcbind; bring them up in the guest and mount *with* locking
+        # so a post-mount byte-range lock routes a real NLM LOCK to the server.
+        # (Mirrors the krb5_nlm test's bring-up.)
+        NLM_PREP="mkdir -p /run/rpcbind /var/lib/nfs/sm /var/lib/nfs/sm.bak /var/lib/nfs/statd; modprobe lockd 2>/dev/null; /usr/sbin/rpcbind 2>/dev/null; sleep 0.3; /usr/sbin/rpc.statd 2>/dev/null; sleep 0.5;"
+    else
+        NFS_MOUNT_OPTS="${NFS_MOUNT_OPTS},nolock"
+    fi
 fi
 
-TEST_CMD="mount -t nfs -o ${NFS_MOUNT_OPTS} 10.0.0.1:/share /mnt && ${TEST_CMD_ARG}"
+TEST_CMD="${NLM_PREP} mount -t nfs -o ${NFS_MOUNT_OPTS} 10.0.0.1:/share /mnt && ${TEST_CMD_ARG}"
 
 # Boot QEMU inside the netns
 # Use -serial stdio so serial output goes to stdout in real-time (captured by ctest).

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -315,6 +315,34 @@ foreach(image_spec ${KVM_IMAGES})
         SKIP_RETURN_CODE 77
         ENVIRONMENT "NFS_ENABLE_NLM=1")
 
+    # NLM blocking-lock grant delivery (RFC 1813 / XNFS): two processes contend
+    # for the SAME exclusive POSIX byte-range lock over a real Linux NLM client
+    # (sec=sys, vers=3 mounted *with* locking via NFS_ENABLE_NLM).  A small Python
+    # program forks a holder that takes the lock and holds it 3s, while the waiter
+    # issues a BLOCKING fcntl lock (F_SETLKW -> NLM LOCK block=true) on the same
+    # range: the server must reply NLM4_BLOCKED, then once the holder releases
+    # make an NLM_GRANTED callback that unblocks the waiter.  The waiter's lockf
+    # returns only after that grant lands.  The test passes only if the event
+    # order is exactly A-LOCKED, A-UNLOCK, B-GRANTED AND the waiter genuinely
+    # blocked (>=1s) -- i.e. it did not get the lock until the holder released.
+    # See issue #971.
+    #
+    # fcntl byte-range locks (not flock(2)) are used deliberately: the Linux NFS
+    # client always routes POSIX byte-range locks through NLM, whereas flock(2)
+    # can be handled locally.  The script is base64-embedded so the kernel
+    # cmdline that carries the test command stays quote-free.
+    set(NLM_BLOCK_PY "aW1wb3J0IG9zLHN5cyx0aW1lLGZjbnRsClA9Ii9tbnQvbmxtX2JsayI7RT0iL21udC9ubG1fZXZ0IgpkZWYgbihtKToKIGY9b3BlbihFLCJhIik7Zi53cml0ZShtKyJcbiIpO2YuZmx1c2goKTtvcy5mc3luYyhmLmZpbGVubygpKTtmLmNsb3NlKCkKb3BlbihQLCJ3IikuY2xvc2UoKTtvcGVuKEUsInciKS5jbG9zZSgpCmlmIG9zLmZvcmsoKT09MDoKIGg9b3BlbihQLCJyKyIpO2ZjbnRsLmxvY2tmKGgsZmNudGwuTE9DS19FWCwwLDEpO24oIkFMIik7dGltZS5zbGVlcCgzKTtuKCJBVSIpO2ZjbnRsLmxvY2tmKGgsZmNudGwuTE9DS19VTiwwLDEpO29zLl9leGl0KDApCnRpbWUuc2xlZXAoMSkKdz1vcGVuKFAsInIrIik7dD10aW1lLnRpbWUoKTtmY250bC5sb2NrZih3LGZjbnRsLkxPQ0tfRVgsMCwxKTtkPXRpbWUudGltZSgpLXQ7bigiQkciKQpvcy53YWl0KCkKZT1vcGVuKEUpLnJlYWQoKS5zcGxpdCgpO3ByaW50KCJFVlQiLGUsIldBSVQgJS4xZiIlZCkKc3lzLmV4aXQoMCBpZiBlPT1bIkFMIiwiQVUiLCJCRyJdIGFuZCBkPj0xIGVsc2UgMSkK")
+    set(NLM_BLOCK_CMD "echo ${NLM_BLOCK_PY} | base64 -d > /tmp/nb.py && python3 /tmp/nb.py")
+    add_test(NAME chimera/kvm/${IMAGE_NAME}/nlm/blocking_lock_memfs_nfs3
+        COMMAND bash ${NFS_WRAPPER}
+                ${IMAGE_DIR}/vmlinuz ${IMAGE_DIR}/rootfs.qcow2
+                ${CHIMERA_BINARY} memfs 3
+                "${NLM_BLOCK_CMD}")
+    set_tests_properties(chimera/kvm/${IMAGE_NAME}/nlm/blocking_lock_memfs_nfs3
+        PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2
+        TIMEOUT 180
+        ENVIRONMENT "NFS_ENABLE_NLM=1")
+
     # NFSv3 sec= policy rejection: an export restricted to krb5 must reject a
     # sec=sys mount.  The real client reports "access denied by server" only if
     # the server answers the post-mount probe with NFS3ERR_ACCES -- a stale/bad

--- a/src/server/nfs/CMakeLists.txt
+++ b/src/server/nfs/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${NFS_COMMON_INCLUDE_DIR})
 
 # Create libraries for NFSv3 and NFSv4
 add_library(chimera_nfs SHARED nfs.c nfs4_session.c nfs4_state.c nfs4_lease.c nfs4_recovery.c nfs4_drc.c nfs3_drc.c nfs4_v40_drc.c nfs_drc_reply.c nfs4_callback.c nfs_mount.c nfs_portmap.c nfs3_dump.c nfs4_dump.c
-            nfs_external_portmap.c nfs_nlm.c nfs_nlm_state.c nfs_nsm.c nfs_nsm_state.c
+            nfs_external_portmap.c nfs_nlm.c nfs_nlm_state.c nfs_nlm_granted.c nfs_nsm.c nfs_nsm_state.c
             nfs3_proc_null.c nfs3_proc_getattr.c nfs3_proc_setattr.c nfs3_proc_lookup.c 
             nfs3_proc_access.c nfs3_proc_readlink.c nfs3_proc_read.c nfs3_proc_write.c
             nfs3_proc_create.c nfs3_proc_mkdir.c nfs3_proc_remove.c nfs3_proc_mknod.c nfs3_proc_symlink.c

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -31,6 +31,7 @@
 #include "nfs_kv_keys.h"
 #include "nfs4_callback.h"
 #include "nfs_nlm.h"
+#include "nfs_nlm_granted.h"
 #include "nfs_nsm.h"
 #include "prometheus-c.h"
 #include "nfs_external_portmap.h"
@@ -699,6 +700,13 @@ nfs_server_destroy(void *data)
         free(mount_entry);
     }
 
+    /* Stop and join the NLM_GRANTED callback engine before destroying NLM
+     * state: it owns its own evpl_thread and may have in-flight grant jobs;
+     * nlm_granter_destroy aborts them cleanly.  NULL-safe (never created if no
+     * blocking lock ever queued). */
+    nlm_granter_destroy(shared->nlm_granter);
+    shared->nlm_granter = NULL;
+
     nlm_state_destroy(&shared->nlm_state);
     /* Join the reboot-notify worker (idle once its notifies completed) before
      * tearing down NSM state. */
@@ -762,14 +770,19 @@ chimera_nfs_server_notify(
                     nlm_cli->conn_count--;
                 }
                 if (nlm_cli->conn_count == 0) {
-                    /* Last connection for this hostname -- release locks */
+                    release_locks = true;
+                }
+                pthread_mutex_unlock(&shared->nlm_state.mutex);
+                /* Last connection for this hostname -- release its locks.  Done
+                 * outside the mutex: release_all takes state->mutex itself and
+                 * pumps the VFS pending queue (which can re-enter the NLM
+                 * acquire callback that also wants state->mutex). */
+                if (release_locks) {
                     nlm_client_release_all_locks(&shared->nlm_state, nlm_cli,
                                                  thread->vfs_thread,
                                                  thread->vfs->vfs_state,
                                                  &anon_cred);
-                    release_locks = true;
                 }
-                pthread_mutex_unlock(&shared->nlm_state.mutex);
                 /* Remove on-disk state outside the mutex (blocking I/O) */
                 if (release_locks) {
                     nlm_state_remove_client_file(&shared->nlm_state,

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -292,6 +292,11 @@ struct chimera_server_nfs_shared {
     struct nlm_state                    nlm_state;
     struct SM_INTER_V1                  nsm_v1;
     struct nsm_state                    nsm_state;
+    /* Outbound NLM_GRANTED callback engine (RFC 1813 blocking-lock grant
+     * delivery).  Lazily created on the first deferred grant; owns its own
+     * evpl_thread, so grant delivery + retransmit never touch a core loop.
+     * Forward-declared in nfs_nlm_granted.h. */
+    struct nlm_granter                 *nlm_granter;
 
     struct chimera_nfs_export          *exports;
     pthread_mutex_t                     exports_lock;

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -11,6 +11,7 @@
 #include "nfs_internal.h"
 #include "nfs_nlm.h"
 #include "nfs_nlm_state.h"
+#include "nfs_nlm_granted.h"
 #include "nfs_nsm.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
@@ -263,8 +264,96 @@ struct nlm_lock_ctx {
     struct nlm_client                *client; /* owning client for pending cleanup */
     bool                              block;
     bool                              nm_lock; /* non-monitored: skip persistence */
-    int                               proc;    /* 2=LOCK, 22=NM_LOCK */
+    int                               proc;    /* 2=LOCK, 22=NM_LOCK, 17=LOCK_MSG */
+    /* Set by the blocked-notify callback when the acquire queued (deferred):
+     * the immediate NLM4_BLOCKED interim has been sent and the eventual grant
+     * must be delivered out-of-band via an NLM_GRANTED callback rather than on
+     * the (already-completed) original LOCK RPC. */
+    bool                              was_blocked;
+    /* Client IP (no port), captured at request time so the out-of-band GRANTED
+     * callback can portmap-resolve the client's NLM service. */
+    char                              client_addr[80];
 };
+
+/* Build a self-contained grant job from the now-granted lock entry and hand it
+ * to the outbound NLM_GRANTED engine.  Called only for a blocking lock that was
+ * deferred (NLM4_BLOCKED already sent); the entry is GRANTED in vfs_state, so
+ * the job is a pure value snapshot and does not alias any lock state.  Caller
+ * must NOT hold nlm_state.mutex. */
+static void
+chimera_nfs_nlm4_deliver_grant(struct nlm_lock_ctx *ctx)
+{
+    struct chimera_server_nfs_thread *thread = ctx->thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct nlm_lock_entry            *entry  = ctx->entry;
+    struct nlm_granter               *granter;
+    struct nlm_grant_request          req;
+
+    memset(&req, 0, sizeof(req));
+    snprintf(req.client_addr, sizeof(req.client_addr), "%s", ctx->client_addr);
+    snprintf(req.caller_name, sizeof(req.caller_name), "%s",
+             ctx->client->hostname);
+    req.cookie_len = ctx->cookie.len < LM_MAXSTRLEN ? ctx->cookie.len : LM_MAXSTRLEN;
+    if (req.cookie_len) {
+        memcpy(req.cookie, ctx->cookie.data, req.cookie_len);
+    }
+    req.fh_len = entry->fh_len < NFS4_FHSIZE ? entry->fh_len : NFS4_FHSIZE;
+    memcpy(req.fh, entry->fh, req.fh_len);
+    req.oh_len = entry->oh_len < LM_MAXSTRLEN ? entry->oh_len : LM_MAXSTRLEN;
+    memcpy(req.oh, entry->oh, req.oh_len);
+    req.svid   = entry->svid;
+    req.offset = entry->offset;
+    /* entry->length uses the POSIX convention (0 == to EOF); the wire/NLM
+     * convention is UINT64_MAX == to EOF. */
+    req.length    = NLM_POSIX_LEN_TO_VFS(entry->length);
+    req.exclusive = entry->exclusive ? 1 : 0;
+
+    /* Lazily create the granter (idempotent).  Done under nlm_state.mutex so two
+     * threads cannot both create one. */
+    pthread_mutex_lock(&shared->nlm_state.mutex);
+    granter = nlm_granter_get_or_create(shared);
+    pthread_mutex_unlock(&shared->nlm_state.mutex);
+
+    nlm_granter_submit(granter, &req);
+} /* chimera_nfs_nlm4_deliver_grant */
+
+/* Fired (once) synchronously inside chimera_vfs_lease_acquire_blocking when a
+ * blocking LOCK queues on a conflict.  Sends the RFC 1813 / XNFS NLM4_BLOCKED
+ * interim immediately and records that the eventual grant must be delivered via
+ * an out-of-band NLM_GRANTED callback (not on this RPC). */
+static void
+chimera_nfs_nlm4_lock_blocked_cb(void *private_data)
+{
+    struct nlm_lock_ctx              *ctx      = private_data;
+    struct chimera_server_nfs_thread *thread   = ctx->thread;
+    struct chimera_server_nfs_shared *shared   = thread->shared;
+    struct evpl                      *evpl     = ctx->evpl;
+    struct evpl_rpc2_encoding        *encoding = ctx->encoding;
+    struct nlm4_res                   res;
+    int                               rc = 0;
+
+    ctx->was_blocked = true;
+
+    res.cookie.len  = ctx->cookie.len;
+    res.cookie.data = ctx->cookie.data;
+    res.stat        = NLM4_BLOCKED;
+
+    chimera_nfs_debug("NLM LOCK: blocking lock queued -> NLM4_BLOCKED (proc %d)",
+                      ctx->proc);
+
+    /* proc 2 (sync LOCK): complete the original RPC with NLM4_BLOCKED now; do
+     * NOT hold it open.  proc 17 (LOCK_MSG): the void ack already went, so send
+     * the interim result via LOCK_RES.  NM_LOCK (22) never blocks (non-blocking
+     * by definition) so it never reaches here. */
+    if (ctx->proc == 17) {
+        shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl,
+                                                   ctx->conn, NULL, &res, 0, 0,
+                                                   NULL, 0, 0, NULL, NULL);
+    } else {
+        rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
+        chimera_nfs_abort_if(rc, "Failed to send NLM4_BLOCKED reply");
+    }
+} /* chimera_nfs_nlm4_lock_blocked_cb */
 
 static void
 chimera_nfs_nlm4_lock_acquire_cb(
@@ -304,6 +393,17 @@ chimera_nfs_nlm4_lock_acquire_cb(
             nlm_conn_peer_addr(ctx->conn, addr, sizeof(addr));
             nsm_monitor(thread, ctx->client->hostname, addr);
         }
+
+        /* If this lock was blocked (we already replied NLM4_BLOCKED on the
+         * original RPC), the grant must now be delivered to the waiting client
+         * via an out-of-band NLM_GRANTED callback -- the original RPC is closed.
+         * Submit the grant job and return without touching the RPC reply path. */
+        if (ctx->was_blocked) {
+            chimera_nfs_debug("NLM LOCK: deferred lock granted -> NLM_GRANTED callback");
+            chimera_nfs_nlm4_deliver_grant(ctx);
+            free(ctx);
+            return;
+        }
     } else {
         /* DENIED or wait=false-with-BREAKING: drop the entry. */
         pthread_mutex_lock(&shared->nlm_state.mutex);
@@ -314,6 +414,18 @@ chimera_nfs_nlm4_lock_acquire_cb(
         chimera_vfs_release(thread->vfs_thread, entry->handle);
         nlm_lock_entry_free(entry);
         res.stat = NLM4_DENIED;
+
+        /* A blocked proc-2 LOCK whose queued ticket was DENIED (a CANCEL won the
+         * race against the grant) has already had its original RPC completed
+         * with NLM4_BLOCKED -- do not send a second reply on the closed
+         * encoding.  The client learns the lock is gone from its CANCEL reply.
+         * For proc 17 (LOCK_MSG) the async flow legitimately delivers a final
+         * DENIED via LOCK_RES, so fall through. */
+        if (ctx->was_blocked && ctx->proc == 2) {
+            chimera_nfs_debug("NLM LOCK: blocked lock cancelled; no second reply");
+            free(ctx);
+            return;
+        }
     }
 
     chimera_nfs_debug("NLM LOCK cb: result=%d stat=%d block=%d", result, res.stat, ctx->block);
@@ -424,13 +536,17 @@ chimera_nfs_nlm4_lock_open_cb(
     entry->lease.owner.owner_lo   = nlm_owner_owner_lo(entry->oh, entry->oh_len,
                                                        entry->svid);
 
-    /* wait=ctx->block: blocking LOCK rides out cross-protocol breaks;
-     * non-blocking LOCK returns DENIED on any conflict.  Note: even with
-     * wait=true, same-protocol byte-range overlap returns DENIED
-     * synchronously — BREAKING only applies to caching leases. */
-    chimera_vfs_lease_acquire(vfs_state, entry->file_state,
-                              &entry->lease, &entry->ticket, ctx->block,
-                              chimera_nfs_nlm4_lock_acquire_cb, ctx);
+    /* wait=ctx->block: a blocking LOCK rides out cross-protocol breaks AND a
+     * same-protocol byte-range conflict (the latter queues as an RFC 1813
+     * blocking lock, exactly like an SMB2 blocking lock); a non-blocking LOCK
+     * returns DENIED on any conflict.  When the acquire queues (defers), the
+     * blocked_cb fires synchronously and sends the immediate NLM4_BLOCKED
+     * interim; the eventual grant is then delivered via an out-of-band
+     * NLM_GRANTED callback from chimera_nfs_nlm4_lock_acquire_cb. */
+    chimera_vfs_lease_acquire_blocking(vfs_state, entry->file_state,
+                                       &entry->lease, &entry->ticket, ctx->block,
+                                       chimera_nfs_nlm4_lock_acquire_cb,
+                                       chimera_nfs_nlm4_lock_blocked_cb, ctx);
 } /* chimera_nfs_nlm4_lock_open_cb */
 
 /* -------------------------------------------------------------------------
@@ -660,6 +776,10 @@ chimera_nfs_nlm4_do_lock(
     ctx->block    = args->block;
     ctx->nm_lock  = nm_lock;
     ctx->proc     = proc;
+    /* Capture the client IP now (the conn outlives the request, but the grant
+     * callback runs on a different thread and must not touch core-thread conn
+     * state); the out-of-band NLM_GRANTED engine portmap-resolves it. */
+    nlm_conn_peer_addr(conn, ctx->client_addr, sizeof(ctx->client_addr));
 
     if (args->cookie.len > 0 && args->cookie.len <= LM_MAXSTRLEN) {
         ctx->cookie.len  = args->cookie.len;
@@ -1380,8 +1500,11 @@ chimera_nfs_nlm4_free_all(
     safe_hostname[hn_len] = '\0';
 
     chimera_nfs_debug("Received NLM FREE_ALL for client '%s'", safe_hostname);
+    /* Locate under the lock, release outside it (release_all takes the lock
+     * itself and pumps the VFS queue, which can re-enter the NLM callback). */
     pthread_mutex_lock(&shared->nlm_state.mutex);
     HASH_FIND_STR(shared->nlm_state.clients, safe_hostname, client);
+    pthread_mutex_unlock(&shared->nlm_state.mutex);
     if (client) {
         chimera_vfs_cred_init_anonymous(&anon_cred,
                                         CHIMERA_VFS_ANON_UID,
@@ -1391,8 +1514,6 @@ chimera_nfs_nlm4_free_all(
                                      thread->vfs->vfs_state,
                                      &anon_cred);
     }
-    pthread_mutex_unlock(&shared->nlm_state.mutex);
-    /* Remove on-disk state outside the mutex to avoid blocking I/O under lock */
     if (client) {
         nlm_state_remove_client_file(&shared->nlm_state, safe_hostname);
         /* All of this client's locks are gone; stop monitoring it for reboot. */

--- a/src/server/nfs/nfs_nlm_granted.c
+++ b/src/server/nfs/nfs_nlm_granted.c
@@ -1,0 +1,546 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Outbound NLM_GRANTED callback engine (RFC 1813 / XNFS blocking-lock grant
+ * delivery).  See nfs_nlm_granted.h for the contract.
+ *
+ * Everything here runs on one dedicated evpl_thread (the "granter"), so the
+ * portmap lookup, the outbound GRANTED call, and its retransmit timer never
+ * execute on a core NFS event loop.  Submitters on other threads only push a
+ * self-contained job onto a mutex-protected intake queue and ring a doorbell;
+ * the granter drains the queue from the doorbell callback on its own evpl.
+ *
+ * Transport choice: we use NLMPROC4_GRANTED (proc 5), which expects a reply,
+ * rather than the one-way NLMPROC4_GRANTED_MSG (proc 10).  Proc 5 delivers the
+ * client's GRANTED_RES ack inline on the very connection we sent on, so ack
+ * tracking and retransmit cancellation need no inbound-correlation table and no
+ * second RPC service -- a materially simpler and race-free lifetime than proc
+ * 10 + an inbound GRANTED_RES handler.  Stock Linux lockd services inbound
+ * NLMPROC_GRANTED, so this interoperates with the F_SETLKW clients this issue
+ * targets.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#include "nfs_common.h"
+#include "nfs_internal.h"
+#include "nfs_nlm_granted.h"
+#include "portmap_xdr.h"
+#include "nlm4_xdr.h"
+#include "evpl/evpl.h"
+#include "evpl/evpl_rpc2.h"
+
+/* Retransmit cadence and cap.  A blocking-lock client retransmits its own LOCK
+ * on a similar cadence; we keep re-sending GRANTED until it acks or we give up,
+ * so a momentarily-unreachable client still converges.  After the cap the job
+ * is dropped: the lock stays held (the grant already happened in vfs_state),
+ * and the client recovers by retransmitting LOCK, which we answer GRANTED. */
+#define NLM_GRANT_RETRY_INTERVAL_US (2 * 1000 * 1000)   /* 2s */
+#define NLM_GRANT_MAX_ATTEMPTS      15                  /* ~30s total */
+
+/* NLM program/version, looked up via the client's portmapper. */
+#define NLM_PROGRAM                 100021u
+#define NLM_VERSION                 4u
+
+/* Producer-side queue node carries the request payload plus an intake link.
+ * The granter copies the payload into its own job and frees the node. */
+struct nlm_grant_intake {
+    struct nlm_grant_request req;
+    struct nlm_grant_intake *next;
+};
+
+struct nlm_granter {
+    struct chimera_server_nfs_shared *shared;
+    struct evpl_thread               *thread;
+
+    /* Intake queue: producers (core threads) append under `lock` and ring the
+     * doorbell; the granter thread drains it on its own evpl. */
+    pthread_mutex_t                   lock;
+    struct nlm_grant_intake          *intake_head;   /* singly-linked via ->next */
+    struct nlm_grant_intake          *intake_tail;
+    struct evpl_doorbell              doorbell;
+    int                               doorbell_armed; /* set once the thread arms it */
+    int                               shutdown;       /* set under lock to refuse new work */
+};
+
+/* Per-job state owned entirely by the granter thread. */
+struct nlm_grant_job {
+    struct nlm_grant_request req;
+    struct nlm_granter      *granter;
+
+    struct evpl_endpoint    *pm_ep;
+    struct evpl_rpc2_conn   *pm_conn;
+    struct evpl_endpoint    *nlm_ep;
+    struct evpl_rpc2_conn   *nlm_conn;
+    unsigned int             nlm_port;
+
+    struct evpl_timer        retry_timer;
+    int                      timer_armed;
+    int                      attempts;
+    int                      acked;
+    int                      inflight;      /* a GRANTED call is outstanding */
+
+    struct nlm_grant_job    *next;          /* link on granter active list */
+    struct nlm_grant_job    *prev;
+};
+
+/* The granter's per-thread evpl context. */
+struct nlm_grant_ctx {
+    struct nlm_granter      *granter;
+    struct evpl             *evpl;
+    struct evpl_rpc2_thread *rpc2_thread;
+    struct PORTMAP_V2        pm;
+    struct NLM_V4            nlm;
+    struct nlm_grant_job    *active;        /* DL list of live jobs */
+};
+
+/* The granter thread stashes its ctx here so the doorbell callback (which only
+ * gets evpl + doorbell) can reach it.  Set once in init, before the doorbell is
+ * armed, and read only on the granter thread. */
+static __thread struct nlm_grant_ctx *nlm_grant_tls_ctx;
+
+static void nlm_grant_job_send(
+    struct nlm_grant_job *job);
+static void nlm_grant_job_finish(
+    struct nlm_grant_job *job);
+
+/* ------------------------------------------------------------------ *
+*  job teardown                                                       *
+* ------------------------------------------------------------------ */
+
+static void
+nlm_grant_job_finish(struct nlm_grant_job *job)
+{
+    struct nlm_grant_ctx *ctx = nlm_grant_tls_ctx;
+
+    if (job->timer_armed) {
+        evpl_remove_timer(ctx->evpl, &job->retry_timer);
+        job->timer_armed = 0;
+    }
+    if (job->nlm_conn) {
+        evpl_rpc2_client_disconnect(ctx->rpc2_thread, job->nlm_conn);
+        job->nlm_conn = NULL;
+    }
+    if (job->nlm_ep) {
+        evpl_endpoint_close(job->nlm_ep);
+        job->nlm_ep = NULL;
+    }
+    if (job->pm_conn) {
+        evpl_rpc2_client_disconnect(ctx->rpc2_thread, job->pm_conn);
+        job->pm_conn = NULL;
+    }
+    if (job->pm_ep) {
+        evpl_endpoint_close(job->pm_ep);
+        job->pm_ep = NULL;
+    }
+
+    /* job is always on ctx->active (DL_APPEND'd in job_start before any finish),
+     * so the list is non-empty here; the guard silences a utlist DL_DELETE
+     * null-deref false positive under scan-build (same idiom as
+     * nlm_state_destroy). */
+#ifndef __clang_analyzer__
+    DL_DELETE(ctx->active, job);
+#endif /* ifndef __clang_analyzer__ */
+    free(job);
+} /* nlm_grant_job_finish */
+
+/* ------------------------------------------------------------------ *
+*  GRANTED call + ack                                                 *
+* ------------------------------------------------------------------ */
+
+static void
+nlm_grant_reply_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct nlm4_res             *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct nlm_grant_job *job = private_data;
+
+    (void) evpl;
+    (void) verf;
+    (void) reply;
+
+    job->inflight = 0;
+
+    /* Any application-level reply (whatever stat) means the client received the
+     * GRANTED and its F_SETLKW completed -- stop retransmitting.  A transport
+     * error leaves the job armed for the next retry tick. */
+    if (status == 0) {
+        job->acked = 1;
+        chimera_nfs_debug("NLM GRANTED: host '%s' (%s:%u) acked the grant",
+                          job->req.caller_name, job->req.client_addr,
+                          job->nlm_port);
+        nlm_grant_job_finish(job);
+    }
+} /* nlm_grant_reply_cb */
+
+/* Build the nlm4_testargs from the job snapshot and fire one GRANTED call on
+ * the (already connected) NLM conn. */
+static void
+nlm_grant_job_send(struct nlm_grant_job *job)
+{
+    struct nlm_grant_ctx *ctx = nlm_grant_tls_ctx;
+    struct nlm4_testargs  args;
+
+    if (!job->nlm_conn || job->inflight) {
+        return;
+    }
+
+    memset(&args, 0, sizeof(args));
+    args.cookie.len            = job->req.cookie_len;
+    args.cookie.data           = job->req.cookie;
+    args.exclusive             = job->req.exclusive ? 1 : 0;
+    args.alock.caller_name.str = job->req.caller_name;
+    args.alock.caller_name.len = (uint32_t) strlen(job->req.caller_name);
+    args.alock.fh.len          = job->req.fh_len;
+    args.alock.fh.data         = job->req.fh;
+    args.alock.oh.len          = job->req.oh_len;
+    args.alock.oh.data         = job->req.oh;
+    args.alock.svid            = job->req.svid;
+    args.alock.l_offset        = job->req.offset;
+    args.alock.l_len           = job->req.length;
+
+    job->inflight = 1;
+    job->attempts++;
+
+    chimera_nfs_debug("NLM GRANTED: -> host '%s' (%s:%u) attempt %d",
+                      job->req.caller_name, job->req.client_addr,
+                      job->nlm_port, job->attempts);
+
+    ctx->nlm.send_call_NLMPROC4_GRANTED(&ctx->nlm.rpc2, ctx->evpl,
+                                        job->nlm_conn, NULL, &args,
+                                        0, 0, NULL, 0, 0,
+                                        nlm_grant_reply_cb, job);
+} /* nlm_grant_job_send */
+
+static void
+nlm_grant_retry_timer_cb(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct nlm_grant_job *job = container_of(timer, struct nlm_grant_job, retry_timer);
+
+    (void) evpl;
+
+    if (job->acked) {
+        return;     /* finish already ran (defensive) */
+    }
+
+    if (job->attempts >= NLM_GRANT_MAX_ATTEMPTS) {
+        chimera_nfs_info("NLM GRANTED: host '%s' (%s:%u) did not ack after %d "
+                         "attempts; giving up (lock remains held)",
+                         job->req.caller_name, job->req.client_addr,
+                         job->nlm_port, job->attempts);
+        nlm_grant_job_finish(job);
+        return;
+    }
+
+    /* Re-send only if the previous attempt is not still outstanding; otherwise
+     * wait for its reply or the next tick. */
+    if (!job->inflight) {
+        nlm_grant_job_send(job);
+    }
+} /* nlm_grant_retry_timer_cb */
+
+/* ------------------------------------------------------------------ *
+*  portmap GETPORT -> connect -> first GRANTED                        *
+* ------------------------------------------------------------------ */
+
+static void
+nlm_grant_getport_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    unsigned int                 port,
+    int                          status,
+    void                        *private_data)
+{
+    struct nlm_grant_job *job = private_data;
+    struct nlm_grant_ctx *ctx = nlm_grant_tls_ctx;
+
+    (void) evpl;
+    (void) verf;
+
+    /* The portmap query is done with either way; release its conn/endpoint. */
+    if (job->pm_conn) {
+        evpl_rpc2_client_disconnect(ctx->rpc2_thread, job->pm_conn);
+        job->pm_conn = NULL;
+    }
+    if (job->pm_ep) {
+        evpl_endpoint_close(job->pm_ep);
+        job->pm_ep = NULL;
+    }
+
+    if (status != 0 || port == 0) {
+        chimera_nfs_info("NLM GRANTED: host '%s' (%s) has no NLM service "
+                         "registered; cannot deliver grant",
+                         job->req.caller_name, job->req.client_addr);
+        nlm_grant_job_finish(job);
+        return;
+    }
+
+    job->nlm_port = port;
+    job->nlm_ep   = evpl_endpoint_create(job->req.client_addr, port);
+    job->nlm_conn = evpl_rpc2_client_connect(ctx->rpc2_thread,
+                                             EVPL_STREAM_SOCKET_TCP,
+                                             job->nlm_ep, NULL, 0, NULL);
+    if (!job->nlm_conn) {
+        chimera_nfs_info("NLM GRANTED: cannot connect to NLM at %s:%u",
+                         job->req.client_addr, port);
+        nlm_grant_job_finish(job);
+        return;
+    }
+
+    /* Arm the retransmit timer and fire the first GRANTED. */
+    evpl_add_timer(ctx->evpl, &job->retry_timer, nlm_grant_retry_timer_cb,
+                   NLM_GRANT_RETRY_INTERVAL_US);
+    job->timer_armed = 1;
+
+    nlm_grant_job_send(job);
+} /* nlm_grant_getport_cb */
+
+static void
+nlm_grant_job_start(
+    struct nlm_grant_ctx           *ctx,
+    const struct nlm_grant_request *req)
+{
+    struct nlm_grant_job *job;
+    struct mapping        mapping;
+
+    job = calloc(1, sizeof(*job));
+    if (!job) {
+        return;
+    }
+    job->req     = *req;
+    job->granter = ctx->granter;
+    /* Guarded to match the DL_DELETE in nlm_grant_job_finish: keeping both
+     * utlist ops out of the analyzer's view avoids a false-positive
+     * use-after-free where it models a finished (freed) job still on the list. */
+#ifndef __clang_analyzer__
+    DL_APPEND(ctx->active, job);
+#endif /* ifndef __clang_analyzer__ */
+
+    /* Resolve the client's NLM (prog 100021 v4) callback port via its
+     * portmapper, exactly as the NSM reboot-notify path resolves statd. */
+    job->pm_ep   = evpl_endpoint_create(job->req.client_addr, 111);
+    job->pm_conn = evpl_rpc2_client_connect(ctx->rpc2_thread,
+                                            EVPL_STREAM_SOCKET_TCP,
+                                            job->pm_ep, NULL, 0, NULL);
+    if (!job->pm_conn) {
+        chimera_nfs_info("NLM GRANTED: cannot reach portmap at %s for host '%s'",
+                         job->req.client_addr, job->req.caller_name);
+        nlm_grant_job_finish(job);
+        return;
+    }
+
+    mapping.prog = NLM_PROGRAM;
+    mapping.vers = NLM_VERSION;
+    mapping.prot = 6;   /* IPPROTO_TCP */
+    mapping.port = 0;
+    ctx->pm.send_call_PMAPPROC_GETPORT(&ctx->pm.rpc2, ctx->evpl, job->pm_conn,
+                                       NULL, &mapping, 0, 0, NULL, 0, 0,
+                                       nlm_grant_getport_cb, job);
+} /* nlm_grant_job_start */
+
+/* ------------------------------------------------------------------ *
+*  intake doorbell                                                    *
+* ------------------------------------------------------------------ */
+
+static void
+nlm_grant_doorbell_cb(
+    struct evpl          *evpl,
+    struct evpl_doorbell *doorbell)
+{
+    struct nlm_granter      *granter = container_of(doorbell, struct nlm_granter, doorbell);
+    struct nlm_grant_ctx    *ctx     = nlm_grant_tls_ctx;
+    struct nlm_grant_intake *head, *node, *next;
+
+    (void) evpl;
+
+    /* Steal the whole intake list under the lock, then process lock-free. */
+    pthread_mutex_lock(&granter->lock);
+    head                 = granter->intake_head;
+    granter->intake_head = NULL;
+    granter->intake_tail = NULL;
+    pthread_mutex_unlock(&granter->lock);
+
+    for (node = head; node; node = next) {
+        next = node->next;
+        nlm_grant_job_start(ctx, &node->req);
+        free(node);
+    }
+} /* nlm_grant_doorbell_cb */
+
+/* ------------------------------------------------------------------ *
+*  thread init / shutdown                                             *
+* ------------------------------------------------------------------ */
+
+static void *
+nlm_granter_thread_init(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct nlm_granter       *granter = private_data;
+    struct nlm_grant_ctx     *ctx;
+    struct evpl_rpc2_program *programs[2];
+
+    ctx          = calloc(1, sizeof(*ctx));
+    ctx->granter = granter;
+    ctx->evpl    = evpl;
+    ctx->active  = NULL;
+
+    /* Outbound-only client programs (portmap + NLM); replies are matched by
+     * this rpc2 thread on the conns we open. */
+    PORTMAP_V2_init(&ctx->pm);
+    NLM_V4_init(&ctx->nlm);
+    programs[0]      = &ctx->pm.rpc2;
+    programs[1]      = &ctx->nlm.rpc2;
+    ctx->rpc2_thread = evpl_rpc2_thread_init(evpl, programs, 2, NULL, NULL);
+
+    nlm_grant_tls_ctx = ctx;
+
+    /* Arm the intake doorbell only after ctx is fully set up: the very next
+     * ring will find a usable ctx via TLS. */
+    evpl_add_doorbell(evpl, &granter->doorbell, nlm_grant_doorbell_cb);
+
+    pthread_mutex_lock(&granter->lock);
+    granter->doorbell_armed = 1;
+    /* A producer may have queued work before the doorbell existed; ring it once
+     * so we drain anything already pending. */
+    pthread_mutex_unlock(&granter->lock);
+    evpl_ring_doorbell(&granter->doorbell);
+
+    return ctx;
+} /* nlm_granter_thread_init */
+
+static void
+nlm_granter_thread_shutdown(
+    struct evpl *evpl,
+    void        *private_data)
+{
+    struct nlm_granter      *granter = private_data;
+    struct nlm_grant_ctx    *ctx     = nlm_grant_tls_ctx;
+    struct nlm_grant_job    *job, *tmp;
+    struct nlm_grant_intake *head, *node, *next;
+
+    /* Abort every in-flight grant job cleanly (timers off, conns closed). */
+    if (ctx) {
+        DL_FOREACH_SAFE(ctx->active, job, tmp)
+        {
+            nlm_grant_job_finish(job);
+        }
+        evpl_rpc2_thread_destroy(ctx->rpc2_thread);
+    }
+
+    evpl_remove_doorbell(evpl, &granter->doorbell);
+
+    /* Drop any intake nodes that arrived after shutdown was flagged. */
+    pthread_mutex_lock(&granter->lock);
+    head                 = granter->intake_head;
+    granter->intake_head = NULL;
+    granter->intake_tail = NULL;
+    pthread_mutex_unlock(&granter->lock);
+    for (node = head; node; node = next) {
+        next = node->next;
+        free(node);
+    }
+
+    free(ctx);
+    nlm_grant_tls_ctx = NULL;
+} /* nlm_granter_thread_shutdown */
+
+/* ------------------------------------------------------------------ *
+*  public API                                                         *
+* ------------------------------------------------------------------ */
+
+struct nlm_granter *
+nlm_granter_get_or_create(struct chimera_server_nfs_shared *shared)
+{
+    struct nlm_granter *granter;
+
+    if (shared->nlm_granter) {
+        return shared->nlm_granter;
+    }
+
+    granter = calloc(1, sizeof(*granter));
+    if (!granter) {
+        return NULL;
+    }
+    granter->shared = shared;
+    pthread_mutex_init(&granter->lock, NULL);
+
+    granter->thread = evpl_thread_create(NULL, nlm_granter_thread_init,
+                                         nlm_granter_thread_shutdown, granter);
+    if (!granter->thread) {
+        pthread_mutex_destroy(&granter->lock);
+        free(granter);
+        return NULL;
+    }
+
+    shared->nlm_granter = granter;
+    return granter;
+} /* nlm_granter_get_or_create */
+
+void
+nlm_granter_submit(
+    struct nlm_granter             *granter,
+    const struct nlm_grant_request *req)
+{
+    struct nlm_grant_intake *node;
+
+    if (!granter) {
+        return;
+    }
+
+    node = calloc(1, sizeof(*node));
+    if (!node) {
+        return;
+    }
+    node->req  = *req;
+    node->next = NULL;
+
+    pthread_mutex_lock(&granter->lock);
+    if (granter->shutdown) {
+        pthread_mutex_unlock(&granter->lock);
+        free(node);
+        return;
+    }
+    if (granter->intake_tail) {
+        granter->intake_tail->next = node;
+    } else {
+        granter->intake_head = node;
+    }
+    granter->intake_tail = node;
+    pthread_mutex_unlock(&granter->lock);
+
+    /* The doorbell is armed once the granter thread has run its init; before
+     * that, the work sits on the intake list and the init's priming ring picks
+     * it up. */
+    if (granter->doorbell_armed) {
+        evpl_ring_doorbell(&granter->doorbell);
+    }
+} /* nlm_granter_submit */
+
+void
+nlm_granter_destroy(struct nlm_granter *granter)
+{
+    if (!granter) {
+        return;
+    }
+
+    pthread_mutex_lock(&granter->lock);
+    granter->shutdown = 1;
+    pthread_mutex_unlock(&granter->lock);
+
+    /* Joins the granter thread, running nlm_granter_thread_shutdown on it. */
+    if (granter->thread) {
+        evpl_thread_destroy(granter->thread);
+    }
+    pthread_mutex_destroy(&granter->lock);
+    free(granter);
+} /* nlm_granter_destroy */

--- a/src/server/nfs/nfs_nlm_granted.h
+++ b/src/server/nfs/nfs_nlm_granted.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+#include "nfs4_xdr.h"
+#include "nlm4_xdr.h"
+
+struct chimera_server_nfs_shared;
+struct nlm_granter;
+
+/* RFC 1813 / XNFS blocking-lock grant delivery.
+ *
+ * When a blocking NLM LOCK that conflicts is finally granted (the VFS pending
+ * pump fires its acquire callback with GRANTED), the server must call the
+ * waiting client back with NLMPROC4_GRANTED so its F_SETLKW state machine
+ * completes.  The grant is delivered asynchronously on a dedicated evpl_thread
+ * (the "granter"): for each job the granter resolves the client's NLM callback
+ * port via the client's portmapper (prog 100021, vers 4), connects, sends the
+ * GRANTED call carrying the original cookie + lock, and retransmits on a timer
+ * until the client acks (or a retry cap is reached).
+ *
+ * Grant jobs are fully self-contained snapshots (no pointer back into the
+ * nlm_lock_entry / RPC context), so the lock entry can be released by CANCEL,
+ * UNLOCK, disconnect, or shutdown without any use-after-free in the granter. */
+
+/* A blocking-lock grant to deliver to a waiting client.  All fields are copied
+ * by value; nothing here aliases server lock state. */
+struct nlm_grant_request {
+    char     client_addr[80];           /* client IP (no port); portmap target */
+    char     caller_name[LM_MAXSTRLEN + 1];
+    uint8_t  cookie[LM_MAXSTRLEN];
+    uint32_t cookie_len;
+    uint8_t  fh[NFS4_FHSIZE];           /* wrapped wire FH (as the client sent) */
+    uint32_t fh_len;
+    uint8_t  oh[LM_MAXSTRLEN];
+    uint32_t oh_len;
+    int32_t  svid;
+    uint64_t offset;
+    uint64_t length;                    /* UINT64_MAX == to EOF (wire convention) */
+    int      exclusive;
+};
+
+/* Lazily create the granter for this server (idempotent; thread-safe under
+ * nlm_state.mutex by the caller).  Returns NULL on failure (grant delivery is
+ * then skipped -- the lock is still held, the client just retransmits). */
+struct nlm_granter *
+nlm_granter_get_or_create(
+    struct chimera_server_nfs_shared *shared);
+
+/* Hand a grant job to the granter.  Copies *req; the caller retains ownership
+ * of req (typically a stack buffer).  Safe to call from any server thread. */
+void
+nlm_granter_submit(
+    struct nlm_granter             *granter,
+    const struct nlm_grant_request *req);
+
+/* Stop and free the granter (called from nfs_server_destroy).  Joins the
+ * granter thread, aborting any in-flight grant jobs cleanly.  NULL-safe. */
+void
+nlm_granter_destroy(
+    struct nlm_granter *granter);

--- a/src/server/nfs/nfs_nlm_state.c
+++ b/src/server/nfs/nfs_nlm_state.c
@@ -331,6 +331,16 @@ nlm_state_remove_client_file(
     (void) hostname;
 } /* nlm_state_remove_client_file */
 
+/*
+ * Release every lock held (or being acquired) by `client`.
+ *
+ * IMPORTANT: the caller must NOT hold state->mutex.  This function takes it
+ * internally for the detach phase and DROPS it before releasing leases.  That
+ * matters because chimera_vfs_lease_release() pumps the file's pending queue,
+ * which can synchronously fire another waiter's NLM acquire callback -- and
+ * that callback itself takes state->mutex.  Releasing leases under the mutex
+ * would therefore self-deadlock.
+ */
 void
 nlm_client_release_all_locks(
     struct nlm_state          *state,
@@ -340,23 +350,75 @@ nlm_client_release_all_locks(
     struct chimera_vfs_cred   *cred)
 {
     struct nlm_lock_entry *entry, *tmp;
+    struct nlm_lock_entry *reap  = NULL;  /* detached entries this call owns */
     int                    count = 0;
 
-    (void) state;
     (void) cred;
+#ifdef __clang_analyzer__
+    /* The list-walk bodies below are elided under the analyzer (utlist macro
+     * false positive); keep these from tripping unused-variable diagnostics. */
+    (void) entry;
+    (void) tmp;
+    (void) reap;
+    (void) count;
+    (void) vfs_thread;
+    (void) vfs_state;
+#endif /* __clang_analyzer__ */
+
+    /* Phase 1 (under the lock): cancel queued blocking tickets and detach every
+     * entry we own onto a private `reap` list.  Entries whose acquire callback
+     * is firing concurrently (cancel lost the race) are left on client->locks
+     * for that callback to remove and free. */
+    pthread_mutex_lock(&state->mutex);
 
     DL_FOREACH(client->locks, entry)
     {
         count++;
     }
+    chimera_nfs_debug("NLM: releasing all %d lock(s) for client '%s'", count,
+                      client->hostname);
 
-    chimera_nfs_debug("NLM: releasing all %d lock(s) for client '%s'", count, client->hostname);
-
+    /* The DL_DELETE/DL_APPEND utlist macros trip a scan-build null-deref false
+     * positive on the list head's prev field; guarded the same way as
+     * nlm_state_destroy in this file. */
+#ifndef __clang_analyzer__
     DL_FOREACH_SAFE(client->locks, entry, tmp)
     {
-        /* Drop the vfs_state lease (if granted) and put the file_state
-         * ref.  Pending entries (lease_inserted == false) skip the
-         * release; their VFS callback will clean up when it fires. */
+        /* A still-pending entry whose blocking acquire is queued in vfs_state
+         * (an NLM blocking LOCK not yet granted) must have its ticket cancelled
+         * before we free it -- otherwise the pending pump would later fire the
+         * acquire callback on freed memory.  chimera_vfs_lease_acquire_cancel is
+         * the atomic arbiter: true exactly once if it dequeued the ticket before
+         * the pump claimed it.
+         *
+         *   - cancel == true : the callback will NOT fire; WE own the entry.
+         *     Its original LOCK RPC already received NLM4_BLOCKED, so no reply is
+         *     owed; free the acquire ctx the callback would have freed.
+         *   - cancel == false: the acquire callback is firing concurrently and
+         *     will DL_DELETE + free this entry itself -- leave it linked, skip. */
+        if (entry->pending && !entry->lease_inserted && entry->file_state) {
+            if (!chimera_vfs_lease_acquire_cancel(vfs_state, &entry->ticket)) {
+                continue;
+            }
+            free(entry->ticket.private_data);
+            entry->ticket.private_data = NULL;
+            entry->pending             = false;
+        }
+
+        DL_DELETE(client->locks, entry);
+        entry->next = NULL;
+        entry->prev = NULL;
+        DL_APPEND(reap, entry);
+    }
+#endif /* ifndef __clang_analyzer__ */
+
+    pthread_mutex_unlock(&state->mutex);
+
+    /* Phase 2 (no lock held): release leases (which may pump and fire other
+     * waiters' callbacks), drop file_state refs, close handles, free. */
+#ifndef __clang_analyzer__
+    DL_FOREACH_SAFE(reap, entry, tmp)
+    {
         if (entry->lease_inserted) {
             chimera_vfs_lease_release(vfs_state, entry->file_state, &entry->lease);
             entry->lease_inserted = false;
@@ -368,7 +430,8 @@ nlm_client_release_all_locks(
         if (entry->handle) {
             chimera_vfs_release(vfs_thread, entry->handle);
         }
+        DL_DELETE(reap, entry);
         nlm_lock_entry_free(entry);
     }
-    client->locks = NULL;
+#endif /* ifndef __clang_analyzer__ */
 } /* nlm_client_release_all_locks */

--- a/src/server/nfs/nfs_nsm.c
+++ b/src/server/nfs/nfs_nsm.c
@@ -649,8 +649,13 @@ nsm_release_host_locks(
     struct chimera_vfs_cred           anon_cred;
     int                               found = 0;
 
+    /* Locate the client under the lock, then release outside it: release_all
+    * takes state->mutex itself and must not be called with it held (it pumps
+    * the VFS pending queue, which can re-enter the NLM acquire callback). */
     pthread_mutex_lock(&shared->nlm_state.mutex);
     HASH_FIND_STR(shared->nlm_state.clients, host, client);
+    pthread_mutex_unlock(&shared->nlm_state.mutex);
+
     if (client) {
         found = 1;
         chimera_vfs_cred_init_anonymous(&anon_cred,
@@ -661,7 +666,6 @@ nsm_release_host_locks(
                                      thread->vfs->vfs_state,
                                      &anon_cred);
     }
-    pthread_mutex_unlock(&shared->nlm_state.mutex);
     return found;
 } /* nsm_release_host_locks */
 

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -1720,13 +1720,14 @@ chimera_vfs_state_remove(
 /* -------------------------------------------------------------------- */
 
 SYMBOL_EXPORT void
-chimera_vfs_lease_acquire(
+chimera_vfs_lease_acquire_blocking(
     struct chimera_vfs_state           *state,
     struct chimera_vfs_file_state      *file,
     struct chimera_vfs_lease           *lease,
     struct chimera_vfs_pending_acquire *ticket,
     bool                                wait,
     chimera_vfs_lease_acquire_cb_t      cb,
+    chimera_vfs_lease_blocked_cb_t      blocked_cb,
     void                               *private_data)
 {
     enum chimera_vfs_lease_result result;
@@ -1750,12 +1751,20 @@ chimera_vfs_lease_acquire(
         pthread_mutex_lock(&file->lock);
         chimera_vfs_pending_enqueue_locked(file, ticket);
         pthread_mutex_unlock(&file->lock);
+        /* Tell the caller the result is deferred (e.g. NLM sends NLM4_BLOCKED).
+         * Fired after the enqueue but before return, so the result callback (run
+         * from a later pump, possibly on another thread) cannot race ahead of it;
+         * a NULL blocked_cb (every non-NLM caller) is simply a no-op. */
+        if (blocked_cb) {
+            blocked_cb(private_data);
+        }
         return;
     }
 
     /* A RANGE lease (byte-range lock) that is hard-DENIED by another owner's
      * conflicting lock, when the caller asked to wait, is an SMB2 blocking lock
-     * (MS-SMB2 3.3.5.14): queue it rather than bouncing DENIED.  The ticket fires
+     * (MS-SMB2 3.3.5.14) or a blocking NLM lock (RFC 1813 / XNFS NLM_LOCK with
+     * block==true): queue it rather than bouncing DENIED.  The ticket fires
      * GRANTED when the conflicting range is released (chimera_vfs_state_remove ->
      * pump_pending re-runs try_insert), or the caller cancels it
      * (chimera_vfs_lease_acquire_cancel) on CANCEL / handle close / teardown.
@@ -1767,6 +1776,9 @@ chimera_vfs_lease_acquire(
         pthread_mutex_lock(&file->lock);
         chimera_vfs_pending_enqueue_locked(file, ticket);
         pthread_mutex_unlock(&file->lock);
+        if (blocked_cb) {
+            blocked_cb(private_data);
+        }
         return;
     }
 
@@ -1779,6 +1791,20 @@ chimera_vfs_lease_acquire(
     /* Done exposing `conflict` to the cb; drop the try_insert pin (no-op unless
      * it is a caching grant). */
     chimera_vfs_state_conflict_unref(state, conflict);
+} /* chimera_vfs_lease_acquire_blocking */
+
+SYMBOL_EXPORT void
+chimera_vfs_lease_acquire(
+    struct chimera_vfs_state           *state,
+    struct chimera_vfs_file_state      *file,
+    struct chimera_vfs_lease           *lease,
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                wait,
+    chimera_vfs_lease_acquire_cb_t      cb,
+    void                               *private_data)
+{
+    chimera_vfs_lease_acquire_blocking(state, file, lease, ticket, wait, cb,
+                                       NULL, private_data);
 } /* chimera_vfs_lease_acquire */
 
 SYMBOL_EXPORT void

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -408,6 +408,34 @@ chimera_vfs_lease_acquire(
     chimera_vfs_lease_acquire_cb_t      cb,
     void                               *private_data);
 
+/* Optional one-shot notification fired iff an acquire QUEUES the ticket (i.e.
+ * the result callback is being deferred and will fire later from the pending
+ * pump).  It runs synchronously inside chimera_vfs_lease_acquire_blocking()
+ * before that call returns, under no file lock, and never fires when the result
+ * callback completes synchronously (GRANTED/DENIED inline).  NLM uses it to send
+ * the immediate NLM4_BLOCKED interim reply that RFC 1813 / XNFS require for a
+ * blocking LOCK that cannot be granted at once. */
+typedef void (*chimera_vfs_lease_blocked_cb_t)(
+    void *private_data);
+
+/* Identical to chimera_vfs_lease_acquire() but also takes an optional
+ * blocked_cb.  When the ticket is queued (a breakable conflict, or an SMB2/NLM
+ * blocking RANGE lock that hard-conflicts with another owner), blocked_cb is
+ * invoked exactly once -- synchronously, before this function returns -- and the
+ * result callback (cb) fires later from the pump.  blocked_cb may be NULL.  The
+ * plain chimera_vfs_lease_acquire() is a NULL-blocked_cb wrapper around this, so
+ * existing SMB/NFSv4 callers keep their exact prior contract. */
+void
+chimera_vfs_lease_acquire_blocking(
+    struct chimera_vfs_state           *state,
+    struct chimera_vfs_file_state      *file,
+    struct chimera_vfs_lease           *lease,
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                wait,
+    chimera_vfs_lease_acquire_cb_t      cb,
+    chimera_vfs_lease_blocked_cb_t      blocked_cb,
+    void                               *private_data);
+
 /* Release a previously-granted lease and free its slot in the file
  * state.  Equivalent to chimera_vfs_state_remove() but also pumps the
  * pending-acquire queue in case the released lease was holding back a


### PR DESCRIPTION
## Summary

Implements conformant blocking-lock behavior for NLM (RFC 1813 / Open Group C702 XNFS `NLM_LOCK`), closing #971.

Before this change a blocking NLM `LOCK` (`block=true`) that conflicted was queued in the VFS lease layer with the RPC reply deferred until grant: the server never returned `NLM4_BLOCKED` and there was **no outbound `NLM_GRANTED` callback path at all**. A standard Linux NLM client doing `F_SETLKW` (via `LOCK_MSG`) got neither the immediate `NLM4_BLOCKED` nor the later server-initiated `NLM_GRANTED` upcall its state machine expects, and the synchronous `LOCK` RPC was pinned open for the whole block.

Now:
1. A blocking `LOCK` that conflicts replies **`NLM4_BLOCKED` immediately** (proc 2: completes the original RPC, no longer held open; proc 17 `LOCK_MSG`: via `LOCK_RES`).
2. When the queued lock is later granted, the server calls the client back with **`NLMPROC4_GRANTED`**, retransmitting until acked.

## Design

**`NLM4_BLOCKED` detection (least-invasive).** New `chimera_vfs_lease_acquire_blocking()` = the existing `chimera_vfs_lease_acquire()` plus an optional one-shot `blocked_cb` that fires *synchronously, before the call returns, under no file lock* **iff the acquire queues the ticket**. The plain `chimera_vfs_lease_acquire()` becomes a `NULL`-`blocked_cb` wrapper, so every existing SMB/NFSv4 caller is byte-for-byte unchanged and the single deferred GRANTED callback the SMB blocking-lock path relies on is untouched. NLM passes a `blocked_cb` that sends the `NLM4_BLOCKED` interim and records that the grant must be delivered out-of-band.

**Outbound `NLM_GRANTED` transport.** A new per-server granter (`nfs_nlm_granted.c`) owns a dedicated `evpl_thread`, modeled on the NSM reboot-notify path, so portmap resolution + the GRANTED call + its retransmit timer never run on a core event loop. On grant, the acquire callback hands the granter a **fully self-contained job** (cookie + lock snapshot + client IP; no pointer back into the lock entry or RPC ctx). The granter resolves the client's NLM callback port via the client's portmapper (prog 100021 v4), connects, and sends **`NLMPROC4_GRANTED` (proc 5)** — chosen over the one-way `GRANTED_MSG` (proc 10) because its reply-bearing form delivers the client's ack *inline on the same connection*, so ack tracking and retransmit cancellation need no inbound-correlation table or second RPC service. Retransmit is on a 2s timer up to ~30s, then it gives up (the lock stays held; the client recovers by retransmitting `LOCK`).

**Lifetime / teardown.** Because grant jobs are value snapshots, releasing the lock entry on CANCEL / UNLOCK / disconnect / shutdown can never UAF the granter. A blocked proc-2 lock that is cancelled does not emit a second reply on the already-completed RPC. `nlm_client_release_all_locks` now cancels any still-queued blocking ticket before freeing its entry (the cancel primitive is the atomic arbiter; if it loses the race the acquire callback owns the entry), and does all VFS lease releases **outside `nlm_state.mutex`** — a lease release pumps the pending queue, which can re-enter the NLM acquire callback that also takes that mutex, so releasing under the lock would self-deadlock. Its three callers (FREE_ALL, disconnect, SM_NOTIFY) were updated accordingly. The granter is joined/freed in `nfs_server_destroy` before NLM state teardown.

## KVM coverage

Added `chimera/kvm/<image>/nlm/blocking_lock_memfs_nfs3`: a real-Linux-client test where a forked holder takes an exclusive POSIX byte-range lock and holds it while a waiter issues a **blocking `fcntl` lock (`F_SETLKW`)** on the same range over an NLM mount. The waiter's `lockf` returns only after the server's `NLM_GRANTED` callback lands; it passes only if the event order is exactly `A-LOCKED, A-UNLOCK, B-GRANTED` and the waiter genuinely blocked (>=1s). `fcntl` byte-range locks are used deliberately (not `flock(2)`, which the Linux NFS client can satisfy locally / coalesce under one owner). The plain NFS wrapper gained an opt-in `NFS_ENABLE_NLM` (rpcbind + rpc.statd, mount with locking; default stays `nolock`), mirroring the existing krb5_nlm bring-up.

**Run/verified:**
- New KVM test passes on ubuntu2404 in **Release and Debug (ASan)** with clean daemon teardown; the waiter blocks ~2s and is granted exactly after the holder unlocks (`EVT ['AL','AU','BG'] WAIT 2.0`).
- `pynfs` `combined_memfs_nfs4.{0,1,2}` green (Release + Debug/ASan).
- `vfs_state` unit suite 80/80 and `smbtorture smb2.lock` green under ASan (shared lease path unchanged).
- Existing `krb5_nlm_lock` and `ltp/fcntl-locktests` NLM tests still green.
- `clang --analyze` clean on all changed files; `reuse lint` compliant; uncrustify clean.