### PR TITLE
vfs: inode-scoped remove for delete-on-close (chimera_vfs_remove_at_match_fh)

### DIFF
--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -171,6 +171,13 @@ struct chimera_smb_durable_doc {
     struct chimera_vfs_thread      *vfs_thread;
     struct chimera_vfs_doc_info     doc_info;
     struct chimera_vfs_open_handle *parent_handle;
+    /* FH of the file this delete-on-close targets, so the async remove only
+     * unlinks the name while it still resolves to THIS object -- not a fresh
+     * file another opener created with the same name in the meantime (the
+     * grace-timer reap of a DELETE_ON_CLOSE handle can land arbitrarily late
+     * under load). */
+    uint8_t                         file_fh[CHIMERA_VFS_FH_SIZE];
+    int                             file_fh_len;
 };
 
 static void
@@ -209,10 +216,11 @@ chimera_smb_durable_doc_open_parent_cb(
         return;
     }
     ctx->parent_handle = oh;
-    chimera_vfs_remove_at(ctx->vfs_thread, &ctx->doc_info.cred, oh,
-                          ctx->doc_info.name, ctx->doc_info.name_len, NULL, 0, 0, 0,
-                          NULL, /* parent_lease_skip */
-                          chimera_smb_durable_doc_remove_cb, ctx);
+    chimera_vfs_remove_at_match_fh(ctx->vfs_thread, &ctx->doc_info.cred, oh,
+                                   ctx->doc_info.name, ctx->doc_info.name_len,
+                                   ctx->file_fh, ctx->file_fh_len, 0, 0,
+                                   NULL, /* parent_lease_skip */
+                                   chimera_smb_durable_doc_remove_cb, ctx);
 } /* chimera_smb_durable_doc_open_parent_cb */
 
 /*
@@ -228,11 +236,18 @@ chimera_smb_durable_release_handle(
 {
     struct chimera_smb_durable_doc *ctx;
     struct chimera_vfs_doc_info     doc_info;
+    uint8_t                         file_fh[CHIMERA_VFS_FH_SIZE];
+    int                             file_fh_len;
     int                             need_doc;
 
     if (!open_file->handle) {
         return;
     }
+
+    /* Capture the target file's FH before release_doc clears the handle, so the
+     * async unlink below is inode-scoped (see struct chimera_smb_durable_doc). */
+    file_fh_len = open_file->handle->fh_len;
+    memcpy(file_fh, open_file->handle->fh, file_fh_len);
 
     need_doc          = chimera_vfs_release_doc(thread->vfs_thread, open_file->handle, &doc_info);
     open_file->handle = NULL;
