### PR TITLE
daemon: write auto-generated REST TLS private key with 0600 perms

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
 #include <unistd.h>
 #include <jansson.h>
 #include <openssl/pem.h>
@@ -108,11 +110,39 @@ generate_self_signed_cert(
         goto cleanup;
     }
 
-    /* Write private key */
-    fp = fopen(key_path, "w");
-    if (!fp) {
-        chimera_server_error("Failed to open key file: %s", key_path);
-        goto cleanup;
+    /*
+     * Write the private key with owner-only (0600) permissions.  The daemon
+     * runs with umask(0) (so client file modes on the data path apply
+     * verbatim), which means fopen("w") would create this control-plane RSA
+     * private key world-readable AND world-writable (mode 0666) -- CWE-276
+     * (Incorrect Default Permissions).  Create the file explicitly with
+     * O_CREAT|O_EXCL|0600 so the mode is enforced regardless of umask and so a
+     * pre-existing (potentially attacker-planted) file in the world-writable
+     * /tmp path is rejected rather than overwritten (CWE-377).
+     */
+    {
+        int key_fd = open(key_path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+
+        if (key_fd < 0) {
+            chimera_server_error("Failed to open key file: %s (%s)",
+                                 key_path, strerror(errno));
+            goto cleanup;
+        }
+
+        /* Belt-and-suspenders: enforce 0600 explicitly (defense in depth). */
+        if (fchmod(key_fd, 0600) < 0) {
+            chimera_server_error("Failed to set key file permissions: %s (%s)",
+                                 key_path, strerror(errno));
+            close(key_fd);
+            goto cleanup;
+        }
+
+        fp = fdopen(key_fd, "w");
+        if (!fp) {
+            chimera_server_error("Failed to open key file stream: %s", key_path);
+            close(key_fd);
+            goto cleanup;
+        }
     }
     PEM_write_PrivateKey(fp, pkey, NULL, NULL, 0, NULL, NULL);
     fclose(fp);

--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include "evpl/evpl.h"
 #include "evpl/evpl_http.h"
 #include "common/logging.h"
@@ -241,6 +242,16 @@ chimera_metrics_dump_file(
         chimera_metrics_error("Failed to open metrics file %s for writing", path);
         free(buf);
         return -1;
+    }
+
+    /*
+     * The daemon runs with umask(0), so fopen("w") would leave this file
+     * world-writable (mode 0666).  Restrict it to 0644 (owner-write,
+     * world-readable is fine for non-sensitive metrics) so other local users
+     * cannot tamper with the dump -- CWE-276 (Incorrect Default Permissions).
+     */
+    if (fchmod(fileno(fp), 0644) < 0) {
+        chimera_metrics_error("Failed to set metrics file permissions on %s", path);
     }
 
     written = fwrite(buf, 1, len, fp);


### PR DESCRIPTION
## Summary

Fixes #1069 (audit V2-027, CWE-276 / CWE-377). The daemon calls `umask(0)` process-wide so client-supplied file modes on the NAS data path are applied verbatim by the VFS. That side-effect leaked to the control plane: `generate_self_signed_cert()` wrote the self-signed REST TLS **private key** via `fopen("w")` (base mode 0666), and with umask 0 the on-disk RSA private key ended up **world-readable AND world-writable** at a predictable `/tmp/chimera-rest-<pid>.key` path. Any local user could read the key (decrypt captured management TLS / impersonate the admin endpoint that carries Basic creds + JWTs) or pre-create/overwrite it.

## Changes

- **`src/daemon/daemon.c`** — write the TLS private key with owner-only `0600` permissions regardless of umask. Create the file explicitly with `open(O_WRONLY|O_CREAT|O_EXCL, 0600)` (atomic restrictive mode + rejects an attacker-planted file in world-writable `/tmp` instead of overwriting it), `fchmod(0600)` as defense-in-depth, then `fdopen()` for `PEM_write_PrivateKey`. The certificate (public) is unchanged.
- **`src/metrics/metrics.c`** — the metrics dump file had the same `umask(0)` exposure (created 0666); tightened to `0644` via `fchmod` so other local users can't tamper with it. Metrics are non-sensitive, so world-readable is acceptable; world-writable is not.

`umask(0)` itself is left intact (the data path relies on it); the fix is per-file explicit modes so no other files are disturbed.

## Validation

- Builds clean (Release, Ninja).
- `ctest -R "rest|tls|auth|https|metrics"` — TLS, HTTP/2-over-TLS, REST auth, and SMB rest/auth suites all pass, no regressions.
- Runtime check: launched the daemon with `rest_https_port` set and TLS auto-generation; the generated key now stats as `600` (was `666`), the cert stays `666` (public), and the HTTPS listener starts normally.
