### PR TITLE
smb/tests: integrate the pike SMB2/3 protocol test suite

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,11 +13,17 @@ ARG ENABLE_CLAUDE=1
 ARG ENABLE_CODEX=1
 ARG ENABLE_UV=1
 ARG ENABLE_WPTS=1
+ARG ENABLE_PIKE=1
 # Pinned to an exact chimera-nas/pynfs commit (on branch chimera-fast-ci).  Using
 # a SHA rather than a moving branch makes the image reproducible and, critically,
 # busts the Docker layer cache whenever pynfs is bumped -- otherwise the cached
 # clone layer keeps shipping a stale pynfs.  Bump this SHA when pynfs changes.
 ARG PYNFS_REF=b861f7b8211b4dc798b88a7e81b300fb4615189c
+# Pinned chimera-nas/pike commit.  pike is a pure-Python SMB2/3 protocol test
+# framework (the SMB analog of pynfs); the MS-SMB2 pike ctests run it host-side
+# in a netns against the chimera daemon.  SHA-pinned for the same reason as
+# pynfs: reproducible image + cache-bust on bump.
+ARG PIKE_REF=bcbb343c5bfb7dd3198d2d79d7381dfdad0f0873
 # Pinned Microsoft Windows Protocol Test Suites (WPTS) FileServer release.
 ARG WPTS_VERSION=4.26.3.0
 ARG ELBENCHO_REF=96b1bf29c35e437715c0527194e69e4c96ed9922
@@ -114,6 +120,19 @@ RUN apt-get -y update && \
     git clone https://github.com/chimera-nas/pynfs.git /opt/pynfs && \
     cd /opt/pynfs && git checkout "$PYNFS_REF" && python3 ./setup.py build && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# pike: a pure-Python SMB2/3 protocol correctness test framework (the SMB analog
+# of pynfs). Cloned at a pinned SHA and run from source via PYTHONPATH=/opt/pike/src
+# (the pike_smb_test_wrapper.sh sets it), exactly like pynfs runs from /opt/pynfs.
+# We deliberately do NOT `pip install` it: that would compile the OPTIONAL
+# pike.kerberos C extension (needs python3-dev + gssapi headers), and the chimera
+# pike ctests authenticate over pure-Python NTLM (PIKE_CREDS), so Kerberos is
+# unneeded. Instead we install only pike's pure-Python runtime deps as wheels.
+RUN if [ "$ENABLE_PIKE" = "1" ] ; then \
+    pip3 install --break-system-packages pytest pytest-timeout pycryptodome pycryptodomex future six attrs && \
+    git clone https://github.com/chimera-nas/pike.git /opt/pike && \
+    cd /opt/pike && git checkout "$PIKE_REF" ; \
+    fi
 
 RUN if [ "$ENABLE_UV" = "1" ] ; then \
     curl -LsSf https://astral.sh/uv/install.sh | sh ; \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -433,7 +433,7 @@ jobs:
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit ${{ matrix.cmake_extra }} /workspace
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.cmake_extra }} /workspace
               ninja
               ccache --show-stats || true
               tar -C /build --exclude=./ccache -czf /workspace/build-os.tar.gz .'
@@ -708,7 +708,7 @@ jobs:
             -w /build \
             ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit ${{ matrix.kvm_cmake }} /workspace
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.kvm_cmake }} /workspace
               ninja
               ccache --show-stats || true
               # Ship the build tree to the test shards (minus the local ccache;
@@ -765,7 +765,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
         build_type: [Release, Debug]
-        category: [pynfs, smbtorture, wpts-smb2, wpts-smb2model, wpts-fsa, wpts-fsamodel, posix-client, pjdfstest, s3, ceph-s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs, kvm-nfstest-lock, kvm-nfstest-dio, kvm-nfstest-rest, kvm-ltp]
+        category: [pynfs, smbtorture, pike, wpts-smb2, wpts-smb2model, wpts-fsa, wpts-fsamodel, posix-client, pjdfstest, s3, ceph-s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs, kvm-nfstest-lock, kvm-nfstest-dio, kvm-nfstest-rest, kvm-ltp]
         include:
           - { arch: amd64, runner: arc-amd64 }
           - { arch: arm64, runner: arc-arm64 }
@@ -825,6 +825,7 @@ jobs:
               case "$CATEGORY" in
                 pynfs)        SEL="-L pynfs" ;;
                 smbtorture)   SEL="-L smbtorture" ;;
+                pike)         SEL="-L pike" ;;
                 # Anchor wpts-smb2$ so it does NOT also match the wpts-smb2model
                 # label (ctest -L is a substring regex; "wpts-smb2" is a prefix
                 # of "wpts-smb2model").
@@ -840,7 +841,7 @@ jobs:
                 s3)           SEL="-L s3 -LE ceph-s3" ;;
                 ceph-s3)      SEL="-L ceph-s3" ;;
                 client)       SEL="-L client" ;;
-                unit)         SEL="-LE pynfs|smbtorture|wpts|posix|pjdfstest|s3|client|kvm" ;;
+                unit)         SEL="-LE pynfs|smbtorture|pike|wpts|posix|pjdfstest|s3|client|kvm" ;;
                 kvm-cthon)    SEL="-L kvm -R /cthon/";    NEED_KVM=1 ;;
                 kvm-xfsprogs) SEL="-L kvm -R /xfstests/"; NEED_KVM=1 ;;
                 kvm-pnfs)     SEL="-L pnfs";              NEED_KVM=1 ;;

--- a/scripts/pike_smb_test_wrapper.sh
+++ b/scripts/pike_smb_test_wrapper.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: pike_smb_test_wrapper.sh <chimera_binary> <backend> <test_list>
+#
+#   <test_list>  comma-separated pytest node-ids (relative to pike's test
+#                directory), e.g.
+#                  negotiate.py::NegotiateTest::test_negotiate_smb2_002,lease.py::LeaseTest::test_lease_break
+#                Run in ONE pytest invocation against a single chimera server
+#                (daemon + netns bringup dominates, so batching is far faster).
+#                Empty test_list runs the WHOLE pike test suite (bootstrap mode).
+#
+# Runs the pike pure-Python SMB2/3 protocol test framework against a standalone
+# chimera SMB server. pike is the SMB analog of pynfs: an ordinary Python test
+# suite that speaks SMB2 from its own client stack, so -- like the WPTS .NET host
+# -- no VM / kernel CIFS client is needed. The runner and the daemon both live in
+# an isolated network namespace and talk over TCP/445.
+#
+# 1. Generates a chimera config exposing the "share" the tests connect to
+# 2. Creates a network namespace with the SUT IP (10.0.0.1)
+# 3. Starts the chimera daemon in the netns (SMB on 10.0.0.1:445)
+# 4. Runs pike's tests via pytest, authenticating with pure-Python NTLM
+# 5. Captures the JUnit result + pytest exit code and cleans up
+#
+# pike is run straight from its source tree (PYTHONPATH=$PIKE_DIR/src) exactly
+# like pynfs runs from /opt/pynfs; the optional pike.kerberos C extension is NOT
+# needed because we authenticate with NTLM (PIKE_CREDS).
+#
+# Optional environment (feature toggles -- mirror the WPTS wrapper so the same
+# config-matrix machinery drives both):
+#   PIKE_DIR                    pike source root (default: /opt/pike)
+#   PIKE_JUNIT_FILE             write a JUnit XML report here
+#   CHIMERA_SMB_PERSISTENT=1    durable/persistent handles + CA share
+#   CHIMERA_SMB_ENCRYPTION=1    SMB3 transport encryption (also drives PIKE_ENCRYPT)
+#   CHIMERA_SMB_MULTICHANNEL=1  advertise a second NIC for multichannel
+#   PIKE_TIMEOUT                per-run wall-clock cap in seconds (default 300)
+
+set -u
+
+# Save and clear LD_PRELOAD immediately to avoid ASAN interference with system
+# binaries (ip, etc.) which exit non-zero under ASAN. Restored only for chimera.
+SAVED_LD_PRELOAD="${LD_PRELOAD:-}"
+unset LD_PRELOAD
+
+CHIMERA_BINARY=$1; shift
+BACKEND=$1; shift
+TEST_LIST="${1:-}"; shift || true
+
+# Resolve the daemon to an absolute path: the runner cd's into pike's test dir
+# before launching pytest, so every other path the script uses (session dir,
+# logs, JUnit) must be absolute to survive that cd.
+CHIMERA_BINARY=$(readlink -f "$CHIMERA_BINARY")
+
+PIKE_DIR="${PIKE_DIR:-/opt/pike}"
+PIKE_TEST_DIR="${PIKE_DIR}/src/pike/test"
+PIKE_TIMEOUT="${PIKE_TIMEOUT:-300}"
+
+if [ ! -d "$PIKE_TEST_DIR" ]; then
+    echo "pike test dir not found: ${PIKE_TEST_DIR} (set PIKE_DIR)" >&2
+    exit 1
+fi
+
+SUT_IP="10.0.0.1"
+SUT_IP2="10.0.0.2"          # second NIC for SMB3 multichannel
+SUT_IPV6="fd00::1"
+NETNS_NAME="pike_smb_$$_$(date +%s%N)"
+DUMMY_IF="pike0"
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/pike_smb_session_XXXXXX")
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+CHIMERA_LOG="${SESSION_DIR}/chimera_stderr.log"
+JUNIT_OUT="${SESSION_DIR}/pike-junit.xml"
+CHIMERA_PID=""
+
+cleanup() {
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        for _ in $(seq 1 20); do
+            kill -0 "$CHIMERA_PID" 2>/dev/null || break
+            sleep 0.1
+        done
+        kill -9 "$CHIMERA_PID" 2>/dev/null || true
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    for pid in $(ip netns pids "${NETNS_NAME}" 2>/dev/null); do
+        kill "$pid" 2>/dev/null || true
+    done
+    sleep 0.1
+    for pid in $(ip netns pids "${NETNS_NAME}" 2>/dev/null); do
+        kill -9 "$pid" 2>/dev/null || true
+    done
+    timeout 2s ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+generate_config() {
+    # The single share the tests connect to (PIKE_SHARE=share). For the path
+    # backends each share gets a real on-disk directory; memfs is mounted at "/".
+    local mpath="/"
+    case "$BACKEND" in
+        linux|io_uring)
+            mpath="${SESSION_DIR}/data/share"
+            mkdir -p "$mpath"
+            ;;
+    esac
+
+    # Continuous-availability is required for the durable/persistent handle tests
+    # to be granted persistent handles; gate it on the persistent config.
+    local share_ca=""
+    if [ "${CHIMERA_SMB_PERSISTENT:-0}" = "1" ]; then
+        share_ca=', "continuous_availability": true'
+    fi
+    # Per-share encrypt_data so the encryption tests (run with PIKE_ENCRYPT=yes)
+    # exercise the encrypted transport path.
+    local share_enc=""
+    if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
+        share_enc=', "encrypt_data": true'
+    fi
+
+    local persistent_line=""
+    if [ "${CHIMERA_SMB_PERSISTENT:-0}" = "1" ]; then
+        persistent_line='"smb_persistent_handles": true,'
+    fi
+    local encryption_line=""
+    if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
+        encryption_line='"smb_encryption": "enabled",'
+    fi
+    local multichannel_line=""
+    if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
+        multichannel_line="\"smb_multichannel\": [{\"address\": \"${SUT_IP}\", \"speed\": 10, \"rdma\": false}, {\"address\": \"${SUT_IP2}\", \"speed\": 10, \"rdma\": false}, {\"address\": \"${SUT_IPV6}\", \"speed\": 10, \"rdma\": false}],"
+    fi
+
+    cat > "$CONFIG_FILE" << EOF
+{
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
+    "server": {
+        ${persistent_line}
+        ${encryption_line}
+        ${multichannel_line}
+        "smb_named_streams": true,
+        "smb_leases": true,
+        "smb_oplocks": true,
+        "threads": 4,
+        "delegation_threads": 4,
+        "external_portmap": false
+    },
+    "mounts": {
+        "share": {"module": "${BACKEND}", "path": "${mpath}"}
+    },
+    "shares": {
+        "share": {"path": "/share"${share_ca}${share_enc}}
+    },
+    "users": [
+        {
+            "username": "administrator",
+            "smbpasswd": "Password01!",
+            "uid": 0,
+            "gid": 0
+        }
+    ]
+}
+EOF
+}
+
+generate_config
+
+ulimit -l unlimited 2>/dev/null || true
+
+# Network namespace with the SUT IP on a dummy interface (locally routed). The
+# pike client connects to 10.0.0.1 from inside the same netns.
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+ip netns exec "${NETNS_NAME}" ip link add "${DUMMY_IF}" type dummy
+ip netns exec "${NETNS_NAME}" ip addr add "${SUT_IP}/24" dev "${DUMMY_IF}"
+if [ "${CHIMERA_SMB_MULTICHANNEL:-0}" = "1" ]; then
+    ip netns exec "${NETNS_NAME}" ip addr add "${SUT_IP2}/24" dev "${DUMMY_IF}"
+    ip netns exec "${NETNS_NAME}" ip -6 addr add "${SUT_IPV6}/64" dev "${DUMMY_IF}"
+fi
+ip netns exec "${NETNS_NAME}" ip link set "${DUMMY_IF}" up
+
+# Start the chimera daemon inside the netns (restore LD_PRELOAD for chimera only).
+ip netns exec "${NETNS_NAME}" env \
+    LD_PRELOAD="${SAVED_LD_PRELOAD}" \
+    ASAN_OPTIONS="detect_leaks=0:handle_abort=2:print_cmdline=1" \
+    "$CHIMERA_BINARY" ${CHIMERA_DEBUG:+-d} -c "$CONFIG_FILE" \
+    >"$CHIMERA_LOG" 2>&1 &
+CHIMERA_PID=$!
+
+# Wait for the SMB port to come up.
+ready=0
+for _ in $(seq 1 50); do
+    if ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/${SUT_IP}/445" 2>/dev/null; then
+        ready=1
+        break
+    fi
+    if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+        echo "chimera daemon exited prematurely"
+        echo "=== Chimera stderr ==="
+        cat "$CHIMERA_LOG"
+        exit 1
+    fi
+    sleep 0.1
+done
+if [ "$ready" != "1" ]; then
+    echo "chimera SMB port ${SUT_IP}:445 never became ready"
+    cat "$CHIMERA_LOG"
+    exit 1
+fi
+
+# Build the pytest target list. An explicit comma-separated node-id list selects
+# exactly those cases; an empty list runs the whole suite (bootstrap mode).
+# pytest runs with cwd = pike's test dir (see below), so node-ids stay short and
+# stable: "module.py::Class::method". An empty list runs the whole suite.
+PYTEST_TARGETS=()
+if [ -n "${TEST_LIST}" ]; then
+    IFS=',' read -ra _ids <<< "${TEST_LIST}"
+    for _id in "${_ids[@]}"; do
+        [ -n "${_id}" ] && PYTEST_TARGETS+=("${_id}")
+    done
+else
+    PYTEST_TARGETS=(".")
+fi
+
+# Encryption config: ask the pike client to negotiate an encrypted session so the
+# transport-encryption path is actually exercised (the share also requires it).
+PIKE_ENCRYPT_ENV=()
+if [ "${CHIMERA_SMB_ENCRYPTION:-0}" = "1" ]; then
+    PIKE_ENCRYPT_ENV=(PIKE_ENCRYPT=yes)
+fi
+
+JUNIT_ARG=()
+if [ -n "${PIKE_JUNIT_FILE:-}" ]; then
+    mkdir -p "$(dirname "${PIKE_JUNIT_FILE}")"
+    JUNIT_ARG=(--junitxml="${JUNIT_OUT}")
+fi
+
+# Run pike from inside the netns so it can reach the SUT IP. cwd is pike's test
+# dir so the node-ids in the CSV stay short and stable ("module.py::Class::method").
+cd "${PIKE_TEST_DIR}"
+ip netns exec "${NETNS_NAME}" env \
+    PYTHONPATH="${PIKE_DIR}/src" \
+    PYTHONUNBUFFERED=1 \
+    PIKE_SERVER="${SUT_IP}" \
+    PIKE_PORT=445 \
+    PIKE_SHARE=share \
+    PIKE_CREDS='administrator%Password01!' \
+    "${PIKE_ENCRYPT_ENV[@]}" \
+    timeout "${PIKE_TIMEOUT}" \
+    python3 -m pytest "${PYTEST_TARGETS[@]}" \
+        --rootdir="${PIKE_TEST_DIR}" \
+        -p no:cacheprovider -o addopts="" \
+        --timeout="${PIKE_CASE_TIMEOUT:-90}" --timeout-method=signal \
+        -rfE --tb=short -q \
+        "${JUNIT_ARG[@]}" \
+    > "${SESSION_DIR}/pike_stdout.log" 2>&1
+PYTEST_RC=$?
+
+cat "${SESSION_DIR}/pike_stdout.log"
+echo "=== pytest exit code: ${PYTEST_RC} ==="
+
+# Copy out the JUnit (the netns run wrote it inside SESSION_DIR).
+if [ -n "${PIKE_JUNIT_FILE:-}" ] && [ -f "${JUNIT_OUT}" ]; then
+    cp -f "${JUNIT_OUT}" "${PIKE_JUNIT_FILE}" 2>/dev/null || true
+fi
+
+# A daemon that died during the run is a finding in its own right.
+if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+    wait "$CHIMERA_PID" 2>/dev/null
+    DAEMON_RC=$?
+    echo "=== chimera daemon exited during run (rc=${DAEMON_RC}) ==="
+    tail -80 "$CHIMERA_LOG" 2>/dev/null || true
+    CHIMERA_PID=""
+    [ "$PYTEST_RC" = "0" ] && PYTEST_RC=70
+elif [ "$PYTEST_RC" != "0" ]; then
+    echo "=== Chimera stderr (last 40 lines) ==="
+    tail -40 "$CHIMERA_LOG" 2>/dev/null || true
+fi
+
+exit ${PYTEST_RC}

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1600,6 +1600,22 @@ chimera_smb_server_handle_smb2(
             goto next_compound_request;
         }
 
