### PR TITLE
smb2/replay: evict orphaned pending durable creates so a settled-break replay succeeds

### DIFF
--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -182,7 +182,19 @@ chimera_smb_async_interim_drain(struct chimera_smb_conn *conn)
         * completion of the orphaned request cannot touch the released open. */
         if (request->smb2_hdr.command == SMB2_CREATE &&
             request->create.r_open_file) {
-            chimera_smb_open_file_release(request, request->create.r_open_file);
+            struct chimera_smb_open_file *of = request->create.r_open_file;
+
+            /* If this CREATE was still pending on a break ack (its half-open is
+             * hashed + CREATE_PENDING), mark it orphaned before dropping the
+             * request ref: the resume that would clear CREATE_PENDING and complete
+             * the open will never come (the connection is gone), but the open must
+             * stay hashed so a replayed durable create with this create_guid still
+             * answers FILE_NOT_AVAILABLE.  Once the break it waited on settles, a
+             * later replay evicts it (chimera_smb_create_guid_replay). */
+            if (of->flags & CHIMERA_SMB_OPEN_FILE_CREATE_PENDING) {
+                of->flags |= CHIMERA_SMB_OPEN_FILE_PENDING_ORPHANED;
+            }
+            chimera_smb_open_file_release(request, of);
             request->create.r_open_file = NULL;
         }
     }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -4121,9 +4121,9 @@ chimera_smb_create_guid_replay(struct chimera_smb_request *request)
     struct chimera_server_smb_thread *thread = request->compound->thread;
     int                               b;
     bool                              req_is_lease, open_is_lease;
-    bool                              pending_match = false;
+    struct chimera_smb_open_file     *pending_of = NULL;
 
