### PR TITLE
smb2: precise NTSTATUS for a not-Breaking oplock acknowledgment (3.3.5.22.1)

### DIFF
--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -641,57 +641,61 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
     open_file = chimera_smb_open_file_resolve(request, &request->oplock_break.file_id);
 
     if (open_file) {
-        if (!open_file->oplock_break_ack_required) {
-            /* No acknowledgment was expected for this break -- e.g. it broke a
-             * LEVEL_II oplock to NONE, which MS-SMB2 says the client must not
-             * acknowledge.  Reply with the protocol error (3.3.5.22.2). */
+        uint8_t ack = request->oplock_break.oplock_level;
+        uint8_t cur = open_file->oplock_level;
+        /* "Open.OplockState == Breaking": a break that requires an ack is
+         * outstanding on this open.  A LEVEL_II break (to NONE) needs no ack, so
+         * such an open is never in this state -- a client ack against it is
+         * handled by the not-Breaking branch below. */
+        bool    breaking = open_file->oplock_break_ack_required &&
+            open_file->grant &&
+            open_file->grant->lease.break_state == CHIMERA_VFS_BREAK_BREAKING;
+
+        if (!breaking) {
+            /* MS-SMB2 3.3.5.22.1: an oplock acknowledgment received while the
+             * open is NOT in the Breaking state is rejected, and the exact
+             * status depends on the acknowledged OplockLevel and the level
+             * currently held on the open:
+             *   - ack == LEASE                          -> INVALID_PARAMETER
+             *   - open EXCLUSIVE/BATCH, ack not II/NONE  -> INVALID_OPLOCK_PROTOCOL
+             *   - open LEVEL_II, ack != NONE            -> INVALID_OPLOCK_PROTOCOL
+             *   - ack == II or NONE                     -> INVALID_DEVICE_STATE
+             * chimera previously collapsed every not-Breaking ack to
+             * INVALID_OPLOCK_PROTOCOL (WPTS OplockOnShareWithForceLevel2
+             * not-Breaking acks expect INVALID_PARAMETER / INVALID_DEVICE_STATE). */
+            uint32_t status;
+
+            if (ack == SMB2_OPLOCK_LEVEL_LEASE) {
+                status = SMB2_STATUS_INVALID_PARAMETER;
+            } else if ((cur == SMB2_OPLOCK_LEVEL_EXCLUSIVE ||
+                        cur == SMB2_OPLOCK_LEVEL_BATCH) &&
+                       ack != SMB2_OPLOCK_LEVEL_II &&
+                       ack != SMB2_OPLOCK_LEVEL_NONE) {
+                status = SMB2_STATUS_INVALID_OPLOCK_PROTOCOL;
+            } else if (cur == SMB2_OPLOCK_LEVEL_II &&
+                       ack != SMB2_OPLOCK_LEVEL_NONE) {
+                status = SMB2_STATUS_INVALID_OPLOCK_PROTOCOL;
+            } else if (ack == SMB2_OPLOCK_LEVEL_II ||
+                       ack == SMB2_OPLOCK_LEVEL_NONE) {
+                status = SMB2_STATUS_INVALID_DEVICE_STATE;
+            } else {
+                status = SMB2_STATUS_INVALID_OPLOCK_PROTOCOL;
+            }
+
             chimera_smb_open_file_release(request, open_file);
-            chimera_smb_complete_request(request,
-                                         SMB2_STATUS_INVALID_OPLOCK_PROTOCOL);
+            chimera_smb_complete_request(request, status);
             return;
         }
 
-        /* MS-SMB2 3.3.5.22.1: the acknowledged OplockLevel may only be
-         * SMB2_OPLOCK_LEVEL_II or SMB2_OPLOCK_LEVEL_NONE -- a client cannot
-         * acknowledge a break by claiming a higher level (EXCLUSIVE/BATCH) or a
-         * garbage value.  The lease path's mapping silently collapses such
-         * values to 0 caching bits, but open_file->oplock_level would still be
-         * stamped with the bogus level; reject up front (#1284).  The spec's
-         * code for an oplock-acknowledgment level violation is
-         * STATUS_INVALID_OPLOCK_PROTOCOL (WPTS OplockOnShare S432), NOT the
-         * generic INVALID_PARAMETER. */
-        if (request->oplock_break.oplock_level != SMB2_OPLOCK_LEVEL_II &&
-            request->oplock_break.oplock_level != SMB2_OPLOCK_LEVEL_NONE) {
-            chimera_smb_open_file_release(request, open_file);
-            chimera_smb_complete_request(request,
-                                         SMB2_STATUS_INVALID_OPLOCK_PROTOCOL);
-            return;
-        }
-
-        /* Resolve the outstanding break with the level the client chose to
-         * keep (it may drop further than what we asked -- e.g. straight to
-         * NONE).  The lease is genuinely BREAKING here (we no longer ack
-         * optimistically), so the canonical ack applies the mode, re-arms a
-         * surviving lease, and pumps any parked acquirer. */
+        /* Breaking: complete the outstanding break with the level the client
+         * chose to keep (it may drop further than what we asked -- e.g. straight
+         * to NONE).  Only LEVEL_II retains a read cache; NONE and any
+         * higher/garbage acknowledged level collapse to no caching. */
         if (open_file->grant) {
             struct chimera_vfs_lease     *lease    = &open_file->grant->lease;
-            uint8_t                       kept_vfs = (request->oplock_break.oplock_level ==
-                                                      SMB2_OPLOCK_LEVEL_II) ?
+            uint8_t                       kept_vfs = (ack == SMB2_OPLOCK_LEVEL_II) ?
                 CHIMERA_VFS_LEASE_MODE_R : 0;
             struct chimera_vfs_lease_mode kept;
-
-            /* MS-SMB2 3.3.5.22.1: an ack is valid only while a break is
-             * outstanding (Open.OplockState == Breaking).  The legacy oplock
-             * path reports a stale/duplicate ack as STATUS_INVALID_OPLOCK_PROTOCOL
-             * (WPTS OplockOnShare S1225) -- not STATUS_UNSUCCESSFUL, which is the
-             * lease-path (3.3.5.22.2) convention -- rather than silently
-             * SUCCEEDing on a settled/revoked break (#1287). */
-            if (lease->break_state != CHIMERA_VFS_BREAK_BREAKING) {
-                chimera_smb_open_file_release(request, open_file);
-                chimera_smb_complete_request(request,
-                                             SMB2_STATUS_INVALID_OPLOCK_PROTOCOL);
-                return;
-            }
 
             /* The kept level must be a subset of what the break left the holder
              * (break_needed_mode).  A break driven by a write / namespace
@@ -713,7 +717,10 @@ chimera_smb_oplock_break(struct chimera_smb_request *request)
         }
         (void) vfs_state;
 
-        open_file->oplock_level              = request->oplock_break.oplock_level;
+        /* 3.3.5.22.1: set Open.OplockLevel to II only when the client kept a
+         * LEVEL_II read cache; otherwise the open drops to NONE. */
+        open_file->oplock_level = (ack == SMB2_OPLOCK_LEVEL_II) ?
+            SMB2_OPLOCK_LEVEL_II : SMB2_OPLOCK_LEVEL_NONE;
         open_file->oplock_break_ack_required = 0;
 
         chimera_smb_open_file_release(request, open_file);

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -4682,6 +4682,14 @@ set(SMBTORTURE_DISABLED_SUBTESTS
     smb2.ioctl.sparse_punch
     smb2.ioctl.sparse_qar_malformed
     smb2.ioctl.sparse_qar_truncated
+    # Acknowledging a LEVEL_II break (to NONE) on an open that is not Breaking:
+    # this Samba test asserts STATUS_INVALID_OPLOCK_PROTOCOL, but MS-SMB2
+    # 3.3.5.22.1 (and the MS-SMB2Model conformance suite,
+    # OplockOnShareWithForceLevel2WithoutSOFS) mandate STATUS_INVALID_DEVICE_STATE
+    # for an ack of II/NONE while not Breaking.  The two expectations are mutually
+    # exclusive; chimera follows the spec.  The test's own comment notes Windows
+    # was historically inconsistent here (NT_STATUS_OK vs OPLOCK_PROTOCOL).
+    smb2.oplock.levelii500
 )
 
 # Group the (backend-agnostic) subtest catalog by parent suite -- the first two

--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -1083,26 +1083,26 @@ OplockOnShareWithForceLevel2AndSOFSTestCaseS954,base,skip,0,env-sofs: STYPE_CLUS
 OplockOnShareWithForceLevel2AndSOFSTestCaseS988,base,skip,0,env-sofs: STYPE_CLUSTER_SOFS clustered share unsupported (standalone server)
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS0,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1006,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1041,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1041,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1075,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1141,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1178,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1211,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1211,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1245,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1279,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1314,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1314,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1332,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1357,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS136,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1387,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1421,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1455,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1455,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1491,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1539,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1578,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1616,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1653,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1688,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1688,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1722,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1741,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS1787,base,green,0,
@@ -1131,13 +1131,13 @@ OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2428,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2450,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2473,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2507,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2553,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2553,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS256,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2561,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2586,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2632,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2655,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2683,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2683,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2708,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2736,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2748,base,green,0,
@@ -1147,7 +1147,7 @@ OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2821,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2836,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2854,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2879,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2917,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2917,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS293,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2932,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS2949,base,green,0,
@@ -1166,10 +1166,10 @@ OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3232,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3270,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS328,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3291,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3296,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3311,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3326,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3341,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3296,base,green,0,
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3311,base,green,0,
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3326,base,green,0,
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3341,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3357,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3369,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS3374,base,green,0,
@@ -1192,7 +1192,7 @@ OplockOnShareWithForceLevel2WithoutSOFSTestCaseS817,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS846,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS898,base,green,0,
 OplockOnShareWithForceLevel2WithoutSOFSTestCaseS934,base,green,0,
-OplockOnShareWithForceLevel2WithoutSOFSTestCaseS972,base,xfail,0,"xfail: oplock-ack not-Breaking status (MS-SMB2 3.3.5.22.1 wants INVALID_DEVICE_STATE/INVALID_PARAMETER, server returns INVALID_OPLOCK_PROTOCOL)"
+OplockOnShareWithForceLevel2WithoutSOFSTestCaseS972,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS0,base,xfail,0,executed but fails (candidate defect)
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1033,base,green,0,
 OplockOnShareWithoutForceLevel2OrSOFSTestCaseS1063,base,xfail,0,executed but fails (candidate defect)


### PR DESCRIPTION
**Stacked on #1355** — review/merge that first. This branch is based on `oplock-break-handle-notify` (which carries the per-share FORCE_LEVELII_OPLOCK work that makes these cases applicable), so until #1355 merges the diff shows its commits too; the new change here is `smb_proc_oplock_break.c` + the two test-list edits.

## Summary

For an `OPLOCK_BREAK` acknowledgment received while the open is **not** in the Breaking state, MS-SMB2 3.3.5.22.1 selects the error from the acknowledged `OplockLevel` and the level currently held:

| condition | status |
|---|---|
| ack == `LEASE` | `INVALID_PARAMETER` |
| open EXCLUSIVE/BATCH, ack ∉ {II, NONE} | `INVALID_OPLOCK_PROTOCOL` |
| open LEVEL_II, ack ≠ NONE | `INVALID_OPLOCK_PROTOCOL` |
| ack ∈ {II, NONE} | `INVALID_DEVICE_STATE` |

chimera collapsed every not-Breaking ack to `INVALID_OPLOCK_PROTOCOL`. The handler is restructured around an explicit Breaking test: a not-Breaking ack returns the spec-selected status; the Breaking path completes the outstanding break (LEVEL_II → retained read cache, anything else → NONE). `Open.OplockLevel` is now only ever set to II or NONE, removing the bogus-level stamping the old flat checks guarded against.

Greens the **13** WPTS MS-SMB2Model `OplockOnShareWithForceLevel2WithoutSOFS` not-Breaking-acknowledgment cases (green 2054 → 2067).

## Conformance note (intentional smbtorture divergence)

This conflicts with Samba's `smb2.oplock.levelii500`, which asserts `INVALID_OPLOCK_PROTOCOL` for acking a LEVEL_II break (to NONE) on a not-Breaking open where the spec mandates `INVALID_DEVICE_STATE`. The two expectations are mutually exclusive; chimera follows the spec. `levelii500` is moved to `SMBTORTURE_DISABLED_SUBTESTS` with a comment — the test's own source notes Windows was historically inconsistent here (`NT_STATUS_OK` vs `OPLOCK_PROTOCOL`), predating the current MS-SMB2 model.

## Results
13 target cases green; `smb2.oplock`/`smb2.lease` smbtorture suites green (78, levelii500 retired); a previously-green force-level2 case (S579) and the base SMB2Model shards verified green.