### PR TITLE
smb2: SMB2Model ResilientHandle conformance (FSCTL_LMR_REQUEST_RESILIENCY)

### DIFF
--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -247,6 +247,12 @@ generate_config() {
             "smbpasswd": "Password01!",
             "uid": 0,
             "gid": 0
+        },
+        {
+            "username": "nonadmin",
+            "smbpasswd": "Password01!",
+            "uid": 1000,
+            "gid": 1000
         }
     ]
 }
@@ -361,6 +367,14 @@ rm -rf "${WPTS_STAGE_DIR}/TestResults" "${WPTS_STAGE_DIR}/.\\TestLog"
 cp "${WPTS_PTFCONFIG_DIR}/CommonTestSuite.deployment.ptfconfig" \
    "${WPTS_PTFCONFIG_DIR}/${WPTS_SUITE_PTFCONFIG}" \
    "${WPTS_STAGE_DIR}/"
+
+# Advertise the second (non-administrator) local account the daemon serves
+# (uid 1000, same PasswordForAllUsers). Cases that reconnect a durable/resilient
+# handle as a different user (MS-SMB2 3.3.5.9.7 step 9 -> STATUS_ACCESS_DENIED)
+# need a NonAdminUserName; without it the driver reports them Inconclusive.
+sed -i \
+    -e 's#<Property name="NonAdminUserName" value=""/>#<Property name="NonAdminUserName" value="nonadmin"/>#' \
+    "${WPTS_STAGE_DIR}/CommonTestSuite.deployment.ptfconfig"
 
 # When persistent handles are enabled, advertise the matching capability +
 # CA-share to the test driver so the DurableHandleV2 / PersistentHandle cases

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -70,6 +70,7 @@ chimera_smb_durable_register(
     struct chimera_server_smb_shared *shared,
     struct chimera_smb_open_file     *open_file,
     uint64_t                          session_id,
+    uint32_t                          owner_uid,
     const uint8_t                    *client_guid,
     const char                       *name,
     uint32_t                          name_len,
@@ -79,6 +80,7 @@ chimera_smb_durable_register(
 
     entry->persistent_id = open_file->file_id.pid;
     entry->session_id    = session_id;
+    entry->owner_uid     = owner_uid;
     entry->open_file     = open_file;
     entry->parked        = false;
     entry->persistent    = persistent;
@@ -415,6 +417,7 @@ chimera_smb_durable_claim(
     uint64_t                          persistent_id,
     const uint8_t                    *create_guid,
     const uint8_t                    *client_guid,
+    uint32_t                          owner_uid,
     const char                       *name,
     uint32_t                          name_len,
     bool                              has_lease_ctx,
@@ -492,6 +495,13 @@ chimera_smb_durable_claim(
          * non-lease (oplock) reconnect both ignore the name entirely: the
          * handle's identity is its persistent id, plus the create_guid for v2. */
         *status = SMB2_STATUS_INVALID_PARAMETER;
+    } else if (!entry->cold && entry->owner_uid != owner_uid) {
+        /* MS-SMB2 3.3.5.9.7 step 9: the reconnecting session's user must be the
+         * same user that owns the durable/resilient open (Open.DurableOwner).  A
+         * reclaim by a different user is denied with STATUS_ACCESS_DENIED.  Cold
+         * (server-restart-recovered) entries carry no in-memory owner, so the
+         * check applies only to warm handles. */
+        *status = SMB2_STATUS_ACCESS_DENIED;
     } else if (entry->cold) {
         /* Recovered-after-restart entry: there is no live open to re-home.
          * Remove it and tell the caller to re-open the file (cold reclaim);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1453,6 +1453,11 @@ struct chimera_smb_durable_entry {
      * session after the original connection dropped. */
     uint8_t                           client_guid[16];
     uint64_t                          session_id; /* original owning session (informational) */
+    /* Owner identity (MS-SMB2 Open.DurableOwner): the uid of the security
+     * context that created the durable/resilient handle.  A durable reconnect
+     * (DH2C/DHnC, 3.3.5.9.7 step 9) by a different user MUST be denied with
+     * STATUS_ACCESS_DENIED. */
+    uint32_t                          owner_uid;
     struct timespec                   deadline;  /* reconnect grace; valid only while parked */
     bool                              parked;    /* true => disconnected, awaiting reconnect */
     /* persistent: the record is also persisted in the share's backend (survives
@@ -1581,6 +1586,7 @@ chimera_smb_durable_register(
     struct chimera_server_smb_shared *shared,
     struct chimera_smb_open_file     *open_file,
     uint64_t                          session_id,
+    uint32_t                          owner_uid,
     const uint8_t                    *client_guid,
     const char                       *name,
     uint32_t                          name_len,
@@ -1599,6 +1605,7 @@ chimera_smb_durable_claim(
     uint64_t                          persistent_id,
     const uint8_t                    *create_guid,
     const uint8_t                    *client_guid,
+    uint32_t                          owner_uid,
     const char                       *name,
     uint32_t                          name_len,
     bool                              has_lease_ctx,

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -400,6 +400,7 @@ chimera_smb_create_register_durable(
     }
     chimera_smb_durable_register(request->compound->thread->shared, open_file,
                                  request->session_handle->session->session_id,
+                                 request->session_handle->session->cred.uid,
                                  request->compound->conn->client_guid,
                                  open_file->name, open_file->name_len,
                                  request->create.persist_pid != 0);
@@ -3813,6 +3814,7 @@ chimera_smb_durable_reconnect_attempt(struct chimera_smb_request *request)
 
     open_file = chimera_smb_durable_claim(shared, persistent_id, create_guid,
                                           request->compound->conn->client_guid,
+                                          request->session_handle->session->cred.uid,
                                           request->create.name, request->create.name_len,
                                           has_lease_ctx, lease_key,
                                           &cold, &retry, &status);
@@ -4280,7 +4282,11 @@ chimera_smb_create(struct chimera_smb_request *request)
      * ignores the create fields entirely -- CreateDisposition, file name, access
      * and the rest are not interpreted (MS-SMB2 3.3.5.9.7/.12) -- so the field
      * validations below must not run for it; it is dispatched straight to
-     * chimera_smb_durable_reconnect. */
+     * chimera_smb_durable_reconnect.  Gated on the persistent-handles config:
+     * that knob enables chimera's whole durable/resilient reconnect machinery
+     * (durable grants, the registry, park/reclaim).  With it off, durable
+     * contexts are not granted, so a DH2C/DHnC carries no reclaimable handle and
+     * is treated as an ordinary create (the context is ignored, per 3.3.5.9). */
     bool is_durable_reconnect =
         request->compound->thread->shared->config.persistent_handles &&
         (request->create.ctx_present_mask &

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -366,6 +366,7 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
                     chimera_smb_durable_register(
                         request->compound->thread->shared, open_file,
                         request->session_handle->session->session_id,
+                        request->session_handle->session->cred.uid,
                         request->compound->conn->client_guid,
                         open_file->name, open_file->name_len, false);
                 }
@@ -471,8 +472,15 @@ chimera_smb_ioctl_reply(
     evpl_iovec_cursor_append_uint16(reply_cursor, SMB2_IOCTL_REPLY_SIZE);
     evpl_iovec_cursor_append_uint16(reply_cursor, 0); /* Reserved (MS-SMB2 2.2.32) */
     evpl_iovec_cursor_append_uint32(reply_cursor, request->ioctl.ctl_code);
-    evpl_iovec_cursor_append_uint64(reply_cursor, 0xffffffffffffffffULL); /* file_id.pid */
-    evpl_iovec_cursor_append_uint64(reply_cursor, 0xffffffffffffffffULL); /* file_id.vid */
+    /* FileId (MS-SMB2 2.2.32): echo the request's FileId.  A file-targeted FSCTL
+     * (e.g. FSCTL_LMR_REQUEST_RESILIENCY -- 3.3.5.15.9 requires the response
+     * FileId.Persistent/Volatile to be the open's DurableFileId/FileId) carries
+     * the open's id, which the client validates against the handle it operated
+     * on; a file-less FSCTL (FSCTL_VALIDATE_NEGOTIATE_INFO,
+     * FSCTL_QUERY_NETWORK_INTERFACE_INFO, ...) carries the { 0xFFFF...FFFF,
+     * 0xFFFF...FFFF } sentinel on the wire and so is echoed back unchanged. */
+    evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.file_id.pid);
+    evpl_iovec_cursor_append_uint64(reply_cursor, request->ioctl.file_id.vid);
     evpl_iovec_cursor_append_uint32(reply_cursor, input_offset); /* input offset */
     evpl_iovec_cursor_append_uint32(reply_cursor, input_length); /* input count */
     evpl_iovec_cursor_append_uint32(reply_cursor, output_offset); /* output_offset */
@@ -631,8 +639,7 @@ chimera_smb_parse_ioctl(
         chimera_smb_error("Received SMB2 IOCTL request with invalid struct size (%u expected %u)",
                           request->request_struct_size,
                           SMB2_IOCTL_REQUEST_SIZE);
-        request->status = SMB2_STATUS_INVALID_PARAMETER;
-        return -1;
+        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
     }
 
 
@@ -682,8 +689,7 @@ chimera_smb_parse_ioctl(
                 if (request->ioctl.input_count < 24) {
                     chimera_smb_error("VALIDATE_NEGOTIATE_INFO input too small (%u < 24)",
                                       request->ioctl.input_count);
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
 
                 /* Parse validate negotiate info request */
@@ -696,14 +702,12 @@ chimera_smb_parse_ioctl(
                 if (request->ioctl.vni_dialect_count > SMB2_MAX_DIALECTS) {
                     chimera_smb_error("VALIDATE_NEGOTIATE_INFO dialect count too large (%u > %u)",
                                       request->ioctl.vni_dialect_count, SMB2_MAX_DIALECTS);
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
 
                 if (request->ioctl.input_count < 24 + (request->ioctl.vni_dialect_count * 2)) {
                     chimera_smb_error("VALIDATE_NEGOTIATE_INFO input too small for dialect count");
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
 
                 for (i = 0; i < request->ioctl.vni_dialect_count; i++) {
@@ -725,8 +729,7 @@ chimera_smb_parse_ioctl(
                 if (request->ioctl.input_count < 8) {
                     chimera_smb_error("SET_REPARSE_POINT input too small (%u < 8)",
                                       request->ioctl.input_count);
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
 
                 evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.rp_reparse_tag);
@@ -738,8 +741,7 @@ chimera_smb_parse_ioctl(
                     if (request->ioctl.input_count < 16) {
                         chimera_smb_error("SET_REPARSE_POINT NFS input too small (%u < 16)",
                                           request->ioctl.input_count);
-                        request->status = SMB2_STATUS_INVALID_PARAMETER;
-                        return -1;
+                        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                     }
 
                     evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.rp_nfs_type);
@@ -753,8 +755,7 @@ chimera_smb_parse_ioctl(
                             if (utf16_data_len <= 0 || utf16_data_len > (CHIMERA_VFS_PATH_MAX - 1) * 2) {
                                 chimera_smb_error("SET_REPARSE_POINT LNK: invalid target len %d",
                                                   utf16_data_len);
-                                request->status = SMB2_STATUS_INVALID_PARAMETER;
-                                return -1;
+                                return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                             }
 
                             {
@@ -776,8 +777,7 @@ chimera_smb_parse_ioctl(
 
                                 if (utf8_len < 0) {
                                     chimera_smb_error("SET_REPARSE_POINT LNK: UTF-16LE conversion failed");
-                                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                                    return -1;
+                                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                                 }
 
                                 request->ioctl.rp_target[utf8_len] = '\0';
@@ -797,8 +797,7 @@ chimera_smb_parse_ioctl(
                             if (reparse_data_len < 16) {
                                 chimera_smb_error("SET_REPARSE_POINT CHR/BLK: data too small (%u < 16)",
                                                   reparse_data_len);
-                                request->status = SMB2_STATUS_INVALID_PARAMETER;
-                                return -1;
+                                return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                             }
                             if (unlikely(evpl_iovec_cursor_try_get_uint32(request_cursor,
                                                                           &request->ioctl.rp_device_major) ||
@@ -828,11 +827,10 @@ chimera_smb_parse_ioctl(
                     if (reparse_data_len < 12) {
                         chimera_smb_error("SET_REPARSE_POINT SYMLINK: data too small (%u < 12)",
                                           reparse_data_len);
-                        request->status = SMB2_STATUS_INVALID_PARAMETER;
-                        return -1;
+                        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                     }
 
-                    int src = 0;
+                    int      src = 0;
                     src |= evpl_iovec_cursor_try_get_uint16(request_cursor, &sub_name_offset);
                     src |= evpl_iovec_cursor_try_get_uint16(request_cursor, &sub_name_length);
                     src |= evpl_iovec_cursor_try_get_uint16(request_cursor, &print_name_offset);
@@ -848,8 +846,7 @@ chimera_smb_parse_ioctl(
                         sub_name_length > (CHIMERA_VFS_PATH_MAX - 1) * 2) {
                         chimera_smb_error("SET_REPARSE_POINT SYMLINK: invalid sub_name_length %u",
                                           sub_name_length);
-                        request->status = SMB2_STATUS_INVALID_PARAMETER;
-                        return -1;
+                        return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                     }
 
                     /* Skip to SubstituteName within PathBuffer */
@@ -879,8 +876,7 @@ chimera_smb_parse_ioctl(
 
                         if (utf8_len < 0) {
                             chimera_smb_error("SET_REPARSE_POINT SYMLINK: UTF-16LE conversion failed");
-                            request->status = SMB2_STATUS_INVALID_PARAMETER;
-                            return -1;
+                            return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                         }
 
                         request->ioctl.rp_target[utf8_len] = '\0';
@@ -914,8 +910,7 @@ chimera_smb_parse_ioctl(
                 if (request->ioctl.input_count < 16) {
                     chimera_smb_error("SET_ZERO_DATA input too small (%u < 16)",
                                       request->ioctl.input_count);
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.sp_zero_offset);
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.sp_zero_beyond);
@@ -925,8 +920,7 @@ chimera_smb_parse_ioctl(
                 if (request->ioctl.input_count < 16) {
                     chimera_smb_error("QUERY_ALLOCATED_RANGES input too small (%u < 16)",
                                       request->ioctl.input_count);
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.sp_qar_offset);
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.sp_qar_length);
@@ -939,8 +933,7 @@ chimera_smb_parse_ioctl(
                 uint32_t reserved, cc, i;
 
                 if (request->ioctl.input_count < 32) {
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 /* The 24-byte SourceKey encodes the source open's FileId. */
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.cc_src_file_id.pid);
@@ -951,8 +944,7 @@ chimera_smb_parse_ioctl(
 
                 if (cc > CHIMERA_SMB_COPYCHUNK_MAX ||
                     request->ioctl.input_count < 32 + (uint64_t) cc * 24) {
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
 
                 request->ioctl.cc_chunk_count = cc;
@@ -969,8 +961,7 @@ chimera_smb_parse_ioctl(
                  * SourceFileID is a 16-byte SMB2 FileId (pid + vid), then
                  * SourceFileOffset(8), TargetFileOffset(8), ByteCount(8). */
                 if (request->ioctl.input_count < 40) {
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.de_src_file_id.pid);
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.de_src_file_id.vid);
@@ -983,8 +974,7 @@ chimera_smb_parse_ioctl(
                  * + TokenTimeToLive(4) + Reserved(4) + FileOffset(8) +
                  * CopyLength(8). */
                 if (request->ioctl.input_count < 32) {
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_skip(request_cursor, 16); /* Size, Flags, TTL, Reserved */
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.od_file_offset);
@@ -995,8 +985,7 @@ chimera_smb_parse_ioctl(
                  * + FileOffset(8) + CopyLength(8) + TransferOffset(8) +
                  * Token(512). */
                 if (request->ioctl.input_count < 32 + SMB2_OFFLOAD_TOKEN_SIZE) {
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_skip(request_cursor, 8); /* Size, Flags */
                 evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.od_file_offset);
@@ -1009,8 +998,7 @@ chimera_smb_parse_ioctl(
                  * NumRanges(4) + NumRanges * { Offset(8), Length(8) }.  We only
                  * need Key (must be 0) and NumRanges (to report processed). */
                 if (request->ioctl.input_count < 8) {
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.tr_key);
                 evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.tr_num_ranges);
@@ -1019,8 +1007,7 @@ chimera_smb_parse_ioctl(
                 /* SET_INTEGRITY_INFORMATION_BUFFER (MS-FSCC 2.3.55):
                  * ChecksumAlgorithm(2) + Reserved(2) + Flags(4). */
                 if (request->ioctl.input_count < 8) {
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_get_uint16(request_cursor, &request->ioctl.ii_algo);
                 evpl_iovec_cursor_skip(request_cursor, 2); /* Reserved */
@@ -1032,8 +1019,7 @@ chimera_smb_parse_ioctl(
                 if (request->ioctl.input_count < 8) {
                     chimera_smb_error("LMR_REQUEST_RESILIENCY input too small (%u < 8)",
                                       request->ioctl.input_count);
-                    request->status = SMB2_STATUS_INVALID_PARAMETER;
-                    return -1;
+                    return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
                 evpl_iovec_cursor_get_uint32(request_cursor, &request->ioctl.rr_timeout_ms);
                 evpl_iovec_cursor_skip(request_cursor, 4); /* Reserved */

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -1000,10 +1000,11 @@ test_durable_register_park_claim(void)
     of.durable_timeout_ms = 60000;
     memcpy(of.create_guid, guid, 16);
 
-    chimera_smb_durable_register(shared, &of, 42, cguid, "foo.txt", 7, false);
+    chimera_smb_durable_register(shared, &of, 42, 0, cguid, "foo.txt", 7, false);
 
     /* Before park: live, not reclaimable. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+                                        status
                                         );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: live (unparked) handle is not reclaimable");
@@ -1015,7 +1016,8 @@ test_durable_register_park_claim(void)
 
     /* Wrong create-guid is rejected. */
     guid[0] = 0xFF;
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+                                        status
                                         );
     guid[0] = 0x10;
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
@@ -1027,7 +1029,8 @@ test_durable_register_park_claim(void)
     /* An oplock-only (no-lease) durable handle is not bound to the ClientGuid:
      * a reconnect from a different ClientGuid reclaims it (MS-SMB2 3.3.5.9.7
      * binds the GUID check to leased opens).  of.oplock_level is 0 here. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, false, NULL, &cold, &retry, &status
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+                                        status
                                         );
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: oplock reconnect ignores client-guid");
@@ -1041,7 +1044,8 @@ test_durable_register_park_claim(void)
     /* A *leased* handle IS bound to the ClientGuid: a mismatch is rejected. */
     of.oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
     memcpy(of.lease_key, lkey, 16);
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, "foo.txt", 7, true, lkey, &cold, &retry, &status)
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, 0, "foo.txt", 7, true, lkey, &cold, &retry, &
+                                        status)
     ;
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: leased reconnect rejects client-guid mismatch");
@@ -1050,7 +1054,8 @@ test_durable_register_park_claim(void)
     }
 
     /* Matching reconnect (correct ClientGuid + lease key) reclaims the open. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, true, lkey, &cold, &retry, &status)
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, true, lkey, &cold, &retry, &
+                                        status)
     ;
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: matching reconnect reclaims the open");
@@ -1060,7 +1065,8 @@ test_durable_register_park_claim(void)
     of.oplock_level = 0;
 
     /* A second reconnect must fail — the handle is now live again. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+                                        status
                                         );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: double-reconnect rejected");
@@ -1071,7 +1077,8 @@ test_durable_register_park_claim(void)
     /* After forget, the persistent id is unknown. */
     chimera_smb_durable_forget(shared, 0xABCDEF);
     chimera_smb_durable_park(shared, &of);  /* no entry -> no-op */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, "foo.txt", 7, false, NULL, &cold, &retry, &status
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+                                        status
                                         );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_FAIL("durable: forgotten handle not found");
@@ -1082,9 +1089,9 @@ test_durable_register_park_claim(void)
     /* v1 reconnect (DHnC): no create-guid supplied. */
     of.file_id.pid   = 0x999;
     of.durable_flags = CHIMERA_SMB_DURABLE_V1;
-    chimera_smb_durable_register(shared, &of, 7, cguid, "bar", 3, false);
+    chimera_smb_durable_register(shared, &of, 7, 0, cguid, "bar", 3, false);
     chimera_smb_durable_park(shared, &of);
-    claimed = chimera_smb_durable_claim(shared, 0x999, NULL, cguid, "bar", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x999, NULL, cguid, 0, "bar", 3, false, NULL, &cold, &retry, &status);
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: v1 (no-guid) reconnect reclaims the open");
     } else {
@@ -1190,14 +1197,14 @@ test_durable_cold_recover_claim(void)
 
     /* Claim of a cold entry returns NULL + SUCCESS + cold=true (caller must
      * re-open the file) and consumes the entry. */
-    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, "abc", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, 0, "abc", 3, false, NULL, &cold, &retry, &status);
     if (claimed == NULL && cold && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable cold: reclaim signals cold re-open");
     } else {
         TEST_FAIL("durable cold: reclaim signals cold re-open");
     }
 
-    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, "abc", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, 0, "abc", 3, false, NULL, &cold, &retry, &status);
     if (claimed == NULL && !cold && status == SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_PASS("durable cold: entry consumed after reclaim");
     } else {
@@ -1207,7 +1214,7 @@ test_durable_cold_recover_claim(void)
     /* Wrong client reclaiming a cold entry is denied. */
     rec.persistent_id = 0x5001;
     chimera_smb_durable_recover_entry(shared, &rec);
-    claimed = chimera_smb_durable_claim(shared, 0x5001, guid, other, "abc", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5001, guid, other, 0, "abc", 3, false, NULL, &cold, &retry, &status);
     if (claimed == NULL && !cold && status == SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_PASS("durable cold: wrong client -> OBJECT_NAME_NOT_FOUND");
     } else {

--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -1955,94 +1955,94 @@ RequestPersistentHandleTestCaseS30,persistent,green,0,
 RequestPersistentHandleTestCaseS50,persistent,green,0,
 RequestPersistentHandleTestCaseS74,persistent,green,0,
 RequestPersistentHandleTestCaseS93,persistent,green,0,
-ResilientHandleBasicTestCaseS0,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS0,persistent,green,0,
 ResilientHandleBasicTestCaseS1031,persistent,green,0,
-ResilientHandleBasicTestCaseS1109,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1199,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1217,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1267,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS1109,persistent,green,0,
+ResilientHandleBasicTestCaseS1199,persistent,green,0,
+ResilientHandleBasicTestCaseS1217,persistent,green,0,
+ResilientHandleBasicTestCaseS1267,persistent,green,0,
 ResilientHandleBasicTestCaseS1333,persistent,green,0,
-ResilientHandleBasicTestCaseS1375,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1566,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1654,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1733,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1799,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1817,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1860,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1926,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS1938,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS1375,persistent,green,0,
+ResilientHandleBasicTestCaseS1566,persistent,green,0,
+ResilientHandleBasicTestCaseS1654,persistent,green,0,
+ResilientHandleBasicTestCaseS1733,persistent,green,0,
+ResilientHandleBasicTestCaseS1799,persistent,green,0,
+ResilientHandleBasicTestCaseS1817,persistent,green,0,
+ResilientHandleBasicTestCaseS1860,persistent,green,0,
+ResilientHandleBasicTestCaseS1926,persistent,green,0,
+ResilientHandleBasicTestCaseS1938,persistent,green,0,
 ResilientHandleBasicTestCaseS2028,persistent,green,0,
 ResilientHandleBasicTestCaseS2148,persistent,green,0,
 ResilientHandleBasicTestCaseS2204,persistent,green,0,
-ResilientHandleBasicTestCaseS2246,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2326,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2368,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS238,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2412,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2454,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2508,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS2246,persistent,green,0,
+ResilientHandleBasicTestCaseS2326,persistent,green,0,
+ResilientHandleBasicTestCaseS2368,persistent,green,0,
+ResilientHandleBasicTestCaseS238,persistent,green,0,
+ResilientHandleBasicTestCaseS2412,persistent,green,0,
+ResilientHandleBasicTestCaseS2454,persistent,green,0,
+ResilientHandleBasicTestCaseS2508,persistent,green,0,
 ResilientHandleBasicTestCaseS2556,persistent,green,0,
-ResilientHandleBasicTestCaseS2670,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2729,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2777,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS2670,persistent,green,0,
+ResilientHandleBasicTestCaseS2729,persistent,green,0,
+ResilientHandleBasicTestCaseS2777,persistent,green,0,
 ResilientHandleBasicTestCaseS2843,persistent,green,0,
 ResilientHandleBasicTestCaseS2898,persistent,green,0,
-ResilientHandleBasicTestCaseS2964,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS2982,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS3036,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS2964,persistent,green,0,
+ResilientHandleBasicTestCaseS2982,persistent,green,0,
+ResilientHandleBasicTestCaseS3036,persistent,green,0,
 ResilientHandleBasicTestCaseS470,persistent,green,0,
-ResilientHandleBasicTestCaseS536,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS536,persistent,green,0,
 ResilientHandleBasicTestCaseS582,persistent,green,0,
-ResilientHandleBasicTestCaseS600,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS642,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS686,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleBasicTestCaseS752,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS600,persistent,green,0,
+ResilientHandleBasicTestCaseS642,persistent,green,0,
+ResilientHandleBasicTestCaseS686,persistent,green,0,
+ResilientHandleBasicTestCaseS752,persistent,green,0,
 ResilientHandleBasicTestCaseS764,persistent,green,0,
-ResilientHandleBasicTestCaseS919,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS0,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS1066,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS1134,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleBasicTestCaseS919,persistent,green,0,
+ResilientHandleDurableTestCaseS0,persistent,green,0,
+ResilientHandleDurableTestCaseS1066,persistent,green,0,
+ResilientHandleDurableTestCaseS1134,persistent,green,0,
 ResilientHandleDurableTestCaseS1367,persistent,green,0,
-ResilientHandleDurableTestCaseS1504,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS1627,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS1753,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS1856,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS1935,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS1967,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2039,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2123,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2192,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleDurableTestCaseS1504,persistent,green,0,
+ResilientHandleDurableTestCaseS1627,persistent,green,0,
+ResilientHandleDurableTestCaseS1753,persistent,green,0,
+ResilientHandleDurableTestCaseS1856,persistent,green,0,
+ResilientHandleDurableTestCaseS1935,persistent,green,0,
+ResilientHandleDurableTestCaseS1967,persistent,green,0,
+ResilientHandleDurableTestCaseS2039,persistent,green,0,
+ResilientHandleDurableTestCaseS2123,persistent,green,0,
+ResilientHandleDurableTestCaseS2192,persistent,green,0,
 ResilientHandleDurableTestCaseS2255,persistent,green,0,
-ResilientHandleDurableTestCaseS2317,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2356,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2420,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS244,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2467,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2516,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2655,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2743,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2816,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2894,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS2967,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleDurableTestCaseS2317,persistent,green,0,
+ResilientHandleDurableTestCaseS2356,persistent,green,0,
+ResilientHandleDurableTestCaseS2420,persistent,green,0,
+ResilientHandleDurableTestCaseS244,persistent,green,0,
+ResilientHandleDurableTestCaseS2467,persistent,green,0,
+ResilientHandleDurableTestCaseS2516,persistent,green,0,
+ResilientHandleDurableTestCaseS2655,persistent,green,0,
+ResilientHandleDurableTestCaseS2743,persistent,green,0,
+ResilientHandleDurableTestCaseS2816,persistent,green,0,
+ResilientHandleDurableTestCaseS2894,persistent,green,0,
+ResilientHandleDurableTestCaseS2967,persistent,green,0,
 ResilientHandleDurableTestCaseS3056,persistent,green,0,
-ResilientHandleDurableTestCaseS3152,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3220,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleDurableTestCaseS3152,persistent,green,0,
+ResilientHandleDurableTestCaseS3220,persistent,green,0,
 ResilientHandleDurableTestCaseS3307,persistent,green,0,
-ResilientHandleDurableTestCaseS3392,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3502,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3611,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3674,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3754,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3831,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3923,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS3980,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS4052,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS476,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS583,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS697,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS781,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS894,base,xfail,0,executed but fails (candidate defect)
-ResilientHandleDurableTestCaseS976,base,xfail,0,executed but fails (candidate defect)
+ResilientHandleDurableTestCaseS3392,persistent,green,0,
+ResilientHandleDurableTestCaseS3502,persistent,green,0,
+ResilientHandleDurableTestCaseS3611,persistent,green,0,
+ResilientHandleDurableTestCaseS3674,persistent,green,0,
+ResilientHandleDurableTestCaseS3754,persistent,green,0,
+ResilientHandleDurableTestCaseS3831,persistent,green,0,
+ResilientHandleDurableTestCaseS3923,persistent,green,0,
+ResilientHandleDurableTestCaseS3980,persistent,green,0,
+ResilientHandleDurableTestCaseS4052,persistent,green,0,
+ResilientHandleDurableTestCaseS476,persistent,green,0,
+ResilientHandleDurableTestCaseS583,persistent,green,0,
+ResilientHandleDurableTestCaseS697,persistent,green,0,
+ResilientHandleDurableTestCaseS781,persistent,green,0,
+ResilientHandleDurableTestCaseS894,persistent,green,0,
+ResilientHandleDurableTestCaseS976,persistent,green,0,
 SessionMgmtBindSessionAfterDisconnectionScenarioTestCaseS0,multichannel,green,0,
 SessionMgmtBindSessionAfterDisconnectionScenarioTestCaseS155,multichannel,green,0,
 SessionMgmtBindSessionAfterDisconnectionScenarioTestCaseS185,multichannel,green,0,


### PR DESCRIPTION
## Summary

Greens **all 88** WPTS MS-SMB2Model `ResilientHandle` cases (44 `Basic` + 44 `Durable`), up from 15 green / 73 xfail. The `ResilientHandle*` families were the single largest cluster of genuine "executed but fails" candidate defects in the SMB2Model suite.

Three independent server defects were blocking these cases:

### 1. IOCTL response `FileId` (MS-SMB2 2.2.32)
`chimera_smb_ioctl_reply` hardcoded the response `FileId` to the `{0xFFFF…, 0xFFFF…}` sentinel for **every** FSCTL. That is correct only for file-less FSCTLs (`VALIDATE_NEGOTIATE_INFO`, `QUERY_NETWORK_INTERFACE_INFO`, …); a file-targeted FSCTL must echo the open's `FileId`. `FSCTL_LMR_REQUEST_RESILIENCY` (3.3.5.15.9) specifically has the client validate the response `FileId.Persistent/Volatile` against the handle it operated on. The reply now echoes `request->ioctl.file_id` — the wire-supplied id, which is already the sentinel for the file-less FSCTLs, so their replies are unchanged.

### 2. Malformed-FSCTL handling tore down the transport
The IOCTL parser failed semantically-invalid but well-framed per-FSCTL input (e.g. a resiliency request with `InputCount < 8`) by returning `-1`, which the dispatcher treats as an unparseable PDU and **closes the connection**. Such a request must answer `STATUS_INVALID_PARAMETER` with the connection left up (MS-SMB2 2.2.32); otherwise the client's next request — `LOGOFF` in the model — times out. These now route through `chimera_smb_parse_reject` (set status, keep the connection), matching the sites the parser already used it for.

### 3. Durable/resilient owner check (MS-SMB2 3.3.5.9.7 step 9)
A `DH2C`/`DHnC` reconnect by a user other than the open's owner (`Open.DurableOwner`) must fail with `STATUS_ACCESS_DENIED`. The owning uid is now recorded on the durable registry entry and compared against the reconnecting session's uid.

## Classification

`ResilientHandle` cases are homed to the **persistent** config in `smb2model_cases.csv`: chimera's durable/resilient reconnect machinery (the registry, park, and reclaim) is enabled by the persistent-handles knob, so reclaiming a resilient handle requires that config. (Decoupling durable-handle granting from the persistent-handles knob — which would let resilient handles reconnect in the base config too — is larger, separable work.)

The WPTS wrapper grows a second (non-administrator) local account and sets `NonAdminUserName` so the different-user reconnect cases become applicable rather than `Inconclusive`.

## Results
- MS-SMB2Model `ResilientHandle`: **88/88 green** (was 15).
- No regressions: base + persistent MS-SMB2Model shards and the MS-SMB2 suite (memfs, memfs_persistent) all green; smbtorture durable/ioctl/replay (102/102) green; the `phase0_contexts` durable-registry unit test green (Release + Debug/ASan).