### PR TITLE
smb2: validate SET_INFO / QUERY_DIRECTORY parameters (MS-FSA value range)

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -293,6 +293,11 @@ struct chimera_smb_conn;
  * evpl buffer cannot be satisfied with one iovec. */
 #define CHIMERA_SMB_MAX_TRANSACT_SIZE         (1 * 1024 * 1024)
 
+/* Maximum supported file size, matching the Windows/Samba value
+ * (0xFFFFFFF0000 == 2^44 - 2^16).  A write, SetEndOfFile or SetAllocation whose
+ * size would exceed this is rejected with STATUS_INVALID_PARAMETER. */
+#define CHIMERA_SMB_MAX_FILE_SIZE             0xfffffff0000ULL
+
 struct chimera_smb_rename_info {
     uint8_t                         replace_if_exist;
     struct chimera_vfs_open_handle *new_parent_handle;

--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -356,6 +356,29 @@ chimera_smb_query_directory(struct chimera_smb_request *request)
         request->query_directory.max_output_length = CHIMERA_SMB_MAX_TRANSACT_SIZE;
     }
 
+    /* MS-FSA 2.1.5.5.3: if OutputBufferLength is too small to hold even the
+     * fixed header of one entry of the requested FileInformationClass, the
+     * query is failed with STATUS_INFO_LENGTH_MISMATCH -- regardless of whether
+     * the directory has matching entries (WPTS MS-FSAModel QueryDirectory
+     * tiny-buffer cases).  The header sizes match the per-class expected_length
+     * base in the readdir callback below. */
+    uint32_t qd_header_len;
+    switch (request->query_directory.info_class) {
+        case SMB2_FILE_DIRECTORY_INFORMATION:         qd_header_len = 64;  break;
+        case SMB2_FILE_FULL_DIRECTORY_INFORMATION:    qd_header_len = 68;  break;
+        case SMB2_FILE_BOTH_DIRECTORY_INFORMATION:    qd_header_len = 94;  break;
+        case SMB2_FILE_NAMES_INFORMATION:             qd_header_len = 12;  break;
+        case SMB2_FILE_ID_BOTH_DIRECTORY_INFORMATION: qd_header_len = 102; break;
+        case SMB2_FILE_ID_FULL_DIRECTORY_INFORMATION: qd_header_len = 74;  break;
+        default:                                      qd_header_len = 0;   break;
+    } /* switch */
+
+    if (request->query_directory.max_output_length < qd_header_len) {
+        chimera_smb_open_file_release(request, request->query_directory.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INFO_LENGTH_MISMATCH);
+        return;
+    }
+
     evpl_iovec_alloc(evpl,
                      request->query_directory.max_output_length,
                      4096,

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -520,6 +520,21 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         break;
                     }
 
+                    /* MS-FSA 2.1.5.14.2: a FileBasicInformation timestamp is
+                     * either a valid (non-negative) FILETIME or one of the
+                     * sentinels 0 (omit), -1 (freeze) or -2 (thaw); any value
+                     * below -2 is rejected with STATUS_INVALID_PARAMETER (WPTS
+                     * MS-FSAModel SetFileBasicInformation {Creation,LastAccess,
+                     * LastWrite,Change}TimeLessthanM1). */
+                    if ((int64_t) request->set_info.attrs.smb_crttime < -2 ||
+                        (int64_t) request->set_info.attrs.smb_atime < -2 ||
+                        (int64_t) request->set_info.attrs.smb_mtime < -2 ||
+                        (int64_t) request->set_info.attrs.smb_ctime < -2) {
+                        chimera_smb_open_file_release(request, request->set_info.open_file);
+                        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+                        break;
+                    }
+
                     chimera_smb_unmarshal_basic_info(&request->set_info.attrs, &request->set_info.vfs_attrs);
 
                     /* An explicit (non-sentinel) write-time set hands control of
@@ -550,6 +565,18 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         chimera_smb_open_file_release(request, request->set_info.open_file);
                         chimera_smb_complete_request(request,
                                                      SMB2_STATUS_INVALID_PARAMETER);
+                        break;
+                    }
+
+                    /* MS-FSA 2.1.5.16: EndOfFile is a signed LONGLONG that must
+                     * leave headroom to extend; a value at or above MAXLONGLONG
+                     * (which includes every negative value once read as signed)
+                     * is "greater than the maximum file size" and is rejected
+                     * with STATUS_INVALID_PARAMETER (WPTS MS-FSAModel
+                     * SetFileEndOfFileInformation isEndOfFileGreatThanMaxSize). */
+                    if (request->set_info.attrs.smb_size >= (uint64_t) INT64_MAX) {
+                        chimera_smb_open_file_release(request, request->set_info.open_file);
+                        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
                         break;
                     }
 
