### PR TITLE
nfs4: fix open/lock owner use-after-free against the lease sweeper

### DIFF
--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -91,6 +91,18 @@ chimera_nfs4_lock_finish(
         }
     }
 
+    /* Drop the owner borrow refs transferred onto the request during
+     * dispatch.  Unconditional so every status/minorversion path releases
+     * them exactly once; NULL to guard against a double drop. */
+    if (req->lock_4_0_open_owner) {
+        nfs_open_owner_put(req->lock_4_0_open_owner);
+        req->lock_4_0_open_owner = NULL;
+    }
+    if (req->lock_4_0_lock_owner) {
+        nfs_lock_owner_put(req->lock_4_0_lock_owner);
+        req->lock_4_0_lock_owner = NULL;
+    }
+
     chimera_nfs4_compound_complete(req, status);
 } /* chimera_nfs4_lock_finish */
 
@@ -217,6 +229,26 @@ chimera_nfs4_lock_complete(
     chimera_nfs4_lock_finish(req, res->status);
 } /* chimera_nfs4_lock_complete */
 
+/*
+ * Shared rejection tail for the new-lock-owner entry-time checks: release the
+ * open_state acquire ref and the lock_owner find_or_create ref,
+ * then complete without touching owner seqid/replay state (replay and the
+ * no-advance statuses land here).
+ */
+static void
+chimera_nfs4_lock_new_owner_reject(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
+    struct nfs_open_state            *open_state,
+    struct nfs_lock_owner            *lock_owner,
+    nfsstat4                          status)
+{
+    nfs_state_table_release(&thread->shared->nfs4_state_table, open_state,
+                            NFS4_SLOT_TYPE_OPEN, thread->vfs_thread);
+    nfs_lock_owner_put(lock_owner);
+    chimera_nfs4_compound_complete(req, status);
+} /* chimera_nfs4_lock_new_owner_reject */
+
 void
 chimera_nfs4_lock(
     struct chimera_server_nfs_thread *thread,
@@ -303,19 +335,15 @@ chimera_nfs4_lock(
                 res->status              = oo->replay.status;
                 res->resok4.lock_stateid = oo->replay.stateid;
                 pthread_mutex_unlock(&oo->lock);
-                nfs_state_table_release(table, open_state,
-                                        NFS4_SLOT_TYPE_OPEN,
-                                        thread->vfs_thread);
-                chimera_nfs4_compound_complete(req, res->status);
+                chimera_nfs4_lock_new_owner_reject(thread, req, open_state,
+                                                   lock_owner, res->status);
                 return;
             }
             if (cls != NFS4_SEQID_NEW) {
                 pthread_mutex_unlock(&oo->lock);
-                nfs_state_table_release(table, open_state,
-                                        NFS4_SLOT_TYPE_OPEN,
-                                        thread->vfs_thread);
                 res->status = NFS4ERR_BAD_SEQID;
-                chimera_nfs4_compound_complete(req, res->status);
+                chimera_nfs4_lock_new_owner_reject(thread, req, open_state,
+                                                   lock_owner, res->status);
                 return;
             }
             pthread_mutex_unlock(&oo->lock);
@@ -326,17 +354,23 @@ chimera_nfs4_lock(
                 open_state->seqid,
                 args->locker.open_owner.open_stateid.seqid);
             if (status != NFS4_OK) {
-                nfs_state_table_release(table, open_state,
-                                        NFS4_SLOT_TYPE_OPEN,
-                                        thread->vfs_thread);
                 res->status = status;
-                chimera_nfs4_compound_complete(req, res->status);
+                chimera_nfs4_lock_new_owner_reject(thread, req, open_state,
+                                                   lock_owner, res->status);
                 return;
             }
 
+            /* Transfer the borrow refs onto the request; dropped in
+             * chimera_nfs4_lock_finish.  open_state is acquire-held here, so
+             * open_state->owner (== oo) is guaranteed alive for the get.  The
+             * lock_owner ref is the find_or_create ref, transferred directly. */
+            nfs_open_owner_get(oo);
             req->lock_4_0_open_owner = oo;
             req->lock_4_0_lock_owner = lock_owner;
         }
+        /* 4.1+: the find_or_create ref is held across nfs_lock_state_create
+         * (whose internal get needs the owner alive) and dropped right after
+         * it -- the state's own pin covers the owner from then on. */
 
         /* Take a distinct +1 dup on the VFS handle: lock_state's lifetime
          * is independent of the open_state's. */
@@ -345,6 +379,25 @@ chimera_nfs4_lock(
 
         lock_state = nfs_lock_state_create(lock_owner, open_state, handle,
                                            table, &res->resok4.lock_stateid);
+
+        if (req->minorversion != 0) {
+            /* chimera_nfs4_lock_finish never touches the owners on 4.1+, so
+             * the borrow ref is not transferred to the request; drop it now
+             * that the state (if created) holds its own pin. */
+            nfs_lock_owner_put(lock_owner);
+        }
+
+        if (!lock_state) {
+            /* The client's lease was reaped while this LOCK was in flight:
+             * the lock_owner is unpublished and/or the open_state destroyed,
+             * so installing lock state now would orphan it. */
+            chimera_vfs_release(thread->vfs_thread, handle);
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = NFS4ERR_EXPIRED;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
 
         /* Release the open_state acquire ref.  The lock_state holds its
          * own dup of the handle; the open_state's lifetime remains its
@@ -432,6 +485,10 @@ chimera_nfs4_lock(
                 return;
             }
 
+            /* Transfer a borrow ref onto the request; dropped in
+             * chimera_nfs4_lock_finish.  lock_state is acquire-held here, so
+             * lock_state->lock_owner (== lo) is guaranteed alive. */
+            nfs_lock_owner_get(lo);
             req->lock_4_0_lock_owner = lo;
         }
     }

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -337,6 +337,7 @@ chimera_nfs4_open_install_state(
     struct nfs_open_owner *owner;
     struct nfs_open_state *existing;
     bool                   created = false;
+    nfsstat4               status;
 
     *out_rflags = 0;
 
@@ -373,23 +374,36 @@ chimera_nfs4_open_install_state(
         }
     }
 
-    owner = nfs_open_owner_find_or_create(client,
-                                          args->owner.owner.data,
-                                          args->owner.owner.len,
-                                          &created);
+    /* Resolve the open_owner on the completion path.  For a 4.0 OPEN the
+    * dispatch path already pinned it on req->open_4_0_owner; passing it as
+    * the adopt candidate means a lease sweep that unpublished it mid-flight
+    * republishes the SAME struct here, keeping the seqid/replay bookkeeping
+    * in chimera_nfs4_open_complete and this open_state on one object. */
+    owner = nfs_open_owner_find_or_adopt(client,
+                                         req->open_4_0_owner,
+                                         args->owner.owner.data,
+                                         args->owner.owner.len,
+                                         &created);
+
+    /* Pathological double-race: the sweep unpublished the pinned owner AND
+     * another OPEN already recreated the key.  Move the request's seqid/replay
+     * bookkeeping onto the published object so the reply is cached where the
+     * client's retransmit will look. */
+    if (req->open_4_0_owner && owner != req->open_4_0_owner) {
+        nfs_open_owner_put(req->open_4_0_owner);
+        nfs_open_owner_get(owner);
+        req->open_4_0_owner = owner;
+    }
 
     /* RFC 7530 §9.10: check share-mode conflict against opens by *other*
      * owners on this client.  Same-owner OPEN coalesces via the
      * find_state path below and is exempt. */
