### PR TITLE
vfs/smb2: directory-rename handle recall breaks only the handle bit (clears handle-lease-break cluster)

### DIFF
--- a/src/server/smb/tests/wpts/smb2model_cases.csv
+++ b/src/server/smb/tests/wpts/smb2model_cases.csv
@@ -277,9 +277,9 @@ BreakReadWriteHandleLeaseV1TestCaseS1763,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS1807,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS184,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS1856,base,green,0,
-BreakReadWriteHandleLeaseV1TestCaseS1896,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV1TestCaseS1936,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV1TestCaseS1972,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
+BreakReadWriteHandleLeaseV1TestCaseS1896,base,green,0,
+BreakReadWriteHandleLeaseV1TestCaseS1936,base,green,0,
+BreakReadWriteHandleLeaseV1TestCaseS1972,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2008,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2036,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2068,base,green,0,
@@ -302,10 +302,10 @@ BreakReadWriteHandleLeaseV1TestCaseS2624,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2656,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2692,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2728,base,green,0,
-BreakReadWriteHandleLeaseV1TestCaseS2768,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV1TestCaseS2792,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
+BreakReadWriteHandleLeaseV1TestCaseS2768,base,green,0,
+BreakReadWriteHandleLeaseV1TestCaseS2792,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS280,base,green,0,
-BreakReadWriteHandleLeaseV1TestCaseS2828,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
+BreakReadWriteHandleLeaseV1TestCaseS2828,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2868,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2900,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS2916,base,green,0,
@@ -329,9 +329,9 @@ BreakReadWriteHandleLeaseV1TestCaseS3504,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS3536,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS3572,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS3608,base,green,0,
-BreakReadWriteHandleLeaseV1TestCaseS3640,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV1TestCaseS3676,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV1TestCaseS3712,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
+BreakReadWriteHandleLeaseV1TestCaseS3640,base,green,0,
+BreakReadWriteHandleLeaseV1TestCaseS3676,base,green,0,
+BreakReadWriteHandleLeaseV1TestCaseS3712,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS3752,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS3780,base,green,0,
 BreakReadWriteHandleLeaseV1TestCaseS3812,base,green,0,
@@ -364,10 +364,10 @@ BreakReadWriteHandleLeaseV2TestCaseS1140,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1183,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1222,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1258,base,green,0,
-BreakReadWriteHandleLeaseV2TestCaseS1298,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
+BreakReadWriteHandleLeaseV2TestCaseS1298,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS130,base,green,0,
-BreakReadWriteHandleLeaseV2TestCaseS1338,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV2TestCaseS1366,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
+BreakReadWriteHandleLeaseV2TestCaseS1338,base,green,0,
+BreakReadWriteHandleLeaseV2TestCaseS1366,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1393,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1410,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1427,base,green,0,
@@ -395,9 +395,9 @@ BreakReadWriteHandleLeaseV2TestCaseS1842,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1866,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1875,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1892,base,green,0,
-BreakReadWriteHandleLeaseV2TestCaseS1901,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV2TestCaseS1922,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
-BreakReadWriteHandleLeaseV2TestCaseS1943,base,xfail,0,xfail: parent-dir-rename handle-break (RWH->RW): server breaks W (RWH->RH) not H
+BreakReadWriteHandleLeaseV2TestCaseS1901,base,green,0,
+BreakReadWriteHandleLeaseV2TestCaseS1922,base,green,0,
+BreakReadWriteHandleLeaseV2TestCaseS1943,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS195,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1964,base,green,0,
 BreakReadWriteHandleLeaseV2TestCaseS1973,base,green,0,