-    for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !match && !pending_match; b++) {
+    for (b = 0; b < CHIMERA_SMB_OPEN_FILE_BUCKETS && !match && !pending_of; b++) {
         pthread_mutex_lock(&tree->open_files_lock[b]);
         HASH_ITER(hh, tree->open_files[b], of, tmp)
         {
@@ -4137,7 +4137,8 @@ chimera_smb_create_guid_replay(struct chimera_smb_request *request)
             if (request->is_replay &&
                 (of->flags & CHIMERA_SMB_OPEN_FILE_CREATE_PENDING) &&
                 memcmp(of->create_guid, request->create.dh2q.create_guid, 16) == 0) {
-                pending_match = true;
+                of->refcnt++;   /* held while we decide reject vs. evict */
+                pending_of = of;
                 break;
             }
 
@@ -4162,9 +4163,51 @@ chimera_smb_create_guid_replay(struct chimera_smb_request *request)
         pthread_mutex_unlock(&tree->open_files_lock[b]);
     }
 
-    if (pending_match) {
-        chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
-        return 1;
+    if (pending_of) {
+        /* A replay matched a still-pending create carrying this create_guid.
+         * Normally the original create is genuinely in flight, so the replay is
+         * answered FILE_NOT_AVAILABLE (MS-SMB2 3.3.5.9.10).  But if that create was
+         * orphaned when its connection disconnected (CREATE_PENDING never resumed)
+         * AND the break it parked on has since settled -- the conflicting holder
+         * closed or acked -- the original create can never complete: evict the
+         * resolved zombie (unhash + full teardown) and fall through to a fresh open.
+         * A still-active break, or a non-orphaned pending create (which resumes
+         * normally), still yields FILE_NOT_AVAILABLE.
+         * smb2.replay.dhv2-pending2*-vs-{lease,oplock}-sane. */
+        struct chimera_vfs_state *vfs_state = thread->vfs_thread->vfs->vfs_state;
+        bool                      evict, won = false;
+
+        evict = (pending_of->flags & CHIMERA_SMB_OPEN_FILE_PENDING_ORPHANED) &&
+            pending_of->handle &&
+            !chimera_vfs_state_caching_breaking(vfs_state,
+                                                pending_of->handle->fh,
+                                                pending_of->handle->fh_len,
+                                                pending_of->handle->fh_hash,
+                                                pending_of->grant);
+
+        if (!evict) {
+            chimera_smb_open_file_release(request, pending_of);
+            chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+            return 1;
+        }
+
+        /* Unhash under the bucket lock (idempotent via CLOSED so concurrent
+         * evictors don't double-unhash); the winner drops the orphan's surviving
+         * handle ref so the open is torn down + freed exactly once.  Every evictor
+         * always drops the scan ref it took above. */
+        b = pending_of->file_id.vid & CHIMERA_SMB_OPEN_FILE_BUCKET_MASK;
+        pthread_mutex_lock(&tree->open_files_lock[b]);
+        if (!(pending_of->flags & CHIMERA_SMB_OPEN_FILE_CLOSED)) {
+            pending_of->flags |= CHIMERA_SMB_OPEN_FILE_CLOSED;
+            HASH_DELETE(hh, tree->open_files[b], pending_of);
+            won = true;
+        }
+        pthread_mutex_unlock(&tree->open_files_lock[b]);
+        chimera_smb_open_file_release(request, pending_of);       /* scan ref */
+        if (won) {
+            chimera_smb_open_file_release(request, pending_of);   /* handle ref */
+        }
+        /* fall through: no pending match remains -> proceed to a fresh open. */
     }
 
     if (!match) {

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -74,6 +74,15 @@ struct chimera_smb_file_id {
  * content break is deferred to this open's close (MS-SMB2; dirlease.v2_request
  * "write ... only the close ... break the directory lease"). */
 #define CHIMERA_SMB_OPEN_FILE_FLAG_MODIFIED        0x00000400
+/* A CREATE_PENDING open whose originating connection disconnected while it was
+ * still parked on a break ack: chimera_smb_async_interim_drain dropped the parked
+ * request without a resume, so the open's CREATE can never complete.  It is left
+ * hashed + CREATE_PENDING so a replayed durable create with this create_guid still
+ * answers FILE_NOT_AVAILABLE -- until the break it waited on settles (the holder
+ * closed/acked), at which point chimera_smb_create_guid_replay lazy-evicts the
+ * resolved zombie and a replay falls through to a fresh open
+ * (smb2.replay.dhv2-pending2*-vs-{lease,oplock}-sane). */
+#define CHIMERA_SMB_OPEN_FILE_PENDING_ORPHANED     0x00000800
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
  * from request->create.ctx_present_mask into the open file so later phases

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1674,6 +1674,12 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-sane
     smb2.replay.dhv2-pending3l-vs-lease-sane
     smb2.replay.dhv2-pending3l-vs-oplock-sane
     smb2.replay.dhv2-pending3n-vs-lease-sane
@@ -2246,6 +2252,12 @@ set(SMBTORTURE_ENABLED_linux
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-sane
     smb2.replay.dhv2-pending3l-vs-lease-sane
     smb2.replay.dhv2-pending3l-vs-oplock-sane
     smb2.replay.dhv2-pending3n-vs-lease-sane
@@ -2763,6 +2775,12 @@ set(SMBTORTURE_ENABLED_io_uring
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-sane
     smb2.replay.dhv2-pending3l-vs-lease-sane
     smb2.replay.dhv2-pending3l-vs-oplock-sane
     smb2.replay.dhv2-pending3n-vs-lease-sane
@@ -3308,6 +3326,12 @@ set(SMBTORTURE_ENABLED_cairn
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-sane
     smb2.replay.dhv2-pending3l-vs-lease-sane
     smb2.replay.dhv2-pending3l-vs-oplock-sane
     smb2.replay.dhv2-pending3n-vs-lease-sane
@@ -3881,6 +3905,12 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-sane
     smb2.replay.dhv2-pending3l-vs-lease-sane
     smb2.replay.dhv2-pending3l-vs-oplock-sane
     smb2.replay.dhv2-pending3n-vs-lease-sane
@@ -4451,6 +4481,12 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     smb2.replay.dhv2-pending1n-vs-oplock-sane
     smb2.replay.dhv2-pending1o-vs-lease-sane
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-sane
     smb2.replay.dhv2-pending3l-vs-lease-sane
     smb2.replay.dhv2-pending3l-vs-oplock-sane
     smb2.replay.dhv2-pending3n-vs-lease-sane


### PR DESCRIPTION
## Problem

A durable-v2 `CREATE` that parks waiting for a conflicting holder to acknowledge a lease/oplock break (MS-SMB2 3.3.5.9 *pending open*) leaves its half-open hashed and flagged `CREATE_PENDING`, so a replayed create with the same `create_guid` is answered `FILE_NOT_AVAILABLE` instead of parking a second time. That pending open is normally resolved by the break-ack resume or the break-deadline timer, both of which clear `CREATE_PENDING` and complete the open.

But when the **originating connection disconnects while the create is still pending**, `chimera_smb_async_interim_drain` dropped the parked request's open reference *without* resuming or tearing the open down. The half-open stayed hashed + `CREATE_PENDING` forever — a zombie — so every later replay of that `create_guid` kept returning `FILE_NOT_AVAILABLE`, even after the conflicting holder closed and the create could have completed.

`smb2.replay.dhv2-pending2*-vs-{lease,oplock}-sane` exercise exactly this (4 channels; the channel carrying the pending create disconnects, then the holder closes, then a replay on a fresh channel must succeed with `STATUS_OK`).

## Fix

Two parts:

1. **On drain**, mark a still-pending open `CHIMERA_SMB_OPEN_FILE_PENDING_ORPHANED` before dropping the request ref. It stays hashed + `CREATE_PENDING` so replays still answer `FILE_NOT_AVAILABLE` *while the conflict holds*.
2. **In `chimera_smb_create_guid_replay`**, when a replay matches an orphaned pending open whose break has since **settled** (caching no longer breaking on the file), lazy-evict the resolved zombie (unhash + full teardown) and fall through to a fresh open, which now grants and returns `OK`. A non-orphaned pending open (which resumes normally) or one whose break is still active is unchanged.

## Result

Enables `smb2.replay.dhv2-pending2{l,n,o}-vs-{lease,oplock}-sane` — **6 cases on all 6 backends**. Verified passing on memfs/cairn/diskfs_io_uring/diskfs_aio/linux/io_uring. The previously-enabled replay/lease/oplock/durable smbtorture subtests stay green on memfs, ASan-clean.

The sibling `smb2.replay.dhv2-pending1n-vs-violation-*-sane` cases stay disabled: they fail earlier with `SHARING_VIOLATION` vs `FILE_NOT_AVAILABLE` on a share-conflicting replay — a distinct root cause, left as a follow-up.