-    {
-        nfsstat4 conflict = nfs_client_check_share_conflict(
-            client, owner,
-            handle->fh, handle->fh_len,
-            args->share_access, args->share_deny);
-        if (conflict != NFS4_OK) {
-            chimera_vfs_release(req->thread->vfs_thread, handle);
-            return conflict;
-        }
+    status = nfs_client_check_share_conflict(client, owner,
+                                             handle->fh, handle->fh_len,
+                                             args->share_access,
+                                             args->share_deny);
+    if (status != NFS4_OK) {
+        goto err_release_handle;
     }
 
     existing = nfs_open_owner_find_state(owner, handle->fh, handle->fh_len);
@@ -401,8 +415,8 @@ chimera_nfs4_open_install_state(
          * normal clients issue, never trip this.) */
         if ((existing->share_access & args->share_deny) ||
             (args->share_access & existing->share_deny)) {
-            chimera_vfs_release(req->thread->vfs_thread, handle);
-            return NFS4ERR_SHARE_DENIED;
+            status = NFS4ERR_SHARE_DENIED;
+            goto err_release_handle;
         }
         nfs_open_state_coalesce(existing,
                                 args->share_access, args->share_deny,
@@ -415,7 +429,6 @@ chimera_nfs4_open_install_state(
          * upstream's intra-client check is likewise coalesce-exempt. */
     } else {
         struct nfs_open_state *new_state;
-        nfsstat4               share_status;
 
         new_state = nfs_open_state_create(owner,
                                           req->principal_flavor,
@@ -426,15 +439,21 @@ chimera_nfs4_open_install_state(
                                           handle,
                                           &req->thread->shared->nfs4_state_table,
                                           out_stateid);
+        if (!new_state) {
+            /* The lease sweeper unpublished the owner between find_or_adopt
+             * and here; installing would orphan the state. */
+            status = NFS4ERR_EXPIRED;
+            goto err_release_handle;
+        }
 
         /* Cross-protocol SHARE coordination.  On conflict, tear the
          * just-created state back down (releasing the handle) and fail. */
-        share_status = chimera_nfs4_open_acquire_share(req, new_state);
-        if (share_status != NFS4_OK) {
+        status = chimera_nfs4_open_acquire_share(req, new_state);
+        if (status != NFS4_OK) {
             nfs_open_state_destroy(new_state,
                                    &req->thread->shared->nfs4_state_table,
                                    req->thread->vfs_thread);
-            return share_status;
+            goto err_put_owner;
         }
     }
 
@@ -445,7 +464,17 @@ chimera_nfs4_open_install_state(
         *out_rflags |= OPEN4_RESULT_CONFIRM;
     }
 
+    /* Done with the synchronous borrow; release the find_or_adopt ref.  The
+     * hash-table slot ref (and any open_state referencing this owner) keeps it
+     * alive. */
+    nfs_open_owner_put(owner);
     return NFS4_OK;
+
+ err_release_handle:
+    chimera_vfs_release(req->thread->vfs_thread, handle);
+ err_put_owner:
+    nfs_open_owner_put(owner);
+    return status;
 } /* chimera_nfs4_open_install_state */
 
 /*
@@ -480,6 +509,15 @@ chimera_nfs4_open_complete(
         nfs4_replay_record(&owner->replay, args->seqid, OP_OPEN, status,
                            status == NFS4_OK ? &res->resok4.stateid : NULL);
         pthread_mutex_unlock(&owner->lock);
+    }
+
+    /* Drop the borrow ref transferred onto the request in
+     * chimera_nfs4_open.  Unconditional -- every 4.0 completion/error path that set
+     * open_4_0_owner funnels through here exactly once; NULL it to guard
+     * against any double drop. */
+    if (req->open_4_0_owner) {
+        nfs_open_owner_put(req->open_4_0_owner);
+        req->open_4_0_owner = NULL;
     }
 
     /* NFS4.1: a successful OPEN sets the COMPOUND's current stateid. */
@@ -1259,6 +1297,9 @@ chimera_nfs4_open(
             res->resok4.num_attrset                = 0;
             res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
             pthread_mutex_unlock(&owner->lock);
+            /* Early return before the borrow ref transfers to the request;
+             * release it here. */
+            nfs_open_owner_put(owner);
             chimera_nfs4_compound_complete(req, res->status);
             return;
         }
@@ -1267,12 +1308,15 @@ chimera_nfs4_open(
             /* NFS4ERR_BAD_SEQID is in the no-advance set; do not touch
              * owner state. */
             pthread_mutex_unlock(&owner->lock);
+            nfs_open_owner_put(owner);
             res->status = NFS4ERR_BAD_SEQID;
             chimera_nfs4_compound_complete(req, res->status);
             return;
         }
 
         pthread_mutex_unlock(&owner->lock);
+        /* Transfer the find_or_create ref onto the request; dropped in
+         * chimera_nfs4_open_complete. */
         req->open_4_0_owner = owner;
     }
 

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -677,8 +677,20 @@ open_state_destroy_locked(
         uint8_t                ls_prev_destroyed;
 
         LL_DELETE2(state->locks, ls, next_in_open);
+        ls->on_open_list = 0;
         if (ls->lock_owner) {
-            LL_DELETE2(ls->lock_owner->states, ls, next_in_owner);
+            /* lock_owner->states is mutated under lock_owner->lock everywhere
+             * else (nfs_lock_state_create / nfs_lock_state_destroy); take it
+             * here too or a concurrent create corrupts the list.
+             * Ordering: owner->lock (held by caller) -> lock_owner->lock.
+             * Flag-guarded: a racing nfs_lock_state_destroy may have unlinked
+             * this side already. */
+            pthread_mutex_lock(&ls->lock_owner->lock);
+            if (ls->on_owner_list) {
+                LL_DELETE2(ls->lock_owner->states, ls, next_in_owner);
+                ls->on_owner_list = 0;
+            }
+            pthread_mutex_unlock(&ls->lock_owner->lock);
         }
         ls_prev_destroyed = atomic_exchange_explicit(&ls->destroyed, 1,
                                                      memory_order_acq_rel);
@@ -752,9 +764,10 @@ nfs_client_destroy(
         }
         pthread_mutex_unlock(&oo->lock);
 
+        /* Unpublish, then drop the hash-table slot ref; a borrowing in-flight
+         * request defers the free to its own put(). */
         HASH_DELETE(hh, client->open_owners_by_str, oo);
-        pthread_mutex_destroy(&oo->lock);
-        free(oo);
+        nfs_open_owner_put(oo);
     }
 
     HASH_ITER(hh, client->lock_owners_by_str, lo, lo_tmp)
@@ -764,8 +777,7 @@ nfs_client_destroy(
         chimera_nfs_abort_if(lo->states != NULL,
                              "lock_owner %p has leftover lock_states", lo);
         HASH_DELETE(hh, client->lock_owners_by_str, lo);
-        pthread_mutex_destroy(&lo->lock);
-        free(lo);
+        nfs_lock_owner_put(lo);
     }
 
     /* pNFS layouts held by the client (NFSv4.1+).  No recall is performed in
@@ -823,9 +835,11 @@ nfs_client_expire_state(
         }
         pthread_mutex_unlock(&oo->lock);
 
+        /* Unpublish, then drop the hash-table slot ref.  If an in-flight OPEN
+         * still borrows this owner, its ref keeps the struct alive until its
+         * own put(); the last put() destroys the lock and frees. */
         HASH_DELETE(hh, client->open_owners_by_str, oo);
-        pthread_mutex_destroy(&oo->lock);
-        free(oo);
+        nfs_open_owner_put(oo);
     }
 
     HASH_ITER(hh, client->lock_owners_by_str, lo, lo_tmp)
@@ -833,8 +847,7 @@ nfs_client_expire_state(
         chimera_nfs_abort_if(lo->states != NULL,
                              "lock_owner %p has leftover lock_states", lo);
         HASH_DELETE(hh, client->lock_owners_by_str, lo);
-        pthread_mutex_destroy(&lo->lock);
-        free(lo);
+        nfs_lock_owner_put(lo);
     }
 
     struct nfs_layout_state *ly, *ly_tmp;
@@ -857,11 +870,12 @@ nfs_client_expire_state(
 } /* nfs_client_expire_state */
 
 struct nfs_open_owner *
-nfs_open_owner_find_or_create(
-    struct nfs_client *client,
-    const void        *owner_bytes,
-    uint16_t           owner_len,
-    bool              *out_created)
+nfs_open_owner_find_or_adopt(
+    struct nfs_client     *client,
+    struct nfs_open_owner *adopt,
+    const void            *owner_bytes,
+    uint16_t               owner_len,
+    bool                  *out_created)
 {
     struct nfs_open_owner *owner;
 
@@ -877,8 +891,28 @@ nfs_open_owner_find_or_create(
         if (out_created) {
             *out_created = false;
         }
+        /* Take the caller ref while still holding client->lock, which is
+         * serialized against teardown's HASH_DELETE. */
+        nfs_open_owner_get(owner);
         pthread_mutex_unlock(&client->lock);
         return owner;
+    }
+
+    if (adopt) {
+        /* Republish a still-pinned owner that a mid-flight lease sweep
+         * unpublished, so an OPEN completing after the sweep keeps its
+         * seqid/replay state on a single object instead of splitting it
+         * across a fresh one.  One get() re-takes the hash-table
+         * slot ref, the other is the caller ref. */
+        nfs_open_owner_get(adopt);
+        nfs_open_owner_get(adopt);
+        HASH_ADD_KEYPTR(hh, client->open_owners_by_str,
+                        adopt->owner, adopt->owner_len, adopt);
+        if (out_created) {
+            *out_created = false;
+        }
+        pthread_mutex_unlock(&client->lock);
+        return adopt;
     }
 
     owner = calloc(1, sizeof(*owner));
@@ -889,6 +923,8 @@ nfs_open_owner_find_or_create(
     owner->seqid     = 0;
     owner->confirmed = false;
     pthread_mutex_init(&owner->lock, NULL);
+    /* refcount 2: one for the hash-table slot, one for the caller. */
+    atomic_init(&owner->refcount, 2);
 
     HASH_ADD_KEYPTR(hh, client->open_owners_by_str,
                     owner->owner, owner->owner_len, owner);
@@ -898,7 +934,41 @@ nfs_open_owner_find_or_create(
     }
     pthread_mutex_unlock(&client->lock);
     return owner;
+} /* nfs_open_owner_find_or_adopt */
+
+struct nfs_open_owner *
+nfs_open_owner_find_or_create(
+    struct nfs_client *client,
+    const void        *owner_bytes,
+    uint16_t           owner_len,
+    bool              *out_created)
+{
+    return nfs_open_owner_find_or_adopt(client, NULL, owner_bytes, owner_len,
+                                        out_created);
 } /* nfs_open_owner_find_or_create */
+
+void
+nfs_open_owner_get(struct nfs_open_owner *owner)
+{
+    uint32_t prev = atomic_fetch_add_explicit(&owner->refcount, 1,
+                                              memory_order_acq_rel);
+
+    chimera_nfs_abort_if(prev == 0, "open_owner get after free on %p", owner);
+} /* nfs_open_owner_get */
+
+void
+nfs_open_owner_put(struct nfs_open_owner *owner)
+{
+    uint32_t prev = atomic_fetch_sub_explicit(&owner->refcount, 1,
+                                              memory_order_acq_rel);
+
+    chimera_nfs_abort_if(prev == 0, "open_owner refcount underflow on %p",
+                         owner);
+    if (prev == 1) {
+        pthread_mutex_destroy(&owner->lock);
+        free(owner);
+    }
+} /* nfs_open_owner_put */
 
 struct nfs_open_state *
 nfs_open_owner_find_state(
@@ -940,6 +1010,8 @@ nfs_open_state_create(
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid)
 {
+    struct nfs_client     *client = owner->client;
+    struct nfs_open_owner *published;
     struct nfs_open_state *state;
     uint8_t                shard;
     uint32_t               slot_idx, gen;
@@ -979,15 +1051,40 @@ nfs_open_state_create(
     atomic_init(&state->refcount, 1);
     atomic_init(&state->destroyed, 0);
 
+    /* Serialize installation against client teardown, mirroring
+     * nfs_lock_state_create: if the lease sweeper already
+     * unpublished this owner, installing a fresh open_state on it would
+     * orphan the state (and any lock_state later rooted on it) forever --
+     * no teardown walk can reach it through the client's owner hash. */
+    pthread_mutex_lock(&client->lock);
+
+    HASH_FIND(hh, client->open_owners_by_str,
+              owner->owner, owner->owner_len, published);
+    if (published != owner) {
+        pthread_mutex_unlock(&client->lock);
+        nfs_state_table_free_slot(table, shard, slot_idx);
+        free(state);
+        return NULL;
+    }
+
+    /* Pin the owner for the state's lifetime so an acquire-held open_state
+     * always has a valid ->owner, even if the lease sweeper reaps the client
+     * mid-flight.  Released in open_state_cleanup. */
+    nfs_open_owner_get(owner);
+
     nfs_state_table_install(table, shard, slot_idx, NFS4_SLOT_TYPE_OPEN, state);
 
     pthread_mutex_lock(&owner->lock);
     HASH_ADD_KEYPTR(hh, owner->states_by_fh, state->fh, state->fh_len, state);
     pthread_mutex_unlock(&owner->lock);
 
+    /* Encode before dropping client->lock: once published, a concurrent
+     * expire may destroy and free the state. */
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_OPEN, shard, slot_idx, gen,
                         table->epoch);
+
+    pthread_mutex_unlock(&client->lock);
     return state;
 } /* nfs_open_state_create */
 
@@ -1137,6 +1234,8 @@ open_state_cleanup(
         chimera_vfs_release(vfs_thread, state->handle);
         state->handle = NULL;
     }
+    /* Release the owner ref taken in nfs_open_state_create. */
+    nfs_open_owner_put(state->owner);
     free(state);
 } /* open_state_cleanup */
 
@@ -1322,6 +1421,8 @@ nfs_lock_owner_find_or_create(
         if (out_created) {
             *out_created = false;
         }
+        /* Take the caller ref while still holding client->lock. */
+        nfs_lock_owner_get(owner);
         pthread_mutex_unlock(&client->lock);
         return owner;
     }
@@ -1333,6 +1434,8 @@ nfs_lock_owner_find_or_create(
     owner->owner_len = owner_len;
     owner->seqid     = 0;
     pthread_mutex_init(&owner->lock, NULL);
+    /* refcount 2: one for the hash-table slot, one for the caller. */
+    atomic_init(&owner->refcount, 2);
 
     HASH_ADD_KEYPTR(hh, client->lock_owners_by_str,
                     owner->owner, owner->owner_len, owner);
@@ -1344,6 +1447,29 @@ nfs_lock_owner_find_or_create(
     return owner;
 } /* nfs_lock_owner_find_or_create */
 
+void
+nfs_lock_owner_get(struct nfs_lock_owner *owner)
+{
+    uint32_t prev = atomic_fetch_add_explicit(&owner->refcount, 1,
+                                              memory_order_acq_rel);
+
+    chimera_nfs_abort_if(prev == 0, "lock_owner get after free on %p", owner);
+} /* nfs_lock_owner_get */
+
+void
+nfs_lock_owner_put(struct nfs_lock_owner *owner)
+{
+    uint32_t prev = atomic_fetch_sub_explicit(&owner->refcount, 1,
+                                              memory_order_acq_rel);
+
+    chimera_nfs_abort_if(prev == 0, "lock_owner refcount underflow on %p",
+                         owner);
+    if (prev == 1) {
+        pthread_mutex_destroy(&owner->lock);
+        free(owner);
+    }
+} /* nfs_lock_owner_put */
+
 struct nfs_lock_state *
 nfs_lock_state_create(
     struct nfs_lock_owner          *lock_owner,
@@ -1352,6 +1478,8 @@ nfs_lock_state_create(
     struct nfs_state_table         *table,
     struct stateid4                *out_stateid)
 {
+    struct nfs_client     *client = lock_owner->client;
+    struct nfs_lock_owner *published;
     struct nfs_lock_state *state;
     uint8_t                shard;
     uint32_t               slot_idx, gen;
@@ -1373,20 +1501,67 @@ nfs_lock_state_create(
     atomic_init(&state->refcount, 1);
     atomic_init(&state->destroyed, 0);
 
+    /* Serialize installation against client teardown.  Under
+     * client->lock the lease sweeper cannot be mid-walk, so either the
+     * lock_owner is still published and the open_state alive (install
+     * proceeds and a later sweep finds the state on both lists), or the
+     * client was already expired (fail: installing now would orphan the
+     * state forever, since teardown has already walked these lists). */
+    pthread_mutex_lock(&client->lock);
+
+    HASH_FIND(hh, client->lock_owners_by_str,
+              lock_owner->owner, lock_owner->owner_len, published);
+    if (published != lock_owner) {
+        pthread_mutex_unlock(&client->lock);
+        nfs_state_table_free_slot(table, shard, slot_idx);
+        free(state);
+        return NULL;
+    }
+
+    /* Both list links happen under open_state->owner->lock so that
+     * open_state_destroy_locked (CLOSE / expiry), which walks and unlinks
+     * under that same lock, sees either no links or both -- never a
+     * lock_state on one list only.  The destroyed check must share that
+     * critical section: destroy_locked flips the flag under owner->lock
+     * before walking. */
+    pthread_mutex_lock(&open_state->owner->lock);
+    if (atomic_load_explicit(&open_state->destroyed, memory_order_acquire)) {
+        pthread_mutex_unlock(&open_state->owner->lock);
+        pthread_mutex_unlock(&client->lock);
+        nfs_state_table_free_slot(table, shard, slot_idx);
+        free(state);
+        return NULL;
+    }
+
+    /* Pin the lock_owner for the state's lifetime; released in
+     * lock_state_cleanup. */
+    nfs_lock_owner_get(lock_owner);
+
+    /* Pin the open_state too: nfs_lock_state_destroy dereferences
+     * state->open_state (owner lock, locks list) and can race the expire
+     * cascade freeing it.  Released in lock_state_cleanup via
+     * nfs_state_table_release, which defers the open_state cleanup to the
+     * last reference as usual. */
+    atomic_fetch_add_explicit(&open_state->refcount, 1, memory_order_acq_rel);
+
     nfs_state_table_install(table, shard, slot_idx, NFS4_SLOT_TYPE_LOCK, state);
 
-    /* Link onto both the lock_owner's list and the open_state's list. */
     pthread_mutex_lock(&lock_owner->lock);
     LL_PREPEND2(lock_owner->states, state, next_in_owner);
+    state->on_owner_list = 1;
     pthread_mutex_unlock(&lock_owner->lock);
 
-    pthread_mutex_lock(&open_state->owner->lock);
     LL_PREPEND2(open_state->locks, state, next_in_open);
+    state->on_open_list = 1;
     pthread_mutex_unlock(&open_state->owner->lock);
 
+    /* Encode before dropping client->lock: once published, a concurrent
+     * expire may destroy and free the state. */
     nfs4_stateid_encode(out_stateid, state->seqid,
                         NFS4_STATEID_TYPE_LOCK, shard, slot_idx, gen,
                         table->epoch);
+
+    pthread_mutex_unlock(&client->lock);
     return state;
 } /* nfs_lock_state_create */
 
@@ -1450,8 +1625,6 @@ lock_state_cleanup(
     struct chimera_vfs_state *vfs_state = vfs_thread ? vfs_thread->vfs->vfs_state : NULL;
     struct nfs4_range_lease  *rl, *tmp;
 
-    (void) table;
-
     /* Drain any byte-range leases still held (ranges not explicitly
      * released by LOCKU before CLOSE / lock-owner teardown). */
     rl                  = state->range_leases;
@@ -1469,6 +1642,14 @@ lock_state_cleanup(
     if (state->handle && vfs_thread) {
         chimera_vfs_release(vfs_thread, state->handle);
         state->handle = NULL;
+    }
+    /* Release the owner and open_state pins taken in
+     * nfs_lock_state_create.  The open_state release goes through the table so a
+     * destroyed-and-otherwise-unreferenced open_state is cleaned up here. */
+    nfs_lock_owner_put(state->lock_owner);
+    if (state->open_state) {
+        nfs_state_table_release(table, state->open_state,
+                                NFS4_SLOT_TYPE_OPEN, vfs_thread);
     }
     free(state);
 } /* lock_state_cleanup */
@@ -1489,13 +1670,22 @@ nfs_lock_state_destroy(
         return;
     }
 
+    /* Flag-guarded unlinks: the expire/CLOSE cascade in
+     * open_state_destroy_locked may race this and unlink either side
+     * first. */
     pthread_mutex_lock(&lock_owner->lock);
-    LL_DELETE2(lock_owner->states, state, next_in_owner);
+    if (state->on_owner_list) {
+        LL_DELETE2(lock_owner->states, state, next_in_owner);
+        state->on_owner_list = 0;
+    }
     pthread_mutex_unlock(&lock_owner->lock);
 
     if (open_state) {
         pthread_mutex_lock(&open_state->owner->lock);
-        LL_DELETE2(open_state->locks, state, next_in_open);
+        if (state->on_open_list) {
+            LL_DELETE2(open_state->locks, state, next_in_open);
+            state->on_open_list = 0;
+        }
         pthread_mutex_unlock(&open_state->owner->lock);
     }
 

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -294,6 +294,14 @@ struct nfs_open_owner {
     struct nfs_open_state   *states_by_fh; /* uthash keyed on {fh, fh_len} */
     UT_hash_handle           hh;
     pthread_mutex_t          lock;
+
+    /* Lifetime: starts at 1 for the hash-table slot.  find_or_create returns
+     * the owner with one extra caller ref (taken under client->lock, the only
+     * point serialized against teardown's HASH_DELETE); an in-flight OPEN that
+     * borrows the owner across an async VFS round-trip holds that ref.  Client
+     * teardown HASH_DELETEs the owner and drops the slot ref; the last put()
+     * destroys the lock and frees the struct. */
+    _Atomic uint32_t         refcount;
 };
 
 struct nfs_open_state {
@@ -343,6 +351,9 @@ struct nfs_lock_owner {
     struct nfs_lock_state   *states;       /* utlist via next_in_owner */
     UT_hash_handle           hh;
     pthread_mutex_t          lock;
+
+    /* Lifetime: same refcount contract as nfs_open_owner (see above). */
+    _Atomic uint32_t         refcount;
 };
 
 struct nfs_lock_state {
@@ -366,6 +377,15 @@ struct nfs_lock_state {
      * cascade, wired up in Phase 4). */
     struct nfs_lock_state          *next_in_open;
     struct nfs_lock_state          *next_in_owner;
+
+    /* Linked-state flags, protected by open_state->owner->lock and
+     * lock_owner->lock respectively.  Two destroyers can race (LOCKU vs the
+     * expire/CLOSE cascade); the destroyed CAS makes the slot/ref phase
+     * idempotent, and these flags make the LIST unlinks idempotent too --
+     * without them the loser deletes an already-removed node and corrupts
+     * the utlist. */
+    uint8_t                         on_open_list;
+    uint8_t                         on_owner_list;
 
     _Atomic uint32_t                refcount;
     _Atomic uint8_t                 destroyed;
@@ -717,13 +737,42 @@ nfs_client_expire_state(
     struct chimera_vfs_thread *vfs_thread);
 
 /* Find an existing open_owner under `client` by byte-string, or create one.
- * Sets *out_created = true if a new one was allocated. */
+ * Sets *out_created = true if a new one was allocated.  Returns the owner with
+ * one caller-owned reference held (taken under client->lock); the caller must
+ * release it with nfs_open_owner_put() when done, or transfer it onto a request
+ * that borrows the owner across an async VFS round-trip. */
 SYMBOL_EXPORT struct nfs_open_owner *
 nfs_open_owner_find_or_create(
     struct nfs_client *client,
     const void        *owner_bytes,
     uint16_t           owner_len,
     bool              *out_created);
+
+/* Like nfs_open_owner_find_or_create, but if the owner is not published and
+ * `adopt` is non-NULL, re-publishes `adopt` (a still-pinned owner that a
+ * mid-flight lease sweep unpublished) instead of creating a fresh struct, so
+ * 4.0 seqid/replay state stays on a single object.  The caller must
+ * hold a reference on `adopt`.  Returns the owner with one caller-owned
+ * reference held, exactly like find_or_create. */
+SYMBOL_EXPORT struct nfs_open_owner *
+nfs_open_owner_find_or_adopt(
+    struct nfs_client     *client,
+    struct nfs_open_owner *adopt,
+    const void            *owner_bytes,
+    uint16_t               owner_len,
+    bool                  *out_created);
+
+/* Refcount helpers for pinning an open_owner across an async operation that
+ * borrowed it, so the lease sweeper cannot free it out from under an in-flight
+ * request.  get() bumps; put() drops and, on the last reference,
+ * destroys the lock and frees the struct.  Both abort on underflow /
+ * get-after-free, matching the sibling state objects. */
+SYMBOL_EXPORT void
+nfs_open_owner_get(
+    struct nfs_open_owner *owner);
+SYMBOL_EXPORT void
+nfs_open_owner_put(
+    struct nfs_open_owner *owner);
 
 /* Find an existing open_state on `owner` whose FH matches.  Returns NULL if
  * none.  Does NOT acquire a ref. */
@@ -737,7 +786,13 @@ nfs_open_owner_find_state(
  * dup'd reference (caller invoked chimera_vfs_dup_handle).  Allocates a slot
  * in `table` and writes the encoded stateid to `out_stateid`.
  *
- * The returned state has refcount = 1 (its lifetime ref). */
+ * Installation is serialized against client teardown under client->lock:
+ * returns NULL (nothing installed; the caller still owns `handle_dup` and
+ * typically fails the OPEN with NFS4ERR_EXPIRED) if the owner was already
+ * unpublished by lease expiry.
+ *
+ * The returned state has refcount = 1 (its lifetime ref) and holds its own
+ * pin on the owner. */
 SYMBOL_EXPORT struct nfs_open_state *
 nfs_open_state_create(
     struct nfs_open_owner          *owner,
@@ -807,7 +862,8 @@ nfs_open_state_destroy(
     struct nfs_state_table    *table,
     struct chimera_vfs_thread *vfs_thread);
 
-/* Lock-owner / lock-state equivalents. */
+/* Lock-owner / lock-state equivalents.  find_or_create returns the lock_owner
+* with one caller-owned reference held (see nfs_open_owner_find_or_create). */
 SYMBOL_EXPORT struct nfs_lock_owner *
 nfs_lock_owner_find_or_create(
     struct nfs_client *client,
@@ -815,6 +871,19 @@ nfs_lock_owner_find_or_create(
     uint16_t           owner_len,
     bool              *out_created);
 
+SYMBOL_EXPORT void
+nfs_lock_owner_get(
+    struct nfs_lock_owner *owner);
+SYMBOL_EXPORT void
+nfs_lock_owner_put(
+    struct nfs_lock_owner *owner);
+
+/* Create a lock_state linking `lock_owner` and `open_state`.  Installation is
+ * serialized against client teardown under client->lock: if the lock_owner
+ * was already unpublished by lease expiry, or the open_state destroyed,
+ * returns NULL (caller fails the LOCK, typically NFS4ERR_EXPIRED) instead of
+ * installing state no teardown path would ever visit.  On success
+ * the state holds its own pin on the lock_owner. */
 SYMBOL_EXPORT struct nfs_lock_state *
 nfs_lock_state_create(
     struct nfs_lock_owner          *lock_owner,

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -114,6 +114,18 @@ target_include_directories(test_fh_security PRIVATE
 add_dependencies(test_fh_security chimera_nfs_common)
 add_test(NAME chimera/server/nfs/fh_security COMMAND test_fh_security)
 
+# Regression test: open_owner / lock_owner refcount lifetime under
+# a lease sweep racing an in-flight OPEN/LOCK.  Links the exported nfs4_state
+# API the same way as test_state_table (no production sources compiled in).
+add_executable(test_open_owner_lifetime test_open_owner_lifetime.c)
+target_link_libraries(test_open_owner_lifetime chimera_nfs chimera_server chimera_vfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
+target_include_directories(test_open_owner_lifetime PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/server/nfs
+    ${NFS_COMMON_INCLUDE_DIR})
+add_test(NAME chimera/server/nfs/open_owner_lifetime
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_open_owner_lifetime)
+
 # Tag every test registered above with the 'nfs' label so these NFS server unit
 # tests can be run independently via `ctest -L nfs`.
 get_property(_nfs_tests DIRECTORY PROPERTY TESTS)

--- a/src/server/nfs/tests/test_open_owner_lifetime.c
+++ b/src/server/nfs/tests/test_open_owner_lifetime.c
@@ -1,0 +1,641 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Regression test: NFSv4.0 open_owner / lock_owner heap-use-after-free
+ * between the lease sweeper and an in-flight OPEN/LOCK.
+ *
+ * The production race: a worker thread resolves an open_owner for an OPEN,
+ * stashes a borrowed pointer on the request (req->open_4_0_owner), and goes
+ * async into the VFS.  Before the async completion runs, the 1 Hz lease
+ * sweeper reaps the idle client and frees every owner via
+ * nfs_client_expire_state().  The completion then writes owner->seqid into
+ * freed memory (nfs4_proc_open.c:479) -- the faulting write in the captured
+ * crash.  LOCK has the same shape via req->lock_4_0_lock_owner /
+ * req->lock_4_0_open_owner and chimera_nfs4_lock_finish().
+ *
+ * This test forces that exact interleaving deterministically -- no threads or
+ * VFS backend needed.  (A CHIMERA_VFS_CAP_BLOCKING backend only widens the
+ * async window in production; here we simply call the sweeper's teardown while
+ * still holding the borrowed reference.)  It holds the caller reference that
+ * find_or_create now returns -- the same reference an in-flight request keeps
+ * -- expires the client, and then dereferences the owner as the OPEN/LOCK
+ * completion does.
+ *
+ *   Pre-fix: nfs_client_expire_state freed the owner unconditionally, so the
+ *            post-expiry owner->seqid write is a heap-use-after-free that ASAN
+ *            (debug builds) reports at the same site as the captured crash.
+ *   Post-fix: the borrow ref keeps the owner alive across expiry; the write is
+ *            safe, and the final put() frees it cleanly with no leak.
+ *
+ * Also covers the follow-up fixes from the review of the same bug:
+ *   - an acquire-held open_state pins its owner across a sweep;
+ *   - nfs_lock_state_create refuses (returns NULL) once the lock_owner is
+ *     unpublished by expiry or the open_state destroyed, instead of
+ *     installing lock state no teardown path would ever visit;
+ *   - a fully-linked lock_state is torn down completely by the sweep
+ *     (no leak, no leftover-states abort);
+ *   - nfs_open_owner_find_or_adopt republishes a pinned owner the sweep
+ *     unpublished, keeping 4.0 seqid/replay state on a single object.
+ *
+ * Exercises the public nfs4_state.h API directly, mirroring test_state_table.c
+ * (no VFS, RPC, or compound dispatch in the picture).
+ */
+
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "nfs4_state.h"
+
+/* CHECK() always evaluates and aborts on failure (assert(3) is a no-op under
+ * NDEBUG in Release builds). */
+#define CHECK(cond)                                                    \
+        do {                                                               \
+            if (!(cond)) {                                                 \
+                fprintf(stderr, "%s:%d: CHECK failed: %s\n",               \
+                        __FILE__, __LINE__, #cond);                        \
+                abort();                                                   \
+            }                                                              \
+        } while (0)
+
+/*
+ * An in-flight OPEN borrows an open_owner across an async VFS round-trip; the
+ * lease sweeper reaps the client before the completion runs.  The borrowed
+ * reference must keep the owner alive so the completion's owner->seqid write
+ * is safe.
+ */
+static void
+test_open_owner_borrow_survives_sweep(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *oo;
+    bool                   created;
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(1, "client-oo", 9, 0x1234, /*minor*/ 0);
+
+    /* OPEN resolves the owner and (in the fixed code) receives a caller ref
+     * that the in-flight request keeps while parked in the VFS. */
+    oo = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    CHECK(created);
+
+    /* The 1 Hz lease sweeper reaps the idle client mid-flight. */
+    nfs_client_expire_state(client, &table, NULL);
+
+    /* Owner is unpublished from the client's hash... */
+    CHECK(HASH_COUNT(client->open_owners_by_str) == 0);
+
+    /* ...but the borrowed reference kept the struct alive, so the OPEN's async
+     * completion can safely advance the seqid (nfs4_proc_open.c:479).  Pre-fix,
+     * expire_state freed oo and this is a heap-use-after-free. */
+    pthread_mutex_lock(&oo->lock);
+    oo->seqid = 42;
+    pthread_mutex_unlock(&oo->lock);
+    CHECK(oo->seqid == 42);
+
+    /* Completion drops the borrow ref; the last reference frees oo cleanly. */
+    nfs_open_owner_put(oo);
+
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: open_owner_borrow_survives_sweep\n");
+} /* test_open_owner_borrow_survives_sweep */
+
+/* Sibling case: an in-flight LOCK borrows a lock_owner the same way. */
+static void
+test_lock_owner_borrow_survives_sweep(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_lock_owner *lo;
+    bool                   created;
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(2, "client-lo", 9, 0x5678, /*minor*/ 0);
+
+    lo = nfs_lock_owner_find_or_create(client, "lockowner-A", 11, &created);
+    CHECK(created);
+
+    nfs_client_expire_state(client, &table, NULL);
+
+    CHECK(HASH_COUNT(client->lock_owners_by_str) == 0);
+
+    pthread_mutex_lock(&lo->lock);
+    lo->seqid = 7;
+    pthread_mutex_unlock(&lo->lock);
+    CHECK(lo->seqid == 7);
+
+    nfs_lock_owner_put(lo);
+
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: lock_owner_borrow_survives_sweep\n");
+} /* test_lock_owner_borrow_survives_sweep */
+
+/*
+ * Regression: ordinary idle expiry with no request borrowing an owner must
+ * still free every owner (no leak, checked by ASAN's leak detector), and leave
+ * the client's owner hashes empty.
+ */
+static void
+test_idle_expiry_frees_owners(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *oo;
+    struct nfs_lock_owner *lo;
+    bool                   created;
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(3, "client-idle", 11, 0x9abc, /*minor*/ 0);
+
+    /* No borrow held: release the find_or_create caller ref immediately, so
+     * only the hash-table slot ref remains. */
+    oo = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    CHECK(created);
+    nfs_open_owner_put(oo);
+
+    lo = nfs_lock_owner_find_or_create(client, "lockowner-A", 11, &created);
+    CHECK(created);
+    nfs_lock_owner_put(lo);
+
+    /* Expiry drops the slot refs -> both owners freed, hashes empty. */
+    nfs_client_expire_state(client, &table, NULL);
+    CHECK(HASH_COUNT(client->open_owners_by_str) == 0);
+    CHECK(HASH_COUNT(client->lock_owners_by_str) == 0);
+
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: idle_expiry_frees_owners\n");
+} /* test_idle_expiry_frees_owners */
+
+/*
+ * An acquire-held open_state pins its owner across a sweep, and a LOCK whose
+ * client was expired mid-flight must fail to install lock state rather than
+ * orphan it: nfs_lock_state_create returns NULL once the lock_owner is
+ * unpublished (the proc layer maps that to NFS4ERR_EXPIRED).
+ */
+static void
+test_lock_state_install_after_expire_fails(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *oo;
+    struct nfs_open_state *os;
+    struct nfs_lock_owner *lo;
+    struct nfs_lock_state *ls;
+    struct stateid4        sid, lock_sid;
+    nfsstat4               status;
+    void                  *acquired;
+    uint8_t                acquired_type;
+    bool                   created;
+    uint8_t                fh[4] = { 0x01, 0x02, 0x03, 0x04 };
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(4, "client-lk1", 10, 0x1111, /*minor*/ 0);
+
+    oo = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    CHECK(created);
+    os = nfs_open_state_create(oo, 0, NULL, 0, fh, sizeof(fh),
+                               OPEN4_SHARE_ACCESS_READ, OPEN4_SHARE_DENY_NONE,
+                               /*handle_dup*/ NULL, &table, &sid);
+    CHECK(os != NULL);
+
+    /* The in-flight LOCK holds the open stateid acquire ref across the async
+     * VFS round-trip. */
+    status = nfs_state_table_acquire(&table, &sid, NFS4_SLOT_TYPE_OPEN,
+                                     &acquired, &acquired_type);
+    CHECK(status == NFS4_OK);
+    CHECK(acquired == os);
+
+    lo = nfs_lock_owner_find_or_create(client, "lockowner-A", 11, &created);
+    CHECK(created);
+
+    /* Sweep reaps the client mid-flight: the open_state destroy is deferred
+     * (we hold the acquire ref), the lock_owner is unpublished. */
+    nfs_client_expire_state(client, &table, NULL);
+
+    /* The state's pin keeps ->owner dereferenceable even though the sweep
+     * dropped the owner's hash-slot ref. */
+    CHECK(os->owner == oo);
+
+    /* Installation after the sweep must refuse rather than orphan. */
+    ls = nfs_lock_state_create(lo, os, NULL, &table, &lock_sid);
+    CHECK(ls == NULL);
+
+    /* Release the acquire ref: the deferred open_state cleanup runs now and
+     * drops its owner pin. */
+    nfs_state_table_release(&table, os, NFS4_SLOT_TYPE_OPEN, NULL);
+
+    nfs_lock_owner_put(lo);
+    nfs_open_owner_put(oo);
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: lock_state_install_after_expire_fails\n");
+} /* test_lock_state_install_after_expire_fails */
+
+/* Sibling refusal: the open_state was destroyed (e.g. a racing CLOSE) while
+ * the lock_owner is still published. */
+static void
+test_lock_state_install_after_close_fails(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *oo;
+    struct nfs_open_state *os;
+    struct nfs_lock_owner *lo;
+    struct nfs_lock_state *ls;
+    struct stateid4        sid, lock_sid;
+    nfsstat4               status;
+    void                  *acquired;
+    uint8_t                acquired_type;
+    bool                   created;
+    uint8_t                fh[4] = { 0x05, 0x06, 0x07, 0x08 };
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(5, "client-lk2", 10, 0x2222, /*minor*/ 0);
+
+    oo = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    os = nfs_open_state_create(oo, 0, NULL, 0, fh, sizeof(fh),
+                               OPEN4_SHARE_ACCESS_READ, OPEN4_SHARE_DENY_NONE,
+                               NULL, &table, &sid);
+    status = nfs_state_table_acquire(&table, &sid, NFS4_SLOT_TYPE_OPEN,
+                                     &acquired, &acquired_type);
+    CHECK(status == NFS4_OK);
+
+    lo = nfs_lock_owner_find_or_create(client, "lockowner-A", 11, &created);
+
+    /* CLOSE destroys the open_state under the LOCK's feet (deferred while
+     * the acquire ref is held). */
+    nfs_open_state_destroy(os, &table, NULL);
+
+    ls = nfs_lock_state_create(lo, os, NULL, &table, &lock_sid);
+    CHECK(ls == NULL);
+
+    nfs_state_table_release(&table, os, NFS4_SLOT_TYPE_OPEN, NULL);
+    nfs_lock_owner_put(lo);
+    nfs_open_owner_put(oo);
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: lock_state_install_after_close_fails\n");
+} /* test_lock_state_install_after_close_fails */
+
+/*
+ * A fully-linked lock_state created BEFORE the sweep must be torn down by it
+ * completely: the expire walk reaches it via open_state->locks, unlinks it
+ * from lock_owner->states (so the leftover-states abort check passes), and
+ * frees it -- no leak, no abort.
+ */
+static void
+test_expire_with_fully_linked_lock_state(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *oo;
+    struct nfs_open_state *os;
+    struct nfs_lock_owner *lo;
+    struct nfs_lock_state *ls;
+    struct stateid4        sid, lock_sid;
+    bool                   created;
+    uint8_t                fh[4] = { 0x09, 0x0A, 0x0B, 0x0C };
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(6, "client-lk3", 10, 0x3333, /*minor*/ 0);
+
+    oo = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    os = nfs_open_state_create(oo, 0, NULL, 0, fh, sizeof(fh),
+                               OPEN4_SHARE_ACCESS_READ, OPEN4_SHARE_DENY_NONE,
+                               NULL, &table, &sid);
+    lo = nfs_lock_owner_find_or_create(client, "lockowner-A", 11, &created);
+
+    /* Client alive: installation succeeds and links both lists. */
+    ls = nfs_lock_state_create(lo, os, NULL, &table, &lock_sid);
+    CHECK(ls != NULL);
+    CHECK(lo->states == ls);
+    CHECK(os->locks == ls);
+
+    /* Sweep: tears down open_state -> lock_state cascade, then asserts every
+     * lock_owner has no leftover states.  Surviving this call (no abort) and
+     * running ASAN-clean (no leak of ls) is the regression check. */
+    nfs_client_expire_state(client, &table, NULL);
+    CHECK(HASH_COUNT(client->open_owners_by_str) == 0);
+    CHECK(HASH_COUNT(client->lock_owners_by_str) == 0);
+    CHECK(lo->states == NULL);
+
+    nfs_lock_owner_put(lo);
+    nfs_open_owner_put(oo);
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: expire_with_fully_linked_lock_state\n");
+} /* test_expire_with_fully_linked_lock_state */
+
+/*
+ * OPEN owner identity across a sweep: a pinned owner that the sweep
+ * unpublished is republished (adopted) by the completion path rather than
+ * replaced with a fresh struct, so seqid/replay state stays on one object.
+ */
+static void
+test_open_owner_adopt_after_sweep(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *oo, *adopted, *found;
+    bool                   created;
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(7, "client-adopt", 12, 0x4444, /*minor*/ 0);
+
+    oo = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    CHECK(created);
+
+    pthread_mutex_lock(&oo->lock);
+    oo->seqid = 5;
+    pthread_mutex_unlock(&oo->lock);
+
+    /* Sweep unpublishes the owner; the request's pin keeps it alive. */
+    nfs_client_expire_state(client, &table, NULL);
+    CHECK(HASH_COUNT(client->open_owners_by_str) == 0);
+
+    /* Completion resolves the owner with the pinned struct as the adopt
+     * candidate: the SAME object comes back, republished. */
+    adopted = nfs_open_owner_find_or_adopt(client, oo, "owner-A", 7, &created);
+    CHECK(adopted == oo);
+    CHECK(!created);
+    CHECK(HASH_COUNT(client->open_owners_by_str) == 1);
+    CHECK(oo->seqid == 5);
+
+    /* A later lookup finds the republished object, not a fresh one. */
+    found = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    CHECK(found == oo);
+    CHECK(!created);
+
+    nfs_open_owner_put(found);
+    nfs_open_owner_put(adopted);
+    nfs_open_owner_put(oo);
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: open_owner_adopt_after_sweep\n");
+} /* test_open_owner_adopt_after_sweep */
+
+/*
+ * Adopt arbitration for the pathological double-race: the sweep unpublished
+ * the pinned owner AND another OPEN already recreated the key.  find_or_adopt
+ * must return the published object (so the reply cache lands where a
+ * retransmit will look), not resurrect the orphan alongside it.
+ */
+static void
+test_adopt_prefers_published_owner(void)
+{
+    struct nfs_state_table table;
+    struct nfs_client     *client;
+    struct nfs_open_owner *oo, *fresh, *adopted;
+    bool                   created;
+
+    nfs_state_table_init(&table, 1);
+    client = nfs_client_alloc(8, "client-race", 11, 0x5555, /*minor*/ 0);
+
+    oo = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    CHECK(created);
+
+    nfs_client_expire_state(client, &table, NULL);
+
+    /* Another OPEN recreates the key while ours is still in flight. */
+    fresh = nfs_open_owner_find_or_create(client, "owner-A", 7, &created);
+    CHECK(created);
+    CHECK(fresh != oo);
+
+    /* Our completion must resolve to the published object, not readopt. */
+    adopted = nfs_open_owner_find_or_adopt(client, oo, "owner-A", 7, &created);
+    CHECK(adopted == fresh);
+    CHECK(!created);
+    CHECK(HASH_COUNT(client->open_owners_by_str) == 1);
+
+    nfs_open_owner_put(adopted);
+    nfs_open_owner_put(fresh);
+    nfs_open_owner_put(oo);
+    nfs_client_destroy(client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: adopt_prefers_published_owner\n");
+} /* test_adopt_prefers_published_owner */
+
+/* --- Death tests: refcount abort diagnostics -------------------------- */
+
+/* Run fn in a forked child and require it to die with SIGABRT (the
+ * chimera_nfs_abort_if diagnostics in the get/put helpers). */
+static void
+expect_abort(void ( *fn )(void))
+{
+    pid_t pid;
+    int   status;
+
+    /* Don't let the child flush inherited stdio buffers into our output. */
+    fflush(NULL);
+    pid = fork();
+    CHECK(pid >= 0);
+    if (pid == 0) {
+        /* Silence the fatal-log line and any sanitizer chatter.  Best
+         * effort: on failure the child output is merely noisy, and the
+         * child aborts momentarily regardless. */
+        if (!freopen("/dev/null", "w", stderr) ||
+            !freopen("/dev/null", "w", stdout)) {
+            /* keep going */
+        }
+        fn();
+        _exit(0);  /* not reached: fn must abort */
+    }
+    CHECK(waitpid(pid, &status, 0) == pid);
+    /* The chimera crash handler may terminate via raw SIGABRT or via a
+     * nonzero exit (sanitizer builds); either way the child must not have
+     * survived to _exit(0). */
+    CHECK((WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT) ||
+          (WIFEXITED(status) && WEXITSTATUS(status) != 0));
+} /* expect_abort */
+
+static void
+die_open_owner_get_after_free(void)
+{
+    struct nfs_open_owner o = { 0 };
+
+    atomic_init(&o.refcount, 0);
+    nfs_open_owner_get(&o);
+} /* die_open_owner_get_after_free */
+
+static void
+die_open_owner_put_underflow(void)
+{
+    struct nfs_open_owner o = { 0 };
+
+    atomic_init(&o.refcount, 0);
+    nfs_open_owner_put(&o);
+} /* die_open_owner_put_underflow */
+
+static void
+die_lock_owner_get_after_free(void)
+{
+    struct nfs_lock_owner o = { 0 };
+
+    atomic_init(&o.refcount, 0);
+    nfs_lock_owner_get(&o);
+} /* die_lock_owner_get_after_free */
+
+static void
+die_lock_owner_put_underflow(void)
+{
+    struct nfs_lock_owner o = { 0 };
+
+    atomic_init(&o.refcount, 0);
+    nfs_lock_owner_put(&o);
+} /* die_lock_owner_put_underflow */
+
+static void
+test_refcount_abort_diagnostics(void)
+{
+    expect_abort(die_open_owner_get_after_free);
+    expect_abort(die_open_owner_put_underflow);
+    expect_abort(die_lock_owner_get_after_free);
+    expect_abort(die_lock_owner_put_underflow);
+    printf("ok: refcount_abort_diagnostics\n");
+} /* test_refcount_abort_diagnostics */
+
+/* --- Concurrency stress: LOCK install vs lease sweep ------------------ */
+
+struct stress_ctx {
+    struct nfs_state_table *table;
+    struct nfs_client      *client;
+    _Atomic int             done;
+};
+
+/* Worker: the OPEN+LOCK fast path, exactly as the proc layer drives it --
+ * resolve owners with caller refs, pin the open_state by acquire before
+ * handing it to nfs_lock_state_create, tolerate NULL (expired mid-flight). */
+static void *
+stress_worker(void *arg)
+{
+    struct stress_ctx *ctx   = arg;
+    uint8_t            fh[4] = { 0xAB, 0xCD, 0xEF, 0x01 };
+
+    for (int i = 0; i < 2000; i++) {
+        struct nfs_open_owner *oo;
+        struct nfs_open_state *os;
+        struct stateid4        sid, lsid;
+        void                  *acq;
+        uint8_t                acq_type;
+
+        oo = nfs_open_owner_find_or_create(ctx->client, "owner-A", 7, NULL);
+        os = nfs_open_state_create(oo, 0, NULL, 0, fh, sizeof(fh),
+                                   OPEN4_SHARE_ACCESS_READ,
+                                   OPEN4_SHARE_DENY_NONE,
+                                   NULL, ctx->table, &sid);
+        if (!os) {
+            /* Sweep unpublished the owner between resolve and install;
+             * the OPEN would fail with NFS4ERR_EXPIRED. */
+            nfs_open_owner_put(oo);
+            continue;
+        }
+
+        if (nfs_state_table_acquire(ctx->table, &sid, NFS4_SLOT_TYPE_OPEN,
+                                    &acq, &acq_type) == NFS4_OK) {
+            struct nfs_lock_owner *lo;
+            struct nfs_lock_state *ls;
+
+            lo = nfs_lock_owner_find_or_create(ctx->client, "lockowner-A", 11,
+                                               NULL);
+            ls = nfs_lock_state_create(lo, os, NULL, ctx->table, &lsid);
+
+            if (ls &&
+                nfs_state_table_acquire(ctx->table, &lsid,
+                                        NFS4_SLOT_TYPE_LOCK,
+                                        &acq, &acq_type) == NFS4_OK) {
+                /* LOCKU-style teardown; idempotent vs a racing expire. */
+                nfs_lock_state_destroy(acq, ctx->table, NULL);
+                nfs_state_table_release(ctx->table, acq,
+                                        NFS4_SLOT_TYPE_LOCK, NULL);
+            }
+
+            nfs_lock_owner_put(lo);
+            nfs_state_table_release(ctx->table, os, NFS4_SLOT_TYPE_OPEN, NULL);
+        }
+
+        nfs_open_owner_put(oo);
+    }
+
+    atomic_store(&ctx->done, 1);
+    return NULL;
+} /* stress_worker */
+
+/* Sweeper: the 1 Hz lease reaper, with the sleep removed. */
+static void *
+stress_sweeper(void *arg)
+{
+    struct stress_ctx *ctx = arg;
+
+    while (!atomic_load(&ctx->done)) {
+        nfs_client_expire_state(ctx->client, ctx->table, NULL);
+        sched_yield();
+    }
+    return NULL;
+} /* stress_sweeper */
+
+/*
+ * Hammer the exact sweeper-vs-worker interleavings under ASAN:
+ * a worker running the OPEN+LOCK install path while the sweeper expires the
+ * client continuously.  Pre-fix this trips the lock_owner UAF (put before
+ * nfs_lock_state_create), the lo->states leftover-states abort, the unlocked
+ * lock_owner->states list race, or leaks orphaned lock_states (caught by
+ * ASAN's leak checker at exit).  Post-fix it must run clean.
+ */
+static void
+test_concurrent_install_vs_expire(void)
+{
+    struct nfs_state_table table;
+    struct stress_ctx      ctx;
+    pthread_t              worker, sweeper;
+
+    nfs_state_table_init(&table, 1);
+    ctx.table  = &table;
+    ctx.client = nfs_client_alloc(9, "client-race2", 12, 0x6666, /*minor*/ 0);
+    atomic_init(&ctx.done, 0);
+
+    CHECK(pthread_create(&worker, NULL, stress_worker, &ctx) == 0);
+    CHECK(pthread_create(&sweeper, NULL, stress_sweeper, &ctx) == 0);
+    CHECK(pthread_join(worker, NULL) == 0);
+    CHECK(pthread_join(sweeper, NULL) == 0);
+
+    /* Final sweep + teardown must leave nothing behind (ASAN leak check). */
+    nfs_client_expire_state(ctx.client, &table, NULL);
+    CHECK(HASH_COUNT(ctx.client->open_owners_by_str) == 0);
+    CHECK(HASH_COUNT(ctx.client->lock_owners_by_str) == 0);
+
+    nfs_client_destroy(ctx.client, &table, NULL, true);
+    nfs_state_table_free(&table, NULL);
+    printf("ok: concurrent_install_vs_expire\n");
+} /* test_concurrent_install_vs_expire */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    (void) argc;
+    (void) argv;
+    test_open_owner_borrow_survives_sweep();
+    test_lock_owner_borrow_survives_sweep();
+    test_idle_expiry_frees_owners();
+    test_lock_state_install_after_expire_fails();
+    test_lock_state_install_after_close_fails();
+    test_expire_with_fully_linked_lock_state();
+    test_open_owner_adopt_after_sweep();
+    test_adopt_prefers_published_owner();
+    test_refcount_abort_diagnostics();
+    test_concurrent_install_vs_expire();
+    printf("PASS: all open_owner lifetime tests\n");
+    return 0;
+} /* main */

--- a/src/server/nfs/tests/test_state_table.c
+++ b/src/server/nfs/tests/test_state_table.c
@@ -198,6 +198,12 @@ test_owner_state_lifecycle(void)
                                      &acquired, &acquired_type);
     CHECK(status != NFS4_OK);
 
+    /* find_or_create returns a caller ref; release both (owner_again is the
+     * same object).  The hash-table slot ref keeps the owner alive until
+     * nfs_client_destroy. */
+    nfs_open_owner_put(owner_again);
+    nfs_open_owner_put(owner);
+
     nfs_client_destroy(client, &table, NULL, true);
     nfs_state_table_free(&table, NULL);
     printf("ok: owner_state_lifecycle\n");
@@ -312,6 +318,9 @@ test_share_mode_conflict(void)
     CHECK(status == NFS4_OK);
 
     nfs_open_state_destroy(state_a, &table, NULL);
+    /* Release the find_or_create caller refs. */
+    nfs_open_owner_put(owner_a);
+    nfs_open_owner_put(owner_b);
     nfs_client_destroy(client, &table, NULL, true);
     nfs_state_table_free(&table, NULL);
     printf("ok: share_mode_conflict\n");


### PR DESCRIPTION
Running pynfs over NFSv4.0 against a blocking (CHIMERA_VFS_CAP_BLOCKING) backend crashes under AddressSanitizer: an OPEN resolves its open_owner at dispatch and stashes a borrowed, unrefcounted pointer on the request while the open goes async into the VFS.  If the client's lease lapses during the round-trip, the lease sweeper frees every owner in nfs_client_expire_state, and the OPEN completion writes owner->seqid into freed memory.  Blocking backends dispatch to a sync delegation thread, stretching the async window from same-tick (memfs, inline) to milliseconds, which is what makes the 1 Hz sweeper race observable.

Fix the lifetime and the surrounding install-vs-expiry races:

- Refcount nfs_open_owner and nfs_lock_owner like every sibling state object: find_or_create returns a caller reference taken under client->lock, in-flight OPEN/LOCK requests hold it across the async VFS round-trip, teardown unpublishes the owner and drops only the hash-slot reference, and the last put() frees.  get/put abort on underflow.
- Pin the owner from open_state/lock_state for the state's lifetime, and pin the open_state from the lock_state (nfs_lock_state_destroy dereferences it with nothing else keeping it alive).
- Serialize open_state/lock_state installation against nfs_client_expire_state under client->lock: creating state on an owner the sweep already unpublished (or a destroyed open_state) now fails and the operation returns NFS4ERR_EXPIRED, instead of installing orphaned state that no teardown walk can ever reach (permanently leaking a dead client's byte-range lock) or tripping the leftover-lock-states abort.
- Keep NFSv4.0 seqid/replay state on a single owner object across a sweep: the OPEN completion re-adopts (republishes) the request's pinned owner rather than creating a fresh one, so a retransmit still finds the cached reply instead of re-executing (e.g. a GUARDED create returning a spurious NFS4ERR_EXIST).
- Make the two lock_state list unlinks idempotent with flags checked under the respective locks: LOCKU racing the expire/CLOSE cascade previously double-unlinked the utlist entries and corrupted the lists.  Encode the stateid of a freshly-created state before dropping the locks; after publication a concurrent sweep can already have freed it.

Add test_open_owner_lifetime covering the borrow-across-sweep cases, the install-after-expiry refusals, full teardown of a linked lock_state, owner re-adoption, refcount abort diagnostics, and a threaded worker-vs-sweeper stress run under ASAN that reproduces the original interleavings.