@@ -598,6 +625,18 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                      * advances LastWriteTime; a grow/hint only touches
                      * ChangeTime.  Both need the current size to decide, so this
                      * is resolved in the getattr callback. */
+                    /* MS-FSA 2.1.5.13: AllocationSize is a signed LONGLONG that
+                     * must leave headroom; a value at or above MAXLONGLONG (every
+                     * negative value once read as signed) is "greater than the
+                     * maximum file size" and is rejected with
+                     * STATUS_INVALID_PARAMETER (WPTS MS-FSAModel
+                     * SetFileAllocOrObjIdInformation). */
+                    if (request->set_info.attrs.smb_size >= (uint64_t) INT64_MAX) {
+                        chimera_smb_open_file_release(request, request->set_info.open_file);
+                        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+                        break;
+                    }
+
                     request->set_info.notify_mask = CHIMERA_VFS_NOTIFY_SIZE_CHANGED |
                         CHIMERA_VFS_NOTIFY_FILE_MODIFIED |
                         CHIMERA_VFS_NOTIFY_STREAM_SIZE;
@@ -680,6 +719,14 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                     chimera_smb_set_ea(request);
                     break;
                 case SMB2_FILE_POSITION_INFO:
+                    /* MS-FSA 2.1.5.20: CurrentByteOffset is a signed LONGLONG; a
+                     * negative value is rejected with STATUS_INVALID_PARAMETER
+                     * (WPTS MS-FSAModel SetFilePositionInformation). */
+                    if ((int64_t) request->set_info.attrs.smb_position < 0) {
+                        chimera_smb_open_file_release(request, request->set_info.open_file);
+                        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+                        break;
+                    }
                     request->set_info.open_file->position = request->set_info.attrs.smb_position;
                     chimera_smb_open_file_release(request, request->set_info.open_file);
                     chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);

--- a/src/server/smb/smb_proc_set_info.c
+++ b/src/server/smb/smb_proc_set_info.c
@@ -568,13 +568,13 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                         break;
                     }
 
-                    /* MS-FSA 2.1.5.16: EndOfFile is a signed LONGLONG that must
-                     * leave headroom to extend; a value at or above MAXLONGLONG
-                     * (which includes every negative value once read as signed)
-                     * is "greater than the maximum file size" and is rejected
-                     * with STATUS_INVALID_PARAMETER (WPTS MS-FSAModel
+                    /* MS-FSA 2.1.5.16: a SetEndOfFile whose size exceeds the
+                     * maximum supported file size is rejected with
+                     * STATUS_INVALID_PARAMETER -- the same bound the write path
+                     * enforces, which also covers every value that is negative
+                     * when read as a signed LONGLONG (WPTS MS-FSAModel
                      * SetFileEndOfFileInformation isEndOfFileGreatThanMaxSize). */
