### PR TITLE
nfs/nlm,nsm: fix NLM CANCEL mode match and implement SM_UNMON/SM_UNMON_ALL teardown

### DIFF
--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -950,16 +950,20 @@ chimera_nfs_nlm4_cancel(
         DL_FOREACH(client->locks, entry)
         {
             /* Only pending entries can be cancelled; granted entries
-             * require UNLOCK to release.  Match the exact (oh, svid,
-             * fh, range) tuple. */
+             * require UNLOCK to release.  CANCEL identifies the specific
+             * outstanding blocked LOCK request, which per RFC 1813 (struct
+             * nlm4_cancargs / nlm4_lock) is keyed by its mode as well as
+             * owner+range, so match the exact
+             * (oh, svid, fh, range, exclusive) tuple. */
             if (!entry->pending) {
                 continue;
             }
-            if (entry->oh_len  != args->alock.oh.len  ||
-                entry->fh_len  != args->alock.fh.len  ||
-                entry->svid    != args->alock.svid    ||
-                entry->offset  != args->alock.l_offset ||
-                entry->length  != want_length          ||
+            if (entry->oh_len    != args->alock.oh.len  ||
+                entry->fh_len    != args->alock.fh.len  ||
+                entry->svid      != args->alock.svid    ||
+                entry->offset    != args->alock.l_offset ||
+                entry->length    != want_length          ||
+                entry->exclusive != args->exclusive      ||
                 memcmp(entry->oh, args->alock.oh.data, entry->oh_len) != 0 ||
                 memcmp(entry->fh, args->alock.fh.data, entry->fh_len) != 0) {
                 continue;

--- a/src/server/nfs/nfs_nsm.c
+++ b/src/server/nfs/nfs_nsm.c
@@ -40,6 +40,10 @@ nsm_kv_done(
     free(private_data);
 } /* nsm_kv_done */
 
+/* Bound on the number of monitor entries an IP- or caller-keyed sweep will
+ * collect on the stack in one pass (SM_NOTIFY fallback / SM_UNMON_ALL). */
+#define NSM_NOTIFY_FALLBACK_MAX 32
+
 static void
 nsm_state_persist(
     struct chimera_vfs_thread *vfs_thread,
@@ -549,7 +553,21 @@ chimera_nfs_sm_unmon(
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct sm_stat                    res;
+    char                              host[SM_MAXSTRLEN + 1];
+    size_t                            hn_len;
     int                               rc;
+
+    /* SM_UNMON removes monitoring of the single named host (mon_id.mon_name),
+     * the same key space used by SM_MON / SM_NOTIFY and the NLM caller_name.
+     * Drop it symmetrically to the add path (nsm_monitor): unlink under the
+     * lock and delete the persisted record. */
+    hn_len = args->mon_name.len < SM_MAXSTRLEN ? args->mon_name.len : SM_MAXSTRLEN;
+    memcpy(host, args->mon_name.str, hn_len);
+    host[hn_len] = '\0';
+
+    chimera_nfs_info("NSM SM_UNMON: stop monitoring host '%s'", host);
+
+    nsm_unmonitor(thread, host);
 
     res.state = (int) nsm_state_current(&shared->nsm_state);
 
@@ -568,8 +586,51 @@ chimera_nfs_sm_unmon_all(
 {
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
+    struct nsm_state                 *nsm    = &shared->nsm_state;
     struct sm_stat                    res;
-    int                               rc;
+    char                              caller[SM_MAXSTRLEN + 1];
+    size_t                            cn_len;
+    char                              matched[NSM_NOTIFY_FALLBACK_MAX][SM_MAXSTRLEN + 1];
+    struct nsm_monitor               *mon, *tmp;
+    int                               n = 0, truncated = 0, i, rc;
+
+    /* SM_UNMON_ALL removes every monitor relationship the calling host
+     * (my_id.my_name) established.  chimera's monitor table is keyed by the
+     * monitored-host name (== the peer's NLM caller_name), which for a host
+     * monitoring itself is the caller's own name; remove the entry matching the
+     * caller plus any other entry the caller reaches at the same key.  Collect
+     * matches under the lock, then drop each symmetrically to the add path. */
+    cn_len = args->my_name.len < SM_MAXSTRLEN ? args->my_name.len : SM_MAXSTRLEN;
+    memcpy(caller, args->my_name.str, cn_len);
+    caller[cn_len] = '\0';
+
+    chimera_nfs_info("NSM SM_UNMON_ALL: drop all monitors for caller '%s' "
+                     "(prog=%d vers=%d proc=%d)", caller,
+                     args->my_prog, args->my_vers, args->my_proc);
+
+    pthread_mutex_lock(&nsm->mutex);
+    HASH_ITER(hh, nsm->monitors, mon, tmp)
+    {
+        if (strcmp(mon->host, caller) != 0) {
+            continue;
+        }
+        if (n < NSM_NOTIFY_FALLBACK_MAX) {
+            snprintf(matched[n++], SM_MAXSTRLEN + 1, "%s", mon->host);
+        } else {
+            truncated = 1;
+        }
+    }
+    pthread_mutex_unlock(&nsm->mutex);
+
+    if (truncated) {
+        chimera_nfs_info("NSM SM_UNMON_ALL: >%d monitors for '%s'; removing "
+                         "only the first %d", NSM_NOTIFY_FALLBACK_MAX, caller,
+                         NSM_NOTIFY_FALLBACK_MAX);
+    }
+
+    for (i = 0; i < n; i++) {
+        nsm_unmonitor(thread, matched[i]);
+    }
 
     res.state = (int) nsm_state_current(&shared->nsm_state);
 
@@ -668,8 +729,6 @@ nsm_release_host_locks(
     }
     return found;
 } /* nsm_release_host_locks */
-
-#define NSM_NOTIFY_FALLBACK_MAX 32
 
 void
 chimera_nfs_sm_notify(


### PR DESCRIPTION
Fixes two NLM/NSM (NFS lock-manager / status-monitor) conformance bugs found by the 2026-06 server-side audit.

## #1175 — NLM CANCEL ignores the lock mode
`chimera_nfs_nlm4_cancel()` matched a pending blocked LOCK by `{owner, svid, fh, range}` only, never comparing the requested mode. Per RFC 1813 (`struct nlm4_cancargs` / `nlm4_lock`), CANCEL identifies the specific outstanding blocked request, which is keyed by its exclusive/shared mode as well as owner and range — so a CANCEL with the wrong mode could match (and tear down) a different request. Fix adds `entry->exclusive == args->exclusive` to the match tuple.

## #1180 — SM_UNMON / SM_UNMON_ALL were pure no-ops
Both handlers only returned the NSM state number and never removed a monitor entry, so a peer could not deregister monitoring (entries persisted until an SM_NOTIFY or lock release). Now:
- `SM_UNMON` removes the single named host (`mon_id.mon_name`) via the existing `nsm_unmonitor()` — unlink under the lock + delete the persisted KV record, symmetric to the `nsm_monitor()` add path.
- `SM_UNMON_ALL` drops every monitor entry for the calling host (`my_id.my_name`); matches are collected under `nsm_state.mutex` and removed outside the `HASH_ITER` walk (mirroring the SM_NOTIFY source-IP fallback) to avoid mutating the hash mid-iteration.

Removal reuses the audited `nsm_unmonitor()` helper, so the ASan-sensitive unlink/free/persist sequencing is unchanged.
