### PR TITLE
nfs: add optional export_id option for exports

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -467,6 +467,16 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict - export name or export_id already in use",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Failed to create export",
             "content": {
@@ -1024,6 +1034,12 @@
           "path": {
             "type": "string",
             "description": "VFS path"
+          },
+          "export_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4095,
+            "description": "Stable export identifier embedded in NFS file handles"
           }
         }
       },
@@ -1038,6 +1054,12 @@
           "path": {
             "type": "string",
             "description": "VFS path"
+          },
+          "export_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4095,
+            "description": "Optional explicit export id (1..4095); auto-assigned when omitted. Must match across clustered servers exporting the same directory so file handles stay valid on failover."
           }
         }
       },
@@ -1129,6 +1151,12 @@
                 "path": {
                   "type": "string",
                   "description": "VFS path"
+                },
+                "export_id": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 4095,
+                  "description": "Stable export identifier embedded in NFS file handles"
                 }
               }
             }

--- a/src/admin/chimera_admin/cli.py
+++ b/src/admin/chimera_admin/cli.py
@@ -44,8 +44,8 @@ def _delete_and_msg(method, ident: str, noun: str) -> str:
 def _add_crud_commands(sub, noun: str, label: str) -> None:
     """Add list/get/create/delete commands for a name+path resource.
 
-    Covers exports, shares, and buckets, which share an identical REST
-    shape. Client methods are resolved by convention: ``list_<noun>s``,
+    Covers shares and buckets, which share an identical REST shape.
+    Client methods are resolved by convention: ``list_<noun>s``,
     ``get_<noun>``, ``create_<noun>``, ``delete_<noun>``.
     """
     plural = noun + "s"
@@ -70,6 +70,45 @@ def _add_crud_commands(sub, noun: str, label: str) -> None:
     p.set_defaults(
         func=lambda c, a: _delete_and_msg(
             getattr(c, f"delete_{noun}"), a.name, noun))
+
+
+def _add_export_commands(sub) -> None:
+    """Add the ``export`` resource commands.
+
+    Exports follow the generic name+path CRUD shape but grow an
+    export-specific ``--export-id`` create option, so they get their own
+    builder rather than sharing _add_crud_commands with shares/buckets.
+    """
+    res = sub.add_parser("export", help="Manage NFS exports")
+    actions = res.add_subparsers(dest="action", required=True)
+
+    p = actions.add_parser("list", help="List NFS exports")
+    p.set_defaults(func=lambda c, a: c.list_exports())
+
+    p = actions.add_parser("get", help="Get a NFS export")
+    p.add_argument("name")
+    p.set_defaults(func=lambda c, a: c.get_export(a.name))
+
+    p = actions.add_parser("create", help="Create a NFS export")
+    p.add_argument("name")
+    p.add_argument("path", help="VFS path for the resource")
+    p.add_argument(
+        "--export-id", type=int, dest="export_id",
+        help="Stable export id (1-4095, default: auto-assigned)")
+    p.add_argument(
+        "--options", choices=["ro", "rw"],
+        help="Access mode (default: rw)")
+    p.add_argument(
+        "--squash", choices=["none", "root", "all"],
+        help="Squash policy (default: none)")
+    p.set_defaults(func=lambda c, a: c.create_export(
+        a.name, a.path, export_id=a.export_id, options=a.options,
+        squash=a.squash))
+
+    p = actions.add_parser("delete", help="Delete a NFS export")
+    p.add_argument("name")
+    p.set_defaults(
+        func=lambda c, a: _delete_and_msg(c.delete_export, a.name, "export"))
 
 
 def _add_user_commands(sub) -> None:
@@ -162,7 +201,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=lambda c, a: c.get_config())
 
     _add_user_commands(sub)
-    _add_crud_commands(sub, "export", "NFS export")
+    _add_export_commands(sub)
     _add_crud_commands(sub, "share", "SMB share")
     _add_crud_commands(sub, "bucket", "S3 bucket")
     _add_mount_commands(sub)

--- a/src/admin/chimera_admin/client.py
+++ b/src/admin/chimera_admin/client.py
@@ -237,22 +237,43 @@ class ChimeraAdminClient:
         """
         return self._request("GET", f"/api/v1/exports/{name}")
 
-    def create_export(self, name: str, path: str) -> dict:
+    def create_export(
+        self,
+        name: str,
+        path: str,
+        export_id: Optional[int] = None,
+        options: Optional[str] = None,
+        squash: Optional[str] = None,
+    ) -> dict:
         """Create a new NFS export.
 
         Args:
             name: Export name.
             path: VFS path for the export.
+            export_id: Optional stable export id (1-4095), embedded in NFS
+                file handles; auto-assigned when omitted. Clustered servers
+                exporting the same directory must pin the same id so file
+                handles stay valid across failover.
+            options: Optional access mode, "ro" or "rw" (server default: rw).
+            squash: Optional squash policy, "none", "root", or "all"
+                (server default: none).
 
         Returns:
             Response message.
 
         Raises:
