### PR TITLE
rest: abort startup if the JWT secret CSPRNG fails (#1108)

### DIFF
--- a/src/server/rest/rest_auth.c
+++ b/src/server/rest/rest_auth.c
@@ -181,7 +181,14 @@ hmac_sha256(
 void
 chimera_rest_auth_init_secret(struct chimera_rest_server *rest)
 {
-    RAND_bytes(rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN);
+    /* RAND_bytes returns 1 on success; on 0/-1 it may not write the buffer at
+     * all (CWE-252).  A zero/unseeded jwt_secret would let anyone forge a valid
+     * JWT for any user -- a full control-plane authentication bypass -- so a
+     * CSPRNG failure must abort startup rather than silently run with a known
+     * key. */
+    if (RAND_bytes(rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN) != 1) {
+        chimera_rest_abort("Failed to seed JWT signing secret from CSPRNG");
+    }
     chimera_rest_info("JWT authentication secret initialized");
 } /* chimera_rest_auth_init_secret */
 

--- a/src/server/rest/rest_internal.h
+++ b/src/server/rest/rest_internal.h
@@ -15,6 +15,7 @@ struct evpl_http_request;
 #define chimera_rest_debug(...) chimera_debug("rest", __FILE__, __LINE__, __VA_ARGS__)
 #define chimera_rest_info(...)  chimera_info("rest", __FILE__, __LINE__, __VA_ARGS__)
 #define chimera_rest_error(...) chimera_error("rest", __FILE__, __LINE__, __VA_ARGS__)
+#define chimera_rest_abort(...) chimera_abort("rest", __FILE__, __LINE__, __VA_ARGS__)
 
 struct chimera_rest_server {
     int                    http_port;


### PR DESCRIPTION
`chimera_rest_auth_init_secret` ignored the return value of `RAND_bytes`. `RAND_bytes` returns 1 on success; on failure (0/-1) it may not write the buffer at all (CWE-252) — reachable in a constrained container, a misconfigured FIPS provider, or under early-boot entropy starvation. The `jwt_secret` lives in a `calloc`'d `chimera_rest_server`, so on RNG failure it stayed all-zero and every JWT was then HMAC-SHA256 signed with a known 32-byte zero key. An attacker could forge a valid token for any user (e.g. a uid-0 account) and obtain full control-plane access with no credentials.

Fix: check the return value and `chimera_rest_abort` on failure — the server must not run with a predictable signing key. Adds a `chimera_rest_abort` macro alongside the existing `chimera_rest_{debug,info,error}` log macros.

Verified: release build clean; `rest/auth_test` and `rest_user_manip` pass (normal RNG path unaffected — the secret is still seeded as before, the change only adds a hard failure on the error path).

Fixes #1108