+        /* A request received inside a TRANSFORM is authenticated by the AEAD
+         * tag, NOT by a signature: encryption and signing are mutually exclusive
+         * per message (MS-SMB2 3.1.4.3).  Its inner header may nonetheless carry
+         * SMB2_FLAGS_SIGNED (some clients set it before encrypting), but the
+         * message is not signed.  Clear the bit on the request now, because the
+         * reply header inherits the request's flags (see reply_hdr->flags below)
+         * and the reply will itself be encrypted, not signed -- leaving the bit
+         * set would make the encrypted reply falsely advertise SMB2_FLAGS_SIGNED
+         * with no valid signature.  A conformant peer skips verifying a decrypted
+         * message's signature (3.3.5.2.9, which this server also does on receive
+         * just below), but a stricter one verifies whenever the flag is set and
+         * then rejects the reply (pike's SMB 3.1.1 encryption cases). */
+        if (received_encrypted) {
+            request->smb2_hdr.flags &= ~SMB2_FLAGS_SIGNED;
+        }
+
         /* A session that exists globally but has no channel on THIS connection
          * (the handle was attached by the global-session lookup above, e.g.
          * for a channel bind in progress or one that failed) may only be

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -560,11 +560,24 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
         if (chimera_smb_is_error_status(request->status) &&
             !(request->smb2_hdr.command == SMB2_IOCTL &&
               request->ioctl.cc_limit_response)) {
-            evpl_iovec_cursor_append_uint16(&reply_cursor, SMB2_ERROR_REPLY_SIZE);
-            evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
-            evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
-            evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
-            evpl_iovec_cursor_append_uint8(&reply_cursor, 0);
+            if (request->status == SMB2_STATUS_BUFFER_TOO_SMALL &&
+                request->smb2_hdr.command == SMB2_QUERY_INFO) {
+                /* MS-SMB2 2.2.2 / 3.3.4.4: a QUERY_INFO that fails
+                 * STATUS_BUFFER_TOO_SMALL returns an ERROR Response whose
+                 * ByteCount is 4 and whose ErrorData is the minimum buffer
+                 * length the client must supply (stashed in output_length). */
+                evpl_iovec_cursor_append_uint16(&reply_cursor, SMB2_ERROR_REPLY_SIZE);
+                evpl_iovec_cursor_append_uint16(&reply_cursor, 0); /* ErrorContextCount + Reserved */
+                evpl_iovec_cursor_append_uint32(&reply_cursor, 4); /* ByteCount */
+                evpl_iovec_cursor_append_uint32(&reply_cursor,
+                                                request->query_info.output_length);
+            } else {
+                evpl_iovec_cursor_append_uint16(&reply_cursor, SMB2_ERROR_REPLY_SIZE);
+                evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
+                evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
+                evpl_iovec_cursor_append_uint16(&reply_cursor, 0);
+                evpl_iovec_cursor_append_uint8(&reply_cursor, 0);
+            }
         } else {
             switch (request->smb2_hdr.command) {
                 case SMB2_NEGOTIATE:

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -571,6 +571,13 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
                 evpl_iovec_cursor_append_uint32(&reply_cursor, 4); /* ByteCount */
                 evpl_iovec_cursor_append_uint32(&reply_cursor,
                                                 request->query_info.output_length);
+            } else if (request->status == SMB2_STATUS_STOPPED_ON_SYMLINK &&
+                       request->smb2_hdr.command == SMB2_CREATE &&
+                       request->create.r_symlink_error) {
+                /* MS-SMB2 2.2.2.2.1: a CREATE that stopped on a symbolic link
+                 * returns the SymbolicLinkErrorResponse body so the client can
+                 * resolve the link target and reissue the open. */
+                chimera_smb_create_emit_symlink_error(&reply_cursor, request);
             } else {
                 evpl_iovec_cursor_append_uint16(&reply_cursor, SMB2_ERROR_REPLY_SIZE);
                 evpl_iovec_cursor_append_uint16(&reply_cursor, 0);

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -1074,6 +1074,12 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
  * default; any larger request is capped at the maximum (MS-SMB2 3.3.5.15.9). */
 #define CHIMERA_SMB_RESILIENCY_DEFAULT_TIMEOUT_MS   120000U
 #define CHIMERA_SMB_RESILIENCY_MAX_TIMEOUT_MS       300000U
+/* Server floor on a requested resiliency timeout: a handle reconnect needs
+ * several round trips after the network drop, so a sub-second window would
+ * expire the handle mid-reconnect under load.  Below every resiliency timeout
+ * the pike persistent.py suite uses (>= 2 s), so it only affects durable.py's
+ * 100 ms cases. */
+#define CHIMERA_SMB_RESILIENCY_MIN_TIMEOUT_MS       1000U
 
 #define SMB2_IO_REPARSE_TAG_NFS                     0x80000014
 #define SMB2_IO_REPARSE_TAG_SYMLINK                 0xA000000C

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -1083,6 +1083,11 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 
 #define SMB2_IO_REPARSE_TAG_NFS                     0x80000014
 #define SMB2_IO_REPARSE_TAG_SYMLINK                 0xA000000C
+/* SymbolicLinkErrorResponse SymLinkErrorTag (MS-SMB2 2.2.2.2.1): 'SYML'. */
+#define SMB2_SYMLINK_ERROR_TAG                      0x4C4D5953
+/* SYMBOLIC_LINK_REPARSE_BUFFER Flags (MS-FSCC 2.1.2.4). */
+#define SMB2_SYMLINK_FLAG_ABSOLUTE                  0x00000000
+#define SMB2_SYMLINK_FLAG_RELATIVE                  0x00000001
 #define SMB2_NFS_SPECFILE_LNK                       0x0000000000004B4E4CULL
 #define SMB2_NFS_SPECFILE_CHR                       0x0000000000524843ULL
 #define SMB2_NFS_SPECFILE_BLK                       0x00000000004B4C42ULL

--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -715,11 +715,14 @@ chimera_smb_append_all_info(
     evpl_iovec_cursor_append_uint32(cursor, open_file->granted_access);
     evpl_iovec_cursor_append_uint64(cursor, open_file->position);
 
-    /* Mode */
+    /* FileModeInformation: no special open-mode flags tracked. */
     evpl_iovec_cursor_append_uint32(cursor, 0);
 
-    /* Alignemnt */
-    evpl_iovec_cursor_append_uint32(cursor, 4095);
+    /* FileAlignmentInformation: FILE_BYTE_ALIGNMENT (0) -- no alignment
+     * requirement for buffered I/O (matches the standalone
+     * FileAlignmentInformation path; 4095/0xFFF is not a valid
+     * AlignmentRequirement value and trips strict clients). */
+    evpl_iovec_cursor_append_uint32(cursor, 0);
 
     /* Name Info: FileNameInformation (MS-FSCC 2.1.7).  FileNameLength is the
      * length in bytes of the UTF-16LE name, followed by the name itself —

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -397,13 +397,21 @@ chimera_smb_durable_park(
     pthread_mutex_lock(&shared->durable.lock);
     HASH_FIND(hh, shared->durable.by_pid, &pid, sizeof(pid), entry);
     if (entry) {
-        /* A resilient open is held for its resiliency timeout; a durable open
-         * for its durable timeout.  When an open is both, keep it for the
-         * longer of the two. */
-        uint64_t timeout_ms = open_file->durable_timeout_ms;
-        if (open_file->resilient && open_file->resilient_timeout_ms > timeout_ms) {
-            timeout_ms = open_file->resilient_timeout_ms;
-        }
+        /* The disconnect-survival timeout: a resiliency request SETS the open's
+         * timeout (MS-SMB2 3.3.5.15.9 -- it governs even when the open is also
+         * durable/persistent, and may be SHORTER than the durable default), so
+         * when the open is resilient the resiliency timeout wins outright; a
+         * plain durable open uses its durable timeout. */
+        uint64_t timeout_ms = open_file->resilient
+            ? open_file->resilient_timeout_ms
+            : open_file->durable_timeout_ms;
+
+        entry->resilient = open_file->resilient;
+        /* A pure persistent (CA) handle with no resiliency timeout holds the
+         * file until an explicit reclaim/close: it never expires on the grace
+         * timer.  A persistent+resilient handle DOES expire at the resiliency
+         * timeout (test_resiliency_*_after_timeout). */
+        entry->never_expires     = entry->persistent && !open_file->resilient;
         entry->parked            = true;
         entry->deadline          = now;
         entry->deadline.tv_sec  += timeout_ms / 1000;
@@ -417,10 +425,13 @@ chimera_smb_durable_park(
 
     /* Mark the caching grant's lease AND the share reservation parked so the
      * vfs_state conflict matrix treats this disconnected holder as
-     * courtesy-held: a compatible new open coexists (keep) and a write-cache
-     * holder is evicted by the caching-acquire path (purge).  The share-resv
-     * flag stops the sole-opener rule from capping a new opener's lease to R on
-     * account of a disconnected holder.  Cleared on reconnect. */
+     * courtesy-held: a compatible new open coexists (keep).  A durable-only
+     * write-cache holder is then evicted by the caching-acquire path (purge,
+     * the MS-SMB2 yield); a resilient/persistent holder within its timeout is
+     * spared by that path (chimera_smb_durable_parked_hold) so a conflicting
+     * open caps its own grant instead.  The share-resv flag stops the
+     * sole-opener rule from capping a new opener's lease to R on account of a
+     * disconnected holder.  Cleared on reconnect. */
     if (open_file->grant) {
         open_file->grant->lease.parked = 1;
     }
@@ -428,6 +439,42 @@ chimera_smb_durable_park(
         open_file->share_lease.parked = 1;
     }
 } /* chimera_smb_durable_park */
+
+/* Classify how a parked durable holder (by persistent id) treats a conflicting
+ * fresh open -- see enum chimera_smb_durable_hold.  A durable-only holder, an
+ * expired holder (past its deadline, whether or not the sweep has reaped it
+ * yet), an unknown id, or a live (not-parked) entry all YIELD (NONE).  A
+ * resilient holder within its timeout is courtesy-held and CAPs the opener; a
+ * persistent holder within its timeout BLOCKs the opener (FILE_NOT_AVAILABLE).
+ * Persistent outranks resilient (a persistent+resilient holder BLOCKs). */
+SYMBOL_EXPORT enum chimera_smb_durable_hold
+chimera_smb_durable_parked_hold(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          persistent_id)
+{
+    struct chimera_smb_durable_entry *entry;
+    enum chimera_smb_durable_hold     hold = CHIMERA_SMB_DURABLE_HOLD_NONE;
+    struct timespec                   now;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    pthread_mutex_lock(&shared->durable.lock);
+    HASH_FIND(hh, shared->durable.by_pid, &persistent_id, sizeof(persistent_id), entry);
+    if (entry && entry->parked && !entry->cold && entry->open_file) {
+        bool within = entry->never_expires ||
+            chimera_timespec_cmp(&now, &entry->deadline) < 0;
+        if (within) {
+            if (entry->persistent) {
+                hold = CHIMERA_SMB_DURABLE_HOLD_BLOCK;
+            } else if (entry->resilient) {
+                hold = CHIMERA_SMB_DURABLE_HOLD_CAP;
+            }
+        }
+    }
+    pthread_mutex_unlock(&shared->durable.lock);
+
+    return hold;
+} /* chimera_smb_durable_parked_hold */
 
 SYMBOL_EXPORT struct chimera_smb_open_file *
 chimera_smb_durable_claim(
@@ -448,9 +495,12 @@ chimera_smb_durable_claim(
     struct chimera_smb_durable_entry *entry;
     struct chimera_smb_open_file     *open_file = NULL;
     bool                              had_lease;
+    struct timespec                   now;
 
     *r_cold  = false;
     *r_retry = false;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
 
     pthread_mutex_lock(&shared->durable.lock);
 
@@ -476,6 +526,14 @@ chimera_smb_durable_claim(
          * lapses into OBJECT_NAME_NOT_FOUND. */
         *r_retry = true;
         *status  = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else if (!entry->never_expires && !entry->cold &&
+               chimera_timespec_cmp(&now, &entry->deadline) >= 0) {
+        /* Lazy expiry: the parked handle has outlived its disconnect-survival
+         * deadline (durable timeout, or a shorter resiliency timeout).  Whether
+         * or not the grace-timer sweep has physically reaped it yet, it is gone
+         * for reclaim purposes -- OBJECT_NAME_NOT_FOUND.  The sweep frees the
+         * carcass (test_resiliency_*_after_timeout). */
+        *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (entry->open_file &&
                (entry->open_file->flags & CHIMERA_SMB_OPEN_FILE_YIELDED)) {
         /* While disconnected, this open's write-caching oplock/lease was
@@ -683,10 +741,11 @@ chimera_smb_durable_sweep(struct chimera_server_smb_thread *thread)
         if (!entry->parked) {
             continue;
         }
-        /* Persistent handles do not expire on the durable grace timer (they
-         * live until explicit close or admin action), and cold entries have no
-         * live open to tear down — skip both. */
-        if (entry->persistent || entry->cold || !entry->open_file) {
+        /* A pure persistent (CA) handle does not expire on the grace timer (it
+         * lives until explicit close or admin action), and cold entries have no
+         * live open to tear down — skip both.  A persistent+resilient handle is
+         * NOT never_expires: its resiliency timeout governs and it IS reaped. */
+        if (entry->never_expires || entry->cold || !entry->open_file) {
             continue;
         }
         if (chimera_timespec_cmp(&now, &entry->deadline) < 0) {

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -282,7 +282,8 @@ chimera_smb_durable_release_handle(
 SYMBOL_EXPORT bool
 chimera_smb_durable_purge_parked(
     struct chimera_server_smb_thread *thread,
-    uint64_t                          persistent_id)
+    uint64_t                          persistent_id,
+    bool                              include_persistent)
 {
     struct chimera_server_smb_shared *shared = thread->shared;
     struct chimera_smb_durable_entry *entry;
@@ -290,8 +291,8 @@ chimera_smb_durable_purge_parked(
 
     pthread_mutex_lock(&shared->durable.lock);
     HASH_FIND(hh, shared->durable.by_pid, &persistent_id, sizeof(persistent_id), entry);
-    if (entry && entry->parked && !entry->persistent && !entry->cold &&
-        entry->open_file) {
+    if (entry && entry->parked && (include_persistent || !entry->persistent) &&
+        !entry->cold && entry->open_file) {
         HASH_DELETE(hh, shared->durable.by_pid, entry);
         open_file = entry->open_file;
         free(entry);

--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -440,6 +440,7 @@ chimera_smb_durable_claim(
     uint32_t                          name_len,
     bool                              has_lease_ctx,
     const uint8_t                    *lease_key,
+    bool                              reconnect_persistent,
     bool                             *r_cold,
     bool                             *r_retry,
     uint32_t                         *status)
@@ -485,6 +486,11 @@ chimera_smb_durable_claim(
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
     } else if (create_guid && memcmp(entry->create_guid, create_guid, 16) != 0) {
         *status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+    } else if (reconnect_persistent && !entry->persistent) {
+        /* MS-SMB2 3.3.5.9.12: the reconnect set SMB2_DHANDLE_FLAG_PERSISTENT but
+         * the surviving Open is not persistent (Open.IsPersistent == FALSE) ->
+         * STATUS_INVALID_PARAMETER (pike durable test_durable_reconnect_v2_fails). */
+        *status = SMB2_STATUS_INVALID_PARAMETER;
     } else if ((had_lease || entry->persistent) && client_guid &&
                memcmp(entry->client_guid, client_guid, 16) != 0) {
         /* Reconnect from a different client.  MS-SMB2 3.3.5.9.7 binds the

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1633,6 +1633,7 @@ chimera_smb_durable_claim(
     uint32_t                          name_len,
     bool                              has_lease_ctx,
     const uint8_t                    *lease_key,
+    bool                              reconnect_persistent,
     bool                             *r_cold,
     bool                             *r_retry,
     uint32_t                         *status);

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1483,6 +1483,14 @@ struct chimera_smb_durable_entry {
      * is not in memory (open_file == NULL) and must be re-opened on reclaim. */
     bool                              persistent;
     bool                              cold;
+    /* Captured at park time so the registry can reason about expiry without
+     * dereferencing open_file: resilient => the open carried a resiliency
+     * grant (its timeout governs the disconnect deadline, MS-SMB2 3.3.5.15.9);
+     * never_expires => a pure persistent (CA) handle that holds the file until
+     * an explicit reclaim/close (it is exempt from the grace-timer sweep and
+     * blocks conflicting opens with STATUS_FILE_NOT_AVAILABLE indefinitely). */
+    bool                              resilient;
+    bool                              never_expires;
     struct chimera_smb_open_file     *open_file;
     uint32_t                          name_len;
     char                              name[SMB_FILENAME_MAX];
@@ -1622,6 +1630,23 @@ void
 chimera_smb_durable_park(
     struct chimera_server_smb_shared *shared,
     struct chimera_smb_open_file     *open_file);
+
+/* How a parked durable holder (identified by persistent id) behaves toward a
+ * conflicting fresh open, per MS-SMB2 disconnected-handle rules.  Returned by
+ * chimera_smb_durable_parked_hold(). */
+enum chimera_smb_durable_hold {
+    CHIMERA_SMB_DURABLE_HOLD_NONE = 0, /* durable-only, expired, or not parked:
+                                        * yields to the conflicting open */
+    CHIMERA_SMB_DURABLE_HOLD_CAP,      /* resilient within its timeout: courtesy-
+                                       * held, the conflicting open caps its own
+                                       * grant instead of evicting this holder */
+    CHIMERA_SMB_DURABLE_HOLD_BLOCK,    /* persistent within its timeout: the
+                                        * conflicting open fails FILE_NOT_AVAILABLE */
+};
+enum chimera_smb_durable_hold
+chimera_smb_durable_parked_hold(
+    struct chimera_server_smb_shared *shared,
+    uint64_t                          persistent_id);
 struct chimera_smb_open_file *
 chimera_smb_durable_claim(
     struct chimera_server_smb_shared *shared,

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -654,6 +654,16 @@ struct chimera_smb_request {
             uint32_t                           dir_break_action;
             uint64_t                           dir_break_skip_lo;
             uint64_t                           dir_break_skip_hi;
+            /* A non-FILE_OPEN_REPARSE_POINT create that stops on a symbolic-link
+             * leaf returns STATUS_STOPPED_ON_SYMLINK with a SymbolicLinkError
+             * Response body (MS-SMB2 2.2.2.2.1) carrying the link target.  The
+             * target is read back from the link and stashed here for the error
+             * reply builder (smb.c); r_symlink_error gates the body emission. */
+            uint8_t                            r_symlink_error;
+            uint8_t                            r_symlink_relative;
+            uint16_t                           r_symlink_target_len;
+            char                               r_symlink_target[CHIMERA_VFS_PATH_MAX];
+            struct chimera_vfs_open_handle    *r_symlink_handle;
         } create;
 
         struct  {
@@ -800,8 +810,16 @@ struct chimera_smb_request {
             int                             rp_target_len;
             char                            rp_target[CHIMERA_VFS_PATH_MAX];
             struct chimera_vfs_attrs        rp_set_attr;
-            /* GET response buffer */
-            uint8_t                         rp_response[16 + (CHIMERA_VFS_PATH_MAX - 1) * 2];
+            /* SET_REPARSE replaces the original object with a freshly-created
+             * special file (symlink/device); its file handle is captured here so
+             * the open's VFS handle can be re-bound to the new inode, keeping the
+             * client's open valid for a following GET_REPARSE / handle op. */
+            uint8_t                         rp_new_fh[CHIMERA_VFS_FH_SIZE + 16];
+            uint32_t                        rp_new_fh_len;
+            /* GET response buffer.  Sized for the largest layout: a SYMLINK-tag
+             * SYMBOLIC_LINK_REPARSE_BUFFER (20-byte header + Substitute and Print
+             * names, each up to the full UTF-16 target). */
+            uint8_t                         rp_response[20 + (CHIMERA_VFS_PATH_MAX - 1) * 2 * 2];
             int                             rp_response_len;
             /* SET_SPARSE / SET_ZERO_DATA / QUERY_ALLOCATED_RANGES fields */
             struct chimera_smb_open_file   *sp_open_file;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -827,6 +827,10 @@ struct chimera_smb_request {
             uint32_t                        cc_chunk_count;
             uint32_t                        cc_chunk_idx;
             uint32_t                        cc_chunks_written;
+            /* SRV_COPYCHUNK_RESPONSE.ChunkBytesWritten: 0 on success, but on a
+             * limit violation it carries MaxChunkSize so the client resubmits
+             * within bounds (MS-SMB2 3.3.5.15.6). */
+            uint32_t                        cc_chunk_bytes;
             uint64_t                        cc_total_written;
             /* Source file size, fetched before copying so an out-of-range chunk
              * (src_offset + length beyond EOF) can be rejected with

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1668,11 +1668,15 @@ chimera_smb_durable_drain_all(
 
 /* Purge a parked (disconnected) durable open by persistent id when a new
  * conflicting open arrives.  Returns true iff found+purged.  No-op for live,
- * persistent, cold, or unknown ids. */
+ * cold, or unknown ids.  Persistent parked opens are purged only when
+ * include_persistent is set: an ordinary conflicting open must not displace a
+ * persistent handle (it has to be reclaimed via CreateGuid), but an
+ * AppInstanceId failover (MS-SMB2 3.3.5.9.7) does displace it. */
 bool
 chimera_smb_durable_purge_parked(
     struct chimera_server_smb_thread *thread,
-    uint64_t                          persistent_id);
+    uint64_t                          persistent_id,
+    bool                              include_persistent);
 
 /* How a conflicting CREATE should treat a share conflict against a not-yet-parked
  * non-persistent durable holder it could not purge.  See

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -322,8 +322,17 @@ chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
         return;
     }
 
-    /* The source is identified by the resume key (its FileId). */
-    src_open_file = chimera_smb_open_file_resolve(request, &request->ioctl.cc_src_file_id);
+    /* The source is identified by the resume key (its FileId).  Resolving it is
+     * an internal lookup that must NOT clobber the compound's related-handle
+     * inheritance: chimera_smb_open_file_resolve updates compound->saved_file_id
+     * to the last resolved handle, but the FSCTL "operates on" the DESTINATION,
+     * so a chained READ/CLOSE after this copychunk must inherit the destination
+     * handle, not the source (MS-SMB2 3.3.5.2.7.2; pike copychunk
+     * ssc_in_compound_req).  Snapshot saved_file_id (= dst, set just above) and
+     * restore it after the source lookup. */
+    struct chimera_smb_file_id cc_saved_file_id = request->compound->saved_file_id;
+    src_open_file                    = chimera_smb_open_file_resolve(request, &request->ioctl.cc_src_file_id);
+    request->compound->saved_file_id = cc_saved_file_id;
     if (unlikely(!src_open_file)) {
         chimera_smb_open_file_release(request, dst_open_file);
         /* An unknown/expired resume key -> OBJECT_NAME_NOT_FOUND per

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -27,15 +27,17 @@
  * resolves that FileId within the same session to find the source handle.
  */
 
-/* MS-SMB2 server-side copy limits (2.2.32.1):
- *   MaxChunkCount  = 16
+/* Server-side copy limits:
+ *   MaxChunkCount  = 256
  *   MaxChunkSize   = 1 MiB
  *   TotalSizeLimit = 16 MiB
  * A request that exceeds any of these is answered with STATUS_INVALID_PARAMETER
  * and a SRV_COPYCHUNK_RESPONSE whose ChunksWritten / ChunkBytesWritten /
  * TotalBytesWritten advertise these maxima so the client resubmits within them
- * (MS-SMB2 3.3.5.15.6). */
-#define CHIMERA_SMB_CC_MAX_CHUNKS    16
+ * (MS-SMB2 3.3.5.15.6).  ServerSideCopyMaxNumberOfChunks is an implementation-
+ * chosen ADM value; we use 256 (the Windows Server value real clients -- pike,
+ * Windows -- expect), not the 16 a prior audit read into the spec. */
+#define CHIMERA_SMB_CC_MAX_CHUNKS    256
 #define CHIMERA_SMB_CC_MAX_CHUNK_LEN (1024 * 1024)
 #define CHIMERA_SMB_CC_MAX_TOTAL_LEN (16 * 1024 * 1024)
 

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -45,6 +45,7 @@ static void
 chimera_smb_copychunk_limit_fail(struct chimera_smb_request *request)
 {
     request->ioctl.cc_chunks_written = CHIMERA_SMB_CC_MAX_CHUNKS;
+    request->ioctl.cc_chunk_bytes    = CHIMERA_SMB_CC_MAX_CHUNK_LEN;
     request->ioctl.cc_total_written  = CHIMERA_SMB_CC_MAX_TOTAL_LEN;
     request->ioctl.cc_limit_response = 1;
     chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
@@ -101,10 +102,22 @@ chimera_smb_copychunk_cb(
     if (error_code != CHIMERA_VFS_OK) {
         /* A backend without server-side copy support must answer
          * NOT_SUPPORTED so the client falls back to a normal read/write
-         * copy rather than treating it as a hard error. */
-        uint32_t status = (error_code == CHIMERA_VFS_ENOTSUP)
-                          ? SMB2_STATUS_NOT_SUPPORTED
-                          : SMB2_STATUS_INVALID_PARAMETER;
+         * copy rather than treating it as a hard error.  A directory source
+         * or destination is rejected with STATUS_INVALID_DEVICE_REQUEST
+         * (MS-SMB2 3.3.5.15.6; smb2.ioctl copychunk-to-a-directory). */
+        uint32_t status;
+
+        switch (error_code) {
+            case CHIMERA_VFS_ENOTSUP:
+                status = SMB2_STATUS_NOT_SUPPORTED;
+                break;
+            case CHIMERA_VFS_EISDIR:
+                status = SMB2_STATUS_INVALID_DEVICE_REQUEST;
+                break;
+            default:
+                status = SMB2_STATUS_INVALID_PARAMETER;
+                break;
+        } /* switch */
 
         chimera_smb_copychunk_done(request, status);
         return;
@@ -262,6 +275,7 @@ chimera_smb_ioctl_copychunk(struct chimera_smb_request *request)
     request->ioctl.cc_dst_open_file  = NULL;
     request->ioctl.cc_chunk_idx      = 0;
     request->ioctl.cc_chunks_written = 0;
+    request->ioctl.cc_chunk_bytes    = 0;
     request->ioctl.cc_total_written  = 0;
     request->ioctl.cc_limit_response = 0;
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -4835,13 +4835,43 @@ build_dhnq_response(
     return 8;
 } /* build_dhnq_response */
 
+/* Build the QFid (SMB2_CREATE_QUERY_ON_DISK_ID) response body.  32 bytes:
+ * DiskFileId(8) | VolumeId(8) | Reserved(16) (MS-SMB2 2.2.14.2.9).  The
+ * DiskFileId must be stable across opens of the same file and unique per file;
+ * the VFS file-handle hash (a 64-bit hash of the persistent file handle) is
+ * exactly such an identifier.  VolumeId/Reserved are left zero -- the client
+ * treats the 32 bytes opaquely (it only checks same-file equality and
+ * cross-file inequality). */
+static int
+build_qfid_response(
+    struct chimera_smb_request *request,
+    uint8_t                    *out,
+    uint32_t                    out_size)
+{
+    struct chimera_smb_open_file *of = request->create.r_open_file;
+    uint64_t                      disk_id;
+    int                           i;
+
+    if (out_size < 32 || !of || !of->handle) {
+        return -1;
+    }
+
+    disk_id = of->handle->fh_hash;
+
+    memset(out, 0, 32);
+    for (i = 0; i < 8; i++) {
+        out[i] = (disk_id >> (8 * i)) & 0xff;  /* DiskFileId, little-endian */
+    }
+    return 32;
+} /* build_qfid_response */
+
 /* *INDENT-OFF* */ /* uncrustify oscillates on aligned struct-init tables */
 static const struct chimera_smb_create_response_emitter smb_create_response_emitters[] = {
     { CHIMERA_SMB_CREATE_CTX_MXAC, "MxAc", build_mxac_response  },
     { CHIMERA_SMB_CREATE_CTX_RQLS, "RqLs", build_rqls_response  },
     { CHIMERA_SMB_CREATE_CTX_DH2Q, "DH2Q", build_dh2q_response  },
     { CHIMERA_SMB_CREATE_CTX_DHNQ, "DHnQ", build_dhnq_response  },
-    /* Phase 8: + QFid (32-byte on-disk id) */
+    { CHIMERA_SMB_CREATE_CTX_QFID, "QFid", build_qfid_response  },
     { 0,                           NULL,   NULL                },
 };
 /* *INDENT-ON* */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -236,10 +236,26 @@ chimera_smb_app_instance_force_close(
     struct chimera_server_smb_thread *thread,
     struct chimera_smb_open_file     *open_file)
 {
-    struct chimera_smb_tree      *tree = open_file->tree;
+    struct chimera_smb_tree      *tree;
     int                           bucket;
     bool                          unhashed = false;
     struct chimera_smb_open_file *to_free  = NULL;
+
+    /* A parked (disconnected durable/persistent) open is no longer in any tree's
+     * open_files hash -- chimera_smb_tree_free already HASH_DELETEd it and
+     * returned its tree to the free pool, leaving open_file->tree dangling at a
+     * recycled tree.  Taking the live-open path below (which locks that tree and
+     * HASH_DELETEs again) would double-delete a stale hash node on a recycled
+     * tree and crash.  Tear it down through the durable registry instead, the
+     * same way the grace-timer sweeper does -- and force the persistent case,
+     * since an AppInstanceId failover displaces even a persistent handle
+     * (MS-SMB2 3.3.5.9.7). */
+    if (open_file->flags & CHIMERA_SMB_OPEN_FILE_PARKED) {
+        return chimera_smb_durable_purge_parked(thread, open_file->file_id.pid,
+                                                true);
+    }
+
+    tree = open_file->tree;
 
     if (!tree) {
         return false;
@@ -449,7 +465,7 @@ chimera_smb_create_purge_parked_writers(
     chimera_vfs_state_put(vfs_state, file_state);
 
     for (i = 0; i < npids; i++) {
-        chimera_smb_durable_purge_parked(thread, pids[i]);
+        chimera_smb_durable_purge_parked(thread, pids[i], false);
     }
 } /* chimera_smb_create_purge_parked_writers */
 
@@ -923,7 +939,7 @@ chimera_smb_create_gen_open_file(
                 break;
             }
 
-            if (!chimera_smb_durable_purge_parked(thread, conflict_pid)) {
+            if (!chimera_smb_durable_purge_parked(thread, conflict_pid, false)) {
                 /* The durable holder is not parked yet.  If its owning connection
                 * is on its way out, the park (and the MS-SMB2 yield) is imminent
                 * but has not landed -- this is the disconnect-vs-conflicting-open

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3889,11 +3889,17 @@ chimera_smb_durable_reconnect_attempt(struct chimera_smb_request *request)
         lease_key = request->create.rqls.key;
     }
 
+    /* A DH2C reconnect that sets SMB2_DHANDLE_FLAG_PERSISTENT must target a
+     * persistent Open; the claim rejects it with INVALID_PARAMETER otherwise
+     * (MS-SMB2 3.3.5.9.12).  DHnC (v1) has no Flags field, so this is false. */
+    bool reconnect_persistent = (ctx & CHIMERA_SMB_CREATE_CTX_DH2C) &&
+        (request->create.dh2c.flags & SMB2_DHANDLE_FLAG_PERSISTENT);
+
     open_file = chimera_smb_durable_claim(shared, persistent_id, create_guid,
                                           request->compound->conn->client_guid,
                                           request->session_handle->session->cred.uid,
                                           request->create.name, request->create.name_len,
-                                          has_lease_ctx, lease_key,
+                                          has_lease_ctx, lease_key, reconnect_persistent,
                                           &cold, &retry, &status);
 
     if (cold) {

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -184,9 +184,15 @@ chimera_smb_app_instance_decision(
      * from the SAME client (same ClientGuid, different connection) is not a
      * failover and must leave the prior open intact.  (SMB2Model AppInstanceId
      * SameClientGuid cases; the MS-SMB2 AppInstanceVersion failover uses two
-     * distinct clients, so its ClientGuids differ and the close still applies.) */
-    if (existing->create_conn &&
-        memcmp(existing->create_conn->client_guid,
+     * distinct clients, so its ClientGuids differ and the close still applies.)
+     *
+     * Compare against the open's stored ClientGuid, not its create_conn: a
+     * parked (disconnected) handle has had its create_conn cleared, and reading
+     * the live connection would miss the same-client match -- wrongly failover-
+     * displacing a parked persistent handle of the requester's own client
+     * instead of leaving it to block the open with FILE_NOT_AVAILABLE (pike
+     * appinstanceid test_appinstanceid_reconnect_same_clientguid). */
+    if (memcmp(existing->client_guid,
                request->compound->conn->client_guid, 16) == 0) {
         return 0;
     }
@@ -462,10 +468,48 @@ chimera_smb_create_purge_parked_writers(
     }
     pthread_mutex_unlock(&file_state->lock);
 
+    /* Classify each parked write holder (registry lock; must NOT be held under
+     * file->lock per the bucket -> registry -> vfs_state order).  A durable-only
+     * or expired holder YIELDS; a resilient holder within its timeout is
+     * courtesy-held (CAP).  (A persistent holder never reaches here -- the
+     * conflicting open was already rejected with FILE_NOT_AVAILABLE upstream.) */
+    enum chimera_smb_durable_hold holds[16];
+    for (i = 0; i < npids; i++) {
+        holds[i] = chimera_smb_durable_parked_hold(thread->shared, pids[i]);
+    }
+
+    /* Courtesy-downgrade the CAP holders' caching to read-only IN PLACE: a
+     * resilient parked handle cannot ack a break (its connection is gone) and
+     * must not be evicted, so instead of the doomed break/revoke we drop its
+     * write+handle caching here under file->lock.  The conflicting open then
+     * caps its own grant to R against the holder's retained read cache, while
+     * the holder stays parked and reclaimable (pike durable
+     * test_resiliency_reconnect_before_timeout).  Re-find the lease by pid under
+     * the lock rather than trusting a pointer cached across the unlock. */
+    pthread_mutex_lock(&file_state->lock);
+    for (lease = file_state->caching_leases; lease; lease = lease->next) {
+        if (!lease->parked || !lease->grant || !lease->grant->holders) {
+            continue;
+        }
+        uint64_t lpid =
+            ((struct chimera_smb_open_file *) lease->grant->holders)->file_id.pid;
+        for (i = 0; i < npids; i++) {
+            if (pids[i] == lpid && holds[i] == CHIMERA_SMB_DURABLE_HOLD_CAP) {
+                lease->mode.granted &= CHIMERA_VFS_LEASE_MODE_R;
+                break;
+            }
+        }
+    }
+    pthread_mutex_unlock(&file_state->lock);
+
     chimera_vfs_state_put(vfs_state, file_state);
 
+    /* The yielding (durable-only / expired) holders are purged so the
+     * conflicting open gets its full grant. */
     for (i = 0; i < npids; i++) {
-        chimera_smb_durable_purge_parked(thread, pids[i], false);
+        if (holds[i] == CHIMERA_SMB_DURABLE_HOLD_NONE) {
+            chimera_smb_durable_purge_parked(thread, pids[i], false);
+        }
     }
 } /* chimera_smb_create_purge_parked_writers */
 
@@ -652,6 +696,8 @@ chimera_smb_create_gen_open_file(
     memset(open_file->lease_key,        0, sizeof(open_file->lease_key));
     memset(open_file->parent_lease_key, 0, sizeof(open_file->parent_lease_key));
     memset(open_file->create_guid,      0, sizeof(open_file->create_guid));
+    memcpy(open_file->client_guid, request->compound->conn->client_guid,
+           sizeof(open_file->client_guid));
     open_file->integrity_algo  = 0;
     open_file->integrity_flags = 0;
 
@@ -755,6 +801,54 @@ chimera_smb_create_gen_open_file(
             } else if (decision > 0) {
                 chimera_smb_app_instance_force_close(thread, match);
             }
+        }
+    }
+
+    /* MS-SMB2 disconnected-persistent-handle rule: a fresh open of a file held
+     * by a *parked* persistent (CA) handle that is still within its timeout
+     * fails with STATUS_FILE_NOT_AVAILABLE -- the file is reserved for the
+     * persistent handle's reclaim and a conflicting open must not coexist (pike
+     * persistent test_open_while_disconnected, test_resiliency_*_before_timeout).
+     * A *resilient* (non-persistent) parked holder does NOT block here: it
+     * courtesy-caps a conflicting lease open instead (in the break path).  The
+     * persistent holder's own DH2C reclaim takes the durable-reconnect path, not
+     * this fresh-create path, so it is never self-blocked.  We are pre-share
+     * here (no leases acquired yet), so reject exactly like the AppInstanceId
+     * path: NULL out the handle, free the open, set force_close_status. */
+    if (type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE && tree->share && oh) {
+        struct chimera_vfs_state      *vfs_state  = thread->vfs_thread->vfs->vfs_state;
+        struct chimera_vfs_file_state *file_state =
+            chimera_vfs_state_get(vfs_state, oh->fh, oh->fh_len, oh->fh_hash, false);
+        bool                           blocked = false;
+
+        if (file_state) {
+            uint64_t block_pids[16];
+            int      nblock = 0, k;
+
+            pthread_mutex_lock(&file_state->lock);
+            for (struct chimera_vfs_lease *l = file_state->share_resvs;
+                 l && nblock < 16; l = l->next) {
+                if (l->parked) {
+                    block_pids[nblock++] = l->owner.owner_lo;
+                }
+            }
+            pthread_mutex_unlock(&file_state->lock);
+            chimera_vfs_state_put(vfs_state, file_state);
+
+            for (k = 0; k < nblock; k++) {
+                if (chimera_smb_durable_parked_hold(thread->shared, block_pids[k]) ==
+                    CHIMERA_SMB_DURABLE_HOLD_BLOCK) {
+                    blocked = true;
+                    break;
+                }
+            }
+        }
+
+        if (blocked) {
+            open_file->handle = NULL;
+            chimera_smb_open_file_free(thread, open_file);
+            request->create.force_close_status = SMB2_STATUS_FILE_NOT_AVAILABLE;
+            return NULL;
         }
     }
 
@@ -3814,17 +3908,20 @@ chimera_smb_durable_rehome(
     struct chimera_smb_tree          *tree   = request->tree;
     int                               bucket;
 
-    /* The persistent id is unchanged; the volatile id is reissued (spec
-     * permits this).  The registry reference becomes the new tree reference; we
-     * add one more for this in-flight request, which the getattr callback
-     * releases below. */
+    /* The surviving open keeps its FileId intact across the reconnect -- both
+     * the persistent id AND the volatile id.  Although MS-SMB2 permits the
+     * volatile id to be reissued, OneFS (and the pike durable/persistent
+     * reconnect tests) require the reconnected handle to report the same
+     * FileId.Volatile it had before the disconnect, so the open_file's
+     * file_id is left untouched here.  The registry reference becomes the new
+     * tree reference; we add one more for this in-flight request, which the
+     * getattr callback releases below. */
     open_file->flags &= ~CHIMERA_SMB_OPEN_FILE_PARKED;
     /* A reclaimed durable open becomes replay-eligible again (MS-SMB2
      * 3.3.5.9.10): a replayed create matching it reports the original
      * create_action until the next non-replay op uses the handle. */
     open_file->flags      |= CHIMERA_SMB_OPEN_FILE_REPLAY_ELIGIBLE;
     open_file->create_conn = request->compound->conn;
-    open_file->file_id.vid = chimera_rand64();
     open_file->refcnt      = 2;
     /* Reseed the channel-sequence baseline from the reconnecting CREATE. */
     open_file->channel_sequence       = request->channel_sequence;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -137,6 +137,70 @@ chimera_smb_create_error_status(enum chimera_vfs_error error_code)
     } /* switch */
 } /* chimera_smb_create_error_status */
 
+/* Emit the SMB2 ERROR Response carrying a SymbolicLinkErrorResponse body
+ * (MS-SMB2 2.2.2 / 2.2.2.2.1) for a create that STATUS_STOPPED_ON_SYMLINK'd.
+ * The link target (UTF-8, already '\'-separated) and its relative flag were
+ * stashed on the request by the create's readlink step.  Called only when
+ * request->create.r_symlink_error is set; a UTF-16 conversion failure degrades
+ * to the bare 9-byte error body so the client still sees STOPPED_ON_SYMLINK. */
+void
+chimera_smb_create_emit_symlink_error(
+    struct evpl_iovec_cursor   *cursor,
+    struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread = request->compound->thread;
+    uint16_t                          utf16[CHIMERA_VFS_PATH_MAX];
+    int                               name_len;
+    uint16_t                          reparse_data_length;
+    uint32_t                          sym_link_length, byte_count, flags;
+
+    name_len = chimera_smb_utf8_to_utf16le(
+        &thread->iconv_ctx,
+        request->create.r_symlink_target,
+        request->create.r_symlink_target_len,
+        utf16,
+        sizeof(utf16));
+
+    if (name_len <= 0) {
+        evpl_iovec_cursor_append_uint16(cursor, SMB2_ERROR_REPLY_SIZE);
+        evpl_iovec_cursor_append_uint16(cursor, 0);
+        evpl_iovec_cursor_append_uint16(cursor, 0);
+        evpl_iovec_cursor_append_uint16(cursor, 0);
+        evpl_iovec_cursor_append_uint8(cursor, 0);
+        return;
+    }
+
+    flags = request->create.r_symlink_relative ?
+        SMB2_SYMLINK_FLAG_RELATIVE : SMB2_SYMLINK_FLAG_ABSOLUTE;
+
+    /* ReparseDataLength counts the SubstituteNameOffset..PathBuffer fields; the
+     * substitute and print names are stored back to back (substitute first). */
+    reparse_data_length = 12 + 2 * name_len;
+    /* SymLinkLength counts everything after itself (SymLinkErrorTag onward). */
+    sym_link_length = 4 /* SymLinkErrorTag */ + 4 /* ReparseTag */ +
+        2 /* ReparseDataLength */ + 2 /* UnparsedPathLength */ + reparse_data_length;
+    byte_count = 4 /* SymLinkLength */ + sym_link_length;
+
+    /* SMB2 ERROR Response header (StructureSize=9, ErrorContextCount=0). */
+    evpl_iovec_cursor_append_uint16(cursor, SMB2_ERROR_REPLY_SIZE);
+    evpl_iovec_cursor_append_uint16(cursor, 0); /* ErrorContextCount + Reserved */
+    evpl_iovec_cursor_append_uint32(cursor, byte_count);
+
+    /* SymbolicLinkErrorResponse (MS-SMB2 2.2.2.2.1). */
+    evpl_iovec_cursor_append_uint32(cursor, sym_link_length);
+    evpl_iovec_cursor_append_uint32(cursor, SMB2_SYMLINK_ERROR_TAG);     /* 'SYML' */
+    evpl_iovec_cursor_append_uint32(cursor, SMB2_IO_REPARSE_TAG_SYMLINK);
+    evpl_iovec_cursor_append_uint16(cursor, reparse_data_length);
+    evpl_iovec_cursor_append_uint16(cursor, 0);        /* UnparsedPathLength */
+    evpl_iovec_cursor_append_uint16(cursor, 0);        /* SubstituteNameOffset */
+    evpl_iovec_cursor_append_uint16(cursor, name_len); /* SubstituteNameLength */
+    evpl_iovec_cursor_append_uint16(cursor, name_len); /* PrintNameOffset */
+    evpl_iovec_cursor_append_uint16(cursor, name_len); /* PrintNameLength */
+    evpl_iovec_cursor_append_uint32(cursor, flags);
+    evpl_iovec_cursor_append_blob(cursor, utf16, name_len); /* SubstituteName */
+    evpl_iovec_cursor_append_blob(cursor, utf16, name_len); /* PrintName */
+} /* chimera_smb_create_emit_symlink_error */
+
 /*
  * Decide what to do when a CREATE carrying an SMB2_CREATE_APP_INSTANCE_ID
  * conflicts with an existing Open that holds the same AppInstanceId on a
@@ -2232,6 +2296,112 @@ chimera_smb_create_open_stream_chain(
         request);
 } /* chimera_smb_create_open_stream_chain */
 
+/* STATUS_STOPPED_ON_SYMLINK must carry a SymbolicLinkErrorResponse body (MS-SMB2
+ * 2.2.2.2.1) so the client can resolve the link and retry.  The target is read
+ * back from a handle on the link (r_symlink_handle) and stashed for the error-
+ * reply builder (chimera_smb_create_emit_symlink_error in smb.c); r_symlink_error
+ * gates the emission.  On any failure we still return the bare error -- a missing
+ * body costs the client only one extra resolve round-trip, never correctness. */
+static void
+chimera_smb_create_symlink_readlink_cb(
+    enum chimera_vfs_error    error_code,
+    int                       target_length,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+    int                         i;
+
+    if (request->create.r_symlink_handle) {
+        chimera_vfs_release(vfs_thread, request->create.r_symlink_handle);
+        request->create.r_symlink_handle = NULL;
+    }
+    chimera_vfs_release(vfs_thread, request->create.parent_handle);
+
+    if (error_code == CHIMERA_VFS_OK && target_length > 0 &&
+        target_length < CHIMERA_VFS_PATH_MAX) {
+        /* SMB substitute names use backslash separators; a leading separator (or
+         * its absence) sets the response's relative/absolute Flags. */
+        request->create.r_symlink_relative =
+            (request->create.r_symlink_target[0] != '/');
+        for (i = 0; i < target_length; i++) {
+            if (request->create.r_symlink_target[i] == '/') {
+                request->create.r_symlink_target[i] = '\\';
+            }
+        }
+        request->create.r_symlink_target_len = target_length;
+        request->create.r_symlink_error      = 1;
+    }
+
+    chimera_smb_complete_request(request, SMB2_STATUS_STOPPED_ON_SYMLINK);
+} /* chimera_smb_create_symlink_readlink_cb */
+
+static void
+chimera_smb_create_symlink_open_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre_attr,
+    struct chimera_vfs_attrs       *dir_post_attr,
+    void                           *private_data)
+{
+    struct chimera_smb_request *request    = private_data;
+    struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        /* Could not reopen the link to read its target -- return the bare error. */
+        chimera_vfs_release(vfs_thread, request->create.parent_handle);
+        chimera_smb_complete_request(request, SMB2_STATUS_STOPPED_ON_SYMLINK);
+        return;
+    }
+
+    request->create.r_symlink_handle = oh;
+
+    chimera_vfs_readlink(
+        vfs_thread,
+        &request->session_handle->session->cred,
+        oh,
+        request->create.r_symlink_target,
+        CHIMERA_VFS_PATH_MAX,
+        0,
+        chimera_smb_create_symlink_readlink_cb,
+        request);
+} /* chimera_smb_create_symlink_open_cb */
+
+/* A create stopped on a symbolic-link leaf (memfs returned ELOOP under the
+ * STOP_SYMLINK open).  Reopen the link itself (NOFOLLOW) to read its target for
+ * the SymbolicLinkErrorResponse body, then complete.  parent_handle is held
+ * until the readlink callback releases it. */
+static void
+chimera_smb_create_stopped_on_symlink(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_thread *vfs_thread = request->compound->thread->vfs_thread;
+
+    request->create.r_symlink_handle = NULL;
+
+    /* open_at requires a (non-NULL) set_attr even for a pure open; this open
+     * carries no CREATE flag so the attrs are not applied. */
+    memset(&request->create.set_attr, 0, sizeof(request->create.set_attr));
+
+    chimera_vfs_open_at(
+        vfs_thread,
+        &request->session_handle->session->cred,
+        request->create.parent_handle,
+        request->create.name,
+        request->create.name_len,
+        /* O_PATH|O_NOFOLLOW: open the link itself (memfs returns ELOOP for a bare
+        * NOFOLLOW data open of a symlink leaf; PATH requests the link handle). */
+        CHIMERA_VFS_OPEN_NOFOLLOW | CHIMERA_VFS_OPEN_PATH,
+        &request->create.set_attr,
+        CHIMERA_VFS_ATTR_FH,
+        0,
+        0,
+        chimera_smb_create_symlink_open_cb,
+        request);
+} /* chimera_smb_create_stopped_on_symlink */
+
 static inline void
 chimera_smb_create_open_at_callback(
     enum chimera_vfs_error          error_code,
@@ -2247,6 +2417,13 @@ chimera_smb_create_open_at_callback(
     struct chimera_smb_open_file *open_file;
 
     if (error_code != CHIMERA_VFS_OK) {
+        if (error_code == CHIMERA_VFS_ELOOP) {
+            /* Stopped on a symbolic-link leaf: read the link target for the
+             * SymbolicLinkErrorResponse body before completing (the readlink
+             * callback releases parent_handle). */
+            chimera_smb_create_stopped_on_symlink(request);
+            return;
+        }
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, chimera_smb_create_error_status(error_code));
         return;
@@ -2259,9 +2436,18 @@ chimera_smb_create_open_at_callback(
      * inode's attributes for a non-NOFOLLOW open of a final-component symlink. */
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) && S_ISLNK(attr->va_mode) &&
         !(request->create.create_options & SMB2_FILE_OPEN_REPARSE_POINT)) {
-        chimera_vfs_release(vfs_thread, oh);
-        chimera_vfs_release(vfs_thread, request->create.parent_handle);
-        chimera_smb_complete_request(request, SMB2_STATUS_STOPPED_ON_SYMLINK);
+        /* Read the link target for the error body, then complete (the callback
+         * releases oh via r_symlink_handle and parent_handle). */
+        request->create.r_symlink_handle = oh;
+        chimera_vfs_readlink(
+            vfs_thread,
+            &request->session_handle->session->cred,
+            oh,
+            request->create.r_symlink_target,
+            CHIMERA_VFS_PATH_MAX,
+            0,
+            chimera_smb_create_symlink_readlink_cb,
+            request);
         return;
     }
 
@@ -4394,6 +4580,8 @@ chimera_smb_create(struct chimera_smb_request *request)
     request->create.access_retry_oh        = NULL;
     request->create.share_conflict_retries = 0;
     request->create.share_conflict_oh      = NULL;
+    request->create.r_symlink_error        = 0;
+    request->create.r_symlink_handle       = NULL;
 
     /* A TWRP ("@GMT-..." timewarp) create context opens a file as of a VSS
      * snapshot.  chimera exposes no snapshots, so any non-zero timewarp names a

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -5128,11 +5128,14 @@ build_dhnq_response(
 
 /* Build the QFid (SMB2_CREATE_QUERY_ON_DISK_ID) response body.  32 bytes:
  * DiskFileId(8) | VolumeId(8) | Reserved(16) (MS-SMB2 2.2.14.2.9).  The
- * DiskFileId must be stable across opens of the same file and unique per file;
- * the VFS file-handle hash (a 64-bit hash of the persistent file handle) is
- * exactly such an identifier.  VolumeId/Reserved are left zero -- the client
- * treats the 32 bytes opaquely (it only checks same-file equality and
- * cross-file inequality). */
+ * DiskFileId must be the SAME unique file id the client also obtains via
+ * FileInternalInformation (IndexNumber) and directory queries -- the VFS inode
+ * number (va_ino).  The Linux kernel cifs client cross-checks the two: if the
+ * QFid DiskFileId disagrees with the IndexNumber it re-resolves the open to a
+ * fresh, empty inode after a write and loses the data (cthon basic test5: a
+ * written file is then seen with size 0).  Use the marshaled inode number,
+ * falling back to the handle hash only if it was somehow not reported.
+ * VolumeId/Reserved are left zero. */
 static int
 build_qfid_response(
     struct chimera_smb_request *request,
@@ -5147,7 +5150,11 @@ build_qfid_response(
         return -1;
     }
 
-    disk_id = of->handle->fh_hash;
+    if (request->create.r_attrs.smb_attr_mask & SMB_ATTR_INODE) {
+        disk_id = request->create.r_attrs.smb_ino;
+    } else {
+        disk_id = of->handle->fh_hash;
+    }
 
     memset(out, 0, 32);
     for (i = 0; i < 8; i++) {

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -1032,6 +1032,10 @@ chimera_smb_parse_ioctl(
                 /* NETWORK_RESILIENCY_REQUEST (MS-SMB2 2.2.31.3): Timeout(4) +
                  * Reserved(4). */
                 if (request->ioctl.input_count < 8) {
+                    /* A NETWORK_RESILIENCY_REQUEST shorter than 8 bytes is
+                     * rejected with STATUS_INVALID_PARAMETER (smb2.durable-v2
+                     * resiliency_buffer_too_small; pike's persistent suite wants
+                     * BUFFER_TOO_SMALL here but that is a OneFS-specific quirk). */
                     chimera_smb_error("LMR_REQUEST_RESILIENCY input too small (%u < 8)",
                                       request->ioctl.input_count);
                     return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -587,7 +587,7 @@ chimera_smb_ioctl_reply(
         case SMB2_FSCTL_SRV_COPYCHUNK:
         case SMB2_FSCTL_SRV_COPYCHUNK_WRITE:
             evpl_iovec_cursor_append_uint32(reply_cursor, request->ioctl.cc_chunks_written);
-            evpl_iovec_cursor_append_uint32(reply_cursor, 0); /* ChunkBytesWritten */
+            evpl_iovec_cursor_append_uint32(reply_cursor, request->ioctl.cc_chunk_bytes); /* ChunkBytesWritten */
             evpl_iovec_cursor_append_uint32(reply_cursor, (uint32_t) request->ioctl.cc_total_written);
             break;
         case SMB2_FSCTL_OFFLOAD_READ:
@@ -947,12 +947,22 @@ chimera_smb_parse_ioctl(
                 evpl_iovec_cursor_get_uint32(request_cursor, &cc);
                 evpl_iovec_cursor_get_uint32(request_cursor, &reserved);
 
-                if (cc > CHIMERA_SMB_COPYCHUNK_MAX ||
-                    request->ioctl.input_count < 32 + (uint64_t) cc * 24) {
+                request->ioctl.cc_chunk_count = cc;
+
+                /* An over-limit ChunkCount is NOT a parse failure: the handler
+                 * answers STATUS_INVALID_PARAMETER with the SRV_COPYCHUNK_RESPONSE
+                 * limit body so the client can resubmit (MS-SMB2 3.3.5.15.6).
+                 * Rejecting it here would leave the client hanging, and parsing
+                 * cc entries would overrun cc_chunks[], so skip the chunk array
+                 * entirely and let the handler reject by count. */
+                if (cc > CHIMERA_SMB_COPYCHUNK_MAX) {
+                    break;
+                }
+
+                if (request->ioctl.input_count < 32 + (uint64_t) cc * 24) {
                     return chimera_smb_parse_reject(request, SMB2_STATUS_INVALID_PARAMETER);
                 }
 
-                request->ioctl.cc_chunk_count = cc;
                 for (i = 0; i < cc; i++) {
                     evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.cc_chunks[i].src_offset);
                     evpl_iovec_cursor_get_uint64(request_cursor, &request->ioctl.cc_chunks[i].dst_offset);

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -354,6 +354,17 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
                     chimera_smb_open_file_release(request, open_file);
                     chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
                     return;
+                } else if (timeout_ms < CHIMERA_SMB_RESILIENCY_MIN_TIMEOUT_MS) {
+                    /* Enforce a server minimum on the disconnect-survival window.
+                     * A client may request an absurdly short timeout (pike's
+                     * durable resiliency cases ask for 100 ms), but a real handle
+                     * reconnect involves several round trips after the network
+                     * drop; honoring a sub-second timeout literally would expire
+                     * the handle mid-reconnect on a loaded server.  OneFS (whose
+                     * suite these are) likewise floors the granted timeout.  The
+                     * grant is reported only as SUCCESS (no granted-timeout field),
+                     * so raising it is invisible to the client. */
+                    timeout_ms = CHIMERA_SMB_RESILIENCY_MIN_TIMEOUT_MS;
                 }
 
                 /* Register the open in the durable registry (as a non-persistent

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -120,13 +120,16 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     if (dialect >= 0x210 && (shared->config.capabilities & SMB2_GLOBAL_CAP_LEASING)) {
         conn->capabilities |= SMB2_GLOBAL_CAP_LEASING;
     }
-    /* Only advertise MULTI_CHANNEL when at least one network interface is
-     * actually configured (MS-SMB2 §3.3.5.4): the capability is meaningless
-     * without interfaces to return from FSCTL_QUERY_NETWORK_INTERFACE_INFO, and
-     * advertising it with an empty interface list invites the client to attempt
-     * a second channel it can never discover an endpoint for. */
+    /* Advertise MULTI_CHANNEL only when (a) at least one network interface is
+     * configured -- the capability is meaningless without interfaces to return
+     * from FSCTL_QUERY_NETWORK_INTERFACE_INFO -- AND (b) the client also offered
+     * SMB2_GLOBAL_CAP_MULTI_CHANNEL in its NEGOTIATE.  Per MS-SMB2 3.3.5.4 the
+     * client drives whether alternate channels are negotiated, so a client that
+     * did not request it must not see it echoed back (pike negotiate
+     * test_smb3_no_advert vs the positive test_smb3 on a multichannel server). */
     if (dialect >= 0x300 && (shared->config.capabilities & SMB2_GLOBAL_CAP_MULTI_CHANNEL) &&
-        shared->config.num_nic_info > 0) {
+        shared->config.num_nic_info > 0 &&
+        (request->negotiate.capabilities & SMB2_GLOBAL_CAP_MULTI_CHANNEL)) {
         conn->capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
     }
     if (dialect >= 0x300 && shared->config.persistent_handles) {

--- a/src/server/smb/smb_proc_reparse.c
+++ b/src/server/smb/smb_proc_reparse.c
@@ -38,6 +38,48 @@ chimera_smb_set_reparse_create_cb(
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_set_reparse_create_cb */
 
+/* The SET created a new symlink inode, replacing the original object that the
+ * client's open still references.  Re-bind the open's VFS handle (open_file->
+ * handle) to the new inode so a following GET_REPARSE_POINT -- or any handle op
+ * -- resolves the link rather than the now-orphaned original
+ * (pike reparse test_set_get_reparse_point). */
+static void
+chimera_smb_set_reparse_rebind_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct chimera_smb_request   *request    = private_data;
+    struct chimera_vfs_thread    *vfs_thread = request->compound->thread->vfs_thread;
+    struct chimera_smb_open_file *open_file  = request->ioctl.rp_open_file;
+
+    chimera_vfs_release(vfs_thread, request->ioctl.rp_parent_handle);
+
+    if (error_code == CHIMERA_VFS_OK && oh) {
+        struct chimera_vfs_open_handle *old = open_file->handle;
+        open_file->handle = oh;
+
+        /* The delete-on-close reservation was armed on the original handle (and
+         * does not fire on a plain release).  Re-arm it on the new handle so the
+         * close still unlinks the link by name (the pike test_set_get create
+         * carries FILE_DELETE_ON_CLOSE). */
+        if (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE) {
+            chimera_vfs_set_delete_on_close(
+                vfs_thread, oh,
+                open_file->parent_fh, open_file->parent_fh_len,
+                open_file->name, open_file->name_len,
+                &request->session_handle->session->cred);
+        }
+
+        if (old) {
+            chimera_vfs_release(vfs_thread, old);
+        }
+    }
+
+    chimera_smb_open_file_release(request, open_file);
+    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+} /* chimera_smb_set_reparse_rebind_cb */
+
 static void
 chimera_smb_set_reparse_symlink_cb(
     enum chimera_vfs_error    error_code,
@@ -49,18 +91,43 @@ chimera_smb_set_reparse_symlink_cb(
     struct chimera_smb_request *request    = private_data;
     struct chimera_vfs_thread  *vfs_thread = request->compound->thread->vfs_thread;
 
-    chimera_vfs_release(vfs_thread, request->ioctl.rp_parent_handle);
-    chimera_smb_open_file_release(request, request->ioctl.rp_open_file);
-
     if (error_code != CHIMERA_VFS_OK) {
         chimera_smb_error("SET_REPARSE: symlink failed error=%d target='%s' target_len=%d",
                           error_code,
                           request->ioctl.rp_target,
                           request->ioctl.rp_target_len);
+        chimera_vfs_release(vfs_thread, request->ioctl.rp_parent_handle);
+        chimera_smb_open_file_release(request, request->ioctl.rp_open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_INTERNAL_ERROR);
         return;
     }
 
+    /* Re-bind the open handle to the new symlink inode (its file handle was
+     * returned in attr->va_fh).  rp_parent_handle and rp_open_file are released
+     * in the rebind callback. */
+    if (attr && (attr->va_set_mask & CHIMERA_VFS_ATTR_FH) &&
+        attr->va_fh_len <= sizeof(request->ioctl.rp_new_fh)) {
+        memcpy(request->ioctl.rp_new_fh, attr->va_fh, attr->va_fh_len);
+        request->ioctl.rp_new_fh_len = attr->va_fh_len;
+
+        /* Open a real (backend) handle on the new inode -- not an INFERRED/PATH
+         * handle -- so the open keeps a valid backend handle for delete-on-close
+         * (the close path closes it via chimera_vfs_close). */
+        chimera_vfs_open_fh(
+            vfs_thread,
+            &request->session_handle->session->cred,
+            request->ioctl.rp_new_fh,
+            request->ioctl.rp_new_fh_len,
+            0,
+            chimera_smb_set_reparse_rebind_cb,
+            request);
+        return;
+    }
+
+    /* No file handle returned -- the open keeps its (now stale) handle, but the
+     * SET itself succeeded. */
+    chimera_vfs_release(vfs_thread, request->ioctl.rp_parent_handle);
+    chimera_smb_open_file_release(request, request->ioctl.rp_open_file);
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_set_reparse_symlink_cb */
 
@@ -264,7 +331,8 @@ chimera_smb_get_reparse_readlink_cb(
     struct chimera_server_smb_thread *thread  = request->compound->thread;
     uint8_t                          *buf     = request->ioctl.rp_response;
     int                               utf16_len;
-    int                               data_len;
+    uint16_t                          reparse_data_length;
+    uint32_t                          flags;
 
     chimera_smb_open_file_release(request, request->ioctl.rp_open_file);
 
@@ -273,6 +341,11 @@ chimera_smb_get_reparse_readlink_cb(
         return;
     }
 
+    /* A relative target carries no leading separator (test before the slash
+     * conversion below). */
+    flags = (target_length > 0 && request->ioctl.rp_target[0] != '/') ?
+        SMB2_SYMLINK_FLAG_RELATIVE : SMB2_SYMLINK_FLAG_ABSOLUTE;
+
     /* Convert Unix forward slashes to Windows backslashes */
     for (int i = 0; i < target_length; i++) {
         if (request->ioctl.rp_target[i] == '/') {
@@ -280,12 +353,16 @@ chimera_smb_get_reparse_readlink_cb(
         }
     }
 
-    /* Convert UTF-8 target to UTF-16LE */
+    /* A symlink is reported as a SYMBOLIC_LINK_REPARSE_BUFFER under
+     * IO_REPARSE_TAG_SYMLINK (MS-FSCC 2.1.2.4): the Windows representation that
+     * Windows-style clients (e.g. pike's get_symlink) decode.  Convert the
+     * target to UTF-16LE for the Substitute name; the Print name is an identical
+     * copy that immediately follows it. */
     utf16_len = chimera_smb_utf8_to_utf16le(
         &thread->iconv_ctx,
         request->ioctl.rp_target,
         target_length,
-        (uint16_t *) (buf + 16),
+        (uint16_t *) (buf + 20),
         (CHIMERA_VFS_PATH_MAX - 1) * 2);
 
     if (utf16_len < 0) {
@@ -293,31 +370,41 @@ chimera_smb_get_reparse_readlink_cb(
         return;
     }
 
-    data_len = 8 + utf16_len; /* InodeType(8) + UTF-16LE target */
+    memcpy(buf + 20 + utf16_len, buf + 20, utf16_len); /* Print name copy */
 
-    /* ReparseTag */
-    buf[0] = (SMB2_IO_REPARSE_TAG_NFS >>  0) & 0xff;
-    buf[1] = (SMB2_IO_REPARSE_TAG_NFS >>  8) & 0xff;
-    buf[2] = (SMB2_IO_REPARSE_TAG_NFS >> 16) & 0xff;
-    buf[3] = (SMB2_IO_REPARSE_TAG_NFS >> 24) & 0xff;
+    reparse_data_length = 12 + 2 * utf16_len;
+
+    /* ReparseTag = IO_REPARSE_TAG_SYMLINK */
+    buf[0] = (SMB2_IO_REPARSE_TAG_SYMLINK >>  0) & 0xff;
+    buf[1] = (SMB2_IO_REPARSE_TAG_SYMLINK >>  8) & 0xff;
+    buf[2] = (SMB2_IO_REPARSE_TAG_SYMLINK >> 16) & 0xff;
+    buf[3] = (SMB2_IO_REPARSE_TAG_SYMLINK >> 24) & 0xff;
     /* ReparseDataLength */
-    buf[4] = (data_len >>  0) & 0xff;
-    buf[5] = (data_len >>  8) & 0xff;
+    buf[4] = (reparse_data_length >> 0) & 0xff;
+    buf[5] = (reparse_data_length >> 8) & 0xff;
     /* Reserved */
     buf[6] = 0;
     buf[7] = 0;
-    /* InodeType = NFS_SPECFILE_LNK */
-    buf[8]  = (SMB2_NFS_SPECFILE_LNK >>  0) & 0xff;
-    buf[9]  = (SMB2_NFS_SPECFILE_LNK >>  8) & 0xff;
-    buf[10] = (SMB2_NFS_SPECFILE_LNK >> 16) & 0xff;
-    buf[11] = (SMB2_NFS_SPECFILE_LNK >> 24) & 0xff;
-    buf[12] = (SMB2_NFS_SPECFILE_LNK >> 32) & 0xff;
-    buf[13] = (SMB2_NFS_SPECFILE_LNK >> 40) & 0xff;
-    buf[14] = (SMB2_NFS_SPECFILE_LNK >> 48) & 0xff;
-    buf[15] = (SMB2_NFS_SPECFILE_LNK >> 56) & 0xff;
-    /* UTF-16LE data is already at buf+16 */
+    /* SubstituteNameOffset = 0 */
+    buf[8] = 0;
+    buf[9] = 0;
+    /* SubstituteNameLength */
+    buf[10] = (utf16_len >> 0) & 0xff;
+    buf[11] = (utf16_len >> 8) & 0xff;
+    /* PrintNameOffset (immediately after the Substitute name) */
+    buf[12] = (utf16_len >> 0) & 0xff;
+    buf[13] = (utf16_len >> 8) & 0xff;
+    /* PrintNameLength */
+    buf[14] = (utf16_len >> 0) & 0xff;
+    buf[15] = (utf16_len >> 8) & 0xff;
+    /* Flags */
+    buf[16] = (flags >>  0) & 0xff;
+    buf[17] = (flags >>  8) & 0xff;
+    buf[18] = (flags >> 16) & 0xff;
+    buf[19] = (flags >> 24) & 0xff;
+    /* PathBuffer (Substitute name + Print name) already at buf+20 */
 
-    request->ioctl.rp_response_len = 8 + data_len; /* header(8) + data */
+    request->ioctl.rp_response_len = 20 + 2 * utf16_len;
 
     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
 } /* chimera_smb_get_reparse_readlink_cb */

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -543,6 +543,31 @@ chimera_smb_acl_to_sd(
     }
     memset(out, 0, SD_HEADER_SIZE);
 
+    /* Emit the body in canonical order: owner SID, group SID, SACL, DACL.
+     * MS-DTYP 2.4.6 lets the self-relative offsets place these blocks anywhere,
+     * but Windows and real clients (Linux cifs, pike) decode the body in this
+     * fixed order and only consult OffsetXxx as a present/absent flag -- a
+     * DACL-first layout is then misparsed (the DACL bytes are read as the owner
+     * SID), so the owner/group SIDs must precede the DACL here. */
+    if (has_owner) {
+        int n = chimera_smb_emit_owner_sid(&out[offset], cap - offset, vfs, uid);
+
+        if (n < 0) {
+            return -1;
+        }
+        owner_off = offset;
+        offset   += n;
+    }
+
+    if (has_group) {
+        if (offset + SID_UNIX_SIZE > cap) {
+            return -1;
+        }
+        group_off = offset;
+        write_unix_sid(&out[offset], 2, gid);
+        offset += SID_UNIX_SIZE;
+    }
+
     if (has_dacl) {
         uint32_t acl_hdr   = offset;
         uint16_t ace_count = 0;
@@ -644,25 +669,6 @@ chimera_smb_acl_to_sd(
 
         dacl_off = acl_hdr;
         offset   = ace_pos;
-    }
-
-    if (has_owner) {
-        int n = chimera_smb_emit_owner_sid(&out[offset], cap - offset, vfs, uid);
-
-        if (n < 0) {
-            return -1;
-        }
-        owner_off = offset;
-        offset   += n;
-    }
-
-    if (has_group) {
-        if (offset + SID_UNIX_SIZE > cap) {
-            return -1;
-        }
-        group_off = offset;
-        write_unix_sid(&out[offset], 2, gid);
-        offset += SID_UNIX_SIZE;
     }
 
     out[0]  = 1; /* revision */

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -1004,8 +1004,11 @@ chimera_smb_query_emit_sd(
 
     /* MS-SMB2 3.3.5.20.3: if the security descriptor does not fit in the
      * client-supplied OutputBufferLength, fail with STATUS_BUFFER_TOO_SMALL
-     * (smb2.getinfo.qsec_buffercheck). */
+     * (smb2.getinfo.qsec_buffercheck).  The error reply carries the minimum
+     * required length so the client can resize and retry (MS-SMB2 2.2.2 /
+     * 3.3.4.4); stash it in output_length, which the error-reply path emits. */
     if (request->query_info.max_response_size < (uint32_t) sd_len) {
+        request->query_info.output_length = (uint32_t) sd_len;
         chimera_smb_complete_request(request, SMB2_STATUS_BUFFER_TOO_SMALL);
         return;
     }

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -730,6 +730,14 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                     chimera_smb_open_file_release(request, request->set_info.open_file);
                     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
                     break;
+                case SMB2_FILE_MODE_INFO:
+                    /* FileModeInformation (MS-FSCC 2.4.26) is a single Mode DWORD
+                     * of per-handle I/O hints (write-through, sequential-only,
+                     * no-buffering, ...); chimera tracks none of them, so accept
+                     * the set and report success (pike set test_set_file_mode_info). */
+                    chimera_smb_open_file_release(request, request->set_info.open_file);
+                    chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+                    break;
                 default:
                     chimera_smb_error("SET_INFO info_class %u not implemented", request->set_info.info_class);
                     chimera_smb_open_file_release(request, request->set_info.open_file);
@@ -853,6 +861,15 @@ chimera_smb_parse_set_info(
                     break;
                 case SMB2_FILE_POSITION_INFO:
                     rc = chimera_smb_parse_position_info(request_cursor, &request->set_info.attrs);
+                    break;
+                case SMB2_FILE_MODE_INFO:
+                    /* FileModeInformation: a 4-byte Mode DWORD (MS-FSCC 2.4.26).
+                     * Nothing to capture (the flags are per-handle I/O hints we
+                     * do not track); just validate the length. */
+                    if (unlikely(request->set_info.buffer_length < SMB2_FILE_MODE_INFO_SIZE)) {
+                        return chimera_smb_parse_reject(request,
+                                                        SMB2_STATUS_INFO_LENGTH_MISMATCH);
+                    }
                     break;
 
                 default:

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -299,6 +299,20 @@ chimera_smb_write(struct chimera_smb_request *request)
         return;
     }
 
+    /* A zero-length write accesses no byte range: per MS-FSA 2.1.5.3 it
+     * completes immediately with Count 0.  It must take NO byte-range-lock
+     * conflict (a 0-byte write inside another owner's exclusive lock is allowed
+     * -- smb2.lock.allow_zero_byte_write) and break NO oplock/lease (it changes
+     * no data, so cached readers stay valid -- smb2 readwrite write_none_*).
+     * Short-circuit here, before the lock-conflict check and the VFS write that
+     * would otherwise drive a read-cache break. */
+    if (request->write.length == 0) {
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
+        return;
+    }
+
     /* When the open holds a caching lease, use the lease's owner identity for
      * the write so chimera_vfs_break_reads_for_write self-exempts (mode.granted
      * & MODE_W AND owner_equal): the holder is writing through its own granted

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -60,6 +60,10 @@ void chimera_smb_create_reply(
     struct evpl_iovec_cursor   *reply_cursor,
     struct chimera_smb_request *request);
 
+void chimera_smb_create_emit_symlink_error(
+    struct evpl_iovec_cursor   *cursor,
+    struct chimera_smb_request *request);
+
 int chimera_smb_parse_close(
     struct evpl_iovec_cursor   *request_cursor,
     struct chimera_smb_request *request);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -186,6 +186,12 @@ struct chimera_smb_open_file {
     uint8_t                           lease_key[16];
     uint8_t                           parent_lease_key[16];
     uint8_t                           create_guid[16];
+    /* The ClientGuid of the connection that created this open.  Retained so a
+     * conflicting CREATE can compare clients even after this open is parked (its
+     * create_conn is cleared at disconnect) -- e.g. the AppInstanceId same-client
+     * rule must not failover-displace a parked persistent handle of its own
+     * client (pike appinstanceid test_appinstanceid_reconnect_same_clientguid). */
+    uint8_t                           client_guid[16];
     /* SMB2_CREATE_APP_INSTANCE_ID / *_VERSION (MS-SMB2 2.2.13.2.13/14).
      * Recorded when the open carried an AppInstanceId so a later CREATE on a
      * different connection can match it and apply the version-gated

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -464,8 +464,13 @@ if(CHIMERA_NETNS_TESTING AND EXISTS ${PIKE_DIR}/src/pike/test)
     # config also enables multichannel: the durable/persistent suites need a CA
     # share, and the appinstanceid / QueryNetworkInterfaceInfo cases need the
     # second NIC -- they share one daemon config.
+    # The persistent config also raises the per-case pytest timeout: durable
+    # test_durable_v2_timer deliberately waits out a real ~80s durable-handle
+    # timer, which exceeds the wrapper's 90s default by too little margin under
+    # CI load.  150s gives it room without risking the whole run (the ctest
+    # entry's own 900s TIMEOUT still bounds it).
     set(_pike_envfrag_base         "")
-    set(_pike_envfrag_persistent   ";CHIMERA_SMB_PERSISTENT=1;CHIMERA_SMB_MULTICHANNEL=1")
+    set(_pike_envfrag_persistent   ";CHIMERA_SMB_PERSISTENT=1;CHIMERA_SMB_MULTICHANNEL=1;PIKE_CASE_TIMEOUT=150")
     set(_pike_envfrag_encryption   ";CHIMERA_SMB_ENCRYPTION=1")
     set(_pike_lbl_base         "")
     set(_pike_lbl_persistent   ";persistent;multichannel")

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -418,6 +418,83 @@ else()
             "(need CHIMERA_NETNS_TESTING + dotnet + x86_64 + MS-FSA DLL)")
 endif()
 
+# ---------------------------------------------------------------------------
+# pike -- pure-Python SMB2/3 protocol correctness suite (the SMB analog of
+# pynfs). Like WPTS it speaks SMB2 from its own (Python) client stack and runs
+# host-side in a netns against the chimera daemon -- no VM / kernel CIFS client
+# needed. pike is run straight from its source tree (PYTHONPATH); the install
+# lives at /opt/pike (the devcontainer clones it there at a pinned SHA, like
+# /opt/pynfs). Override with -DPIKE_DIR=<path>.
+#
+# pike/pike_cases.csv maps every pike case (a pytest node-id
+# "module.py::Class::method") to the config whose features it needs (home_config)
+# and a status: green (CI-gating), xfail (applicable but currently failing -- a
+# tracked defect, NOT gated here), or skip (never-applicable today, e.g. needs a
+# second client NIC). CI gates ONLY on status=green. Each config's green list
+# runs in ONE pytest invocation against a single daemon.
+# ---------------------------------------------------------------------------
+set(PIKE_DIR /opt/pike CACHE PATH "pike SMB2/3 test framework source root")
+if(CHIMERA_NETNS_TESTING AND EXISTS ${PIKE_DIR}/src/pike/test)
+    set(CHIMERA_DAEMON $<TARGET_FILE:chimera>)
+    set(PIKE_JUNIT_DIR ${CMAKE_BINARY_DIR}/pike-junit
+        CACHE PATH "Directory for per-case pike JUnit XML output.")
+
+    set(_pike_configs base persistent encryption)
+    foreach(_c ${_pike_configs})
+        set(PIKE_GREEN_${_c} "")
+    endforeach()
+
+    file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/pike/pike_cases.csv _pike_rows)
+    foreach(_row ${_pike_rows})
+        if(_row MATCHES "^case,")             # CSV header
+            continue()
+        endif()
+        string(REPLACE "," ";" _f "${_row}")
+        list(GET _f 0 _case)
+        list(GET _f 1 _home)
+        list(GET _f 2 _status)
+        if(NOT _status STREQUAL "green")      # CI gates only on green
+            continue()
+        endif()
+        list(APPEND PIKE_GREEN_${_home} "${_case}")
+    endforeach()
+
+    # Per-config CHIMERA_SMB_* env fragment (drives the wrapper's daemon config),
+    # ctest label suffix, and ctest-name suffix. base = none. The persistent
+    # config also enables multichannel: the durable/persistent suites need a CA
+    # share, and the appinstanceid / QueryNetworkInterfaceInfo cases need the
+    # second NIC -- they share one daemon config.
+    set(_pike_envfrag_base         "")
+    set(_pike_envfrag_persistent   ";CHIMERA_SMB_PERSISTENT=1;CHIMERA_SMB_MULTICHANNEL=1")
+    set(_pike_envfrag_encryption   ";CHIMERA_SMB_ENCRYPTION=1")
+    set(_pike_lbl_base         "")
+    set(_pike_lbl_persistent   ";persistent;multichannel")
+    set(_pike_lbl_encryption   ";encryption")
+    set(_pike_suf_base         "")
+    set(_pike_suf_persistent   "_persistent")
+    set(_pike_suf_encryption   "_encryption")
+
+    foreach(_cfg ${_pike_configs})
+        if(NOT PIKE_GREEN_${_cfg})
+            continue()                        # no green cases for this config
+        endif()
+        string(REPLACE ";" "," _tests "${PIKE_GREEN_${_cfg}}")
+        set(_name chimera/server/smb/pike/memfs${_pike_suf_${_cfg}})
+        add_test(NAME ${_name}
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/pike_smb_test_wrapper.sh
+                    ${CHIMERA_DAEMON} memfs "${_tests}")
+        set_tests_properties(${_name} PROPERTIES
+            LABELS "smb;pike${_pike_lbl_${_cfg}}"
+            TIMEOUT 900
+            ENVIRONMENT "PIKE_DIR=${PIKE_DIR};PIKE_JUNIT_FILE=${PIKE_JUNIT_DIR}/memfs${_pike_suf_${_cfg}}.xml${_pike_envfrag_${_cfg}}")
+    endforeach()
+
+    message(STATUS "pike SMB tests: enabled (${PIKE_DIR})")
+else()
+    message(STATUS "pike SMB tests: disabled "
+            "(need CHIMERA_NETNS_TESTING + pike at ${PIKE_DIR})")
+endif()
+
 # SMB smbtorture integration tests
 add_executable(smbtorture_test smbtorture_test.c)
 target_link_libraries(smbtorture_test chimera_server chimera_metrics jansson)

--- a/src/server/smb/tests/phase0_contexts_test.c
+++ b/src/server/smb/tests/phase0_contexts_test.c
@@ -1003,7 +1003,8 @@ test_durable_register_park_claim(void)
     chimera_smb_durable_register(shared, &of, 42, 0, cguid, "foo.txt", 7, false);
 
     /* Before park: live, not reclaimable. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, false, &cold, &
+                                        retry, &
                                         status
                                         );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
@@ -1016,7 +1017,8 @@ test_durable_register_park_claim(void)
 
     /* Wrong create-guid is rejected. */
     guid[0] = 0xFF;
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, false, &cold, &
+                                        retry, &
                                         status
                                         );
     guid[0] = 0x10;
@@ -1029,7 +1031,8 @@ test_durable_register_park_claim(void)
     /* An oplock-only (no-lease) durable handle is not bound to the ClientGuid:
      * a reconnect from a different ClientGuid reclaims it (MS-SMB2 3.3.5.9.7
      * binds the GUID check to leased opens).  of.oplock_level is 0 here. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, 0, "foo.txt", 7, false, NULL, false, &cold, &
+                                        retry, &
                                         status
                                         );
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
@@ -1044,7 +1047,8 @@ test_durable_register_park_claim(void)
     /* A *leased* handle IS bound to the ClientGuid: a mismatch is rejected. */
     of.oplock_level = SMB2_OPLOCK_LEVEL_LEASE;
     memcpy(of.lease_key, lkey, 16);
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, 0, "foo.txt", 7, true, lkey, &cold, &retry, &
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, other, 0, "foo.txt", 7, true, lkey, false, &cold, &retry
+                                        , &
                                         status)
     ;
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
@@ -1054,7 +1058,8 @@ test_durable_register_park_claim(void)
     }
 
     /* Matching reconnect (correct ClientGuid + lease key) reclaims the open. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, true, lkey, &cold, &retry, &
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, true, lkey, false, &cold, &retry
+                                        , &
                                         status)
     ;
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
@@ -1065,7 +1070,8 @@ test_durable_register_park_claim(void)
     of.oplock_level = 0;
 
     /* A second reconnect must fail — the handle is now live again. */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, false, &cold, &
+                                        retry, &
                                         status
                                         );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
@@ -1077,7 +1083,8 @@ test_durable_register_park_claim(void)
     /* After forget, the persistent id is unknown. */
     chimera_smb_durable_forget(shared, 0xABCDEF);
     chimera_smb_durable_park(shared, &of);  /* no entry -> no-op */
-    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, &cold, &retry, &
+    claimed = chimera_smb_durable_claim(shared, 0xABCDEF, guid, cguid, 0, "foo.txt", 7, false, NULL, false, &cold, &
+                                        retry, &
                                         status
                                         );
     if (claimed != NULL || status != SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
@@ -1091,7 +1098,8 @@ test_durable_register_park_claim(void)
     of.durable_flags = CHIMERA_SMB_DURABLE_V1;
     chimera_smb_durable_register(shared, &of, 7, 0, cguid, "bar", 3, false);
     chimera_smb_durable_park(shared, &of);
-    claimed = chimera_smb_durable_claim(shared, 0x999, NULL, cguid, 0, "bar", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x999, NULL, cguid, 0, "bar", 3, false, NULL, false, &cold, &retry, &
+                                        status);
     if (claimed == &of && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable: v1 (no-guid) reconnect reclaims the open");
     } else {
@@ -1197,14 +1205,16 @@ test_durable_cold_recover_claim(void)
 
     /* Claim of a cold entry returns NULL + SUCCESS + cold=true (caller must
      * re-open the file) and consumes the entry. */
-    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, 0, "abc", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, 0, "abc", 3, false, NULL, false, &cold, &retry, &
+                                        status);
     if (claimed == NULL && cold && status == SMB2_STATUS_SUCCESS) {
         TEST_PASS("durable cold: reclaim signals cold re-open");
     } else {
         TEST_FAIL("durable cold: reclaim signals cold re-open");
     }
 
-    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, 0, "abc", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5000, guid, cguid, 0, "abc", 3, false, NULL, false, &cold, &retry, &
+                                        status);
     if (claimed == NULL && !cold && status == SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_PASS("durable cold: entry consumed after reclaim");
     } else {
@@ -1214,7 +1224,8 @@ test_durable_cold_recover_claim(void)
     /* Wrong client reclaiming a cold entry is denied. */
     rec.persistent_id = 0x5001;
     chimera_smb_durable_recover_entry(shared, &rec);
-    claimed = chimera_smb_durable_claim(shared, 0x5001, guid, other, 0, "abc", 3, false, NULL, &cold, &retry, &status);
+    claimed = chimera_smb_durable_claim(shared, 0x5001, guid, other, 0, "abc", 3, false, NULL, false, &cold, &retry, &
+                                        status);
     if (claimed == NULL && !cold && status == SMB2_STATUS_OBJECT_NAME_NOT_FOUND) {
         TEST_PASS("durable cold: wrong client -> OBJECT_NAME_NOT_FOUND");
     } else {

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -1,0 +1,188 @@
+case,home_config,status,skip_reason
+acl.py::SecTest::test_set_sec_dacl,base,xfail,ValueError: Invalid AclRevision: 1
+acl.py::SecTest::test_set_sec_dacl_append_ace,base,xfail,ValueError: Invalid AclRevision: 1
+acl.py::SecTest::test_set_sec_dacl_new,base,xfail,ValueError: Invalid AclRevision: 1
+acl.py::SecTest::test_set_sec_dacl_partial_copy,base,xfail,ValueError: Invalid AclRevision: 1
+acl.py::SecTest::test_set_sec_group,base,xfail,ValueError: Invalid AclRevision: 1
+acl.py::SecTest::test_set_sec_owner,base,xfail,ValueError: Invalid AclRevision: 1
+acl.py::SecTest::test_set_sec_same,base,xfail,ValueError: Invalid AclRevision: 1
+appinstanceid.py::AppInstanceIdTest::test_appinstanceid,persistent,green,
+appinstanceid.py::AppInstanceIdTest::test_appinstanceid_persistent_with_disconnect,persistent,xfail,daemon-crash
+appinstanceid.py::AppInstanceIdTest::test_appinstanceid_reconnect_same_clientguid,persistent,xfail,daemon-crash
+changenotify.py::ChangeNotifyTest::test_change_notify_cancel,base,green,
+changenotify.py::ChangeNotifyTest::test_change_notify_file_name,base,green,
+compound.py::CompoundTest::test_create_close,base,green,
+compound.py::CompoundTest::test_create_failed_and_query,base,green,
+compound.py::CompoundTest::test_create_query_close,base,green,
+compound.py::CompoundTest::test_create_write_close,base,green,
+compound.py::CompoundTest::test_create_write_close_access_denied,base,green,
+copychunk.py::TestServerSideCopy::test_bogus_resume_key,base,green,
+copychunk.py::TestServerSideCopy::test_copy_big_file,base,green,
+copychunk.py::TestServerSideCopy::test_copy_max_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_copy_multiple_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_copy_small_file,base,green,
+copychunk.py::TestServerSideCopy::test_copy_write_max_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_copy_write_multiple_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_copy_write_small_file,base,green,
+copychunk.py::TestServerSideCopy::test_multiple_resume_key,base,green,
+copychunk.py::TestServerSideCopy::test_multiple_ssc_file,base,green,
+copychunk.py::TestServerSideCopy::test_multiple_ssc_file_with_writethrough_flag,base,green,
+copychunk.py::TestServerSideCopy::test_multiple_ssc_same_dest_file,base,green,
+copychunk.py::TestServerSideCopy::test_multiple_ssc_same_source_file,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size,base,xfail,AssertionError: 0 != 1048576
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size_allf,base,xfail,AssertionError: 0 != 1048576
+copychunk.py::TestServerSideCopy::test_neg_cross_max_chunks,base,xfail,pike.exceptions.TimeoutError: Timed out after 30 seconds Request: Smb2 credit_charge: 1 ch
+copychunk.py::TestServerSideCopy::test_neg_cross_offset_basic,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_offset_fifth_chunk,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_offset_second_chunk,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_second_chunk_size,base,xfail,AssertionError: 0 != 1048576
+copychunk.py::TestServerSideCopy::test_neg_dst_exc_brl,base,green,
+copychunk.py::TestServerSideCopy::test_neg_dst_is_a_dir,base,xfail,daemon-crash
+copychunk.py::TestServerSideCopy::test_neg_dst_no_read,base,green,
+copychunk.py::TestServerSideCopy::test_neg_dst_no_write,base,green,
+copychunk.py::TestServerSideCopy::test_neg_src_exc_brl,base,green,
+copychunk.py::TestServerSideCopy::test_neg_src_no_read,base,green,
+copychunk.py::TestServerSideCopy::test_offset_copy_big_file,base,green,
+copychunk.py::TestServerSideCopy::test_offset_copy_multiple_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_offset_copy_small_file,base,green,
+copychunk.py::TestServerSideCopy::test_other_resume_key,base,green,
+copychunk.py::TestServerSideCopy::test_overlap_15_chunks_4096_overlap,base,green,
+copychunk.py::TestServerSideCopy::test_overlap_16_chunks_1024_overlap,base,green,
+copychunk.py::TestServerSideCopy::test_overlap_multiple_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_random_all,base,green,
+copychunk.py::TestServerSideCopy::test_random_chunk_size,base,green,
+copychunk.py::TestServerSideCopy::test_random_copy_length,base,green,
+copychunk.py::TestServerSideCopy::test_random_file_offset,base,green,
+copychunk.py::TestServerSideCopy::test_same_big_file,base,green,
+copychunk.py::TestServerSideCopy::test_same_multiple_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_same_offset_big_file,base,green,
+copychunk.py::TestServerSideCopy::test_same_offset_multiple_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_same_offset_small_file,base,green,
+copychunk.py::TestServerSideCopy::test_same_small_file,base,green,
+copychunk.py::TestServerSideCopy::test_ssc_in_compound_req,base,xfail,pike.exceptions.ResponseError: (SMB2_CLOSE; STATUS_FILE_CLOSED)
+copychunk.py::TestServerSideCopy::test_ssc_in_multchannel,base,green,
+credit.py::AsyncCreditTest::test_async_lock,base,xfail,AssertionError: 3 != 0
+credit.py::AsyncCreditTest::test_async_write,base,green,
+credit.py::EdgeCreditTest::test_sequence_number_wrap,base,green,
+credit.py::PowerOf2CreditTest::test_16_128k_write_2_1m_read,base,green,
+credit.py::PowerOf2CreditTest::test_16_128k_write_4_512k_read,base,green,
+credit.py::PowerOf2CreditTest::test_16_512k_write_8_1m_read,base,green,
+credit.py::PowerOf2CreditTest::test_16_64k_write_1_1m_read,base,green,
+credit.py::PowerOf2CreditTest::test_1_1m_write_1_1m_read,base,green,
+credit.py::PowerOf2CreditTest::test_4_1m_write_64_64k_read,base,green,
+credit.py::PowerOf2CreditTest::test_5_192k_write_1_960k_read,base,green,
+credit.py::PowerOf2CreditTest::test_8_1m_write_64_128k_read,base,green,
+durable.py::DurableHandleTest::test_durable,persistent,green,
+durable.py::DurableHandleTest::test_durable_invalidate,persistent,green,
+durable.py::DurableHandleTest::test_durable_reconnect,persistent,green,
+durable.py::DurableHandleTest::test_durable_reconnect_fails_client_guid,persistent,green,
+durable.py::DurableHandleTest::test_durable_reconnect_v2,persistent,green,
+durable.py::DurableHandleTest::test_durable_reconnect_v2_fails,persistent,xfail,AssertionError: No error raised when "STATUS_INVALID_PARAMETER" expected
+durable.py::DurableHandleTest::test_durable_reconnect_v2_fails_client_guid,persistent,green,
+durable.py::DurableHandleTest::test_durable_reconnect_without_durable_open,persistent,green,
+durable.py::DurableHandleTest::test_durable_v2,persistent,green,
+durable.py::DurableHandleTest::test_durable_v2_invalidate,persistent,green,
+durable.py::DurableHandleTest::test_durable_v2_timer,persistent,xfail,Failed: Timeout (>40.0s) from pytest-timeout.
+durable.py::DurableHandleTest::test_resiliency_buffer_too_small,persistent,green,
+durable.py::DurableHandleTest::test_resiliency_reconnect_after_timeout,persistent,green,
+durable.py::DurableHandleTest::test_resiliency_reconnect_before_timeout,persistent,xfail,AssertionError: SMB2_LEASE_READ_CACHING | SMB2_LEASE_WRITE_CACHING != SMB2_LEASE_READ_CACH
+durable.py::DurableHandleTest::test_resiliency_upgrade_buffer_too_small,persistent,green,
+durable.py::DurableHandleTest::test_resiliency_upgrade_reconnect_after_timeout,persistent,green,
+durable.py::DurableHandleTest::test_resiliency_upgrade_reconnect_before_timeout,persistent,xfail,AssertionError: SMB2_LEASE_READ_CACHING | SMB2_LEASE_WRITE_CACHING != SMB2_LEASE_READ_CACH
+echo.py::EchoTest::test_echo,base,green,
+encryption.py::TestEncryption::test_smb_3_0_2_encryption,encryption,green,
+encryption.py::TestEncryption::test_smb_3_0_encryption,encryption,green,
+encryption.py::TestEncryption::test_smb_3_1_1_compound,encryption,xfail,pike.core.BadPacket
+encryption.py::TestEncryption::test_smb_3_1_1_encryption_ccm,encryption,xfail,pike.core.BadPacket
+encryption.py::TestEncryption::test_smb_3_1_1_encryption_gcm,encryption,xfail,pike.core.BadPacket
+invalid_session.py::InvalidSessionTest::test_ioctl,base,green,
+invalid_session.py::InvalidSessionTest::test_logoff,base,green,
+invalid_session.py::InvalidSessionTest::test_oplock_break_ack,base,green,
+invalid_session.py::InvalidSessionTest::test_treeconnect,base,green,
+invalid_tree.py::InvalidTreeTest::test_ioctl,base,green,
+invalid_tree.py::InvalidTreeTest::test_oplock_break_ack,base,green,
+invalid_tree.py::InvalidTreeTest::test_treeconnect,base,green,
+ioctl.py::QueryNetworkInterfaceInfo::test_query_interface_info_smb3,persistent,green,
+ioctl.py::ValidateNegotiateInfo::test_validate_negotiate_smb3,base,green,
+lease.py::LeaseTest::test_lease_break_close_ack,base,green,
+lease.py::LeaseTest::test_lease_multiple_connections,base,green,
+lease.py::LeaseTest::test_lease_upgrade_break,base,green,
+lock.py::LockTest::test_allow_zero_byte_write,base,xfail,pike.exceptions.ResponseError: (SMB2_WRITE; STATUS_FILE_LOCK_CONFLICT)
+lock.py::LockTest::test_cancel,base,green,
+lock.py::LockTest::test_deny_write,base,green,
+lock.py::LockTest::test_lock,base,green,
+multichannel.py::MultiChannelTest::test_open_bind_close,base,green,
+multichannel.py::MultiChannelTest::test_write_fence_reject_stale,persistent,skip,pike-bug-assertEquals-removed-py3.12
+negotiate.py::CapMultichannel::test_downlevel,base,green,
+negotiate.py::CapMultichannel::test_downlevel_no_advert,base,green,
+negotiate.py::CapMultichannel::test_smb3,base,green,
+negotiate.py::CapMultichannel::test_smb3_many_capabilities,base,green,
+negotiate.py::CapMultichannel::test_smb3_no_advert,base,xfail,AssertionError: SMB2_GLOBAL_CAP_MULTI_CHANNEL != 0
+negotiate.py::CapMulticredit::test_downlevel,base,green,
+negotiate.py::CapMulticredit::test_smb21,base,green,
+negotiate.py::CapMulticredit::test_smb3,base,green,
+negotiate.py::CapMulticredit::test_smb3_many_capabilities,base,green,
+negotiate.py::CapPersistent::test_downlevel,base,green,
+negotiate.py::CapPersistent::test_downlevel_no_advert,base,green,
+negotiate.py::CapPersistent::test_smb3,persistent,green,
+negotiate.py::CapPersistent::test_smb3_many_capabilities,persistent,green,
+negotiate.py::CapPersistent::test_smb3_no_advert,base,green,
+negotiate.py::NegotiateContext::test_encryption_capabilities_both_prefer_ccm,base,xfail,AssertionError: SMB2_AES_128_CCM not found in [SMB2_AES_128_GCM]
+negotiate.py::NegotiateContext::test_encryption_capabilities_both_prefer_gcm,base,green,
+negotiate.py::NegotiateContext::test_encryption_capabilities_ccm,base,green,
+negotiate.py::NegotiateContext::test_encryption_capabilities_gcm,base,green,
+negotiate.py::NegotiateContext::test_preauth_integrity_capabilities,base,green,
+oplock.py::OplockTest::test_oplock_break,base,green,
+persistent.py::Persistent::test_buffer_too_small,persistent,xfail,AssertionError: "STATUS_INVALID_PARAMETER" raised when "STATUS_BUFFER_TOO_SMALL" expected
+persistent.py::Persistent::test_create,persistent,green,
+persistent.py::Persistent::test_open_while_disconnected,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
+persistent.py::Persistent::test_reconnect,persistent,green,
+persistent.py::Persistent::test_reconnect_fails,persistent,xfail,AssertionError: No error raised when "STATUS_OBJECT_NAME_NOT_FOUND" expected
+persistent.py::Persistent::test_resiliency_reconnect_after_timeout,persistent,green,
+persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
+persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,xfail,Failed: Timeout (>40.0s) from pytest-timeout.
+persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
+query.py::QueryTest::test_mismatch_0_file_alignment_info,base,green,
+query.py::QueryTest::test_mismatch_0_file_all_info,base,green,
+query.py::QueryTest::test_mismatch_0_file_basic_info,base,green,
+query.py::QueryTest::test_mismatch_0_file_ea_info,base,green,
+query.py::QueryTest::test_mismatch_0_file_internal_info,base,green,
+query.py::QueryTest::test_mismatch_0_file_mode_info,base,green,
+query.py::QueryTest::test_mismatch_0_file_position_info,base,green,
+query.py::QueryTest::test_mismatch_0_file_standard_info,base,green,
+query.py::QueryTest::test_query_file_alignment_info,base,green,
+query.py::QueryTest::test_query_file_all_info,base,xfail,ValueError: Invalid Alignment: fff
+query.py::QueryTest::test_query_file_basic_info,base,green,
+query.py::QueryTest::test_query_file_ea_info,base,green,
+query.py::QueryTest::test_query_file_internal_info,base,green,
+query.py::QueryTest::test_query_file_mode_info,base,green,
+query.py::QueryTest::test_query_file_position_info,base,green,
+query.py::QueryTest::test_query_file_sec_info_all,base,xfail,ValueError: Invalid AclRevision: 1
+query.py::QueryTest::test_query_file_sec_info_dacl,base,green,
+query.py::QueryTest::test_query_file_sec_info_group,base,green,
+query.py::QueryTest::test_query_file_sec_info_owner,base,green,
+query.py::QueryTest::test_query_file_standard_info,base,green,
+query.py::QueryTest::test_query_sec_desc_0,base,xfail,IndexError: list index out of range
+querydirectory.py::QueryDirectoryTest::test_file_directory_info,base,green,
+querydirectory.py::QueryDirectoryTest::test_file_id_both_directory_information,base,green,
+querydirectory.py::QueryDirectoryTest::test_restart_scan,base,green,
+querydirectory.py::QueryDirectoryTest::test_specific_name,base,green,
+queryondiskid.py::TestQueryOnDiskID::test_qfid_diff_file,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
+queryondiskid.py::TestQueryOnDiskID::test_qfid_functional,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
+queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
+queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
+queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq_delete,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
+readwrite.py::ReadWriteTest::test_write,base,green,
+readwrite.py::ReadWriteTest::test_write_none,base,green,
+readwrite.py::ReadWriteTest::test_write_none_access,base,green,
+readwrite.py::ReadWriteTest::test_write_none_lease,base,xfail,AssertionError: TimeoutError not raised
+readwrite.py::ReadWriteTest::test_write_none_oplock,base,xfail,AssertionError: TimeoutError not raised
+reparse.py::TestReparsePoint::test_set_get_reparse_point,base,xfail,pike.exceptions.ResponseError: (SMB2_IOCTL; STATUS_NOT_A_REPARSE_POINT)
+reparse.py::TestReparsePoint::test_symbolic_link_error_response,base,xfail,IndexError: list index out of range
+session.py::SessionTest::test_session_logoff,base,green,
+session.py::SessionTest::test_session_multiplex,base,green,
+set.py::SetTest::test_set_file_basic_info,base,green,
+set.py::SetTest::test_set_file_mode_info,base,xfail,pike.exceptions.ResponseError: (SMB2_SET_INFO; STATUS_NOT_IMPLEMENTED)
+set.py::SetTest::test_set_file_name,base,green,
+set.py::SetTest::test_set_file_position_info,base,green,
+tree.py::TreeTest::test_tree,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -7,8 +7,8 @@ acl.py::SecTest::test_set_sec_group,base,xfail,ValueError: Invalid AclRevision: 
 acl.py::SecTest::test_set_sec_owner,base,xfail,ValueError: Invalid AclRevision: 1
 acl.py::SecTest::test_set_sec_same,base,xfail,ValueError: Invalid AclRevision: 1
 appinstanceid.py::AppInstanceIdTest::test_appinstanceid,persistent,green,
-appinstanceid.py::AppInstanceIdTest::test_appinstanceid_persistent_with_disconnect,persistent,xfail,daemon-crash
-appinstanceid.py::AppInstanceIdTest::test_appinstanceid_reconnect_same_clientguid,persistent,xfail,daemon-crash
+appinstanceid.py::AppInstanceIdTest::test_appinstanceid_persistent_with_disconnect,persistent,green,
+appinstanceid.py::AppInstanceIdTest::test_appinstanceid_reconnect_same_clientguid,persistent,xfail,same-client-guid AppInstanceId reopen should return FILE_NOT_AVAILABLE
 changenotify.py::ChangeNotifyTest::test_change_notify_cancel,base,green,
 changenotify.py::ChangeNotifyTest::test_change_notify_file_name,base,green,
 compound.py::CompoundTest::test_create_close,base,green,
@@ -29,15 +29,15 @@ copychunk.py::TestServerSideCopy::test_multiple_ssc_file,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_file_with_writethrough_flag,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_same_dest_file,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_same_source_file,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size,base,xfail,AssertionError: 0 != 1048576
-copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size_allf,base,xfail,AssertionError: 0 != 1048576
-copychunk.py::TestServerSideCopy::test_neg_cross_max_chunks,base,xfail,pike.exceptions.TimeoutError: Timed out after 30 seconds Request: Smb2 credit_charge: 1 ch
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size_allf,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_max_chunks,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_basic,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_fifth_chunk,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_second_chunk,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_second_chunk_size,base,xfail,AssertionError: 0 != 1048576
+copychunk.py::TestServerSideCopy::test_neg_cross_second_chunk_size,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_exc_brl,base,green,
-copychunk.py::TestServerSideCopy::test_neg_dst_is_a_dir,base,xfail,daemon-crash
+copychunk.py::TestServerSideCopy::test_neg_dst_is_a_dir,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_no_read,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_no_write,base,green,
 copychunk.py::TestServerSideCopy::test_neg_src_exc_brl,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -29,13 +29,13 @@ copychunk.py::TestServerSideCopy::test_multiple_ssc_file,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_file_with_writethrough_flag,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_same_dest_file,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_same_source_file,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size_allf,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_max_chunks,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size_allf,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
+copychunk.py::TestServerSideCopy::test_neg_cross_max_chunks,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_basic,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_fifth_chunk,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_second_chunk,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_second_chunk_size,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_second_chunk_size,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
 copychunk.py::TestServerSideCopy::test_neg_dst_exc_brl,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_is_a_dir,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_no_read,base,green,
@@ -60,7 +60,7 @@ copychunk.py::TestServerSideCopy::test_same_offset_multiple_chunks,base,green,
 copychunk.py::TestServerSideCopy::test_same_offset_small_file,base,green,
 copychunk.py::TestServerSideCopy::test_same_small_file,base,green,
 copychunk.py::TestServerSideCopy::test_ssc_in_compound_req,base,xfail,pike.exceptions.ResponseError: (SMB2_CLOSE; STATUS_FILE_CLOSED)
-copychunk.py::TestServerSideCopy::test_ssc_in_multchannel,base,green,
+copychunk.py::TestServerSideCopy::test_ssc_in_multchannel,persistent,green,
 credit.py::AsyncCreditTest::test_async_lock,base,xfail,AssertionError: 3 != 0
 credit.py::AsyncCreditTest::test_async_write,base,green,
 credit.py::EdgeCreditTest::test_sequence_number_wrap,base,green,
@@ -77,7 +77,7 @@ durable.py::DurableHandleTest::test_durable_invalidate,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect_fails_client_guid,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect_v2,persistent,green,
-durable.py::DurableHandleTest::test_durable_reconnect_v2_fails,persistent,xfail,AssertionError: No error raised when "STATUS_INVALID_PARAMETER" expected
+durable.py::DurableHandleTest::test_durable_reconnect_v2_fails,persistent,xfail,"AssertionError: No error raised when ""STATUS_INVALID_PARAMETER"" expected"
 durable.py::DurableHandleTest::test_durable_reconnect_v2_fails_client_guid,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect_without_durable_open,persistent,green,
 durable.py::DurableHandleTest::test_durable_v2,persistent,green,
@@ -111,12 +111,12 @@ lock.py::LockTest::test_allow_zero_byte_write,base,green,
 lock.py::LockTest::test_cancel,base,green,
 lock.py::LockTest::test_deny_write,base,green,
 lock.py::LockTest::test_lock,base,green,
-multichannel.py::MultiChannelTest::test_open_bind_close,base,green,
+multichannel.py::MultiChannelTest::test_open_bind_close,persistent,green,
 multichannel.py::MultiChannelTest::test_write_fence_reject_stale,persistent,skip,pike-bug-assertEquals-removed-py3.12
 negotiate.py::CapMultichannel::test_downlevel,base,green,
 negotiate.py::CapMultichannel::test_downlevel_no_advert,base,green,
-negotiate.py::CapMultichannel::test_smb3,base,green,
-negotiate.py::CapMultichannel::test_smb3_many_capabilities,base,green,
+negotiate.py::CapMultichannel::test_smb3,persistent,green,
+negotiate.py::CapMultichannel::test_smb3_many_capabilities,persistent,green,
 negotiate.py::CapMultichannel::test_smb3_no_advert,base,green,
 negotiate.py::CapMulticredit::test_downlevel,base,green,
 negotiate.py::CapMulticredit::test_smb21,base,green,
@@ -133,15 +133,15 @@ negotiate.py::NegotiateContext::test_encryption_capabilities_ccm,base,green,
 negotiate.py::NegotiateContext::test_encryption_capabilities_gcm,base,green,
 negotiate.py::NegotiateContext::test_preauth_integrity_capabilities,base,green,
 oplock.py::OplockTest::test_oplock_break,base,green,
-persistent.py::Persistent::test_buffer_too_small,persistent,xfail,AssertionError: "STATUS_INVALID_PARAMETER" raised when "STATUS_BUFFER_TOO_SMALL" expected
+persistent.py::Persistent::test_buffer_too_small,persistent,xfail,"AssertionError: ""STATUS_INVALID_PARAMETER"" raised when ""STATUS_BUFFER_TOO_SMALL"" expected"
 persistent.py::Persistent::test_create,persistent,green,
-persistent.py::Persistent::test_open_while_disconnected,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
+persistent.py::Persistent::test_open_while_disconnected,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
 persistent.py::Persistent::test_reconnect,persistent,green,
-persistent.py::Persistent::test_reconnect_fails,persistent,xfail,AssertionError: No error raised when "STATUS_OBJECT_NAME_NOT_FOUND" expected
+persistent.py::Persistent::test_reconnect_fails,persistent,xfail,"AssertionError: No error raised when ""STATUS_OBJECT_NAME_NOT_FOUND"" expected"
 persistent.py::Persistent::test_resiliency_reconnect_after_timeout,persistent,green,
-persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
+persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
 persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,xfail,passes but waits a real >90s resiliency timer; too slow for the gated run
-persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
+persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
 query.py::QueryTest::test_mismatch_0_file_alignment_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_all_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_basic_info,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -82,7 +82,7 @@ durable.py::DurableHandleTest::test_durable_reconnect_v2_fails_client_guid,persi
 durable.py::DurableHandleTest::test_durable_reconnect_without_durable_open,persistent,green,
 durable.py::DurableHandleTest::test_durable_v2,persistent,green,
 durable.py::DurableHandleTest::test_durable_v2_invalidate,persistent,green,
-durable.py::DurableHandleTest::test_durable_v2_timer,persistent,xfail,Failed: Timeout (>40.0s) from pytest-timeout.
+durable.py::DurableHandleTest::test_durable_v2_timer,persistent,xfail,passes but waits a real ~80s durable timer; too slow for the gated run
 durable.py::DurableHandleTest::test_resiliency_buffer_too_small,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_reconnect_after_timeout,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_reconnect_before_timeout,persistent,xfail,AssertionError: SMB2_LEASE_READ_CACHING | SMB2_LEASE_WRITE_CACHING != SMB2_LEASE_READ_CACH
@@ -107,7 +107,7 @@ ioctl.py::ValidateNegotiateInfo::test_validate_negotiate_smb3,base,green,
 lease.py::LeaseTest::test_lease_break_close_ack,base,green,
 lease.py::LeaseTest::test_lease_multiple_connections,base,green,
 lease.py::LeaseTest::test_lease_upgrade_break,base,green,
-lock.py::LockTest::test_allow_zero_byte_write,base,xfail,pike.exceptions.ResponseError: (SMB2_WRITE; STATUS_FILE_LOCK_CONFLICT)
+lock.py::LockTest::test_allow_zero_byte_write,base,green,
 lock.py::LockTest::test_cancel,base,green,
 lock.py::LockTest::test_deny_write,base,green,
 lock.py::LockTest::test_lock,base,green,
@@ -117,7 +117,7 @@ negotiate.py::CapMultichannel::test_downlevel,base,green,
 negotiate.py::CapMultichannel::test_downlevel_no_advert,base,green,
 negotiate.py::CapMultichannel::test_smb3,base,green,
 negotiate.py::CapMultichannel::test_smb3_many_capabilities,base,green,
-negotiate.py::CapMultichannel::test_smb3_no_advert,base,xfail,AssertionError: SMB2_GLOBAL_CAP_MULTI_CHANNEL != 0
+negotiate.py::CapMultichannel::test_smb3_no_advert,base,green,
 negotiate.py::CapMulticredit::test_downlevel,base,green,
 negotiate.py::CapMulticredit::test_smb21,base,green,
 negotiate.py::CapMulticredit::test_smb3,base,green,
@@ -140,7 +140,7 @@ persistent.py::Persistent::test_reconnect,persistent,green,
 persistent.py::Persistent::test_reconnect_fails,persistent,xfail,AssertionError: No error raised when "STATUS_OBJECT_NAME_NOT_FOUND" expected
 persistent.py::Persistent::test_resiliency_reconnect_after_timeout,persistent,green,
 persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
-persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,xfail,Failed: Timeout (>40.0s) from pytest-timeout.
+persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,xfail,passes but waits a real >90s resiliency timer; too slow for the gated run
 persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,xfail,AssertionError: No error raised when "STATUS_FILE_NOT_AVAILABLE" expected
 query.py::QueryTest::test_mismatch_0_file_alignment_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_all_info,base,green,
@@ -175,8 +175,8 @@ queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq_delete,base,xfail,A
 readwrite.py::ReadWriteTest::test_write,base,green,
 readwrite.py::ReadWriteTest::test_write_none,base,green,
 readwrite.py::ReadWriteTest::test_write_none_access,base,green,
-readwrite.py::ReadWriteTest::test_write_none_lease,base,xfail,oplock/lease broken on a zero-length write (should be a no-op)
-readwrite.py::ReadWriteTest::test_write_none_oplock,base,xfail,oplock/lease broken on a zero-length write (should be a no-op)
+readwrite.py::ReadWriteTest::test_write_none_lease,base,green,
+readwrite.py::ReadWriteTest::test_write_none_oplock,base,xfail,delete-on-close unlinks on first of two DOC handles' close not last
 reparse.py::TestReparsePoint::test_set_get_reparse_point,base,xfail,pike.exceptions.ResponseError: (SMB2_IOCTL; STATUS_NOT_A_REPARSE_POINT)
 reparse.py::TestReparsePoint::test_symbolic_link_error_response,base,xfail,IndexError: list index out of range
 session.py::SessionTest::test_session_logoff,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -167,11 +167,11 @@ querydirectory.py::QueryDirectoryTest::test_file_directory_info,base,green,
 querydirectory.py::QueryDirectoryTest::test_file_id_both_directory_information,base,green,
 querydirectory.py::QueryDirectoryTest::test_restart_scan,base,green,
 querydirectory.py::QueryDirectoryTest::test_specific_name,base,green,
-queryondiskid.py::TestQueryOnDiskID::test_qfid_diff_file,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
-queryondiskid.py::TestQueryOnDiskID::test_qfid_functional,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
-queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
-queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
-queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq_delete,base,xfail,AssertionError: unexpectedly None : CreateResponse didn't contain a QueryOnDiskIDResponse:
+queryondiskid.py::TestQueryOnDiskID::test_qfid_diff_file,base,green,
+queryondiskid.py::TestQueryOnDiskID::test_qfid_functional,base,green,
+queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file,base,green,
+queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq,base,green,
+queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq_delete,base,green,
 readwrite.py::ReadWriteTest::test_write,base,green,
 readwrite.py::ReadWriteTest::test_write_none,base,green,
 readwrite.py::ReadWriteTest::test_write_none_access,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -8,7 +8,7 @@ acl.py::SecTest::test_set_sec_owner,base,green,
 acl.py::SecTest::test_set_sec_same,base,green,
 appinstanceid.py::AppInstanceIdTest::test_appinstanceid,persistent,green,
 appinstanceid.py::AppInstanceIdTest::test_appinstanceid_persistent_with_disconnect,persistent,green,
-appinstanceid.py::AppInstanceIdTest::test_appinstanceid_reconnect_same_clientguid,persistent,xfail,same-client-guid AppInstanceId reopen should return FILE_NOT_AVAILABLE
+appinstanceid.py::AppInstanceIdTest::test_appinstanceid_reconnect_same_clientguid,persistent,green,
 changenotify.py::ChangeNotifyTest::test_change_notify_cancel,base,green,
 changenotify.py::ChangeNotifyTest::test_change_notify_file_name,base,green,
 compound.py::CompoundTest::test_create_close,base,green,
@@ -85,10 +85,10 @@ durable.py::DurableHandleTest::test_durable_v2_invalidate,persistent,green,
 durable.py::DurableHandleTest::test_durable_v2_timer,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_buffer_too_small,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_reconnect_after_timeout,persistent,green,
-durable.py::DurableHandleTest::test_resiliency_reconnect_before_timeout,persistent,xfail,AssertionError: SMB2_LEASE_READ_CACHING | SMB2_LEASE_WRITE_CACHING != SMB2_LEASE_READ_CACH
+durable.py::DurableHandleTest::test_resiliency_reconnect_before_timeout,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_upgrade_buffer_too_small,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_upgrade_reconnect_after_timeout,persistent,green,
-durable.py::DurableHandleTest::test_resiliency_upgrade_reconnect_before_timeout,persistent,xfail,AssertionError: SMB2_LEASE_READ_CACHING | SMB2_LEASE_WRITE_CACHING != SMB2_LEASE_READ_CACH
+durable.py::DurableHandleTest::test_resiliency_upgrade_reconnect_before_timeout,persistent,green,
 echo.py::EchoTest::test_echo,base,green,
 encryption.py::TestEncryption::test_smb_3_0_2_encryption,encryption,green,
 encryption.py::TestEncryption::test_smb_3_0_encryption,encryption,green,
@@ -133,15 +133,15 @@ negotiate.py::NegotiateContext::test_encryption_capabilities_ccm,base,green,
 negotiate.py::NegotiateContext::test_encryption_capabilities_gcm,base,green,
 negotiate.py::NegotiateContext::test_preauth_integrity_capabilities,base,green,
 oplock.py::OplockTest::test_oplock_break,base,green,
-persistent.py::Persistent::test_buffer_too_small,persistent,xfail,wants OneFS BUFFER_TOO_SMALL for short resiliency FSCTL (chimera+durable suite use INVALID_PARAMETER); also cluster-A blocked
+persistent.py::Persistent::test_buffer_too_small,persistent,xfail,OneFS-only: persistent.py wants BUFFER_TOO_SMALL but pike durable.py wants INVALID_PARAMETER (chimera returns the latter) -- contradictory
 persistent.py::Persistent::test_create,persistent,green,
-persistent.py::Persistent::test_open_while_disconnected,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
+persistent.py::Persistent::test_open_while_disconnected,persistent,green,
 persistent.py::Persistent::test_reconnect,persistent,green,
-persistent.py::Persistent::test_reconnect_fails,persistent,xfail,"AssertionError: No error raised when ""STATUS_OBJECT_NAME_NOT_FOUND"" expected"
+persistent.py::Persistent::test_reconnect_fails,persistent,xfail,pike-bug: persistent=False inherits durable_flags=PERSISTENT (model.py:1477) so the DH2C reconnect is byte-identical to the passing test_reconnect -- cannot trigger 3.3.5.9.12 ONNF
 persistent.py::Persistent::test_resiliency_reconnect_after_timeout,persistent,green,
-persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
-persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,xfail,cluster-A: new open should displace the expired handle so reconnect fails OBJECT_NAME_NOT_FOUND
-persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
+persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,green,
+persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,green,
+persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,green,
 query.py::QueryTest::test_mismatch_0_file_alignment_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_all_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_basic_info,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -171,7 +171,7 @@ queryondiskid.py::TestQueryOnDiskID::test_qfid_diff_file,base,green,
 queryondiskid.py::TestQueryOnDiskID::test_qfid_functional,base,green,
 queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file,base,green,
 queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq,base,green,
-queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq_delete,base,green,
+queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq_delete,base,xfail,wants a unique on-disk id after delete+recreate of the same name; chimera's DiskFileId is the inode number (va_ino) to stay consistent with FileInternalInformation IndexNumber (the Linux cifs client cross-checks them -- a mismatch loses writes), and memfs recycles inode numbers after delete so the recreated file reuses the id. A unique-across-delete id would need a generation-bearing IndexNumber everywhere (separate change)
 readwrite.py::ReadWriteTest::test_write,base,green,
 readwrite.py::ReadWriteTest::test_write_none,base,green,
 readwrite.py::ReadWriteTest::test_write_none_access,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -175,8 +175,8 @@ queryondiskid.py::TestQueryOnDiskID::test_qfid_same_file_seq_delete,base,xfail,A
 readwrite.py::ReadWriteTest::test_write,base,green,
 readwrite.py::ReadWriteTest::test_write_none,base,green,
 readwrite.py::ReadWriteTest::test_write_none_access,base,green,
-readwrite.py::ReadWriteTest::test_write_none_lease,base,xfail,AssertionError: TimeoutError not raised
-readwrite.py::ReadWriteTest::test_write_none_oplock,base,xfail,AssertionError: TimeoutError not raised
+readwrite.py::ReadWriteTest::test_write_none_lease,base,xfail,oplock/lease broken on a zero-length write (should be a no-op)
+readwrite.py::ReadWriteTest::test_write_none_oplock,base,xfail,oplock/lease broken on a zero-length write (should be a no-op)
 reparse.py::TestReparsePoint::test_set_get_reparse_point,base,xfail,pike.exceptions.ResponseError: (SMB2_IOCTL; STATUS_NOT_A_REPARSE_POINT)
 reparse.py::TestReparsePoint::test_symbolic_link_error_response,base,xfail,IndexError: list index out of range
 session.py::SessionTest::test_session_logoff,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -82,7 +82,7 @@ durable.py::DurableHandleTest::test_durable_reconnect_v2_fails_client_guid,persi
 durable.py::DurableHandleTest::test_durable_reconnect_without_durable_open,persistent,green,
 durable.py::DurableHandleTest::test_durable_v2,persistent,green,
 durable.py::DurableHandleTest::test_durable_v2_invalidate,persistent,green,
-durable.py::DurableHandleTest::test_durable_v2_timer,persistent,xfail,passes but waits a real ~80s durable timer; too slow for the gated run
+durable.py::DurableHandleTest::test_durable_v2_timer,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_buffer_too_small,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_reconnect_after_timeout,persistent,green,
 durable.py::DurableHandleTest::test_resiliency_reconnect_before_timeout,persistent,xfail,AssertionError: SMB2_LEASE_READ_CACHING | SMB2_LEASE_WRITE_CACHING != SMB2_LEASE_READ_CACH
@@ -133,14 +133,14 @@ negotiate.py::NegotiateContext::test_encryption_capabilities_ccm,base,green,
 negotiate.py::NegotiateContext::test_encryption_capabilities_gcm,base,green,
 negotiate.py::NegotiateContext::test_preauth_integrity_capabilities,base,green,
 oplock.py::OplockTest::test_oplock_break,base,green,
-persistent.py::Persistent::test_buffer_too_small,persistent,xfail,"AssertionError: ""STATUS_INVALID_PARAMETER"" raised when ""STATUS_BUFFER_TOO_SMALL"" expected"
+persistent.py::Persistent::test_buffer_too_small,persistent,xfail,wants OneFS BUFFER_TOO_SMALL for short resiliency FSCTL (chimera+durable suite use INVALID_PARAMETER); also cluster-A blocked
 persistent.py::Persistent::test_create,persistent,green,
 persistent.py::Persistent::test_open_while_disconnected,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
 persistent.py::Persistent::test_reconnect,persistent,green,
 persistent.py::Persistent::test_reconnect_fails,persistent,xfail,"AssertionError: No error raised when ""STATUS_OBJECT_NAME_NOT_FOUND"" expected"
 persistent.py::Persistent::test_resiliency_reconnect_after_timeout,persistent,green,
 persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
-persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,xfail,passes but waits a real >90s resiliency timer; too slow for the gated run
+persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,xfail,cluster-A: new open should displace the expired handle so reconnect fails OBJECT_NAME_NOT_FOUND
 persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,xfail,"AssertionError: No error raised when ""STATUS_FILE_NOT_AVAILABLE"" expected"
 query.py::QueryTest::test_mismatch_0_file_alignment_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_all_info,base,green,
@@ -162,7 +162,7 @@ query.py::QueryTest::test_query_file_sec_info_dacl,base,green,
 query.py::QueryTest::test_query_file_sec_info_group,base,green,
 query.py::QueryTest::test_query_file_sec_info_owner,base,green,
 query.py::QueryTest::test_query_file_standard_info,base,green,
-query.py::QueryTest::test_query_sec_desc_0,base,xfail,BUFFER_TOO_SMALL reply needs the 4-byte required-length error body
+query.py::QueryTest::test_query_sec_desc_0,base,green,
 querydirectory.py::QueryDirectoryTest::test_file_directory_info,base,green,
 querydirectory.py::QueryDirectoryTest::test_file_id_both_directory_information,base,green,
 querydirectory.py::QueryDirectoryTest::test_restart_scan,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -29,13 +29,13 @@ copychunk.py::TestServerSideCopy::test_multiple_ssc_file,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_file_with_writethrough_flag,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_same_dest_file,base,green,
 copychunk.py::TestServerSideCopy::test_multiple_ssc_same_source_file,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
-copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size_allf,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
-copychunk.py::TestServerSideCopy::test_neg_cross_max_chunks,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_chunk_size_allf,base,green,
+copychunk.py::TestServerSideCopy::test_neg_cross_max_chunks,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_basic,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_fifth_chunk,base,green,
 copychunk.py::TestServerSideCopy::test_neg_cross_offset_second_chunk,base,green,
-copychunk.py::TestServerSideCopy::test_neg_cross_second_chunk_size,base,xfail,chimera caps COPYCHUNK MaxChunkCount at 16 per MS-SMB2 (8057501d); pike expects Windows 256
+copychunk.py::TestServerSideCopy::test_neg_cross_second_chunk_size,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_exc_brl,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_is_a_dir,base,green,
 copychunk.py::TestServerSideCopy::test_neg_dst_no_read,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -92,9 +92,9 @@ durable.py::DurableHandleTest::test_resiliency_upgrade_reconnect_before_timeout,
 echo.py::EchoTest::test_echo,base,green,
 encryption.py::TestEncryption::test_smb_3_0_2_encryption,encryption,green,
 encryption.py::TestEncryption::test_smb_3_0_encryption,encryption,green,
-encryption.py::TestEncryption::test_smb_3_1_1_compound,encryption,xfail,pike.core.BadPacket
-encryption.py::TestEncryption::test_smb_3_1_1_encryption_ccm,encryption,xfail,pike.core.BadPacket
-encryption.py::TestEncryption::test_smb_3_1_1_encryption_gcm,encryption,xfail,pike.core.BadPacket
+encryption.py::TestEncryption::test_smb_3_1_1_compound,encryption,green,
+encryption.py::TestEncryption::test_smb_3_1_1_encryption_ccm,encryption,green,
+encryption.py::TestEncryption::test_smb_3_1_1_encryption_gcm,encryption,green,
 invalid_session.py::InvalidSessionTest::test_ioctl,base,green,
 invalid_session.py::InvalidSessionTest::test_logoff,base,green,
 invalid_session.py::InvalidSessionTest::test_oplock_break_ack,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -59,9 +59,9 @@ copychunk.py::TestServerSideCopy::test_same_offset_big_file,base,green,
 copychunk.py::TestServerSideCopy::test_same_offset_multiple_chunks,base,green,
 copychunk.py::TestServerSideCopy::test_same_offset_small_file,base,green,
 copychunk.py::TestServerSideCopy::test_same_small_file,base,green,
-copychunk.py::TestServerSideCopy::test_ssc_in_compound_req,base,xfail,pike.exceptions.ResponseError: (SMB2_CLOSE; STATUS_FILE_CLOSED)
+copychunk.py::TestServerSideCopy::test_ssc_in_compound_req,base,green,
 copychunk.py::TestServerSideCopy::test_ssc_in_multchannel,persistent,green,
-credit.py::AsyncCreditTest::test_async_lock,base,xfail,AssertionError: 3 != 0
+credit.py::AsyncCreditTest::test_async_lock,base,xfail,async-final double-grants credits (fixable) AND over-credit write must terminate conn via seq-window (deeper); 2 fixes needed
 credit.py::AsyncCreditTest::test_async_write,base,green,
 credit.py::EdgeCreditTest::test_sequence_number_wrap,base,green,
 credit.py::PowerOf2CreditTest::test_16_128k_write_2_1m_read,base,green,
@@ -77,7 +77,7 @@ durable.py::DurableHandleTest::test_durable_invalidate,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect_fails_client_guid,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect_v2,persistent,green,
-durable.py::DurableHandleTest::test_durable_reconnect_v2_fails,persistent,xfail,"AssertionError: No error raised when ""STATUS_INVALID_PARAMETER"" expected"
+durable.py::DurableHandleTest::test_durable_reconnect_v2_fails,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect_v2_fails_client_guid,persistent,green,
 durable.py::DurableHandleTest::test_durable_reconnect_without_durable_open,persistent,green,
 durable.py::DurableHandleTest::test_durable_v2,persistent,green,
@@ -182,7 +182,7 @@ reparse.py::TestReparsePoint::test_symbolic_link_error_response,base,xfail,Index
 session.py::SessionTest::test_session_logoff,base,green,
 session.py::SessionTest::test_session_multiplex,base,green,
 set.py::SetTest::test_set_file_basic_info,base,green,
-set.py::SetTest::test_set_file_mode_info,base,xfail,pike.exceptions.ResponseError: (SMB2_SET_INFO; STATUS_NOT_IMPLEMENTED)
+set.py::SetTest::test_set_file_mode_info,base,green,
 set.py::SetTest::test_set_file_name,base,green,
 set.py::SetTest::test_set_file_position_info,base,green,
 tree.py::TreeTest::test_tree,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -1,11 +1,11 @@
 case,home_config,status,skip_reason
-acl.py::SecTest::test_set_sec_dacl,base,xfail,ValueError: Invalid AclRevision: 1
-acl.py::SecTest::test_set_sec_dacl_append_ace,base,xfail,ValueError: Invalid AclRevision: 1
-acl.py::SecTest::test_set_sec_dacl_new,base,xfail,ValueError: Invalid AclRevision: 1
-acl.py::SecTest::test_set_sec_dacl_partial_copy,base,xfail,ValueError: Invalid AclRevision: 1
-acl.py::SecTest::test_set_sec_group,base,xfail,ValueError: Invalid AclRevision: 1
-acl.py::SecTest::test_set_sec_owner,base,xfail,ValueError: Invalid AclRevision: 1
-acl.py::SecTest::test_set_sec_same,base,xfail,ValueError: Invalid AclRevision: 1
+acl.py::SecTest::test_set_sec_dacl,base,green,
+acl.py::SecTest::test_set_sec_dacl_append_ace,base,green,
+acl.py::SecTest::test_set_sec_dacl_new,base,green,
+acl.py::SecTest::test_set_sec_dacl_partial_copy,base,green,
+acl.py::SecTest::test_set_sec_group,base,green,
+acl.py::SecTest::test_set_sec_owner,base,green,
+acl.py::SecTest::test_set_sec_same,base,green,
 appinstanceid.py::AppInstanceIdTest::test_appinstanceid,persistent,green,
 appinstanceid.py::AppInstanceIdTest::test_appinstanceid_persistent_with_disconnect,persistent,green,
 appinstanceid.py::AppInstanceIdTest::test_appinstanceid_reconnect_same_clientguid,persistent,xfail,same-client-guid AppInstanceId reopen should return FILE_NOT_AVAILABLE
@@ -151,18 +151,18 @@ query.py::QueryTest::test_mismatch_0_file_mode_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_position_info,base,green,
 query.py::QueryTest::test_mismatch_0_file_standard_info,base,green,
 query.py::QueryTest::test_query_file_alignment_info,base,green,
-query.py::QueryTest::test_query_file_all_info,base,xfail,ValueError: Invalid Alignment: fff
+query.py::QueryTest::test_query_file_all_info,base,green,
 query.py::QueryTest::test_query_file_basic_info,base,green,
 query.py::QueryTest::test_query_file_ea_info,base,green,
 query.py::QueryTest::test_query_file_internal_info,base,green,
 query.py::QueryTest::test_query_file_mode_info,base,green,
 query.py::QueryTest::test_query_file_position_info,base,green,
-query.py::QueryTest::test_query_file_sec_info_all,base,xfail,ValueError: Invalid AclRevision: 1
+query.py::QueryTest::test_query_file_sec_info_all,base,green,
 query.py::QueryTest::test_query_file_sec_info_dacl,base,green,
 query.py::QueryTest::test_query_file_sec_info_group,base,green,
 query.py::QueryTest::test_query_file_sec_info_owner,base,green,
 query.py::QueryTest::test_query_file_standard_info,base,green,
-query.py::QueryTest::test_query_sec_desc_0,base,xfail,IndexError: list index out of range
+query.py::QueryTest::test_query_sec_desc_0,base,xfail,BUFFER_TOO_SMALL reply needs the 4-byte required-length error body
 querydirectory.py::QueryDirectoryTest::test_file_directory_info,base,green,
 querydirectory.py::QueryDirectoryTest::test_file_id_both_directory_information,base,green,
 querydirectory.py::QueryDirectoryTest::test_restart_scan,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -139,7 +139,7 @@ persistent.py::Persistent::test_open_while_disconnected,persistent,green,
 persistent.py::Persistent::test_reconnect,persistent,green,
 persistent.py::Persistent::test_reconnect_fails,persistent,xfail,pike-bug: persistent=False inherits durable_flags=PERSISTENT (model.py:1477) so the DH2C reconnect is byte-identical to the passing test_reconnect -- cannot trigger 3.3.5.9.12 ONNF
 persistent.py::Persistent::test_resiliency_reconnect_after_timeout,persistent,green,
-persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,green,
+persistent.py::Persistent::test_resiliency_reconnect_before_timeout,persistent,xfail,flaky cross-test artifact: persistent.py shares persistent.txt (FILE_OPEN_IF+DELETE_ON_CLOSE) across the suite; a prior test's parked persistent handle's grace-timer reap fires delete-on-close and unlinks the SAME inode mid-test (chimera durable-reap delete is eager not last-close) so the conflicting open sees ONNF not FILE_NOT_AVAILABLE. match_fh (#1485) can't help (same inode); needs delete-on-close-last-close (core change). 9fc630c6 made it 3/4 in CI
 persistent.py::Persistent::test_resiliency_same_timeout_reconnect_after_timeout,persistent,green,
 persistent.py::Persistent::test_resiliency_same_timeout_reconnect_before_timeout,persistent,green,
 query.py::QueryTest::test_mismatch_0_file_alignment_info,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv
+++ b/src/server/smb/tests/pike/pike_cases.csv
@@ -177,8 +177,8 @@ readwrite.py::ReadWriteTest::test_write_none,base,green,
 readwrite.py::ReadWriteTest::test_write_none_access,base,green,
 readwrite.py::ReadWriteTest::test_write_none_lease,base,green,
 readwrite.py::ReadWriteTest::test_write_none_oplock,base,xfail,delete-on-close unlinks on first of two DOC handles' close not last
-reparse.py::TestReparsePoint::test_set_get_reparse_point,base,xfail,pike.exceptions.ResponseError: (SMB2_IOCTL; STATUS_NOT_A_REPARSE_POINT)
-reparse.py::TestReparsePoint::test_symbolic_link_error_response,base,xfail,IndexError: list index out of range
+reparse.py::TestReparsePoint::test_set_get_reparse_point,base,green,
+reparse.py::TestReparsePoint::test_symbolic_link_error_response,base,green,
 session.py::SessionTest::test_session_logoff,base,green,
 session.py::SessionTest::test_session_multiplex,base,green,
 set.py::SetTest::test_set_file_basic_info,base,green,

--- a/src/server/smb/tests/pike/pike_cases.csv.license
+++ b/src/server/smb/tests/pike/pike_cases.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -3825,6 +3825,26 @@ memfs_copy_range(
         return;
     }
 
+    /* Range copy is only defined between regular files.  The inode's block fork
+     * (inode->file) shares a union with the directory dirent tree (inode->dir)
+     * and the symlink target, so treating a non-regular inode as a file here
+     * would scribble over that other union member and corrupt the heap (a
+     * directory destination with FILE_DELETE_ON_CLOSE then double-frees its
+     * dirent tree on teardown).  Reject a directory with EISDIR (the SMB
+     * copychunk path maps it to STATUS_INVALID_DEVICE_REQUEST) and any other
+     * non-regular type with EINVAL. */
+    if (S_ISDIR(src_inode->mode) || S_ISDIR(dst_inode->mode)) {
+        request->status = CHIMERA_VFS_EISDIR;
+        request->complete(request);
+        return;
+    }
+
+    if (!S_ISREG(src_inode->mode) || !S_ISREG(dst_inode->mode)) {
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
+    }
+
     src_offset = request->copy_range.src_offset;
     dst_offset = request->copy_range.dst_offset;
     length     = request->copy_range.length;


### PR DESCRIPTION
## Summary

Integrates [pike](https://github.com/chimera-nas/pike) — a pure-Python SMB2/3 protocol correctness framework, the SMB analog of pynfs — into ctest, wired the same way as pynfs/WPTS: it runs host-side in a network namespace against the chimera daemon over TCP/445, authenticating with pure-Python NTLM (no Kerberos/compiled deps).

## What's here

- **`scripts/pike_smb_test_wrapper.sh`** — netns + memfs SMB daemon + pytest runner, modeled on `wpts_smb_test_wrapper.sh`. Per-case JUnit; feature toggles (`CHIMERA_SMB_PERSISTENT`/`ENCRYPTION`/`MULTICHANNEL`) mirror the WPTS matrix.
- **`src/server/smb/tests/pike/pike_cases.csv`** — feature-aware case map with a `green`/`xfail`/`skip` status, mirroring `wpts_cases.csv`. CI gates **only on green**: **147 green / 39 xfail / 1 skip** across three configs (`base`, `persistent`(+multichannel), `encryption`). The full pike suite runs as one ctest per config (~24s total).
- **`src/server/smb/tests/CMakeLists.txt`** — registers the per-config combined runs.
- **`.devcontainer/Dockerfile`** — clones pike at a pinned SHA to `/opt/pike` and installs its pure-Python deps (pike runs from source via `PYTHONPATH`; the optional `pike.kerberos` C extension is skipped — we use NTLM).

## Defects pike found, fixed in this PR

The baseline sweep surfaced **3 daemon crashers**, all fixed here:

| Case | Bug | Fix |
|---|---|---|
| `copychunk::test_neg_dst_is_a_dir` | `FSCTL_SRV_COPYCHUNK` to a **directory** destination → double-free / heap corruption (the dir inode's dirent tree shares a union with the file block fork) | `memfs_copy_range` rejects a non-regular inode (`EISDIR`/`EINVAL`); SMB maps `EISDIR`→`STATUS_INVALID_DEVICE_REQUEST` |
| `appinstanceid::test_appinstanceid_persistent_with_disconnect` / `…reconnect_same_clientguid` | AppInstanceId failover force-closing a **parked** (disconnected) persistent open took the live-open path → double `HASH_DELETE` against a recycled tree → SIGSEGV | route a parked open's force-close through the durable registry (`purge_parked` gains an `include_persistent` flag) |

Also fixed: `copychunk` **ChunkCount > 256 hung the client** (the IOCTL parser dropped the request instead of letting the handler answer) and the limit response now reports `ChunkBytesWritten = MaxChunkSize`.

## Remaining xfails (tracked, not gated)

Conformance gaps pike flags but that aren't fixed here: security-descriptor `AclRevision`, `QueryOnDiskId` create-context, SMB 3.1.1 encrypted-response framing, an oplock break on a zero-length write, and the same-client-GUID AppInstanceId `FILE_NOT_AVAILABLE` semantic. All recorded as `xfail` so the gated runs stay green and noise-free.

Draft while the xfails are burned down.