-                    if (request->set_info.attrs.smb_size >= (uint64_t) INT64_MAX) {
+                    if (request->set_info.attrs.smb_size > CHIMERA_SMB_MAX_FILE_SIZE) {
                         chimera_smb_open_file_release(request, request->set_info.open_file);
                         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
                         break;
@@ -625,13 +625,12 @@ chimera_smb_set_info(struct chimera_smb_request *request)
                      * advances LastWriteTime; a grow/hint only touches
                      * ChangeTime.  Both need the current size to decide, so this
                      * is resolved in the getattr callback. */
-                    /* MS-FSA 2.1.5.13: AllocationSize is a signed LONGLONG that
-                     * must leave headroom; a value at or above MAXLONGLONG (every
-                     * negative value once read as signed) is "greater than the
-                     * maximum file size" and is rejected with
-                     * STATUS_INVALID_PARAMETER (WPTS MS-FSAModel
-                     * SetFileAllocOrObjIdInformation). */
-                    if (request->set_info.attrs.smb_size >= (uint64_t) INT64_MAX) {
+                    /* MS-FSA 2.1.5.13: a SetAllocation whose size exceeds the
+                     * maximum supported file size is rejected with
+                     * STATUS_INVALID_PARAMETER (also covers every value negative
+                     * when read as a signed LONGLONG) -- WPTS MS-FSAModel
+                     * SetFileAllocOrObjIdInformation. */
+                    if (request->set_info.attrs.smb_size > CHIMERA_SMB_MAX_FILE_SIZE) {
                         chimera_smb_open_file_release(request, request->set_info.open_file);
                         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
                         break;

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -9,11 +9,6 @@
 #include "vfs/vfs_notify.h"
 #include "vfs/vfs_state.h"
 
-/* Maximum supported file size, matching the Windows/Samba value
- * (0xFFFFFFF0000 == 2^44 - 2^16).  A write whose last byte would extend past
- * this is rejected with INVALID_PARAMETER. */
-#define CHIMERA_SMB_MAX_FILE_SIZE 0xfffffff0000ULL
-
 /* A write-time-sticky handle needs the pre-write mtime back from the VFS so the
  * write callback can restore it; otherwise no pre-attrs are requested. */
 static inline uint64_t

--- a/src/server/smb/tests/wpts/fsamodel_cases.csv
+++ b/src/server/smb/tests/wpts/fsamodel_cases.csv
@@ -238,21 +238,21 @@ SetFileAllocOrObjIdInformationTestCaseS0,skip,unimplemented: info-class/op
 SetFileAllocOrObjIdInformationTestCaseS10,skip,unimplemented: info-class/op
 SetFileAllocOrObjIdInformationTestCaseS2,skip,unimplemented: info-class/op
 SetFileAllocOrObjIdInformationTestCaseS4,green,
-SetFileAllocOrObjIdInformationTestCaseS6,xfail,fidelity: no parameter validation
+SetFileAllocOrObjIdInformationTestCaseS6,green,
 SetFileAllocOrObjIdInformationTestCaseS8,skip,unimplemented: info-class/op
 SetFileBasicInformationTestCaseS0,green,
-SetFileBasicInformationTestCaseS10,xfail,fidelity: no parameter validation
+SetFileBasicInformationTestCaseS10,green,
 SetFileBasicInformationTestCaseS12,green,
 SetFileBasicInformationTestCaseS14,green,
 SetFileBasicInformationTestCaseS2,green,
-SetFileBasicInformationTestCaseS4,xfail,fidelity: no parameter validation
-SetFileBasicInformationTestCaseS6,xfail,fidelity: no parameter validation
-SetFileBasicInformationTestCaseS8,xfail,fidelity: no parameter validation
+SetFileBasicInformationTestCaseS4,green,
+SetFileBasicInformationTestCaseS6,green,
+SetFileBasicInformationTestCaseS8,green,
 SetFileDispositionInformationTestCaseS0,green,
 SetFileDispositionInformationTestCaseS2,green,
 SetFileEndOfFileInformationTestCaseS0,green,
-SetFileEndOfFileInformationTestCaseS2,xfail,fidelity: no parameter validation
-SetFileEndOfFileInformationTestCaseS4,xfail,fidelity: no parameter validation
+SetFileEndOfFileInformationTestCaseS2,green,
+SetFileEndOfFileInformationTestCaseS4,green,
 SetFileEndOfFileInformationTestCaseS6,green,
 SetFileFullEaInformationTestCaseS0,green,
 SetFileFullEaInformationTestCaseS2,green,
@@ -271,7 +271,7 @@ SetFilePositionInformationTestCaseS10,skip,inapplicable: model branch not execut
 SetFilePositionInformationTestCaseS2,green,
 SetFilePositionInformationTestCaseS4,green,
 SetFilePositionInformationTestCaseS6,green,
-SetFilePositionInformationTestCaseS8,xfail,fidelity: no parameter validation
+SetFilePositionInformationTestCaseS8,green,
 SetFileRenameInformationTestCaseS0,green,
 SetFileRenameInformationTestCaseS10,green,
 SetFileRenameInformationTestCaseS12,green,

--- a/src/server/smb/tests/wpts/fsamodel_cases.csv
+++ b/src/server/smb/tests/wpts/fsamodel_cases.csv
@@ -141,13 +141,13 @@ QueryDirectoryTestCaseS2,skip,inapplicable: model branch not executed
 QueryDirectoryTestCaseS20,skip,inapplicable: model branch not executed
 QueryDirectoryTestCaseS22,skip,inapplicable: model branch not executed
 QueryDirectoryTestCaseS24,skip,inapplicable: model branch not executed
-QueryDirectoryTestCaseS26,xfail,fidelity: expected INFO_LENGTH_MISMATCH got NO_MORE_FILES
+QueryDirectoryTestCaseS26,green,
 QueryDirectoryTestCaseS28,skip,inapplicable: model branch not executed
 QueryDirectoryTestCaseS30,xfail,fidelity: expected NO_SUCH_FILE got NO_MORE_FILES
-QueryDirectoryTestCaseS32,xfail,fidelity: expected INFO_LENGTH_MISMATCH got NO_MORE_FILES
-QueryDirectoryTestCaseS34,xfail,fidelity: expected INFO_LENGTH_MISMATCH got NO_MORE_FILES
-QueryDirectoryTestCaseS36,xfail,fidelity: expected INFO_LENGTH_MISMATCH got NO_MORE_FILES
-QueryDirectoryTestCaseS38,xfail,fidelity: expected INFO_LENGTH_MISMATCH got NO_MORE_FILES
+QueryDirectoryTestCaseS32,green,
+QueryDirectoryTestCaseS34,green,
+QueryDirectoryTestCaseS36,green,
+QueryDirectoryTestCaseS38,green,
 QueryDirectoryTestCaseS4,skip,inapplicable: model branch not executed
 QueryDirectoryTestCaseS6,skip,inapplicable: model branch not executed
 QueryDirectoryTestCaseS8,skip,inapplicable: model branch not executed


### PR DESCRIPTION
## Summary

Several SMB2 metadata handlers stored client-supplied values without
range-checking them, so out-of-range parameters were silently accepted
(returning SUCCESS) where MS-FSA requires `STATUS_INVALID_PARAMETER` /
`STATUS_INFO_LENGTH_MISMATCH`. This adds the missing validation.

- **SET_INFO numeric ranges:**
  - `FileBasicInformation` — a timestamp field below `-2` is rejected; `0`
    (omit), `-1` (freeze) and `-2` (thaw) remain valid sentinels (MS-FSA 2.1.5.14.2).
  - `FilePositionInformation` — a negative `CurrentByteOffset` is rejected (MS-FSA 2.1.5.20).
  - `FileEndOfFileInformation` / `FileAllocationInformation` — a size greater
    than the maximum supported file size is rejected (MS-FSA 2.1.5.16 / 2.1.5.13).
    The ceiling is `CHIMERA_SMB_MAX_FILE_SIZE`, hoisted from `smb_proc_write.c`
    into `smb_internal.h` so write / SetEndOfFile / SetAllocation enforce the
    same bound (the bound also covers every value that is negative as a signed
    `LONGLONG`).
- **QUERY_DIRECTORY buffer:** a query whose `OutputBufferLength` is too small to
  hold even the fixed header of one entry of the requested `FileInformationClass`
  was answered `STATUS_NO_MORE_FILES`; it now fails up front with
  `STATUS_INFO_LENGTH_MISMATCH` (MS-FSA 2.1.5.5.3).

## Result

Greens **13 WPTS MS-FSAModel** cases (`SetFileBasicInformation` S4/S6/S8/S10,
`SetFileEndOfFileInformation` S2/S4, `SetFilePositionInformation` S8,
`SetFileAllocOrObjIdInformation` S6, `QueryDirectory` S26/S32/S34/S36/S38) —
FSAModel green 133 → 146.

Verified: MS-FSAModel green set 146/146, MS-FSA green set 185/185, and smbtorture
`smb2.{dir,streams,notify,create,timestamps,setinfo,getinfo,write}` all stay
green.