### PR TITLE
smb2: complete a delete-on-close open when its break is SENT, not queued (fixes #733 lease.unlink flake)

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -637,6 +637,13 @@ struct chimera_smb_request {
             uint8_t                            park_fh[CHIMERA_VFS_FH_SIZE];
             uint8_t                            park_fh_len;
             uint64_t                           park_fh_hash;
+            /* This parked open is a delete-on-close namespace mutation waiting
+             * only for its triggered break to be NOTIFIED (sent on the wire),
+             * not acked -- the holder need never ack.  Resumed when the file's
+             * break leaves the pending-notify state, vs. park_fh's caching
+             * leases settling for an ordinary ack-required park.  (smb2.lease.
+             * unlink cross-connection ordering.) */
+            uint8_t                            park_on_notify;
             /* Durable-reconnect retry: a reclaim that finds its handle still
              * flagged live (the previous connection's disconnect has not yet
              * been processed -- a cross-connection race) re-arms a short timer
@@ -1747,6 +1754,12 @@ chimera_smb_durable_deserialize(
 struct chimera_smb_lease_break_msg {
     struct chimera_smb_conn            *conn;
     bool                                is_lease;
+    /* FH of the file whose lease is breaking, so the flush can mark the break
+     * delivered (chimera_vfs_state_mark_break_notified) once it is sent -- which
+     * resumes a delete-on-close open parked waiting for that delivery. */
+    uint8_t                             fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t                             fh_len;
+    uint64_t                            fh_hash;
     uint8_t                             lease_key[16];
     uint8_t                             current_state;
     uint8_t                             new_state;

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2595,6 +2595,7 @@ chimera_smb_create_open_finish(
 
     request->create.r_open_file       = open_file;
     request->create.dir_break_pending = 0;
+    request->create.park_on_notify    = 0;
 
     open_file->granted_access = request->create.r_granted_access;
     open_file->maximal_access = request->create.r_maximal_access;
@@ -2611,20 +2612,35 @@ chimera_smb_create_open_finish(
          * oplock's deferred handle) is informational -- the holder relinquishes
          * asynchronously and the deferred removal at LAST close still drains the
          * break (chimera_vfs_remove_at's io_recall) -- so this open must NOT wait
-         * for a break ack the holder is never obliged to send.  smbtorture passes
-         * the equivalent flows only because its lease handler auto-acks; the WPTS
+         * for a break ack the holder is never obliged to send (the WPTS
          * MS-SMB2Model BreakRead{,Write}HandleLease holder deliberately never
-         * acks, so waiting here deadlocks the open for the model's ~20s timeout.
+         * acks; waiting for an ack here deadlocks the open for the model's ~20s
+         * timeout).
+         *
+         * But "on notify" means once the break is actually SENT, not merely
+         * queued: park until its notification reaches the holder so this open's
+         * reply cannot overtake the break on the wire.  smbtorture's
+         * smb2.lease.unlink checks lease_break_info.count the instant the unlink
+         * returns -- a cross-connection RH->R break delivered a hair late (the
+         * holder thread had not yet flushed its doorbell) read as count 0 (the
+         * dominant CI flake).  This park resumes the moment the break flush marks
+         * it delivered (chimera_vfs_state_caching_break_pending_notify ->
+         * mark_break_notified), so an ack the holder never sends is irrelevant.
          *
          * A DATA open (read / write / truncate) still pends on a write/read-cache
          * break for flush coherence (smb2.lease.breaking3), and a delete-on-close
          * that ALSO requested its own oplock still parks to re-arbitrate that
          * grant once the holder's break settles (smb2.durable-open.oplock). */
+        struct chimera_vfs_open_handle *oh = open_file->handle;
+
         if (!delete_on_close || open_file->grant != NULL) {
-            struct chimera_vfs_open_handle *oh = open_file->handle;
             will_park = chimera_vfs_state_caching_breaking(vfs_state, oh->fh,
                                                            oh->fh_len, oh->fh_hash,
                                                            open_file->grant);
+        } else if (chimera_vfs_state_caching_break_pending_notify(
+                       vfs_state, oh->fh, oh->fh_len, oh->fh_hash)) {
+            will_park                      = true;
+            request->create.park_on_notify = 1;
         }
     }
 
@@ -2865,14 +2881,23 @@ chimera_smb_create_resume_parked_conn(
      * re-walk / re-cancel the list we are iterating. */
     pp = &conn->parked_requests;
     while ((req = *pp)) {
+        /* req->create is only valid for a parked CREATE; the command check must
+         * gate the create-field reads below (the parked list also carries other
+         * commands, e.g. a byte-range LOCK parked on a lease break).  A
+         * delete-on-close open parked for delivery (park_on_notify) resumes the
+         * moment its break leaves the pending-notify state -- i.e. the
+         * notification has been sent -- whereas an ordinary ack-required park
+         * resumes only once the file's caching leases actually settle. */
         if (req->smb2_hdr.command == SMB2_CREATE &&
-            !chimera_vfs_state_caching_breaking(vfs_state,
-                                                req->create.park_fh,
-                                                req->create.park_fh_len,
-                                                req->create.park_fh_hash,
-                                                req->create.r_open_file
-                                                ? req->create.r_open_file->grant
-                                                : NULL)) {
+            (req->create.park_on_notify
+             ? !chimera_vfs_state_caching_break_pending_notify(
+                 vfs_state, req->create.park_fh, req->create.park_fh_len,
+                 req->create.park_fh_hash)
+             : !chimera_vfs_state_caching_breaking(
+                 vfs_state, req->create.park_fh, req->create.park_fh_len,
+                 req->create.park_fh_hash,
+                 req->create.r_open_file ? req->create.r_open_file->grant
+                                         : NULL))) {
             *pp                  = req->async.park_next;
             req->async.park_next = resume;
             req->async.armed     = 0; /* already unlinked; skip re-cancel */

--- a/src/server/smb/smb_proc_oplock_break.c
+++ b/src/server/smb/smb_proc_oplock_break.c
@@ -317,6 +317,9 @@ chimera_smb_lease_break_cb(
                 msg           = calloc(1, sizeof(*msg));
                 msg->conn     = conn;
                 msg->is_lease = true;
+                memcpy(msg->fh, file->fh, file->fh_len);
+                msg->fh_len  = file->fh_len;
+                msg->fh_hash = file->fh_hash;
                 memcpy(msg->lease_key, lease_key, 16);
                 msg->current_state             = current_smb;
                 msg->new_state                 = new_smb;
@@ -429,6 +432,9 @@ SYMBOL_EXPORT void
 chimera_smb_lease_break_flush(struct chimera_server_smb_thread *thread)
 {
     struct chimera_smb_lease_break_msg *list, *msg, *fifo = NULL;
+    struct chimera_vfs_state           *vfs_state =
+        thread->vfs_thread->vfs->vfs_state;
+    bool                                sent_lease = false;
 
     pthread_mutex_lock(&thread->lease_break_lock);
     list                      = thread->lease_break_ready;
@@ -454,6 +460,12 @@ chimera_smb_lease_break_flush(struct chimera_server_smb_thread *thread)
             chimera_smb_send_oplock_break_lease(msg->conn, msg->lease_key,
                                                 msg->current_state, msg->new_state,
                                                 msg->ack_required, msg->new_epoch);
+            /* The notification is now on the wire: mark the break delivered so a
+             * delete-on-close open parked for delivery (not for an ack) resumes
+             * with its reply ordered AFTER this break (smb2.lease.unlink). */
+            chimera_vfs_state_mark_break_notified(vfs_state, msg->fh, msg->fh_len,
+                                                  msg->fh_hash, msg->lease_key);
+            sent_lease = true;
         } else {
             chimera_smb_send_oplock_break_legacy(msg->conn,
                                                  msg->file_id_pid,
@@ -461,6 +473,13 @@ chimera_smb_lease_break_flush(struct chimera_server_smb_thread *thread)
                                                  msg->new_oplock_level);
         }
         free(msg);
+    }
+
+    /* Wake any delete-on-close open parked on a now-delivered break so it can
+     * complete on notify.  Broadcast (not just this thread) because the parked
+     * open lives on the triggering connection's thread, not the holder's. */
+    if (sent_lease) {
+        chimera_smb_create_resume_parked_broadcast(thread);
     }
 } /* chimera_smb_lease_break_flush */
 

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -148,6 +148,15 @@ struct chimera_vfs_lease {
     uint8_t                           break_floor;
     uint64_t                          break_deadline; /* stopwatch ticks */
 
+    /* Set once the protocol server has actually SENT the outstanding break
+     * notification to the holder (not merely queued it).  Re-armed to 0 each
+     * time a new break begins (begin_break, should_invoke).  A namespace
+     * mutation that completes ON NOTIFY rather than on the holder's ack (an SMB
+     * delete-on-close open whose holder need never ack) waits for this so its
+     * reply cannot overtake the break on the wire -- the cross-connection
+     * ordering smbtorture smb2.lease.unlink checks. */
+    uint8_t                           break_notified;
+
     /* For a SHARE probe only: a caching (handle) lease held under this same
      * key is the requester's own lease (SMB2 same-client, same lease key) and
      * must NOT be broken when acquiring the share — the opens coalesce.  Set by

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -2241,6 +2241,93 @@ chimera_vfs_state_caching_breaking(
     return breaking;
 } /* chimera_vfs_state_caching_breaking */
 
+/*
+ * True while a caching break has been BEGUN on this file but its notification
+ * has NOT yet been delivered to the holder (break_notified == 0).  An SMB
+ * delete-on-close open -- a namespace mutation that must complete ON NOTIFY
+ * rather than on an ack the holder need never send -- parks on this so its reply
+ * cannot overtake the break on the wire (smbtorture smb2.lease.unlink, a
+ * cross-connection RH->R handle break).  Once the protocol server flushes the
+ * notification (chimera_vfs_state_mark_break_notified) this returns false and
+ * the parked open resumes.
+ */
+SYMBOL_EXPORT bool
+chimera_vfs_state_caching_break_pending_notify(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+    bool                           pending = false;
+
+    if (!state || fh_len == 0) {
+        return false;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return false;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
+            !cur->break_notified) {
+            pending = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    chimera_vfs_state_put(state, file);
+    return pending;
+} /* chimera_vfs_state_caching_break_pending_notify */
+
+/*
+ * Mark the outstanding break on this file's SMB2 caching lease identified by
+ * `lease_key` as DELIVERED: the protocol server has now sent the notification on
+ * the wire.  Called from the lease-break flush right after the send, so a
+ * delete-on-close open parked in caching_break_pending_notify resumes only after
+ * its break has actually left for the holder.  No-op if the lease has already
+ * settled (acked/closed) or no longer matches.
+ */
+SYMBOL_EXPORT void
+chimera_vfs_state_mark_break_notified(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash,
+    const uint8_t            *lease_key)
+{
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_lease      *cur;
+
+    if (!state || fh_len == 0) {
+        return;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->caching_leases; cur; cur = cur->next) {
+        if (cur->break_state == CHIMERA_VFS_BREAK_BREAKING &&
+            cur->owner.is_lease &&
+            memcmp(&cur->owner.owner_lo, lease_key, 8) == 0 &&
+            memcmp(&cur->owner.owner_hi, lease_key + 8, 8) == 0) {
+            cur->break_notified = 1;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_state_mark_break_notified */
+
 SYMBOL_EXPORT bool
 chimera_vfs_lease_acquire_cancel(
     struct chimera_vfs_state           *state,
@@ -2433,7 +2520,11 @@ chimera_vfs_lease_begin_break_ex(
         lease->break_state       = CHIMERA_VFS_BREAK_BREAKING;
         lease->break_floor       = floor;
         lease->break_needed_mode = step;
-        lease->break_deadline    = chimera_vfs_now_ticks() +
+        /* A fresh notification is about to be queued for this break: it has not
+         * been delivered to the holder yet (set under file->lock, paired with
+         * break_state, so caching_break_pending_notify observes them together). */
+        lease->break_notified = 0;
+        lease->break_deadline = chimera_vfs_now_ticks() +
             chimera_vfs_ns_to_ticks((uint64_t) deadline_ms * 1000000ULL);
         /* Publish break_ack_required ATOMICALLY with break_state, under file->lock.
          * A break needs a client acknowledgment when it strips write or handle

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -363,6 +363,30 @@ chimera_vfs_state_caching_breaking(
     uint64_t                                fh_hash,
     const struct chimera_vfs_caching_grant *except);
 
+/* True while a break on this file has been begun but its notification has NOT
+ * yet been delivered to the holder.  An SMB delete-on-close open that completes
+ * ON NOTIFY (rather than on an ack the holder need never send) parks on this so
+ * its reply cannot overtake the break on the wire (smb2.lease.unlink).  Caller
+ * must NOT hold file->lock. */
+bool
+chimera_vfs_state_caching_break_pending_notify(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash);
+
+/* Mark the outstanding break on this file's SMB2 caching lease `lease_key` as
+ * delivered (the protocol server has sent the notification).  Resumes any
+ * delete-on-close open parked in caching_break_pending_notify.  Caller must NOT
+ * hold file->lock. */
+void
+chimera_vfs_state_mark_break_notified(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash,
+    const uint8_t            *lease_key);
+
 /* Forcibly revoke every caching lease on the file that is mid-break, EXCLUDING
  * the grant `except`.  Used when a parked open's break deadline expires (the
  * holder never acknowledged): the holder is revoked so the waiting open can


### PR DESCRIPTION
## Summary

Fixes the dominant CI flake tracked in #733: `smbtorture smb2.lease.unlink`, which failed across **every** backend (~16 times in the trailing 48h, all dated **after** ee2357fa landed on Jun 26).

`smb2.lease.unlink` holds an `RH` lease on connection 1, then unlinks the file from connection 2. The unlink's DELETE-intent open breaks `LEASE1` `RH→R`, and the test asserts `lease_break_info.count == 1` the instant the unlink returns:

```c
smb2_util_close(tree2, h2);
smb2_util_unlink(tree2, fname);          // breaks LEASE1 RH->R on conn 1
CHECK_VAL(lease_break_info.count, 1);    // lease.c:4749 — the flaky assert
```

### Root cause

ee2357fa ("complete delete-on-close opens on handle-lease-break notify") correctly stopped a delete-on-close open from waiting for an ack the holder need never send — but it let the open complete the moment the break was **queued**. The break notification is delivered asynchronously on the holder thread's doorbell, so the open's reply can overtake it on the wire. When the holder thread hasn't flushed its doorbell yet, connection 1 sees the break a hair late and `count` reads `0`.

Cross-thread this is a timing flake; same-thread it is a deterministic failure (the break flushes *after* the reply).

### Fix

"Complete ON NOTIFY" must mean once the break is actually **sent**, not merely queued. Track delivery on the VFS lease (`break_notified`, re-armed when a break begins, set when the protocol server flushes the notification) and:

- park a delete-on-close open (with no oplock grant of its own) only while its break is *pending delivery* (`chimera_vfs_state_caching_break_pending_notify`), reusing the existing async-interim pending-open path;
- resume it the instant the break-flush marks the notification delivered (`chimera_vfs_state_mark_break_notified`) and broadcasts the resume doorbell.

This waits for **delivery, never for an ack**, so the WPTS MS-SMB2Model `BreakRead*HandleLease` holder (which deliberately never acks) still completes promptly — the break is always sent. A data open (read/write/truncate) still parks on the ack for flush coherence, and a delete-on-close that also requested its own oplock still parks to re-arbitrate that grant — both unchanged.

### Verification

- **Deterministic repro** (delay the holder's break-flush by 25 ms): baseline fails 6/6 at `lease.c:4749` (`count 0`); with the fix, 8/8 pass.
- `smb2.lease` / `smb2.oplock` / `smb2.durable*` / `smb2.dirlease` — all backends green (769 tests).
- `make check` green.