@@ -245,6 +260,8 @@ chimera_smb_durable_release_handle(
     ctx->vfs_thread    = thread->vfs_thread;
     ctx->doc_info      = doc_info;
     ctx->parent_handle = NULL;
+    ctx->file_fh_len   = file_fh_len;
+    memcpy(ctx->file_fh, file_fh, file_fh_len);
 
     chimera_vfs_open_fh(thread->vfs_thread, &ctx->doc_info.cred,
                         ctx->doc_info.parent_fh, ctx->doc_info.parent_fh_len,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2516,6 +2516,32 @@ memfs_remove_at(
         return;
     }
 
+    /* Inode-scoped removal (request->remove_at.match_child_fh): only unlink the
+     * name while it STILL resolves to the caller's object.  Guards an async
+     * delete-on-close against a file that was removed and re-created with the
+     * same name by another opener in the meantime -- removing the replacement
+     * would destroy an unrelated file.  The original is already gone, so report
+     * success and leave the new entry intact.  Gated on the flag so every
+     * ordinary by-name caller is unaffected. */
+    if (request->remove_at.match_child_fh &&
+        request->remove_at.child_fh && request->remove_at.child_fh_len > 0) {
+        uint64_t want_inum;
+        uint32_t want_gen;
+
+        memfs_fh_to_inum(&want_inum, &want_gen,
+                         request->remove_at.child_fh,
+                         request->remove_at.child_fh_len);
+
+        if (want_inum != dirent->inum || want_gen != dirent->gen) {
+            pthread_mutex_unlock(&inode->lock);
+            pthread_mutex_unlock(&parent_inode->lock);
+            request->remove_at.r_unmatched = 1;
+            request->status                = CHIMERA_VFS_OK;
+            request->complete(request);
+            return;
+        }
+    }
+
     if (S_ISDIR(inode->mode) && !rb_tree_empty(&inode->dir.dirents)) {
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&inode->lock);

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -48,6 +48,10 @@ add_executable(vfs_clone_range_test vfs_clone_range_test.c)
 target_link_libraries(vfs_clone_range_test chimera_vfs chimera_vfs_memfs evpl)
 add_test(chimera/vfs/clone_range_test vfs_clone_range_test)
 
+add_executable(vfs_inode_scoped_remove_test vfs_inode_scoped_remove_test.c)
+target_link_libraries(vfs_inode_scoped_remove_test chimera_vfs chimera_vfs_memfs evpl)
+add_test(chimera/vfs/inode_scoped_remove_test vfs_inode_scoped_remove_test)
+
 add_executable(vfs_idmap_test vfs_idmap_test.c)
 target_link_libraries(vfs_idmap_test chimera_vfs)
 add_test(chimera/vfs/idmap_test vfs_idmap_test)

--- a/src/vfs/tests/vfs_inode_scoped_remove_test.c
+++ b/src/vfs/tests/vfs_inode_scoped_remove_test.c
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Inode-scoped remove (chimera_vfs_remove_at_match_fh): the unlink must only
+ * take effect while the name STILL resolves to the caller-supplied child FH.
+ * This guards an asynchronous delete-on-close against a file that was removed
+ * and re-created with the SAME name by another opener in the meantime -- the
+ * replacement must NOT be destroyed.  Drives memfs directly.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/vfs_attrs.h"
+#include "vfs/vfs_cred.h"
+#include "vfs/vfs_error.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+struct test_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *vfs_thread;
+    struct evpl                    *evpl;
+    struct chimera_vfs_open_handle *handle;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh_len;
+};
+
+static void
+wait_done(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_done */
+
+static void
+mount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, attr->va_fh, attr->va_fh_len);
+        ctx->fh_len = attr->va_fh_len;
+    }
+    ctx->done = 1;
+} /* lookup_cb */
+
+static void
+openfh_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openfh_cb */
+
+static void
+openat_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre,
+    struct chimera_vfs_attrs       *dir_post,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, oh->fh, oh->fh_len);
+        ctx->fh_len = oh->fh_len;
+    }
+    ctx->done = 1;
+} /* openat_cb */
+
+static void
+remove_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* remove_cb */
+
+/* Create `name` under `dir`; capture the new file's FH in ctx->fh and return
+ * (and keep) the open handle. */
+static struct chimera_vfs_open_handle *
+create_file(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *dir,
+    const char                     *name)
+{
+    struct chimera_vfs_attrs sattr;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
+    sattr.va_mode     = 0644;
+
+    chimera_vfs_open_at(ctx->vfs_thread, cred, dir, name, strlen(name),
+                        CHIMERA_VFS_OPEN_CREATE, &sattr, CHIMERA_VFS_ATTR_FH,
+                        0, 0, openat_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    return ctx->handle;
+} /* create_file */
+
+static struct chimera_vfs_open_handle *
+open_fh(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *fh,
+    uint32_t                       fh_len)
+{
+    chimera_vfs_open_fh(ctx->vfs_thread, cred, fh, fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    return ctx->handle;
+} /* open_fh */
+
+/* Look up `name` under `dir`; return the status (and the FH in ctx->fh on OK). */
+static enum chimera_vfs_error
+do_lookup(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *dir,
+    const char                     *name)
+{
+    chimera_vfs_lookup(ctx->vfs_thread, cred, dir->fh, dir->fh_len,
+                       name, strlen(name),
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, ctx);
+    wait_done(ctx);
+    return ctx->status;
+} /* do_lookup */
+
+static enum chimera_vfs_error
+do_remove(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *dir,
+    const char                     *name)
+{
+    chimera_vfs_remove_at(ctx->vfs_thread, cred, dir, name, strlen(name),
+                          NULL, 0, 0, 0, NULL, remove_cb, ctx);
+    wait_done(ctx);
+    return ctx->status;
+} /* do_remove */
+
+static enum chimera_vfs_error
+do_remove_match(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *dir,
+    const char                     *name,
+    const uint8_t                  *child_fh,
+    uint32_t                        child_fh_len)
+{
+    chimera_vfs_remove_at_match_fh(ctx->vfs_thread, cred, dir, name, strlen(name),
+                                   child_fh, child_fh_len, 0, 0, NULL,
+                                   remove_cb, ctx);
+    wait_done(ctx);
+    return ctx->status;
+} /* do_remove_match */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_ctx                 ctx = { 0 };
+    struct chimera_vfs_module_cfg   module_cfgs[2];
+    struct prometheus_metrics      *metrics;
+    struct chimera_vfs_cred         cred;
+    uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        root_fh_len;
+    uint8_t                         fh1[CHIMERA_VFS_FH_SIZE], fh2[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh1_len, fh2_len;
+    struct chimera_vfs_open_handle *root_handle, *h1, *h2;
+
+    chimera_log_init();
+    chimera_vfs_cred_init_unix(&cred, 0, 0, 0, NULL);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    strncpy(module_cfgs[0].module_name, "memfs", sizeof(module_cfgs[0].module_name) - 1);
+    strncpy(module_cfgs[1].module_name, "memkv", sizeof(module_cfgs[1].module_name) - 1);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 1, 0, metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", "memfs", "/", NULL,
+                      mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
+    chimera_vfs_lookup(ctx.vfs_thread, &cred, root_fh, root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    memcpy(root_fh, ctx.fh, ctx.fh_len);
+    root_fh_len = ctx.fh_len;
+
+    root_handle = open_fh(&ctx, &cred, root_fh, root_fh_len);
+
+    /* Create "foo" -> inode #1, capture its FH, then unlink the name. */
+    h1      = create_file(&ctx, &cred, root_handle, "foo");
+    fh1_len = ctx.fh_len;
+    memcpy(fh1, ctx.fh, fh1_len);
+    assert(do_remove(&ctx, &cred, root_handle, "foo") == CHIMERA_VFS_OK);
+
+    /* Re-create "foo" -> inode #2 (same name, different object). */
+    h2      = create_file(&ctx, &cred, root_handle, "foo");
+    fh2_len = ctx.fh_len;
+    memcpy(fh2, ctx.fh, fh2_len);
+    assert(!(fh1_len == fh2_len && memcmp(fh1, fh2, fh1_len) == 0));
+    TEST_PASS("recreate yields a distinct FH");
+
+    /* Inode-scoped remove targeting the STALE inode #1 must be a no-op: the
+     * name now resolves to inode #2, which must survive. */
+    assert(do_remove_match(&ctx, &cred, root_handle, "foo", fh1, fh1_len) ==
+           CHIMERA_VFS_OK);
+    assert(do_lookup(&ctx, &cred, root_handle, "foo") == CHIMERA_VFS_OK);
+    assert(ctx.fh_len == fh2_len && memcmp(ctx.fh, fh2, fh2_len) == 0);
+    TEST_PASS("match_fh against a stale FH leaves the recreated file intact");
+
+    /* Inode-scoped remove targeting the CURRENT inode #2 unlinks it. */
+    assert(do_remove_match(&ctx, &cred, root_handle, "foo", fh2, fh2_len) ==
+           CHIMERA_VFS_OK);
+    assert(do_lookup(&ctx, &cred, root_handle, "foo") == CHIMERA_VFS_ENOENT);
+    TEST_PASS("match_fh against the current FH unlinks the file");
+
+    /* Release the open handles (both inodes are now unlinked) and tear the
+     * module down so the allocator does not flag leaked references. */
+    chimera_vfs_release(ctx.vfs_thread, h1);
+    chimera_vfs_release(ctx.vfs_thread, h2);
+    chimera_vfs_release(ctx.vfs_thread, root_handle);
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+
+    fprintf(stderr, "vfs_inode_scoped_remove_test: ALL PASS\n");
+    return 0;
+} /* main */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -844,6 +844,19 @@ struct chimera_vfs_request {
             uint64_t                        name_hash;
             const uint8_t                  *child_fh;     /* Optional: child FH if known */
             int                             child_fh_len; /* 0 if child_fh not provided */
+            /* Inode-scoped removal: when set (with child_fh), the backend MUST
+             * only unlink the name while it still resolves to child_fh -- if the
+             * original object was removed and a new one created with the same
+             * name, the name is left intact.  Used by delete-on-close so an
+             * async unlink cannot destroy an unrelated file another opener
+             * created at the same path.  Default 0 = unconditional by-name
+             * remove (every existing caller's behaviour is unchanged). */
+            uint8_t                         match_child_fh;
+            /* Backend-set: the match_child_fh guard found the name resolving to
+             * a different object and left it intact, so NO unlink happened.
+             * The op still completes OK, but the post-removal bookkeeping
+             * (negative name-cache entry, FILE_REMOVED notify) must be skipped. */
+            uint8_t                         r_unmatched;
             /* SMB3 directory-lease self-exemption (see link_at): spare the dir
              * lease named by the deleting open's ParentLeaseKey from the
              * FILE_REMOVED break on the parent.  NULL caller = break all. */

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -23,7 +23,7 @@ chimera_vfs_remove_at_complete(struct chimera_vfs_request *request)
     struct chimera_vfs_name_cache   *name_cache = thread->vfs->vfs_name_cache;
     chimera_vfs_remove_at_callback_t callback   = request->proto_callback;
 
-    if (request->status == CHIMERA_VFS_OK) {
+    if (request->status == CHIMERA_VFS_OK && !request->remove_at.r_unmatched) {
         /* Pick FILE_REMOVED vs DIR_REMOVED based on the removed
          * object's mode.  Clients filtering only SMB2_NOTIFY_CHANGE_DIR_NAME
          * would otherwise miss rmdir entirely, since the SMB
@@ -128,6 +128,7 @@ chimera_vfs_remove_at_dispatch(
     int                              namelen,
     const uint8_t                   *child_fh,
     int                              child_fh_len,
+    int                              match_child_fh,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,
@@ -143,14 +144,16 @@ chimera_vfs_remove_at_dispatch(
         return;
     }
 
-    request->opcode                 = CHIMERA_VFS_OP_REMOVE_AT;
-    request->complete               = chimera_vfs_remove_at_complete;
-    request->remove_at.handle       = handle;
-    request->remove_at.name         = name;
-    request->remove_at.namelen      = namelen;
-    request->remove_at.name_hash    = chimera_vfs_hash(name, namelen);
-    request->remove_at.child_fh     = child_fh;
-    request->remove_at.child_fh_len = child_fh_len;
+    request->opcode                   = CHIMERA_VFS_OP_REMOVE_AT;
+    request->complete                 = chimera_vfs_remove_at_complete;
+    request->remove_at.handle         = handle;
+    request->remove_at.name           = name;
+    request->remove_at.namelen        = namelen;
+    request->remove_at.name_hash      = chimera_vfs_hash(name, namelen);
+    request->remove_at.child_fh       = child_fh;
+    request->remove_at.child_fh_len   = child_fh_len;
+    request->remove_at.match_child_fh = match_child_fh ? 1 : 0;
+    request->remove_at.r_unmatched    = 0;
     if (parent_lease_skip) {
         memcpy(request->remove_at.parent_lease_skip, parent_lease_skip, 16);
         request->remove_at.parent_lease_skip_valid = 1;
@@ -190,6 +193,7 @@ struct chimera_vfs_remove_at_gate {
     int                              namelen;
     const uint8_t                   *child_fh;
     int                              child_fh_len;
+    int                              match_child_fh;
     uint64_t                         pre_attr_mask;
     uint64_t                         post_attr_mask;
     uint8_t                          parent_lease_skip[16];
@@ -213,7 +217,8 @@ chimera_vfs_remove_at_gate_complete(
 
     chimera_vfs_remove_at_dispatch(gate->thread, gate->cred, gate->handle,
                                    gate->name, gate->namelen, gate->child_fh,
-                                   gate->child_fh_len, gate->pre_attr_mask,
+                                   gate->child_fh_len, gate->match_child_fh,
+                                   gate->pre_attr_mask,
                                    gate->post_attr_mask,
                                    gate->parent_lease_skip_valid ?
                                    gate->parent_lease_skip : NULL,
@@ -222,8 +227,8 @@ chimera_vfs_remove_at_gate_complete(
     free(gate);
 } /* chimera_vfs_remove_at_gate_complete */
 
-SYMBOL_EXPORT void
-chimera_vfs_remove_at(
+static void
+chimera_vfs_remove_at_common(
     struct chimera_vfs_thread       *thread,
     const struct chimera_vfs_cred   *cred,
     struct chimera_vfs_open_handle  *handle,
@@ -231,6 +236,7 @@ chimera_vfs_remove_at(
     int                              namelen,
     const uint8_t                   *child_fh,
     int                              child_fh_len,
+    int                              match_child_fh,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,
@@ -264,6 +270,7 @@ chimera_vfs_remove_at(
         gate->namelen        = namelen;
         gate->child_fh       = child_fh;
         gate->child_fh_len   = child_fh_len;
+        gate->match_child_fh = match_child_fh;
         gate->pre_attr_mask  = pre_attr_mask;
         gate->post_attr_mask = post_attr_mask;
         if (parent_lease_skip) {
@@ -291,7 +298,60 @@ chimera_vfs_remove_at(
     }
 
     chimera_vfs_remove_at_dispatch(thread, cred, handle, name, namelen,
-                                   child_fh, child_fh_len, pre_attr_mask,
+                                   child_fh, child_fh_len, match_child_fh,
+                                   pre_attr_mask,
                                    post_attr_mask, parent_lease_skip,
                                    callback, private_data);
+} /* chimera_vfs_remove_at_common */
+
+/* Remove a name in a directory (unconditional by-name unlink).  child_fh, when
+ * supplied, is used for delegation/oplock recall and change-notify, NOT to guard
+ * the unlink. */
+SYMBOL_EXPORT void
+chimera_vfs_remove_at(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    const char                      *name,
+    int                              namelen,
+    const uint8_t                   *child_fh,
+    int                              child_fh_len,
+    uint64_t                         pre_attr_mask,
+    uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
+    chimera_vfs_remove_at_callback_t callback,
+    void                            *private_data)
+{
+    chimera_vfs_remove_at_common(thread, cred, handle, name, namelen,
+                                 child_fh, child_fh_len, 0 /* match_child_fh */,
+                                 pre_attr_mask, post_attr_mask, parent_lease_skip,
+                                 callback, private_data);
 } /* chimera_vfs_remove_at */
+
+/* Inode-scoped variant: only unlink the name while it STILL resolves to
+ * child_fh.  If the original object was removed and a different one created at
+ * the same name in the meantime, the name is left intact and the callback
+ * reports success (the caller's object is already gone).  Used by delete-on-
+ * close so an async unlink cannot destroy an unrelated file (see
+ * remove_at.match_child_fh).  Requires child_fh; a backend that does not honor
+ * the flag falls back to an unconditional remove. */
+SYMBOL_EXPORT void
+chimera_vfs_remove_at_match_fh(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    const char                      *name,
+    int                              namelen,
+    const uint8_t                   *child_fh,
+    int                              child_fh_len,
+    uint64_t                         pre_attr_mask,
+    uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
+    chimera_vfs_remove_at_callback_t callback,
+    void                            *private_data)
+{
+    chimera_vfs_remove_at_common(thread, cred, handle, name, namelen,
+                                 child_fh, child_fh_len, 1 /* match_child_fh */,
+                                 pre_attr_mask, post_attr_mask, parent_lease_skip,
+                                 callback, private_data);
+} /* chimera_vfs_remove_at_match_fh */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -476,6 +476,23 @@ chimera_vfs_remove_at(
     chimera_vfs_remove_at_callback_t callback,
     void                            *private_data);
 
+/* Inode-scoped remove (only unlinks the name while it still resolves to
+ * child_fh).  Same signature as chimera_vfs_remove_at; see its definition. */
+void
+chimera_vfs_remove_at_match_fh(
+    struct chimera_vfs_thread       *thread,
+    const struct chimera_vfs_cred   *cred,
+    struct chimera_vfs_open_handle  *handle,
+    const char                      *name,
+    int                              namelen,
+    const uint8_t                   *child_fh,
+    int                              child_fh_len,
+    uint64_t                         pre_attr_mask,
+    uint64_t                         post_attr_mask,
+    const uint8_t                   *parent_lease_skip,
+    chimera_vfs_remove_at_callback_t callback,
+    void                            *private_data);
+
 typedef void (*chimera_vfs_read_callback_t)(
     enum chimera_vfs_error    error_code,
     uint32_t                  count,


### PR DESCRIPTION
## Problem

A delete-on-close issued asynchronously unlinked its target purely **by name**. When the SMB durable/persistent grace-timer reaps a `DELETE_ON_CLOSE` handle, that unlink can land arbitrarily late under load. If the original file was removed and a *different* file created at the same path in the meantime, the late unlink destroyed the **unrelated replacement**.

This surfaced as a rare flake in the pike `persistent.py` resiliency suite, whose tests all reuse the path `persistent.txt`: a prior test's reaped handle could delete a later test's freshly-created file.

## Fix

Add `chimera_vfs_remove_at_match_fh()` — same signature as `chimera_vfs_remove_at`, but the unlink only takes effect while the name **still resolves to the supplied child FH**:

- A new opt-in `request->remove_at.match_child_fh` flag is threaded to the backend.
- memfs compares the resolved dirent's `(inum, gen)` against the caller's FH; on a mismatch it leaves the name intact and reports success with `r_unmatched` set, so `chimera_vfs_remove_at_complete` skips the post-removal bookkeeping (negative name-cache entry / `FILE_REMOVED` notify).
- The flag is **opt-in**: `chimera_vfs_remove_at` and every existing caller are byte-for-byte unchanged (unconditional by-name remove). A backend that does not honor the flag falls back to an unconditional unlink.

The SMB durable-reap delete-on-close path now uses the inode-scoped variant, passing the handle's own FH.

## Validation

- New unit test `vfs/inode_scoped_remove_test` drives memfs directly: a **stale** FH leaves a recreated file intact; the **current** FH unlinks it. Passes on Release and Debug/ASan.
- No regression: smbtorture durable/lease, pjd unlink/rmdir, nfs3, and vfs unit tests — **818/818** on Release; **67/67** durable/lease/unit on Debug/ASan. The flag does not perturb any ordinary by-name delete.