--- a/src/vfs/vfs_proc_recall.c
+++ b/src/vfs/vfs_proc_recall.c
@@ -98,14 +98,17 @@ chimera_vfs_recall_caching_fh_complete(struct chimera_vfs_request *request)
 } /* chimera_vfs_recall_caching_fh_complete */
 
 /* Single-step recall of EVERY caching lease on the file named by a bare FH
- * (no open handle, so nothing is spared), breaking each holder's handle cache
- * once (RH -> R) and PARKing until the recall drains, then report whether a
- * holder kept the file open.  A well-behaved holder closes on the handle-lease
- * break (freeing its share reservation); a holder that only acks keeps the file
- * open at R.  Used by the SMB directory-rename path to break the handle leases
- * of files open inside a directory being renamed (MS-SMB2 / Windows: a
- * directory rename breaks the handle lease of each contained open and proceeds
- * only once every holder has released). */
+ * (no open handle, so nothing is spared), breaking each holder's HANDLE cache
+ * once -- and ONLY the handle cache (RWH -> RW, RH -> R) -- then PARKing until
+ * the recall drains and reporting whether a holder kept the file open.  A
+ * directory rename invalidates only the cached path/handle of a contained open,
+ * not its data: per MS-SMB2 3.3.4.7 / [MS-FSA] 2.1.5.1.2 the handle-caching bit
+ * is revoked while read+write caching is retained, so the retain floor is R|W
+ * (a single RWH->RW break, NOT a RWH->RH->R cascade that would strip the write
+ * cache first).  A well-behaved holder closes on the handle-lease break (freeing
+ * its share reservation); a holder that only acks keeps the file open.  Used by
+ * the SMB directory-rename path to break the handle leases of files open inside
+ * a directory being renamed. */
 SYMBOL_EXPORT void
 chimera_vfs_recall_caching_fh(
     struct chimera_vfs_thread       *thread,
@@ -131,6 +134,6 @@ chimera_vfs_recall_caching_fh(
     request->proto_private_data = private_data;
 
     chimera_vfs_io_recall_single(request, fh, fh_len, request->fh_hash,
-                                 CHIMERA_VFS_LEASE_MODE_R,
+                                 CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W,
                                  chimera_vfs_recall_caching_fh_complete);
 } /* chimera_vfs_recall_caching_fh */


### PR DESCRIPTION
**Stacked on #1362** — review/merge that first. Until #1362 merges the diff shows both commits; the new change here is `vfs_proc_recall.c` + the 15-row CSV reclassification.

## Summary

Completes the WPTS MS-SMB2Model `BreakRead{,Write}HandleLease` cluster: greens the final **15** cases (all `BreakReadWriteHandleLease` driven by `PARENT_DIR_RENAMED`), bringing the cluster from 47/62 (#1362) to **62/62**. smb2model green 2114 → 2129.

## Problem

The SMB directory-rename path recalls each contained open's caching lease via `chimera_vfs_recall_caching_fh`, which used a retain floor of **R**. For an RWH holder that cascades `RWH → RH → R` — stripping the **write** cache first and emitting an `RWH → RH` notification. But MS-SMB2 3.3.4.7 / [MS-FSA] 2.1.5.1.2 say a directory rename invalidates only the cached **path/handle** of a contained open, not its data: the handle bit is revoked while read+write caching is retained (`RWH → RW`).

## Fix

Raise the recall floor to **R|W** so `break_step` strips exactly the H bit — a single `RWH → RW` (and `RH → R`) break, no W-first cascade. `chimera_vfs_recall_caching_fh` is used only by the directory-rename path, so the change is scoped to it.

## Diagnosis note

Confirmed with instrumentation: the contained-child recall *was* firing, but `begin_break(floor=R)` cascaded W→H, so the first notification was `RWH→RH`, which the model rejects (it wants `RWH→RW` or `RWH→NONE`).

## Out of scope (still xfail)

The 3 `BreakReadHandleLeaseV1` "ack on an already-settled break → STATUS_UNSUCCESSFUL" cases are a distinct duplicate-ack-semantics issue (touching code that guards smbtorture `lease.v2_complex2`); left xfail. The MS-SMB2 `DirectoryLeasing_*` siblings are a separate **directory**-lease (not file-lease) area.

## Results
- 62/62 `BreakRead*HandleLease` green (verified isolated + batched).
- No regression: smbtorture `smb2.rename`/`smb2.lease`/`smb2.dirlease`/`smb2.oplock`/`smb2.durable*` (145/145 memfs); base SMB2Model shards green.