### PR TITLE
vfs: export chimera_vfs_release_handle for out-of-tree VFS tests

### DIFF
--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -440,3 +440,17 @@ chimera_vfs_open(
             request);
     }
 } /* chimera_vfs_open */
+
+/*
+ * Non-inline export of chimera_vfs_release() (defined inline in the internal
+ * vfs_release.h).  Lets out-of-tree consumers that link libchimera_vfs -- e.g.
+ * downstream in-process VFS module tests -- release open handles without
+ * pulling in the internal open-cache headers.  Declared in vfs_procs.h.
+ */
+SYMBOL_EXPORT void
+chimera_vfs_release_handle(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle)
+{
+    chimera_vfs_release(thread, handle);
+} /* chimera_vfs_release_handle */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -422,6 +422,17 @@ chimera_vfs_close(
     chimera_vfs_close_callback_t callback,
     void                        *private_data);
 
+/*
+ * Release an open handle returned by chimera_vfs_open_fh()/open_at().  This is
+ * a non-inline export of the internal inline chimera_vfs_release(); out-of-tree
+ * consumers that link libchimera_vfs (e.g. in-process VFS module tests) use it
+ * to avoid pulling in the internal open-cache headers.
+ */
+void
+chimera_vfs_release_handle(
+    struct chimera_vfs_thread      *thread,
+    struct chimera_vfs_open_handle *handle);
+
 typedef void (*chimera_vfs_mkdir_at_callback_t)(
     enum chimera_vfs_error    error_code,
     struct chimera_vfs_attrs *set_attr,

--- a/src/vfs/vfs_release.h
+++ b/src/vfs/vfs_release.h
@@ -40,7 +40,7 @@ chimera_vfs_release(
     } else {
         chimera_vfs_abort("invalid cache id");
     }
-} /* chimera_vfs_release_handle */
+} /* chimera_vfs_release */
 
 /* Duplicate a handle by incrementing its opencnt (for dup operations) */
 static inline void
@@ -151,4 +151,4 @@ chimera_vfs_release_failed(
     } else {
         chimera_vfs_abort("invalid cache id");
     }
-} /* chimera_vfs_release_handle */
+} /* chimera_vfs_release_failed */


### PR DESCRIPTION
An out-of-tree VFS backend's in-process test opens handles via chimera_vfs_open_fh/open_at and must release them, or they leak under AddressSanitizer.  chimera_vfs_release() is defined inline in the internal vfs_release.h, which pulls in the open-cache / vfs_internal headers (and liburcu) -- not shippable to out-of-tree consumers.

Add a non-inline export chimera_vfs_release_handle() (a thin wrapper over the inline) and declare it in vfs_procs.h, so a consumer that only links libchimera_vfs can release handles without any internal header.

While here, fix two stale end-of-function comments in vfs_release.h that mislabelled chimera_vfs_release() and chimera_vfs_release_failed() as chimera_vfs_release_handle().