### PR TITLE
smb2: support DIR::$INDEX_ALLOCATION and enforce FILE_NON_DIRECTORY_FILE

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -590,6 +590,10 @@ struct chimera_smb_request {
              * directory has no data fork, so the open path rejects this form on
              * a directory target (smb2.streams.dir). */
             uint8_t                            explicit_data_fork;
+            /* "DNAME::$INDEX_ALLOCATION" names a directory's index stream (the
+             * directory itself); valid only on a directory, so the open path
+             * rejects this form on a non-directory target (MS-FSCC 2.1.5). */
+            uint8_t                            explicit_index_fork;
             uint16_t                           stream_name_len;
             char                               stream_name[SMB_FILENAME_MAX];
             struct chimera_vfs_open_handle    *base_oh;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2298,6 +2298,32 @@ chimera_smb_create_open_at_callback(
         return;
     }
 
+    /* "DNAME::$INDEX_ALLOCATION" names a directory's index stream -- the
+     * directory itself, so it is valid only when the target really is a
+     * directory; reject it on a file (WPTS MS-FSAModel directory-index-stream
+     * cases). */
+    if (request->create.explicit_index_fork && !S_ISDIR(attr->va_mode)) {
+        chimera_smb_create_release_handle(vfs_thread, oh);
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request, SMB2_STATUS_NOT_A_DIRECTORY);
+        return;
+    }
+
+    /* FILE_NON_DIRECTORY_FILE on a target that resolved to a directory is
+     * STATUS_FILE_IS_A_DIRECTORY (MS-SMB2 3.3.5.9 / MS-FSA 2.1.5.1).  chimera
+     * only translates FILE_DIRECTORY_FILE into the VFS open, so without this an
+     * open of a directory with the non-directory option silently succeeded.
+     * Applies only when the base object itself is the target: a named-stream
+     * open ("dir:stream:$DATA") opens a data fork, so the non-directory option
+     * is about the stream, not the directory carrying it (FSA ADS-on-dir). */
+    if ((request->create.create_options & SMB2_FILE_NON_DIRECTORY_FILE) &&
+        !request->create.has_stream && S_ISDIR(attr->va_mode)) {
+        chimera_smb_create_release_handle(vfs_thread, oh);
+        chimera_smb_create_release_parent(request);
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_IS_A_DIRECTORY);
+        return;
+    }
+
     /* Named-stream open: the base file is now open; open the stream on it and
      * build the SMB open_file around the stream handle. */
     if (request->create.has_stream) {
@@ -3965,14 +3991,16 @@ chimera_smb_parse_stream_name(
     const char **r_stream,
     uint16_t    *r_stream_len,
     uint8_t     *r_has_stream,
-    uint8_t     *r_explicit_data_fork)
+    uint8_t     *r_explicit_data_fork,
+    uint8_t     *r_explicit_index_fork)
 {
     const char *colon = memchr(name, ':', name_len);
     const char *rest, *type, *colon2;
     uint16_t    base_len, rest_len, stream_len;
 
-    *r_has_stream         = 0;
-    *r_explicit_data_fork = 0;
+    *r_has_stream          = 0;
+    *r_explicit_data_fork  = 0;
+    *r_explicit_index_fork = 0;
 
     if (!colon) {
         *r_base_len = name_len;
@@ -3990,8 +4018,17 @@ chimera_smb_parse_stream_name(
         type       = colon2 + 1;
         uint16_t type_len = rest_len - stream_len - 1;
 
-        /* Only the $DATA stream type is supported. */
-        if (type_len != 5 || strncasecmp(type, "$DATA", 5) != 0) {
+        /* $DATA names a data fork; $INDEX_ALLOCATION (only as the bare
+         * "::$INDEX_ALLOCATION" form) names a directory's index stream -- i.e.
+         * the directory itself.  Every other stream type is unsupported. */
+        if (type_len == 5 && strncasecmp(type, "$DATA", 5) == 0) {
+            /* data fork -- falls through to the stream-name handling below */
+        } else if (type_len == 17 && stream_len == 0 &&
+                   strncasecmp(type, "$INDEX_ALLOCATION", 17) == 0) {
+            *r_base_len            = base_len;
+            *r_explicit_index_fork = 1;
+            return SMB2_STATUS_SUCCESS;
+        } else {
             return SMB2_STATUS_OBJECT_NAME_INVALID;
         }
     } else {
@@ -4224,9 +4261,10 @@ chimera_smb_create(struct chimera_smb_request *request)
     enum chimera_smb_pipe_magic   pipe_magic;
     chimera_smb_pipe_transceive_t transceive;
 
-    request->create.has_stream         = 0;
-    request->create.explicit_data_fork = 0;
-    request->create.base_oh            = NULL;
+    request->create.has_stream          = 0;
+    request->create.explicit_data_fork  = 0;
+    request->create.explicit_index_fork = 0;
+    request->create.base_oh             = NULL;
     /* Only the regular-file open path (open_at_callback) registers a finish
      * callback and may park on a batch-oplock break; clear it so the mkdir /
      * stream / pipe paths never inherit a stale callback and park. */
@@ -4260,23 +4298,28 @@ chimera_smb_create(struct chimera_smb_request *request)
             return;
         }
 
-        const char *sname              = NULL;
-        uint16_t    base_len           = request->create.name_len;
-        uint16_t    sname_len          = 0;
-        uint8_t     has_stream         = 0;
-        uint8_t     explicit_data_fork = 0;
-        uint32_t    pstatus            = chimera_smb_parse_stream_name(
+        const char *sname               = NULL;
+        uint16_t    base_len            = request->create.name_len;
+        uint16_t    sname_len           = 0;
+        uint8_t     has_stream          = 0;
+        uint8_t     explicit_data_fork  = 0;
+        uint8_t     explicit_index_fork = 0;
+        uint32_t    pstatus             = chimera_smb_parse_stream_name(
             request->create.name, request->create.name_len,
-            &base_len, &sname, &sname_len, &has_stream, &explicit_data_fork);
+            &base_len, &sname, &sname_len, &has_stream, &explicit_data_fork,
+            &explicit_index_fork);
 
         if (pstatus != SMB2_STATUS_SUCCESS) {
             chimera_smb_complete_request(request, pstatus);
             return;
         }
 
-        /* "DNAME::$DATA" names the default data fork explicitly; remember it so
-         * the open-completion path can reject it on a directory target. */
-        request->create.explicit_data_fork = explicit_data_fork;
+        /* "DNAME::$DATA" names the default data fork explicitly; "DNAME::
+         * $INDEX_ALLOCATION" names a directory's index stream.  Remember which
+         * so the open-completion path can reject the data form on a directory
+         * and the index form on a non-directory. */
+        request->create.explicit_data_fork  = explicit_data_fork;
+        request->create.explicit_index_fork = explicit_index_fork;
 
         /* A wildcard/invalid character in the BASE file name of a stream path
          * is rejected with OBJECT_NAME_INVALID (smb2.streams.names "stream*").

--- a/src/server/smb/tests/wpts/fsamodel_cases.csv
+++ b/src/server/smb/tests/wpts/fsamodel_cases.csv
@@ -1,10 +1,10 @@
 case,status,skip_reason
 ChangeNotificationTestCaseS0,skip,inapplicable: model branch not executed
-ChangeNotificationTestCaseS2,xfail,fidelity: expected SUCCESS got OBJECT_NAME_INVALID
+ChangeNotificationTestCaseS2,green,
 CloseFileTestCaseS0,green,
 CreateFileTestCaseS0,green,
 CreateFileTestCaseS10,green,
-CreateFileTestCaseS12,xfail,fidelity: expected INVALID_PARAMETER got OBJECT_NAME_INVALID
+CreateFileTestCaseS12,green,
 CreateFileTestCaseS14,skip,inapplicable: model branch not executed
 CreateFileTestCaseS16,skip,inapplicable: model branch not executed
 CreateFileTestCaseS18,xfail,fidelity: expected INVALID_PARAMETER got ACCESS_DENIED
@@ -17,11 +17,11 @@ CreateFileTestCaseS28,skip,inapplicable: model branch not executed
 CreateFileTestCaseS30,skip,inapplicable: model branch not executed
 CreateFileTestCaseS32,xfail,fidelity: expected OBJECT_NAME_INVALID got 3221225734
 CreateFileTestCaseS34,xfail,fidelity: expected OBJECT_NAME_INVALID got OBJECT_PATH_NOT_FOUND
-CreateFileTestCaseS38,xfail,fidelity: expected OBJECT_NAME_NOT_FOUND got OBJECT_NAME_INVALID
-CreateFileTestCaseS4,xfail,fidelity: no parameter validation
-CreateFileTestCaseS40,xfail,fidelity: expected OBJECT_NAME_NOT_FOUND got OBJECT_NAME_INVALID
+CreateFileTestCaseS38,green,
+CreateFileTestCaseS4,green,
+CreateFileTestCaseS40,green,
 CreateFileTestCaseS42,skip,unimplemented: symlink reparse fixture
-CreateFileTestCaseS44,xfail,fidelity: expected IS_A_DIRECTORY got SUCCESS
+CreateFileTestCaseS44,green,
 CreateFileTestCaseS46,xfail,fidelity: no parameter validation
 CreateFileTestCaseS48,xfail,fidelity: expected CANNOT_DELETE got OBJECT_NAME_INVALID
 CreateFileTestCaseS50,green,
@@ -102,12 +102,12 @@ IoCtlRequestTestCaseS98,skip,inapplicable: model branch not executed
 LockAndUnlockTestCaseS0,xfail,fidelity: expected SUCCESS got OBJECT_NAME_INVALID
 LockAndUnlockTestCaseS2,green,
 OpenFileTestCaseS0,green,
-OpenFileTestCaseS10,xfail,fidelity: no parameter validation
+OpenFileTestCaseS10,green,
 OpenFileTestCaseS12,skip,inapplicable: model branch not executed
 OpenFileTestCaseS14,skip,inapplicable: model branch not executed
 OpenFileTestCaseS16,xfail,fidelity: expected INVALID_PARAMETER got ACCESS_DENIED
 OpenFileTestCaseS18,skip,inapplicable: model branch not executed
-OpenFileTestCaseS2,xfail,fidelity: no parameter validation
+OpenFileTestCaseS2,green,
 OpenFileTestCaseS20,green,
 OpenFileTestCaseS22,green,
 OpenFileTestCaseS24,green,

--- a/src/vfs/smb/smb_ops.c
+++ b/src/vfs/smb/smb_ops.c
@@ -584,7 +584,12 @@ chimera_smb_client_open_at(
 {
     uint32_t       disposition;
     uint32_t       desired_access;
-    uint32_t       options = SMB2_FILE_NON_DIRECTORY_FILE;
+    /* A directory open must request FILE_DIRECTORY_FILE; only a non-directory
+     * open may set FILE_NON_DIRECTORY_FILE.  The server now enforces the option
+     * against the target type (FILE_IS_A_DIRECTORY otherwise), so a directory
+     * open that left NON_DIRECTORY_FILE set would be refused. */
+    uint32_t       options = (request->open_at.flags & CHIMERA_VFS_OPEN_DIRECTORY)
+                             ? SMB2_FILE_DIRECTORY_FILE : SMB2_FILE_NON_DIRECTORY_FILE;
     uint8_t        lease_ctx[CHIMERA_SMB_LEASE_CTX_SIZE];
     uint8_t        lease_key[16];
     const uint8_t *ctx     = NULL;


### PR DESCRIPTION
## Summary

Two related directory-vs-file gaps in the SMB2 create path, surfaced by the WPTS
MS-FSAModel CreateFile / OpenFile / ChangeNotification cases:

- **`DNAME::$INDEX_ALLOCATION`** names a directory's index stream — i.e. the
  directory itself (MS-FSCC 2.1.5). The stream-name parser only accepted the
  `$DATA` stream type and rejected this with `OBJECT_NAME_INVALID`. Accept the
  bare `::$INDEX_ALLOCATION` form (it opens the base object as a directory) and,
  mirroring the existing `::$DATA` handling, reject it on a non-directory target
  with `STATUS_NOT_A_DIRECTORY`.

- **`FILE_NON_DIRECTORY_FILE`** on a target that resolved to a directory must
  fail with `STATUS_FILE_IS_A_DIRECTORY` (MS-SMB2 3.3.5.9 / MS-FSA 2.1.5.1).
  chimera only translated `FILE_DIRECTORY_FILE` into the VFS open, so a
  non-directory open of a directory silently succeeded. The check applies only
  when the base object itself is the target — a named-stream open
  (`dir:stream:$DATA`) opens a data fork, so the option is about the stream, not
  the directory carrying it (this gate keeps the FSA AlternateDataStream-on-
  directory cases green).

## Result

Greens **8 WPTS MS-FSAModel** cases (ChangeNotification S2, CreateFile
S4/S12/S38/S40/S44, OpenFile S2/S10) — FSAModel green 146 → 154.

Verified: MS-FSAModel green 154/154, MS-FSA green 185/185, smbtorture
`smb2.{create,streams,lock,oplock,durable}` green, and the FSA
AlternateDataStream-on-directory cases stay green (the gate that prevents the
non-directory check from firing on a stream open).