### PR TITLE
smb: batch of 10 SMB2 conformance fixes (server audit V2)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -4,6 +4,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/random.h>
 #include <pthread.h>
 #include <arpa/inet.h>
 #include <gssapi/gssapi.h>
@@ -44,6 +49,71 @@ chimera_smb_is_error_status(unsigned int status)
            status != SMB2_STATUS_MORE_PROCESSING_REQUIRED &&
            status != SMB2_STATUS_NOTIFY_ENUM_DIR;
 } /* chimera_smb_is_error_status */
+
+/*
+ * Establish the server's ServerGuid (MS-SMB2 2.2.4 / 3.3.5.4).  The ServerGuid
+ * must uniquely identify this server AND stay stable across restarts so that
+ * SMB3 clients can session-bind / durable-reconnect / multichannel-match to the
+ * same node.  Generate it once and persist it under the configured state_dir
+ * (mirroring the NFS fh.key mechanism); regenerate only if the file is absent
+ * or invalid.  If no state_dir is configured, fall back to a per-process random
+ * GUID (unique, but not stable -- acceptable for an ephemeral deployment).
+ */
+static void
+chimera_smb_server_guid_init(
+    struct chimera_server_smb_shared   *shared,
+    const struct chimera_server_config *config)
+{
+    const char *state_dir = chimera_server_config_get_state_dir(config);
+    char        path[512];
+    int         fd;
+
+    if (state_dir && state_dir[0]) {
+        snprintf(path, sizeof(path), "%s/smb_server.guid", state_dir);
+
+        fd = open(path, O_RDONLY);
+        if (fd >= 0) {
+            ssize_t n = read(fd, shared->guid, SMB2_GUID_SIZE);
+            close(fd);
+            if (n == (ssize_t) SMB2_GUID_SIZE) {
+                chimera_smb_info("Loaded SMB ServerGuid from %s", path);
+                return;
+            }
+            chimera_smb_error("Short read of SMB ServerGuid %s; regenerating", path);
+        }
+    }
+
+    if (getrandom(shared->guid, SMB2_GUID_SIZE, 0) != (ssize_t) SMB2_GUID_SIZE) {
+        /* Last-resort fallback: derive from a per-host identity so two distinct
+         * hosts still differ even if getrandom is unavailable. */
+        XXH128_hash_t h = XXH3_128bits(shared->config.identity,
+                                       strlen(shared->config.identity));
+        memcpy(shared->guid, &h, SMB2_GUID_SIZE);
+        chimera_smb_error("getrandom failed for SMB ServerGuid; "
+                          "falling back to identity-derived GUID");
+        return;
+    }
+
+    if (!state_dir || !state_dir[0]) {
+        chimera_smb_info("Generated per-process SMB ServerGuid "
+                         "(no state_dir; not stable across restarts)");
+        return;
+    }
+
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd >= 0) {
+        if (write(fd, shared->guid, SMB2_GUID_SIZE) != (ssize_t) SMB2_GUID_SIZE) {
+            chimera_smb_error("Failed to persist SMB ServerGuid to %s; GUID will "
+                              "not survive restart", path);
+        } else {
+            chimera_smb_info("Generated and persisted SMB ServerGuid at %s", path);
+        }
+        close(fd);
+    } else {
+        chimera_smb_error("Could not persist SMB ServerGuid to %s (%s); GUID will "
+                          "not survive restart", path, strerror(errno));
+    }
+} /* chimera_smb_server_guid_init */
 
 static void *
 chimera_smb_server_init(
@@ -173,7 +243,10 @@ chimera_smb_server_init(
     shared->vfs     = vfs;
     shared->metrics = metrics;
 
-    *(XXH128_hash_t *) shared->guid = XXH3_128bits(shared->config.identity, strlen(shared->config.identity));
+    /* ServerGuid: unique per server, stable across restarts (persisted under
+     * state_dir).  Was previously XXH3_128("chimera") -- identical on every
+     * instance (issue #984). */
+    chimera_smb_server_guid_init(shared, config);
 
     /* Derive the server's account-domain (machine) SID S-1-5-21-X-Y-Z once, from
      * a stable per-host identity (/etc/machine-id, else hostname), so the SIDs

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -248,6 +248,15 @@ chimera_smb_server_init(
      * instance (issue #984). */
     chimera_smb_server_guid_init(shared, config);
 
+    /* Capture this SMB server instance's start time (MS-SMB2 3.3.1.5 Global
+     * ServerStartTime).  Reported in NEGOTIATE so clients can detect an
+     * in-place restart -- this is the instance start, not the OS boot time. */
+    {
+        struct timespec start;
+        clock_gettime(CLOCK_REALTIME, &start);
+        shared->server_start_time = chimera_nt_time(&start);
+    }
+
     /* Derive the server's account-domain (machine) SID S-1-5-21-X-Y-Z once, from
      * a stable per-host identity (/etc/machine-id, else hostname), so the SIDs
      * the LSARPC/SAMR services hand out are unique per server and survive a

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1497,6 +1497,11 @@ struct chimera_server_smb_shared {
     int                               rdma;
     enum evpl_protocol_id             tcp_protocol;
     uint8_t                           guid[SMB2_GUID_SIZE];
+    /* MS-SMB2 2.2.4 / 3.3.1.5 Global ServerStartTime: the instant this SMB
+     * server instance started (NT time), captured once at init.  Reported in
+     * NEGOTIATE so clients can detect an in-place restart -- distinct from the
+     * OS boot time. */
+    uint64_t                          server_start_time;
     /* Account-domain (machine) SID sub-authorities: S-1-5-21-X-Y-Z, derived once
      * at startup from a stable per-host id (see chimera_smb_server_init).  The
      * LSARPC/SAMR services issue domain-relative SIDs under this. */

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -632,10 +632,13 @@ chimera_smb_close(struct chimera_smb_request *request)
 
         /* Named-pipe FIDs carry handle==NULL; fall through to the zero-attrs
          * path rather than dereferencing NULL in getattr (MS-SMB2 3.3.5.10). */
+        /* The POSTQUERY response is FILE_NETWORK_OPEN_INFORMATION whose first
+         * field is CreationTime (BTIME).  MASK_STAT deliberately omits BTIME, so
+         * request it explicitly or CreationTime is emitted as 0 (issue #1117). */
         chimera_vfs_getattr(thread->vfs_thread,
                             &request->session_handle->session->cred,
                             request->close.open_file->handle,
-                            CHIMERA_VFS_ATTR_MASK_STAT,
+                            CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_BTIME,
                             chimera_smb_close_getattr_callback,
                             request);
 

--- a/src/server/smb/smb_proc_flush.c
+++ b/src/server/smb/smb_proc_flush.c
@@ -8,6 +8,26 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
 
+/* Map a VFS commit error to the SMB2 status a client expects at FLUSH time.
+ * FLUSH is where a write-back backend surfaces a deferred-write failure, so the
+ * real status (disk-full / quota / write-protected / IO) MUST be reported rather
+ * than collapsing everything to INTERNAL_ERROR (issue #1250, MS-SMB2 3.3.5.11 /
+ * MS-FSA flush). */
+static inline uint32_t
+chimera_smb_flush_error_status(enum chimera_vfs_error error_code)
+{
+    switch (error_code) {
+        case CHIMERA_VFS_OK:     return SMB2_STATUS_SUCCESS;
+        case CHIMERA_VFS_ENOSPC:
+        case CHIMERA_VFS_EDQUOT: return SMB2_STATUS_DISK_FULL;
+        case CHIMERA_VFS_EROFS:  return SMB2_STATUS_MEDIA_WRITE_PROTECTED;
+        case CHIMERA_VFS_EACCES:
+        case CHIMERA_VFS_EPERM:  return SMB2_STATUS_ACCESS_DENIED;
+        case CHIMERA_VFS_EIO:    return SMB2_STATUS_IO_DEVICE_ERROR;
+        default:                 return SMB2_STATUS_INTERNAL_ERROR;
+    } /* switch */
+} /* chimera_smb_flush_error_status */
+
 static void
 chimera_smb_flush_callback(
     enum chimera_vfs_error    error_code,
@@ -19,7 +39,7 @@ chimera_smb_flush_callback(
 
     chimera_smb_open_file_release(request, request->flush.open_file);
 
-    chimera_smb_complete_request(request, error_code ? SMB2_STATUS_INTERNAL_ERROR : SMB2_STATUS_SUCCESS);
+    chimera_smb_complete_request(request, chimera_smb_flush_error_status(error_code));
 } /* chimera_smb_flush_callback */
 
 void

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -515,7 +515,12 @@ chimera_smb_ioctl_reply(
             for (int i = 0; i < shared->config.num_nic_info; i++) {
                 nic_info = &shared->config.nic_info[i];
 
-                caps = 0x1; /* RSS */
+                /* MS-SMB2 2.2.32 RSS_CAPABLE (0x1) must mirror the real NIC
+                 * capability; chimera has no RSS backing and no config knob, so
+                 * report 0 (no RSS) rather than asserting it unconditionally
+                 * (issue #1289).  RDMA_CAPABLE (0x2) is reported only when the
+                 * interface is actually configured for RDMA. */
+                caps = 0;
 
                 if (nic_info->rdma) {
                     caps |= 0x2; /* RDMA */
@@ -523,7 +528,7 @@ chimera_smb_ioctl_reply(
 
                 evpl_iovec_cursor_append_uint32(reply_cursor,  i == shared->config.num_nic_info - 1 ? 0 : 152); /* next */
                 evpl_iovec_cursor_append_uint32(reply_cursor, i + 1); /* ifindex */
-                evpl_iovec_cursor_append_uint32(reply_cursor, caps); /* capabilities (RSS) */
+                evpl_iovec_cursor_append_uint32(reply_cursor, caps); /* capabilities (RSS/RDMA) */
                 evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* reserved */
                 evpl_iovec_cursor_append_uint64(reply_cursor, nic_info->speed); /* speed */
                 /* SOCKADDR_STORAGE.ss_family is the Windows AF_* value on the

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -729,6 +729,16 @@ chimera_smb_lock(struct chimera_smb_request *request)
 
     request->lock.open_file = open_file;
 
+    /* Byte-range locking applies to a file (data stream); a directory handle has
+     * no byte range to lock.  Reject LOCK against a directory FID with
+     * STATUS_INVALID_DEVICE_REQUEST -- locking is not a directory operation
+     * (MS-SMB2 3.3.5.14; issue #1254). */
+    if (unlikely(open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY)) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_DEVICE_REQUEST);
+        return;
+    }
+
     /* LockCount==0 is illegal, and more than CHIMERA_SMB_LOCK_MAX_ELEMENTS is
      * rejected rather than parsed; both reply INVALID_PARAMETER without dropping
      * the connection. */

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -1017,8 +1017,15 @@ chimera_smb_select_negotiated_algorithms(
                 conn->negotiated.compression_flags = SMB2_COMPRESSION_FLAG_CHAINED;
             }
         } else {
-            /* No shared algorithm: do not emit a response context. */
-            conn->negotiated.ctx_present_mask &= ~CHIMERA_SMB_NEGOTIATE_CTX_COMPRESSION;
+            /* No shared algorithm: MS-SMB2 3.3.5.4 still requires the server to
+             * build a COMPRESSION_CAPABILITIES response context when it processed
+             * the request context, advertising CompressionAlgorithmCount=1 with
+             * the algorithm NONE.  This lets the client distinguish "no common
+             * algorithm" from "no compression support" (issue #1031).  Keep the
+             * context bit set so the emitter runs. */
+            conn->negotiated.compression_algs[0]   = SMB2_COMPRESSION_NONE;
+            conn->negotiated.compression_alg_count = 1;
+            conn->negotiated.compression_flags     = 0;
         }
     }
 } /* chimera_smb_select_negotiated_algorithms */

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -53,7 +53,7 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     struct chimera_server_smb_thread *thread = request->compound->thread;
     struct chimera_server_smb_shared *shared = thread->shared;
     struct chimera_smb_conn          *conn   = request->compound->conn;
-    struct timespec                   now, up, boot;
+    struct timespec                   now;
     uint16_t                          dialect = 0, candidate;
     int                               i, j;
 
@@ -81,19 +81,6 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     clock_gettime(
         CLOCK_REALTIME,
         &now);
-
-    clock_gettime(
-        CLOCK_BOOTTIME,
-        &up);
-
-    boot.tv_sec = now.tv_sec  - up.tv_sec;
-
-    if (now.tv_nsec >= up.tv_nsec) {
-        boot.tv_nsec = now.tv_nsec - up.tv_nsec;
-    } else {
-        boot.tv_nsec = up.tv_nsec - now.tv_nsec;
-        boot.tv_sec--;
-    }
 
     for (i = 0; i < request->negotiate.dialect_count; i++) {
 
@@ -178,7 +165,10 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     request->negotiate.r_max_read_size     = 8 * 1024 * 1024;
     request->negotiate.r_max_write_size    = 8 * 1024 * 1024;
     request->negotiate.r_system_time       = chimera_nt_time(&now);
-    request->negotiate.r_server_start_time = chimera_nt_time(&boot);
+    /* ServerStartTime is the SMB server instance start time (captured once at
+     * init), not the OS boot time -- so an in-place chimera restart is visible
+     * to clients keying off this field (issue #1225, MS-SMB2 3.3.1.5). */
+    request->negotiate.r_server_start_time = shared->server_start_time;
 
     memcpy(request->negotiate.r_server_guid, shared->guid, SMB2_GUID_SIZE);
 

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -1081,6 +1081,18 @@ chimera_smb_parse_negotiate(
     request->negotiate.ctx_present_mask = 0;
 
     if (request->negotiate.negotiate_context_count) {
+        /* Bound NegotiateContextCount up-front (MS-SMB2 2.2.3.1 / 3.3.5.4): a
+         * hostile count (e.g. 0xFFFF) would otherwise drive the parse loop until
+         * a truncation guard fires.  There are only a handful of valid context
+         * types; reject anything beyond the supported maximum rather than
+         * leniently scanning off the end of the message (issue #1224). */
+        if (request->negotiate.negotiate_context_count > SMB2_MAX_NEGOTIATE_CONTEXTS) {
+            chimera_smb_error("SMB2 NEGOTIATE context count %u exceeds max %u",
+                              request->negotiate.negotiate_context_count,
+                              SMB2_MAX_NEGOTIATE_CONTEXTS);
+            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
+        }
+
         /* Seek to the context list (validated forward and within the message);
          * smb_cursor_seek_to subsumes the old precedes-consumed underflow guard. */
         if (unlikely(smb_cursor_seek_to(request_cursor,

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -540,6 +540,19 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         request);
                     break;
                 case SMB2_FILE_ENDOFFILE_INFO:
+
+                    /* EndOfFile/Allocation apply to a data stream; a directory
+                     * has none, so Windows fails the set with
+                     * STATUS_INVALID_PARAMETER (MS-FSCC 2.4.14 / MS-FSA
+                     * 2.1.5.14.13; issue #1261). */
+                    if (request->set_info.open_file->flags &
+                        CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY) {
+                        chimera_smb_open_file_release(request, request->set_info.open_file);
+                        chimera_smb_complete_request(request,
+                                                     SMB2_STATUS_INVALID_PARAMETER);
+                        break;
+                    }
+
                     chimera_smb_unmarshal_end_of_file_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
                     /* A size change fires FILE_NOTIFY_CHANGE_SIZE (and, via the
@@ -568,6 +581,17 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         request);
                     break;
                 case SMB2_FILE_ALLOCATION_INFO:
+
+                    /* A directory has no data stream to (de)allocate; reject with
+                    * STATUS_INVALID_PARAMETER (MS-FSCC 2.4.4 / MS-FSA; #1261). */
+                    if (request->set_info.open_file->flags &
+                        CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY) {
+                        chimera_smb_open_file_release(request, request->set_info.open_file);
+                        chimera_smb_complete_request(request,
+                                                     SMB2_STATUS_INVALID_PARAMETER);
+                        break;
+                    }
+
                     /* AllocationInfo only changes the file when the requested
                      * allocation is below the current EOF, in which case the
                      * file is truncated to it (MS-FSCC §2.4.4).  A truncation

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -93,6 +93,13 @@ chimera_smb_tree_connect(struct chimera_smb_request *request)
             return;
         }
 
+        /* realloc() does not zero the newly grown region.  The free-slot scan
+         * above and the dispatcher's TreeId resolution both rely on unused
+         * slots being NULL, so zero every newly added slot before publishing
+         * the grown array. */
+        memset(&grown[session->max_trees], 0,
+               session->max_trees * sizeof(struct chimera_smb_tree *));
+
         session->max_trees           *= 2;
         session->trees                = grown;
         session->trees[tree->tree_id] = tree;


### PR DESCRIPTION
A batch of 10 small, conservative SMB2 conformance fixes from the 2026-06 server-side conformance audit. One commit per issue.

## Fixes

- **#1062** (high, memory-safety) — TREE_CONNECT `trees[]` grow path `realloc()`'d without zeroing the new slots; the free-slot scan and TreeId dispatch rely on unused slots being NULL, so garbage slots could leak TIDs or be dereferenced as a wild `chimera_smb_tree`. Now `memset`s the grown region before publishing it.
- **#984** (med) — ServerGuid was `XXH3_128("chimera")`, identical on every instance. Now generated once and persisted under `state_dir` (mirroring the NFS `fh.key` mechanism) so it is unique per server and stable across restarts; falls back to a per-process random GUID when no `state_dir` is configured.
- **#1225** (low) — ServerStartTime reported OS boot time (CLOCK_REALTIME − CLOCK_BOOTTIME). Now captures the SMB instance start time once at init and reports that, so an in-place restart is visible to clients.
- **#1117** (med) — CLOSE with POSTQUERY_ATTRIB returned CreationTime=0 because the post-close getattr used MASK_STAT (no BTIME). Adds `CHIMERA_VFS_ATTR_BTIME` to the request mask.
- **#1224** (low) — NegotiateContextCount was used as a parse-loop bound with no up-front cap. Rejects a count exceeding `SMB2_MAX_NEGOTIATE_CONTEXTS` with STATUS_INVALID_PARAMETER; valid path unchanged.
- **#1289** (low) — NETWORK_INTERFACE_INFO hardcoded RSS_CAPABLE (0x1) with no backing. Now reports 0 (RDMA_CAPABLE still set when configured).
- **#1261** (low) — SET_INFO FileEndOfFile / FileAllocationInformation were not rejected on a directory handle. Now returns STATUS_INVALID_PARAMETER for a directory (MS-FSCC 2.4.14 / 2.4.4).
- **#1254** (low) — Byte-range LOCK was accepted on a directory handle. Now rejected with STATUS_INVALID_DEVICE_REQUEST (MS-SMB2 3.3.5.14).
- **#1250** (low) — FLUSH collapsed every VFS commit error to STATUS_INTERNAL_ERROR. Now maps ENOSPC/EDQUOT→DISK_FULL, EROFS→MEDIA_WRITE_PROTECTED, EACCES/EPERM→ACCESS_DENIED, EIO→IO_DEVICE_ERROR (default INTERNAL_ERROR).
- **#1031** (low) — COMPRESSION_CAPABILITIES response context was omitted when no common algorithm existed. Now emits the context advertising CompressionAlgorithmCount=1 / NONE (MS-SMB2 3.3.5.4).

## Notes

All 10 landed; none dropped. (#1254 status choice: there is no smbtorture test pinning the exact status for LOCK-on-directory, so STATUS_INVALID_DEVICE_REQUEST was chosen as the spec-correct "operation invalid for this object type" status.)

## Validation

Local smbtorture + WPTS, no regressions, clean ASan teardown:
- Release: `smbtorture_smb2_{negotiate,lock,create,getinfo,setinfo,session,ioctl,compound}` — 74/74 pass; `smbtorture_smb2_{getinfo,ioctl,tcon}` pass; WPTS `memfs`, `memfs_compression`, `wpts-fsa/memfs` pass.
- Debug/ASan: `smbtorture_smb2_{lock,create}` + WPTS `memfs` pass (covers #1062 tree-connect growth and the directory type-check changes).