-            ChimeraAdminError: If the request fails
+            ChimeraAdminError: If the request fails (e.g. 400 for an
+                out-of-range export_id, 409 if the name or export_id is
+                already in use).
         """
-        return self._request(
-            "POST", "/api/v1/exports", json={"name": name, "path": path}
-        )
+        data = {"name": name, "path": path}
+        if export_id is not None:
+            data["export_id"] = export_id
+        if options is not None:
+            data["options"] = options
+        if squash is not None:
+            data["squash"] = squash
+        return self._request("POST", "/api/v1/exports", json=data)
 
     def delete_export(self, name: str) -> None:
         """Delete an NFS export.

--- a/src/admin/tests/test_api.py
+++ b/src/admin/tests/test_api.py
@@ -84,6 +84,135 @@ class TestExportsAPI:
             client.get_export("nonexistent_export")
         assert exc_info.value.status_code == 404
 
+    def test_create_get_delete_export(self, client):
+        """Test creating, fetching, and deleting an export."""
+        name = "sdk_test_export"
+        try:
+            client.create_export(name, "/testshare")
+
+            export = client.get_export(name)
+            assert export["name"] == name
+            assert export["path"] == "/testshare"
+            # Auto-assigned export ids start at 1; 0 is reserved.
+            assert export["export_id"] >= 1
+        finally:
+            client.delete_export(name)
+
+        with pytest.raises(ChimeraAdminError) as exc_info:
+            client.get_export(name)
+        assert exc_info.value.status_code == 404
+
+    def test_create_export_id_round_trip(self, client):
+        """An explicit export_id is echoed back everywhere."""
+        name = "sdk_test_export_id"
+        export_id = 4000
+        try:
+            client.create_export(name, "/testshare", export_id=export_id)
+
+            # get_export echoes the id.
+            export = client.get_export(name)
+            assert export["export_id"] == export_id
+
+            # list_exports carries it on the matching entry.
+            listed = next(
+                e for e in client.list_exports() if e["name"] == name)
+            assert listed["export_id"] == export_id
+
+            # The running config round-trips it for chimera.json.
+            config = client.get_config()
+            assert config["exports"][name]["export_id"] == export_id
+        finally:
+            client.delete_export(name)
+
+    def test_create_export_options_round_trip(self, client):
+        """Access options given at create time are echoed back."""
+        name = "sdk_test_export_opts"
+        try:
+            client.create_export(
+                name, "/testshare", export_id=4003,
+                options="ro", squash="none")
+
+            export = client.get_export(name)
+            assert export["export_id"] == 4003
+            assert export["options"] == "ro"
+            assert export["squash"] == "none"
+
+            # The running config round-trips them for chimera.json.
+            config = client.get_config()
+            assert config["exports"][name]["options"] == "ro"
+            assert config["exports"][name]["squash"] == "none"
+        finally:
+            client.delete_export(name)
+
+    def test_create_export_duplicate_id(self, client):
+        """A second export reusing an export_id is rejected with 409."""
+        name = "sdk_test_export_dup"
+        other = "sdk_test_export_dup2"
+        export_id = 4001
+        try:
+            client.create_export(name, "/testshare", export_id=export_id)
+
+            with pytest.raises(ChimeraAdminError) as exc_info:
+                client.create_export(other, "/testshare",
+                                     export_id=export_id)
+            assert exc_info.value.status_code == 409
+
+            # The rejected export must not have been created.
+            with pytest.raises(ChimeraAdminError) as exc_info:
+                client.get_export(other)
+            assert exc_info.value.status_code == 404
+        finally:
+            client.delete_export(name)
+
+    def test_create_export_invalid_id(self, client):
+        """Out-of-range export ids are rejected with 400."""
+        for bad_id in (0, 4096, -5):
+            with pytest.raises(ChimeraAdminError) as exc_info:
+                client.create_export(
+                    "sdk_test_export_bad", "/testshare", export_id=bad_id)
+            assert exc_info.value.status_code == 400
+
+        with pytest.raises(ChimeraAdminError) as exc_info:
+            client.get_export("sdk_test_export_bad")
+        assert exc_info.value.status_code == 404
+
+    def test_auto_assign_skips_explicit_id(self, client):
+        """Auto-assignment never reuses a slot pinned explicitly."""
+        auto1 = "sdk_test_export_auto1"
+        pinned = "sdk_test_export_pinned"
+        auto2 = "sdk_test_export_auto2"
+        created = []
+        try:
+            client.create_export(auto1, "/testshare")
+            created.append(auto1)
+            base = client.get_export(auto1)["export_id"]
+            if base + 2 > 4095:
+                pytest.skip("export id space nearly exhausted")
+
+            client.create_export(pinned, "/testshare", export_id=base + 1)
+            created.append(pinned)
+
+            client.create_export(auto2, "/testshare")
+            created.append(auto2)
+            assert client.get_export(auto2)["export_id"] == base + 2
+        finally:
+            for name in created:
+                client.delete_export(name)
+
+    def test_export_id_reusable_after_delete(self, client):
+        """Deleting an export frees its id for a new export."""
+        export_id = 4002
+        client.create_export(
+            "sdk_test_export_free", "/testshare", export_id=export_id)
+        client.delete_export("sdk_test_export_free")
+
+        name = "sdk_test_export_reuse"
+        try:
+            client.create_export(name, "/testshare", export_id=export_id)
+            assert client.get_export(name)["export_id"] == export_id
+        finally:
+            client.delete_export(name)
+
 
 class TestSharesAPI:
     """Test the SMB Shares API endpoints."""

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -208,7 +208,7 @@ client_test_init(
 
         // Create NFSv3 server export entry
         if (env->use_nfs) {
-            chimera_server_create_export(env->server, "/share", "/share");
+            chimera_server_create_export(env->server, "/share", "/share", 0);
         }
 
         chimera_server_start(env->server);

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1081,9 +1081,19 @@ main(
 
     exports = json_object_get(config, "exports");
 
-    if (exports) {
+    /* Two passes over the exports object: entries pinning an explicit
+     * export_id are created first so auto-assignment for the remaining
+     * entries cannot take an id a later entry pins; with a single pass,
+     * whether startup succeeds would depend on key order in the config. */
+    for (int pass = 0; exports && pass < 2; pass++) {
         json_object_foreach(exports, name, export)
         {
+            json_t     *exp_id_j = json_object_get(export, "export_id");
+
+            if ((exp_id_j != NULL) != (pass == 0)) {
+                continue;
+            }
+
             json_t     *opt_j     = json_object_get(export, "options");
             json_t     *squash_j  = json_object_get(export, "squash");
             json_t     *rsq_j     = json_object_get(export, "root_squash");
@@ -1091,6 +1101,7 @@ main(
             json_t     *allsq_j   = json_object_get(export, "all_squash");
             json_t     *anonuid_j = json_object_get(export, "anonuid");
             json_t     *anongid_j = json_object_get(export, "anongid");
+            uint32_t    export_id = 0;
             const char *opt_s     = json_string_value(opt_j);
             const char *squash_s  = json_string_value(squash_j);
             uint32_t    options   = CHIMERA_NFS_EXPORT_OPT_RW;
@@ -1144,6 +1155,24 @@ main(
                 anongid = (uint32_t) json_integer_value(anongid_j);
             }
 
+            /* Stable export id: the id is embedded in wire file handles, so
+             * clustered servers exporting the same directory must pin the
+             * same value.  A wrong id silently defeats that, so reject bad
+             * values outright rather than falling back to auto-assignment. */
+            if (exp_id_j) {
+                json_int_t v = json_is_integer(exp_id_j) ?
+                    json_integer_value(exp_id_j) : -1;
+
+                if (!json_is_integer(exp_id_j) ||
+                    v < 1 || v > CHIMERA_NFS_EXPORT_ID_MAX) {
+                    chimera_server_error("Export '%s': invalid export_id "
+                                         "(expected integer 1..%u)",
+                                         name, CHIMERA_NFS_EXPORT_ID_MAX);
+                    exit(1);
+                }
+                export_id = (uint32_t) v;
+            }
+
             /* Allowed security flavors: an optional array of
              * "sys"/"krb5"/"krb5i"/"krb5p".  Absent (mask 0) permits any
              * flavor, preserving historical behavior; a non-empty list
@@ -1175,12 +1204,27 @@ main(
                 }
             }
 
-            chimera_server_info("Adding NFS export %s -> %s (%s, %s)", name, path,
+            char export_id_str[16] = "auto";
+
+            if (export_id) {
+                snprintf(export_id_str, sizeof(export_id_str), "%u", export_id);
+            }
+
+            chimera_server_info("Adding NFS export %s -> %s (%s, %s, export_id %s)",
+                                name, path,
                                 options & CHIMERA_NFS_EXPORT_OPT_RO ? "ro" : "rw",
                                 squash == CHIMERA_NFS_SQUASH_ALL ? "all_squash" :
                                 squash == CHIMERA_NFS_SQUASH_NONE ? "no_root_squash" :
-                                "root_squash");
-            chimera_server_create_export(server, name, path);
+                                "root_squash",
+                                export_id_str);
+            if (chimera_server_create_export(server, name, path, export_id) != 0) {
+                /* Duplicate or unusable export_id: proceeding would mint file
+                 * handles under a different id than the operator pinned, which
+                 * breaks cluster failover in a way clients only notice later.
+                 * Fail hard like the mount-path errors above. */
+                chimera_server_error("Failed to create export '%s'", name);
+                exit(1);
+            }
             chimera_server_export_set_options(server, name, options, squash,
                                               anonuid, anongid);
             if (sec_mask) {

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -4024,7 +4024,7 @@ main(
             }
 
             // Create NFSv3 server export entry
-            chimera_server_create_export(chimera_server, "/share", "/share");
+            chimera_server_create_export(chimera_server, "/share", "/share", 0);
 
             chimera_server_start(chimera_server);
 

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -470,7 +470,7 @@ posix_test_start_nfs_server(struct posix_test_env *env)
     chimera_server_mount(env->server, "share", share_module, share_module_path,
                          NULL);
 
-    chimera_server_create_export(env->server, "/share", "/share");
+    chimera_server_create_export(env->server, "/share", "/share", 0);
 
     if (posix_test_ro_export) {
         /* Second, read-only mount of the same backend rooted at the subdir.
@@ -486,7 +486,7 @@ posix_test_start_nfs_server(struct posix_test_env *env)
             exit(EXIT_FAILURE);
         }
 
-        chimera_server_create_export(env->server, "/roshare", "/roshare");
+        chimera_server_create_export(env->server, "/roshare", "/roshare", 0);
     }
 
     chimera_server_start(env->server);

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -38,6 +38,12 @@
 
 #include "common/macros.h"
 
+/* nfs.h defines the public id range without seeing nfs_common.h; if the two
+ * constants ever drift apart, the range check in chimera_nfs_add_export()
+ * would index exports_by_id[] out of bounds. */
+_Static_assert(CHIMERA_NFS_EXPORT_ID_MAX == CHIMERA_NFS_MAX_EXPORTS - 1,
+               "CHIMERA_NFS_EXPORT_ID_MAX must match the exports_by_id table size");
+
 #define NFS_PROGIDX_PORTMAP_V2 0
 #define NFS_PROGIDX_MOUNT_V3   1
 #define NFS_PROGIDX_V3         2
@@ -906,14 +912,23 @@ nfs_server_thread_destroy(void *data)
     free(thread);
 } /* nfs_server_thread_destroy */
 
-SYMBOL_EXPORT void
+SYMBOL_EXPORT int
 chimera_nfs_add_export(
     void       *nfs_shared,
     const char *name,
-    const char *path)
+    const char *path,
+    uint32_t    export_id)
 {
     struct chimera_server_nfs_shared *shared = nfs_shared;
-    struct chimera_nfs_export        *export = calloc(1, sizeof(*export));
+    struct chimera_nfs_export        *export;
+
+    if (export_id > CHIMERA_NFS_EXPORT_ID_MAX) {
+        chimera_nfs_error("Export '%s' id %u out of range (1..%u)",
+                          name, export_id, CHIMERA_NFS_EXPORT_ID_MAX);
+        return -EINVAL;
+    }
+
+    export = calloc(1, sizeof(*export));
 
     snprintf(export->name, sizeof(export->name), "%s", name);
     snprintf(export->path, sizeof(export->path), "%s", path);
@@ -932,24 +947,53 @@ chimera_nfs_add_export(
     pthread_mutex_lock(&shared->exports_lock);
 
     /* Assign a stable, non-zero id and publish into the direct index used for
-     * per-request attribution.  Ids start at 1 (slot 0 reserved as invalid). */
-    if (shared->next_export_id == 0) {
-        shared->next_export_id = 1;
-    }
-    if (shared->next_export_id < CHIMERA_NFS_MAX_EXPORTS) {
-        export->id                        = shared->next_export_id++;
-        shared->exports_by_id[export->id] = export;
+     * per-request attribution.  Ids start at 1 (slot 0 reserved as invalid).
+     * An explicit id is honored verbatim (or rejected if taken); auto
+     * assignment scans forward from the last assigned id, skipping slots
+     * pinned explicitly, and wraps around the end of the id space. */
+    if (export_id) {
+        if (shared->exports_by_id[export_id]) {
+            /* Log before dropping the lock: a concurrent remove can free the
+             * owning export and NULL the slot the moment it is released. */
+            chimera_nfs_error("Export '%s' id %u already in use by export '%s'",
+                              name, export_id,
+                              shared->exports_by_id[export_id]->name);
+            pthread_mutex_unlock(&shared->exports_lock);
+            free(export);
+            return -EEXIST;
+        }
+        export->id = (uint16_t) export_id;
     } else {
-        chimera_nfs_error("Export id space exhausted (max %d); export '%s' will "
-                          "not be addressable by file handle",
-                          CHIMERA_NFS_MAX_EXPORTS, name);
-        export->id = 0;
+        uint16_t id = shared->next_export_id;
+
+        if (id == 0 || id >= CHIMERA_NFS_MAX_EXPORTS) {
+            id = 1;
+        }
+        for (int probes = 0; probes < CHIMERA_NFS_MAX_EXPORTS - 1; probes++) {
+            if (!shared->exports_by_id[id]) {
+                break;
+            }
+            id = (id == CHIMERA_NFS_MAX_EXPORTS - 1) ? 1 : id + 1;
+        }
+        if (shared->exports_by_id[id]) {
+            pthread_mutex_unlock(&shared->exports_lock);
+            chimera_nfs_error("Export id space exhausted (max %d); cannot "
+                              "create export '%s'",
+                              CHIMERA_NFS_MAX_EXPORTS, name);
+            free(export);
+            return -ENOSPC;
+        }
+        export->id             = id;
+        shared->next_export_id = id + 1;
     }
+
+    shared->exports_by_id[export->id] = export;
 
     LL_PREPEND(shared->exports, export);
     shared->num_exports++;
     pthread_mutex_unlock(&shared->exports_lock);
 
+    return 0;
 } /* chimera_nfs_add_export */
 
 SYMBOL_EXPORT int

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -35,6 +35,12 @@ struct chimera_nfs_export;
         (CHIMERA_NFS_SEC_SYS | CHIMERA_NFS_SEC_KRB5 | \
          CHIMERA_NFS_SEC_KRB5I | CHIMERA_NFS_SEC_KRB5P)
 
+/*
+ * Largest export id an operator may assign.  Ids are embedded in wire file
+ * handles as a 16-bit field; id 0 is reserved as invalid/pseudo-root and the
+ * id space is bounded by CHIMERA_NFS_MAX_EXPORTS (4096) internally.
+ */
+#define CHIMERA_NFS_EXPORT_ID_MAX 4095u
 
 /**
  * @brief Adds a new NFS export to the shared context.
@@ -42,11 +48,18 @@ struct chimera_nfs_export;
  * @param nfs_shared Pointer to the NFS shared context.
  * @param name       Name of the export.
  * @param path       Filesystem path for the export.
+ * @param export_id  Explicit export id (1..CHIMERA_NFS_EXPORT_ID_MAX), or 0
+ *                   to auto-assign the next free id.  The id is embedded in
+ *                   wire file handles, so clustered servers exporting the
+ *                   same directory must pin identical ids.
+ * @return 0 on success, -EINVAL if export_id is out of range, -EEXIST if the
+ *         id is already in use, -ENOSPC if the id space is exhausted.
  */
-void chimera_nfs_add_export(
+int chimera_nfs_add_export(
     void       *nfs_shared,
     const char *name,
-    const char *path);
+    const char *path,
+    uint32_t    export_id);
 
 
 /**

--- a/src/server/rest/rest_config.c
+++ b/src/server/rest/rest_config.c
@@ -65,6 +65,8 @@ config_export_callback(
     obj = json_object();
     json_object_set_new(obj, "path",
                         json_string(chimera_nfs_export_get_path(export)));
+    json_object_set_new(obj, "export_id",
+                        json_integer(chimera_nfs_export_get_id(export)));
     json_object_set_new(obj, "options",
                         json_string(chimera_nfs_export_get_options(export) &
                                     CHIMERA_NFS_EXPORT_OPT_RO ? "ro" : "rw"));

--- a/src/server/rest/rest_shares.c
+++ b/src/server/rest/rest_shares.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <errno.h>
 #include <jansson.h>
 
 #include "evpl/evpl.h"
@@ -61,6 +62,8 @@ export_to_json_callback(
                         json_string(chimera_nfs_export_get_name(export)));
     json_object_set_new(obj, "path",
                         json_string(chimera_nfs_export_get_path(export)));
+    json_object_set_new(obj, "export_id",
+                        json_integer(chimera_nfs_export_get_id(export)));
     export_options_to_json(export, obj);
 
     json_array_append_new(ctx->array, obj);
@@ -106,6 +109,8 @@ chimera_rest_handle_exports_get(
                         json_string(chimera_nfs_export_get_name(export)));
     json_object_set_new(obj, "path",
                         json_string(chimera_nfs_export_get_path(export)));
+    json_object_set_new(obj, "export_id",
+                        json_integer(chimera_nfs_export_get_id(export)));
     export_options_to_json(export, obj);
 
     chimera_rest_send_json(evpl, request, 200, obj);
@@ -123,6 +128,8 @@ chimera_rest_handle_exports_create(
     json_error_t error;
     const char  *name;
     const char  *path;
+    json_t      *exp_id_j;
+    uint32_t     export_id = 0;
     int          rc;
     json_t      *obj;
 
@@ -143,6 +150,23 @@ chimera_rest_handle_exports_create(
         return;
     }
 
+    /* Optional stable export id.  Validate the signed json value before any
+     * unsigned cast so negatives and non-integers are rejected rather than
+     * silently becoming auto-assignment (0) or wrapping into range. */
+    exp_id_j = json_object_get(root, "export_id");
+    if (exp_id_j) {
+        json_int_t v = json_integer_value(exp_id_j);
+
+        if (!json_is_integer(exp_id_j) ||
+            v < 1 || v > CHIMERA_NFS_EXPORT_ID_MAX) {
+            json_decref(root);
+            chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                    "export_id must be an integer in range 1..4095");
+            return;
+        }
+        export_id = (uint32_t) v;
+    }
+
     if (chimera_server_get_export(thread->shared->server, name)) {
         json_decref(root);
         chimera_rest_send_error(evpl, request, 409, "Conflict",
@@ -150,7 +174,22 @@ chimera_rest_handle_exports_create(
         return;
     }
 
-    rc = chimera_server_create_export(thread->shared->server, name, path);
+    rc = chimera_server_create_export(thread->shared->server, name, path,
+                                      export_id);
+
+    if (rc == -EEXIST) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "export_id already in use");
+        return;
+    }
+
+    if (rc == -EINVAL) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                "export_id out of range");
+        return;
+    }
 
     if (rc != 0) {
         json_decref(root);

--- a/src/server/rest/tests/CMakeLists.txt
+++ b/src/server/rest/tests/CMakeLists.txt
@@ -23,3 +23,14 @@ add_test(NAME chimera/server/rest/mounts_test
             ${CMAKE_CURRENT_BINARY_DIR}/rest_mounts_test)
 set_tests_properties(chimera/server/rest/mounts_test PROPERTIES
     ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/src/server/smb/tests/suppressions.txt")
+
+# REST API NFS exports test (export_id round-trip and validation)
+add_executable(rest_exports_test rest_exports_test.c)
+target_link_libraries(rest_exports_test chimera_server chimera_metrics jansson)
+target_include_directories(rest_exports_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+add_test(NAME chimera/server/rest/exports_test
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+            ${CMAKE_CURRENT_BINARY_DIR}/rest_exports_test)
+set_tests_properties(chimera/server/rest/exports_test PROPERTIES
+    ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/src/server/smb/tests/suppressions.txt")

--- a/src/server/rest/tests/rest_exports_test.c
+++ b/src/server/rest/tests/rest_exports_test.c
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * REST API NFS Exports Test
+ *
+ * Exercises the /api/v1/exports endpoints in rest_shares.c with REST
+ * authentication disabled, focusing on the export_id support:
+ *   1. Create an export with an explicit export_id returns 201
+ *   2. GET the export echoes the export_id back
+ *   3. List exports includes the export_id on the matching entry
+ *   4. GET /api/v1/config round-trips the export_id
+ *   5. A duplicate export_id returns 409 and the export is not created
+ *   6. Out-of-range or non-integer export_id returns 400
+ *   7. Auto-assignment skips slots pinned by explicit ids
+ *   8. Delete frees the id so it can be pinned again
+ *   9. Missing required fields return 400; a duplicate name returns 409
+ */
+
+#include "common/logging.h"
+#include "prometheus-c.h"
+#include "server/server.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define REST_PORT 18082
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+static void
+test_pass(const char *name)
+{
+    fprintf(stderr, "  PASS: %s\n", name);
+    tests_passed++;
+} /* test_pass */
+
+static void
+test_fail(const char *name)
+{
+    fprintf(stderr, "  FAIL: %s\n", name);
+    tests_failed++;
+} /* test_fail */
+
+/* Issue a request and return only the HTTP status code. */
+static int
+curl_get_code(
+    const char *method,
+    const char *path,
+    const char *body,
+    long       *http_code)
+{
+    char  cmd[8192];
+    char  output[4096];
+    FILE *fp;
+    int   rc;
+
+    if (body) {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -o /dev/null -w '%%{http_code}' "
+                 "-X %s -H 'Content-Type: application/json' "
+                 "-d '%s' http://localhost:%d%s 2>&1",
+                 method, body, REST_PORT, path);
+    } else {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -o /dev/null -w '%%{http_code}' "
+                 "-X %s http://localhost:%d%s 2>&1",
+                 method, REST_PORT, path);
+    }
+
+    fp = popen(cmd, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    output[0] = '\0';
+    if (fgets(output, sizeof(output), fp) == NULL) {
+        output[0] = '\0';
+    }
+
+    rc = pclose(fp);
+
+    if (WIFEXITED(rc) && WEXITSTATUS(rc) == 0) {
+        *http_code = strtol(output, NULL, 10);
+        return 0;
+    }
+
+    return -1;
+} /* curl_get_code */
+
+/* Issue a request and capture both the response body and the status code. */
+static int
+curl_get_body(
+    const char *method,
+    const char *path,
+    const char *body,
+    char       *response,
+    int         response_size,
+    long       *http_code)
+{
+    char  cmd[8192];
+    char  output[8192];
+    FILE *fp;
+    int   rc;
+
+    if (body) {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -w '\\n%%{http_code}' "
+                 "-X %s -H 'Content-Type: application/json' "
+                 "-d '%s' http://localhost:%d%s 2>&1",
+                 method, body, REST_PORT, path);
+    } else {
+        snprintf(cmd, sizeof(cmd),
+                 "curl -s -w '\\n%%{http_code}' "
+                 "-X %s http://localhost:%d%s 2>&1",
+                 method, REST_PORT, path);
+    }
+
+    fp = popen(cmd, "r");
+    if (!fp) {
+        return -1;
+    }
+
+    output[0] = '\0';
+    {
+        int total = 0;
+        while (fgets(output + total, sizeof(output) - total, fp) != NULL) {
+            total += strlen(output + total);
+        }
+    }
+
+    rc = pclose(fp);
+
+    if (!WIFEXITED(rc) || WEXITSTATUS(rc) != 0) {
+        return -1;
+    }
+
+    /* Last line is the HTTP code */
+    {
+        char *last_newline = strrchr(output, '\n');
+        if (last_newline && last_newline > output) {
+            *http_code    = strtol(last_newline + 1, NULL, 10);
+            *last_newline = '\0';
+        } else {
+            *http_code = 0;
+        }
+    }
+
+    snprintf(response, response_size, "%s", output);
+
+    return 0;
+} /* curl_get_body */
+
+/* Assert that a request returns the expected status code. */
+static void
+check_code(
+    const char *name,
+    const char *method,
+    const char *path,
+    const char *body,
+    long        expect,
+    int        *failures)
+{
+    long http_code = 0;
+    int  rc        = curl_get_code(method, path, body, &http_code);
+
+    if (rc == 0 && http_code == expect) {
+        test_pass(name);
+    } else {
+        test_fail(name);
+        fprintf(stderr, "    Expected %ld, got %ld\n", expect, http_code);
+        (*failures)++;
+    }
+} /* check_code */
+
+/* Assert that a request returns the expected status code and that its body
+ * does or does not contain a given substring. */
+static void
+check_body_contains(
+    const char *name,
+    const char *method,
+    const char *path,
+    const char *body,
+    long        expect_code,
+    const char *needle,
+    int         want_present,
+    int        *failures)
+{
+    char response[8192];
+    long http_code = 0;
+    int  rc        = curl_get_body(method, path, body, response,
+                                   sizeof(response), &http_code);
+    int  present;
+
+    if (rc != 0 || http_code != expect_code) {
+        test_fail(name);
+        fprintf(stderr, "    Expected %ld, got %ld (rc %d)\n",
+                expect_code, http_code, rc);
+        (*failures)++;
+        return;
+    }
+
+    present = (needle && strstr(response, needle) != NULL);
+    if (present == want_present) {
+        test_pass(name);
+    } else {
+        test_fail(name);
+        fprintf(stderr, "    %s substring \"%s\" in: %s\n",
+                want_present ? "missing" : "unexpected", needle, response);
+        (*failures)++;
+    }
+} /* check_body_contains */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct chimera_server        *server;
+    struct chimera_server_config *config;
+    struct prometheus_metrics    *metrics;
+    int                           failures = 0;
+
+    (void) argc;
+    (void) argv;
+
+    fprintf(stderr, "\n========================================\n");
+    fprintf(stderr, "REST API NFS Exports Test\n");
+    fprintf(stderr, "========================================\n");
+
+    if (system("which curl >/dev/null 2>&1") != 0) {
+        fprintf(stderr, "\nERROR: curl not found in PATH\n");
+        return EXIT_FAILURE;
+    }
+
+    ChimeraLogLevel = CHIMERA_LOG_INFO;
+    evpl_set_log_fn(chimera_vlog, chimera_log_flush);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    if (!metrics) {
+        fprintf(stderr, "Failed to create metrics\n");
+        return EXIT_FAILURE;
+    }
+
+    config = chimera_server_config_init();
+    chimera_server_config_set_rest_http_port(config, REST_PORT);
+    /* Disable auth so the export endpoints can be exercised directly,
+     * mirroring the admin pytest setup. */
+    chimera_server_config_set_rest_auth_enabled(config, 0);
+
+    server = chimera_server_init(config, metrics);
+    if (!server) {
+        fprintf(stderr, "Failed to initialize server\n");
+        prometheus_metrics_destroy(metrics);
+        return EXIT_FAILURE;
+    }
+
+    chimera_server_mount(server, "share", "memfs", "/", NULL);
+
+    chimera_server_start(server);
+    fprintf(stderr, "Server started (REST on port %d)\n", REST_PORT);
+    usleep(200000);
+
+    /* ===== Test 1: Create an export with an explicit export_id ===== */
+    fprintf(stderr, "\n  Test: Create export with explicit export_id...\n");
+    check_code("POST /api/v1/exports with export_id returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"exp1\",\"path\":\"/share\",\"export_id\":42}",
+               201, &failures);
+
+    /* ===== Test 2: GET echoes the export_id back ===== */
+    fprintf(stderr, "\n  Test: export_id is echoed on read...\n");
+    check_body_contains("GET /api/v1/exports/exp1 echoes export_id",
+                        "GET", "/api/v1/exports/exp1", NULL,
+                        200, "\"export_id\":42", 1, &failures);
+
+    /* ===== Test 3: List includes the export_id ===== */
+    check_body_contains("GET /api/v1/exports lists export_id",
+                        "GET", "/api/v1/exports", NULL,
+                        200, "\"export_id\":42", 1, &failures);
+
+    /* ===== Test 4: Config round-trips the export_id ===== */
+    check_body_contains("GET /api/v1/config round-trips export_id",
+                        "GET", "/api/v1/config", NULL,
+                        200, "\"export_id\":42", 1, &failures);
+
+    /* ===== Test 5: Duplicate export_id is rejected with 409 ===== */
+    fprintf(stderr, "\n  Test: Duplicate export_id rejected with 409...\n");
+    check_body_contains("Duplicate export_id returns 409",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"exp2\",\"path\":\"/share\",\"export_id\":42}",
+                        409, "export_id already in use", 1, &failures);
+
+    check_code("Rejected export exp2 does not exist (404)",
+               "GET", "/api/v1/exports/exp2", NULL, 404, &failures);
+
+    /* ===== Test 6: Out-of-range / non-integer export_id ===== */
+    fprintf(stderr, "\n  Test: Invalid export_id rejected with 400...\n");
+    check_code("export_id 0 returns 400",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"bad1\",\"path\":\"/share\",\"export_id\":0}",
+               400, &failures);
+
+    check_code("export_id 4096 returns 400",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"bad2\",\"path\":\"/share\",\"export_id\":4096}",
+               400, &failures);
+
+    check_code("Negative export_id returns 400",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"bad3\",\"path\":\"/share\",\"export_id\":-1}",
+               400, &failures);
+
+    check_code("Non-integer export_id returns 400",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"bad4\",\"path\":\"/share\",\"export_id\":\"abc\"}",
+               400, &failures);
+
+    check_code("Rejected export bad1 does not exist (404)",
+               "GET", "/api/v1/exports/bad1", NULL, 404, &failures);
+
+    check_code("Rejected export bad2 does not exist (404)",
+               "GET", "/api/v1/exports/bad2", NULL, 404, &failures);
+
+    check_code("Rejected export bad3 does not exist (404)",
+               "GET", "/api/v1/exports/bad3", NULL, 404, &failures);
+
+    check_code("Rejected export bad4 does not exist (404)",
+               "GET", "/api/v1/exports/bad4", NULL, 404, &failures);
+
+    /* ===== Test 7: Auto-assignment skips explicit ids =====
+     * On this fresh server the auto counter is at 1.  Pin id 1, then an auto
+     * export must skip to 2; pin 3, and the next auto export must skip over
+     * it to 4. */
+    fprintf(stderr, "\n  Test: Auto-assignment skips explicit ids...\n");
+    check_code("POST export pinned to id 1 returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expa\",\"path\":\"/share\",\"export_id\":1}",
+               201, &failures);
+
+    check_code("POST auto-assigned export returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expb\",\"path\":\"/share\"}",
+               201, &failures);
+
+    check_body_contains("Auto export skipped pinned id 1, got 2",
+                        "GET", "/api/v1/exports/expb", NULL,
+                        200, "\"export_id\":2", 1, &failures);
+
+    check_code("POST export pinned to id 3 returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expc\",\"path\":\"/share\",\"export_id\":3}",
+               201, &failures);
+
+    check_code("POST second auto-assigned export returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expd\",\"path\":\"/share\"}",
+               201, &failures);
+
+    check_body_contains("Auto export skipped pinned id 3, got 4",
+                        "GET", "/api/v1/exports/expd", NULL,
+                        200, "\"export_id\":4", 1, &failures);
+
+    /* ===== Test 8: Delete frees the id for reuse ===== */
+    fprintf(stderr, "\n  Test: Delete frees the export_id...\n");
+    check_code("DELETE /api/v1/exports/exp1 returns 204",
+               "DELETE", "/api/v1/exports/exp1", NULL, 204, &failures);
+
+    check_code("GET deleted export returns 404",
+               "GET", "/api/v1/exports/exp1", NULL, 404, &failures);
+
+    check_code("Freed export_id can be pinned again",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"exp1b\",\"path\":\"/share\",\"export_id\":42}",
+               201, &failures);
+
+    /* ===== Test 9: Missing fields / duplicate name regressions ===== */
+    fprintf(stderr, "\n  Test: Bad requests and conflicts...\n");
+    check_code("Missing path returns 400",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"nopath\"}",
+               400, &failures);
+
+    check_code("Duplicate export name returns 409",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"exp1b\",\"path\":\"/share\"}",
+               409, &failures);
+
+    fprintf(stderr, "\n========================================\n");
+    fprintf(stderr, "Test Summary\n");
+    fprintf(stderr, "========================================\n");
+    fprintf(stderr, "Passed: %d\n", tests_passed);
+    fprintf(stderr, "Failed: %d\n", tests_failed);
+
+    chimera_server_destroy(server);
+    prometheus_metrics_destroy(metrics);
+
+    if (failures > 0) {
+        fprintf(stderr, "\nSome tests FAILED\n\n");
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "\nAll tests PASSED\n\n");
+    return EXIT_SUCCESS;
+} /* main */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2208,15 +2208,14 @@ SYMBOL_EXPORT int
 chimera_server_create_export(
     struct chimera_server *server,
     const char            *name,
-    const char            *path)
+    const char            *path,
+    uint32_t               export_id)
 {
     if (!server->nfs_shared) {
         return -1;
     }
 
-    chimera_nfs_add_export(server->nfs_shared, name, path);
-
-    return 0;
+    return chimera_nfs_add_export(server->nfs_shared, name, path, export_id);
 } /* chimera_server_create_export */
 
 SYMBOL_EXPORT int

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -675,11 +675,19 @@ chimera_server_share_set_force_level2_oplock(
     struct chimera_server *server,
     const char            *share_name);
 
+/*
+ * Create an NFS export.  export_id pins the stable id embedded in wire file
+ * handles (1..CHIMERA_NFS_EXPORT_ID_MAX); 0 auto-assigns the next free id.
+ * Returns 0 on success, -EINVAL for an out-of-range id, -EEXIST if the id is
+ * already in use, -ENOSPC if the id space is exhausted, -1 if the NFS
+ * protocol is not initialized.
+ */
 int
 chimera_server_create_export(
     struct chimera_server *server,
     const char            *share_name,
-    const char            *share_path);
+    const char            *share_path,
+    uint32_t               export_id);
 
 int
 chimera_server_export_set_options(


### PR DESCRIPTION
The NFS export id is embedded in every wire file handle, so clustered servers exporting the same directory must mint identical ids for file handles to survive failover.  Ids were previously auto-assigned in registration order, which only matched across nodes if configs listed exports identically.

Allow an explicit export_id (1..4095, 0 reserved) to be pinned per export:

- chimera_nfs_add_export()/chimera_server_create_export() take an export_id argument (0 = auto-assign) and return errno-style errors; auto-assignment now scans past explicitly pinned slots and id space exhaustion fails creation instead of minting an unaddressable id 0
- a static assert ties CHIMERA_NFS_EXPORT_ID_MAX to the exports_by_id[] table size so the constants cannot drift apart
- daemon config accepts "export_id" in exports entries and fails hard on invalid or duplicate ids; exports are created in two passes (pinned ids first) so auto-assignment cannot take an id a later config entry pins, keeping startup independent of key order
- REST POST /api/v1/exports accepts export_id (400 out of range, 409 duplicate); export GET/list and /api/v1/config emit it so the config output round-trips through the daemon parser
- OpenAPI schemas document the new field and the 409 response
- python admin client create_export() gains export_id, options and squash parameters; CLI export create gains --export-id, --options and --squash
- new rest_exports_test C test and TestExportsAPI pytest coverage