### PR TITLE
s3: fix -Wstring-plus-int breaking the clang coverage build

### DIFF
--- a/src/server/s3/s3_metadata.c
+++ b/src/server/s3/s3_metadata.c
@@ -154,7 +154,7 @@ chimera_s3_meta_capture_user_cb(
     /* Lower-case the user key so the xattr name is canonical (S3 metadata keys
      * are case-insensitive and AWS returns them lower-cased). */
     suffix_len = snprintf(suffix, sizeof(suffix), "%s",
-                          CHIMERA_S3_XATTR_META + CHIMERA_S3_XATTR_PREFIX_LEN);
+                          &CHIMERA_S3_XATTR_META[CHIMERA_S3_XATTR_PREFIX_LEN]);
 
     for (i = 0; i < key_len && suffix_len < (int) sizeof(suffix) - 1; i++) {
         suffix[suffix_len++] = (char) tolower((unsigned char) key[i]);


### PR DESCRIPTION
## Problem

`make coverage` (and any plain-clang `-Werror` build) fails to compile:

```
src/server/s3/s3_metadata.c:157:49: error: adding 'unsigned long' to a string
does not append to the string [-Werror,-Wstring-plus-int]
```

`chimera_s3_meta_capture_user_cb` skips the `"user.s3."` prefix of the
`CHIMERA_S3_XATTR_META` string-literal macro via `MACRO + CHIMERA_S3_XATTR_PREFIX_LEN`.
clang's `-Wall` enables `-Wstring-plus-int` (which gcc lacks), and the global
`-Werror` turns it into a hard error.

The **Coverage** build is the only one compiled with plain `clang`
(`-DCMAKE_C_COMPILER=clang`); Release/Debug use gcc and CI's `build_clang`
runs scan-build over gcc, so none of them catch this. As a result `make coverage`
has been broken since the object-metadata-xattr change landed (16a83e6b) while
every PR check stayed green.

## Fix

Use the equivalent `&CHIMERA_S3_XATTR_META[CHIMERA_S3_XATTR_PREFIX_LEN]` form —
same pointer (`"meta."`), expresses the intended element address, and is clang's
recommended way to silence the warning. No behaviour change; keeps the warning
active everywhere else rather than globally suppressing it.

Verified: clang Coverage build now compiles clean and the full coverage run
completes.