### PR TITLE
nfs: widen the export id space to 16 bits and harden export configuration

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -184,14 +184,27 @@ GET /api/v1/exports
 
 ```json
 [
-  { "name": "export", "path": "/memfs/export" }
+  {
+    "name": "export",
+    "path": "/memfs/export",
+    "export_id": 1,
+    "access": "rw",
+    "squash": "none",
+    "anonuid": 65534,
+    "anongid": 65534
+  }
 ]
 ```
 
-| Field  | Type   | Description |
-|--------|--------|-------------|
-| `name` | string | Export name |
-| `path` | string | VFS path    |
+| Field       | Type   | Description |
+|-------------|--------|-------------|
+| `name`      | string | Export name |
+| `path`      | string | VFS path    |
+| `export_id` | int    | Stable id (1..65535) embedded in NFS file handles |
+| `access`    | string | Access mode: `ro` or `rw` |
+| `squash`    | string | Credential squashing policy: `none`, `root`, or `all` |
+| `anonuid`   | int    | Anonymous uid squashed callers are mapped to |
+| `anongid`   | int    | Anonymous gid squashed callers are mapped to |
 
 ```bash
 curl http://localhost:8080/api/v1/exports
@@ -207,7 +220,8 @@ GET /api/v1/exports/{name}
 |----------------|--------|-----------------|
 | `name`         | string | Name of export  |
 
-**Response `200`** - a single export object (`name`, `path`).
+**Response `200`** - a single export object with the same fields as a list
+entry (`name`, `path`, `export_id`, `access`, `squash`, `anonuid`, `anongid`).
 
 **Errors:** `404` if the export does not exist.
 
@@ -223,10 +237,15 @@ POST /api/v1/exports
 
 **Request body**
 
-| Field  | Type   | Required | Description |
-|--------|--------|----------|-------------|
-| `name` | string | yes      | Export name |
-| `path` | string | yes      | VFS path    |
+| Field       | Type   | Required | Description |
+|-------------|--------|----------|-------------|
+| `name`      | string | yes      | Export name |
+| `path`      | string | yes      | VFS path    |
+| `export_id` | int    | no       | Explicit stable id (1..65535); auto-assigned when omitted. Clustered servers exporting the same directory must pin the same id so file handles stay valid across failover. |
+| `access`    | string | no       | Access mode, `ro` or `rw` (default `rw`). Replaces the former `options` field, which is now rejected with `400`. |
+| `squash`    | string | no       | Squashing policy: `none`/`no_root_squash`, `root`/`root_squash`, or `all`/`all_squash` (default `none`). |
+| `anonuid`   | int    | no       | Anonymous uid squashed callers are mapped to (default `65534`). |
+| `anongid`   | int    | no       | Anonymous gid squashed callers are mapped to (default `65534`). |
 
 **Response `201`**
 
@@ -234,12 +253,16 @@ POST /api/v1/exports
 { "message": "Export created" }
 ```
 
-**Errors:** `400` (invalid JSON, or missing `name`/`path`), `500` (creation failed).
+**Errors:** `400` (invalid JSON, missing `name`/`path`, out-of-range
+`export_id`, an unrecognized `access`/`squash` value, a non-integer or
+out-of-range `anonuid`/`anongid`, or the legacy `options` field), `409`
+(export name or `export_id` already in use, or the `nfs_max_exports` limit
+is reached), `500` (creation failed).
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/exports \
   -H "Content-Type: application/json" \
-  -d '{"name":"export","path":"/memfs/export"}'
+  -d '{"name":"export","path":"/memfs/export","export_id":7,"access":"ro","squash":"root"}'
 ```
 
 ### Delete export

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -205,6 +205,7 @@ GET /api/v1/exports
 | `squash`    | string | Credential squashing policy: `none`, `root`, or `all` |
 | `anonuid`   | int    | Anonymous uid squashed callers are mapped to |
 | `anongid`   | int    | Anonymous gid squashed callers are mapped to |
+| `sec`       | array  | Allowed RPC security flavors (`sys`/`krb5`/`krb5i`/`krb5p`); present only when a restriction is configured, absent means any flavor |
 
 ```bash
 curl http://localhost:8080/api/v1/exports
@@ -221,7 +222,8 @@ GET /api/v1/exports/{name}
 | `name`         | string | Name of export  |
 
 **Response `200`** - a single export object with the same fields as a list
-entry (`name`, `path`, `export_id`, `access`, `squash`, `anonuid`, `anongid`).
+entry (`name`, `path`, `export_id`, `access`, `squash`, `anonuid`, `anongid`,
+plus `sec` when a security-flavor restriction is configured).
 
 **Errors:** `404` if the export does not exist.
 
@@ -246,6 +248,7 @@ POST /api/v1/exports
 | `squash`    | string | no       | Squashing policy: `none`/`no_root_squash`, `root`/`root_squash`, or `all`/`all_squash` (default `none`). |
 | `anonuid`   | int    | no       | Anonymous uid squashed callers are mapped to (default `65534`). |
 | `anongid`   | int    | no       | Anonymous gid squashed callers are mapped to (default `65534`). |
+| `sec`       | array  | no       | Allowed RPC security flavors: any of `sys`, `krb5`, `krb5i`, `krb5p`; other flavors are rejected. Omitted or empty permits any flavor. |
 
 **Response `201`**
 
@@ -255,9 +258,10 @@ POST /api/v1/exports
 
 **Errors:** `400` (invalid JSON, missing `name`/`path`, out-of-range
 `export_id`, an unrecognized `access`/`squash` value, a non-integer or
-out-of-range `anonuid`/`anongid`, or the legacy `options` field), `409`
-(export name or `export_id` already in use, or the `nfs_max_exports` limit
-is reached), `500` (creation failed).
+out-of-range `anonuid`/`anongid`, a malformed `sec` array or unknown sec
+flavor, or the legacy `options` field), `409` (export name or `export_id`
+already in use, or the `nfs_max_exports` limit is reached), `500`
+(creation failed).
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/exports \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,7 @@ the canonical place to set them.
 | `nfs4_grace_time` | int (s) | `180` | NFSv4 grace period after restart (state reclaim window). |
 | `nfs4_courtesy_time` | int (s) | `86400` | How long expired-but-courteous client state is retained. |
 | `nfs_server_scope` | int | `42` | NFSv4.1 `EXCHANGE_ID` server scope. Give independent servers (e.g. an MDS and a co-located DS) distinct values so clients don't coalesce them. |
+| `nfs_max_exports` | int | `4096` | Maximum number of NFS exports that may exist at once (1..65535). Distinct from the export id space, which is always 1..65535; creating an export past this cap fails. |
 | `data_server` | bool | `false` | pNFS data-server mode: bind only the NFSv4 service (no portmap/mount/NLM) so a DS can share a host with its MDS. |
 | `kv_module` | string | - | Key-value module used to persist server state. |
 | `state_dir` | string | `<prefix>/share/state` | Directory for persisted NFS/SMB state. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ reads the file:
 | Section | Type | Read by | Purpose |
 |---|---|---|---|
 | `common` | object | server + client | Shared transport, memory, and delegation settings. |
-| `server` | object | server | Daemon-wide settings (threads, protocols, ports, REST, pNFS…). |
+| `server` | object | server | Daemon-wide settings (threads, protocols, ports, REST, pNFS...). |
 | `mounts` | object | server | VFS backends to instantiate, keyed by name. |
 | `exports` | object | server | NFS exports. |
 | `shares` | object | server | SMB shares. |
@@ -74,17 +74,17 @@ the canonical place to set them.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `tcp_flavor` | string | `"plain"` | TCP stream backend: `"plain"` (kernel sockets), `"io_uring"`, or `"xlio"` (Mellanox userspace TCP). |
-| `sync_delegation` | bool | — | Enable the synchronous VFS delegation thread pool. Overrides `server.sync_delegation` / `config.sync_delegation`. |
-| `sync_delegation_threads` | int | — | Size of the synchronous delegation pool. |
-| `async_delegation` | bool | — | Enable the asynchronous VFS delegation thread pool. |
-| `async_delegation_threads` | int | — | Size of the asynchronous delegation pool. |
+| `sync_delegation` | bool | - | Enable the synchronous VFS delegation thread pool. Overrides `server.sync_delegation` / `config.sync_delegation`. |
+| `sync_delegation_threads` | int | - | Size of the synchronous delegation pool. |
+| `async_delegation` | bool | - | Enable the asynchronous VFS delegation thread pool. |
+| `async_delegation_threads` | int | - | Size of the asynchronous delegation pool. |
 | `huge_pages` | bool | libevpl default | Allocate libevpl memory from huge pages. |
 | `huge_page_size` | size | libevpl default | Huge page size to request (e.g. `"2M"`, `"1G"`). |
 | `slab_size` | size | libevpl default | libevpl memory slab size. |
 | `preallocate_slabs` | int | libevpl default | Number of memory slabs to preallocate at startup. |
 | `preallocate_threads` | int | libevpl default | Threads used to preallocate slabs in parallel. |
-| `rdmacm_tos` | int | `0` | RoCEv2 traffic class stamped on every RDMA QP. ToS = DSCP × 4 (e.g. `104` for DSCP 26) so the fabric's lossless/PFC class carries Chimera traffic. |
-| `metrics_file` | string | — | On shutdown, write a final Prometheus scrape to this file (so short runs keep their metrics). |
+| `rdmacm_tos` | int | `0` | RoCEv2 traffic class stamped on every RDMA QP. ToS = DSCP x 4 (e.g. `104` for DSCP 26) so the fabric's lossless/PFC class carries Chimera traffic. |
+| `metrics_file` | string | - | On shutdown, write a final Prometheus scrape to this file (so short runs keep their metrics). |
 
 ---
 
@@ -103,10 +103,10 @@ the canonical place to set them.
 | `nfs_port` | int | `2049` | NFS (v3/v4) listen port. |
 | `lockmgr_port` | int | `32803` | NLM (NFSv3 lock manager) port. |
 | `rdma` | bool | `false` | Enable NFS-over-RDMA. |
-| `rdma_hostname` | string | — | Address to bind the RDMA listener to. |
+| `rdma_hostname` | string | - | Address to bind the RDMA listener to. |
 | `rdma_port` | int | `20049` | NFS-over-RDMA listen port. |
 | `external_portmap` | bool | `false` | Register with an external `rpcbind`/portmap instead of the built-in one. |
-| `portmap_hostname` | string | — | Hostname/IP to advertise in portmap registrations. |
+| `portmap_hostname` | string | - | Hostname/IP to advertise in portmap registrations. |
 | `nfs4_session_slots` | int | `64` | Max in-flight compounds per NFSv4.1 session. |
 | `nfs4_delegations` | bool | `false` | Hand out NFSv4 read/write delegations. |
 | `nfs4_lease_time` | int (s) | `90` | NFSv4 lease duration. |
@@ -114,18 +114,18 @@ the canonical place to set them.
 | `nfs4_courtesy_time` | int (s) | `86400` | How long expired-but-courteous client state is retained. |
 | `nfs_server_scope` | int | `42` | NFSv4.1 `EXCHANGE_ID` server scope. Give independent servers (e.g. an MDS and a co-located DS) distinct values so clients don't coalesce them. |
 | `data_server` | bool | `false` | pNFS data-server mode: bind only the NFSv4 service (no portmap/mount/NLM) so a DS can share a host with its MDS. |
-| `kv_module` | string | — | Key-value module used to persist server state. |
+| `kv_module` | string | - | Key-value module used to persist server state. |
 | `state_dir` | string | `<prefix>/share/state` | Directory for persisted NFS/SMB state. |
 | `smb_persistent_handles` | bool | `false` | Enable SMB durable/persistent handles (needed for Continuous Availability). |
 | `smb_named_streams` | bool | `false` | Enable SMB named streams (alternate data streams). |
 | `smb_encryption` | string/int | `"off"` | SMB3 transport encryption: `"off"`/`"disabled"` (0), `"enabled"`/`"on"` (1), or `"required"` (2). |
 | `smb_acl_inherited_canonicalize` | bool | `true` | Canonicalize inherited ACLs on SMB. |
 | `metrics_port` | int | `9000` | Prometheus metrics port (`/metrics`). Make it distinct when running multiple daemons per host. |
-| `rest_http_port` | int | — | HTTP port for the REST admin API. Set to enable it (examples use `8080`). |
+| `rest_http_port` | int | - | HTTP port for the REST admin API. Set to enable it (examples use `8080`). |
 | `rest_https_port` | int | `0` | HTTPS port for the REST API (`0` = disabled). |
-| `rest_ssl_cert` | string | — | TLS certificate path. Auto-generated (self-signed) if HTTPS is enabled and this is unset. |
-| `rest_ssl_key` | string | — | TLS private-key path. Auto-generated alongside the cert if unset. |
-| `rest_auth_enabled` | bool | `true` | Require authentication (JWT Bearer token or HTTP Basic credentials) on all `/api/v1/*` endpoints. Set to `false` to disable auth entirely — only safe on a trusted/loopback-only management network. |
+| `rest_ssl_cert` | string | - | TLS certificate path. Auto-generated (self-signed) if HTTPS is enabled and this is unset. |
+| `rest_ssl_key` | string | - | TLS private-key path. Auto-generated alongside the cert if unset. |
+| `rest_auth_enabled` | bool | `true` | Require authentication (JWT Bearer token or HTTP Basic credentials) on all `/api/v1/*` endpoints. Set to `false` to disable auth entirely - only safe on a trusted/loopback-only management network. |
 | `soft_fail_bad_req` | bool | `false` | Return a soft error on a malformed REST request instead of dropping the connection. |
 
 See [Advanced and testing options](#advanced-and-testing-options) for a small set
@@ -139,10 +139,10 @@ Domain-authentication backends for SMB.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `winbind_enabled` | bool | `false` | Authenticate via Winbind (domain-joined). |
-| `winbind_domain` | string | — | Winbind domain name. |
+| `winbind_domain` | string | - | Winbind domain name. |
 | `kerberos_enabled` | bool | `false` | Enable Kerberos authentication. |
-| `kerberos_keytab` | string | — | Path to the Kerberos keytab. |
-| `kerberos_realm` | string | — | Kerberos realm. |
+| `kerberos_keytab` | string | - | Path to the Kerberos keytab. |
+| `kerberos_realm` | string | - | Kerberos realm. |
 
 #### `server.smb_multichannel`
 
@@ -165,14 +165,14 @@ Each entry of `data_servers`:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `netid` | string | — | Transport: `"tcp"`, `"tcp6"`, `"rdma"`, or `"rdma6"`. |
+| `netid` | string | - | Transport: `"tcp"`, `"tcp6"`, `"rdma"`, or `"rdma6"`. |
 | `uaddr` | string | required | Data server address as `host` or `host:port`. |
 | `backing_path` | string | required | Chimera VFS path (an `nfs`-module mount) the MDS uses to create backing files on the DS. |
 | `version` | int/string | `3` | NFS version clients use to reach the DS: `3`, `4`, `"4.0"`, or `"4.1"`. |
 
-#### `server.vfs` — loading external VFS plugins
+#### `server.vfs` - loading external VFS plugins
 
-Built-in modules (`memfs`, `linux`, `diskfs`, `io_uring`, …) need no
+Built-in modules (`memfs`, `linux`, `diskfs`, `io_uring`, ...) need no
 registration. A VFS module shipped as a separate shared object (e.g. `cairn`)
 is registered here, keyed by module name, before it can be used in `mounts`:
 
@@ -199,9 +199,9 @@ becomes visible in the Chimera namespace at `/<name>`.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `module` | string | required | VFS module name (`memfs`, `linux`, `diskfs`, `cairn`, `io_uring`, `nfs`, …). |
+| `module` | string | required | VFS module name (`memfs`, `linux`, `diskfs`, `cairn`, `io_uring`, `nfs`, ...). |
 | `path` | string | required | Backend-specific root. For passthrough modules this is a host path; for `nfs` it's the upstream export; for in-memory modules it's typically `/`. |
-| `options` | string | — | Module-specific mount options (e.g. `"vers=4.1,rdma,port=20049"` for the `nfs` module). |
+| `options` | string | - | Module-specific mount options (e.g. `"vers=4.1,rdma,port=20049"` for the `nfs` module). |
 
 ### `exports`, `shares`, `buckets`
 
@@ -291,8 +291,8 @@ read `server`/`mounts`/`exports`/`shares`/`buckets`.
 | `async_delegation_threads` | int | `8` | Asynchronous delegation pool size. |
 | `cache_ttl` | int (s) | `60` | Metadata (attribute) cache TTL. |
 | `max_fds` | int | `1024` | Maximum concurrent open file descriptors. |
-| `kv_module` | string | — | Key-value module for client-side state. |
-| `vfs` | object | — | Per-module config, keyed by module name; each value is `{ "path": …, "config": … }` (both strings). Used to register/point at VFS modules. |
+| `kv_module` | string | - | Key-value module for client-side state. |
+| `vfs` | object | - | Per-module config, keyed by module name; each value is `{ "path": ..., "config": ... }` (both strings). Used to register/point at VFS modules. |
 
 > The `common.*` delegation keys override the values in `config`, exactly as they
 > override `server` on the daemon side.
@@ -320,23 +320,23 @@ otherwise driven by fio job-file options rather than the `config` section:
 
 | fio option | Type | Default | Description |
 |---|---|---|---|
-| `chimera_config` | string | — | Path to a Chimera JSON config file (for its `common` section and module/mount definitions). |
-| `chimera_log` | string | — | Redirect Chimera/libevpl logging to this file. |
+| `chimera_config` | string | - | Path to a Chimera JSON config file (for its `common` section and module/mount definitions). |
+| `chimera_log` | string | - | Redirect Chimera/libevpl logging to this file. |
 | `chimera_debug` | bool | `false` | Enable debug-level logging. |
-| `chimera_buffer_size` | int | `0` (auto) | Override the libevpl buffer-pool size; `0` auto-sizes from the job's `iodepth × bs`. |
+| `chimera_buffer_size` | int | `0` (auto) | Override the libevpl buffer-pool size; `0` auto-sizes from the job's `iodepth x bs`. |
 
 ---
 
 ## VFS module options
 
-These keys go inside a module's `config` object — either the per-mount config or,
+These keys go inside a module's `config` object - either the per-mount config or,
 for plugins, the `config` under `server.vfs.<name>`.
 
 ### `memfs` (in-memory)
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `block_size` | int | `65536` | Block size in bytes (power of two, 4 KiB–1 MiB). |
+| `block_size` | int | `65536` | Block size in bytes (power of two, 4 KiB-1 MiB). |
 | `fsid` | int/string | random | Stable filesystem ID so handles survive a restart. |
 | `noatime` | bool | `false` | Disable atime updates (default keeps relatime semantics). |
 
@@ -351,7 +351,7 @@ for plugins, the `config` under `server.vfs.<name>`.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `path` | string | required | Directory holding the `metadb`/`datadb` RocksDB stores. |
-| `cache` | int (MB) | `64` | Block-cache budget, split ~¼ metadb / ~¾ datadb. |
+| `cache` | int (MB) | `64` | Block-cache budget, split ~1/4 metadb / ~3/4 datadb. |
 | `compression` | bool | `true` | LZ4-compress `datadb` (`metadb` is always uncompressed). |
 | `bloom_filter` | bool | `true` | Enable bloom filters on both stores. |
 | `statistics` | bool | `false` | Collect RocksDB statistics (diagnostics). |
@@ -369,7 +369,7 @@ The `config` object takes a `devices` array plus filesystem-level knobs.
 | `noatime` | bool | `false` | Disable atime updates. |
 | `mtime_defer_ms` | int (ms) | `1000` | Coalescing window for deferred mtime updates (`0` writes mtime on every write). |
 | `intent_log_size` | int (bytes) | `1073741824` (1 GiB) | Size of the device-0 intent (redo) log; a larger log lets more redo records pipeline before the ring laps. Persisted in the superblock at format time (a remount uses the formatted value). Must fit device 0's first allocation group alongside the superblock and per-AG log; floored at 4 MiB. The block cache default scales with this. |
-| `block_cache_blocks` | int | `0` (2× the intent-log block count) | Resident block-buffer cap (`0` = default; floored at 1.5× the intent-log block count). |
+| `block_cache_blocks` | int | `0` (2x the intent-log block count) | Resident block-buffer cap (`0` = default; floored at 1.5x the intent-log block count). |
 | `inode_cache_inodes` | int | `262144` | Resident inode cap (`0` = default). |
 | `block_layout` | bool | `false` | Source RFC 5663 pNFS **block** layouts (mutually exclusive with `scsi_layout`). |
 | `scsi_layout` | bool | `false` | Source RFC 8154 pNFS **SCSI** layouts (mutually exclusive with `block_layout`). |
@@ -382,9 +382,9 @@ Each entry of `devices`:
 | `path` | string | required | Device path, file path, or PCI BDF (e.g. `"01:00.0"` for VFIO). |
 | `size` | int | auto | Device size in bytes (auto-detected for file-backed if omitted). |
 | `role` | string | `"local"` | `"local"`, or `"remote"` for a pNFS-only data device. |
-| `deviceid` | string | — | 16-byte hex device ID (remote devices). |
-| `signature` | object | — | SIMPLE-volume signature: `{ "offset": int, "bytes": "<hex>" }` (block layout). |
-| `scsi` | object | — | SCSI designator: `{ "designator_type": "naa"\|"eui64"\|"t10", "code_set": "binary"\|"ascii", "id": "<hex>", "pr_key": int }` (SCSI layout). |
+| `deviceid` | string | - | 16-byte hex device ID (remote devices). |
+| `signature` | object | - | SIMPLE-volume signature: `{ "offset": int, "bytes": "<hex>" }` (block layout). |
+| `scsi` | object | - | SCSI designator: `{ "designator_type": "naa"\|"eui64"\|"t10", "code_set": "binary"\|"ascii", "id": "<hex>", "pr_key": int }` (SCSI layout). |
 
 The `nfs` and `root` modules take no `config` object; the `nfs` module is
 configured through mount `options` instead.
@@ -394,7 +394,7 @@ configured through mount `options` instead.
 ## Advanced and testing options
 
 These keys exist for development, debugging, and benchmarking. They are **not**
-intended for production deployments — they either weaken durability guarantees or
+intended for production deployments - they either weaken durability guarantees or
 expose unauthenticated mutation endpoints. They are documented here for
 completeness; leave them at their defaults unless you understand the trade-off.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,15 +204,30 @@ becomes visible in the Chimera namespace at `/<name>`.
 | `path` | string | required | Backend-specific root. For passthrough modules this is a host path; for `nfs` it's the upstream export; for in-memory modules it's typically `/`. |
 | `options` | string | - | Module-specific mount options (e.g. `"vers=4.1,rdma,port=20049"` for the `nfs` module). |
 
-### `exports`, `shares`, `buckets`
+### `exports` (NFS)
 
-Each is an object keyed by the published name. All three take a `path` that
+An object keyed by export name. Each export publishes a VFS path
+(`/<mount-name>[/subdir]`) over NFSv3/NFSv4.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `path` | string | required | VFS path to export; a missing or non-string value fails startup. |
+| `export_id` | int | auto | Stable id (1..65535) embedded in every NFS file handle minted for this export; auto-assigned when omitted. Clustered servers exporting the same directory must pin the same id so file handles stay valid across failover. Startup fails on an out-of-range or already-used id. |
+| `access` | string | `"rw"` | Access mode, `"ro"` or `"rw"`; any other value fails startup. (Renamed from `options`; the old key is rejected at startup.) |
+| `squash` | string | `"none"` | Credential squashing policy: `"none"` (aka `"no_root_squash"`), `"root"` (aka `"root_squash"`), or `"all"` (aka `"all_squash"`); any other value fails startup. |
+| `root_squash` / `no_root_squash` / `all_squash` | bool | - | Boolean aliases for `squash`; an explicit `squash` string takes precedence. |
+| `anonuid` | int | `65534` | Anonymous uid that squashed callers are mapped to (0..4294967295; anything else fails startup). |
+| `anongid` | int | `65534` | Anonymous gid that squashed callers are mapped to (0..4294967295; anything else fails startup). |
+| `sec` | array | any | Allowed RPC security flavors: any of `"sys"` (aka `"auth_sys"`), `"krb5"`, `"krb5i"`, `"krb5p"`. Absent or empty permits any flavor; a non-empty list rejects others (NFSv4: `NFS4ERR_WRONGSEC`). An unknown flavor, non-string entry, or non-array value fails startup (silently dropping one would leave the export open to any flavor). |
+
+### `shares`, `buckets`
+
+Each is an object keyed by the published name. Both take a `path` that
 points into the Chimera namespace (`/<mount-name>[/subdir]`). `shares` also
 accepts one extra key.
 
 | Section | Key | Type | Default | Description |
 |---|---|---|---|---|
-| `exports` (NFS) | `path` | string | required | VFS path to export. |
 | `shares` (SMB) | `path` | string | required | VFS path to share. |
 | `shares` (SMB) | `continuous_availability` | bool | `false` | Advertise SMB Continuous Availability (requires `smb_persistent_handles`). |
 | `buckets` (S3) | `path` | string | required | VFS path backing the bucket. |
@@ -261,7 +276,15 @@ An **array** of S3 credentials. Both keys are required per entry.
     "mounts": {
         "data": { "module": "memfs", "path": "/" }
     },
-    "exports": { "/nfs": { "path": "/data" } },
+    "exports": {
+        "/nfs": {
+            "path": "/data",
+            "export_id": 1,
+            "access": "rw",
+            "squash": "root",
+            "sec": ["sys", "krb5"]
+        }
+    },
     "shares":  { "data": { "path": "/data", "continuous_availability": true } },
     "buckets": { "data": { "path": "/data" } },
     "users": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -458,7 +458,7 @@
             }
           },
           "400": {
-            "description": "Bad request (missing name/path, out-of-range export_id, an unrecognized access/squash value, a non-integer or out-of-range anonuid/anongid, or the legacy \"options\" field, which was renamed to \"access\")",
+            "description": "Bad request (missing name/path, out-of-range export_id, an unrecognized access/squash value, a non-integer or out-of-range anonuid/anongid, a malformed sec array or unknown sec flavor, or the legacy \"options\" field, which was renamed to \"access\")",
             "content": {
               "application/json": {
                 "schema": {
@@ -1058,6 +1058,14 @@
           "anongid": {
             "type": "integer",
             "description": "Anonymous gid squashed callers are mapped to"
+          },
+          "sec": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["sys", "krb5", "krb5i", "krb5p"]
+            },
+            "description": "Allowed RPC security flavors; present only when a restriction is configured (absent means any flavor is permitted)"
           }
         }
       },
@@ -1100,6 +1108,14 @@
             "minimum": 0,
             "maximum": 4294967295,
             "description": "Optional anonymous gid squashed callers are mapped to"
+          },
+          "sec": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["sys", "krb5", "krb5i", "krb5p"]
+            },
+            "description": "Optional allowed RPC security flavors; other flavors are rejected. Omitted or empty permits any flavor."
           }
         }
       },
@@ -1215,6 +1231,14 @@
                 "anongid": {
                   "type": "integer",
                   "description": "Anonymous gid squashed callers are mapped to"
+                },
+                "sec": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["sys", "krb5", "krb5i", "krb5p"]
+                  },
+                  "description": "Allowed RPC security flavors; present only when a restriction is configured (absent means any flavor is permitted)"
                 }
               }
             }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -458,7 +458,7 @@
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Bad request (missing name/path, out-of-range export_id, an unrecognized access/squash value, a non-integer or out-of-range anonuid/anongid, or the legacy \"options\" field, which was renamed to \"access\")",
             "content": {
               "application/json": {
                 "schema": {
@@ -468,7 +468,7 @@
             }
           },
           "409": {
-            "description": "Conflict - export name or export_id already in use",
+            "description": "Conflict - export name or export_id already in use, or the configured nfs_max_exports limit is reached",
             "content": {
               "application/json": {
                 "schema": {
@@ -1040,6 +1040,24 @@
             "minimum": 1,
             "maximum": 65535,
             "description": "Stable export identifier embedded in NFS file handles"
+          },
+          "access": {
+            "type": "string",
+            "enum": ["ro", "rw"],
+            "description": "Access mode"
+          },
+          "squash": {
+            "type": "string",
+            "enum": ["none", "root", "all"],
+            "description": "Credential squashing policy"
+          },
+          "anonuid": {
+            "type": "integer",
+            "description": "Anonymous uid squashed callers are mapped to"
+          },
+          "anongid": {
+            "type": "integer",
+            "description": "Anonymous gid squashed callers are mapped to"
           }
         }
       },
@@ -1060,6 +1078,28 @@
             "minimum": 1,
             "maximum": 65535,
             "description": "Optional explicit export id (1..65535); auto-assigned when omitted. Must match across clustered servers exporting the same directory so file handles stay valid on failover."
+          },
+          "access": {
+            "type": "string",
+            "enum": ["ro", "rw"],
+            "description": "Optional access mode (default rw)"
+          },
+          "squash": {
+            "type": "string",
+            "enum": ["none", "root", "all", "no_root_squash", "root_squash", "all_squash"],
+            "description": "Optional credential squashing policy (default none). The *_squash values are aliases; responses always use the canonical none/root/all."
+          },
+          "anonuid": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "Optional anonymous uid squashed callers are mapped to"
+          },
+          "anongid": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295,
+            "description": "Optional anonymous gid squashed callers are mapped to"
           }
         }
       },
@@ -1157,6 +1197,24 @@
                   "minimum": 1,
                   "maximum": 65535,
                   "description": "Stable export identifier embedded in NFS file handles"
+                },
+                "access": {
+                  "type": "string",
+                  "enum": ["ro", "rw"],
+                  "description": "Access mode"
+                },
+                "squash": {
+                  "type": "string",
+                  "enum": ["none", "root", "all"],
+                  "description": "Credential squashing policy"
+                },
+                "anonuid": {
+                  "type": "integer",
+                  "description": "Anonymous uid squashed callers are mapped to"
+                },
+                "anongid": {
+                  "type": "integer",
+                  "description": "Anonymous gid squashed callers are mapped to"
                 }
               }
             }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1038,7 +1038,7 @@
           "export_id": {
             "type": "integer",
             "minimum": 1,
-            "maximum": 4095,
+            "maximum": 65535,
             "description": "Stable export identifier embedded in NFS file handles"
           }
         }
@@ -1058,8 +1058,8 @@
           "export_id": {
             "type": "integer",
             "minimum": 1,
-            "maximum": 4095,
-            "description": "Optional explicit export id (1..4095); auto-assigned when omitted. Must match across clustered servers exporting the same directory so file handles stay valid on failover."
+            "maximum": 65535,
+            "description": "Optional explicit export id (1..65535); auto-assigned when omitted. Must match across clustered servers exporting the same directory so file handles stay valid on failover."
           }
         }
       },
@@ -1155,7 +1155,7 @@
                 "export_id": {
                   "type": "integer",
                   "minimum": 1,
-                  "maximum": 4095,
+                  "maximum": 65535,
                   "description": "Stable export identifier embedded in NFS file handles"
                 }
               }

--- a/src/admin/README.md
+++ b/src/admin/README.md
@@ -70,7 +70,8 @@ python3 -m chimera_admin mount delete data
 
 # Users, NFS exports, SMB shares, and S3 buckets
 python3 -m chimera_admin user create alice --uid 1000 --gid 1000
-python3 -m chimera_admin export create home /home
+python3 -m chimera_admin export create home /home \
+    --export-id 7 --access ro --squash root --sec krb5
 python3 -m chimera_admin share list
 python3 -m chimera_admin bucket delete photos
 ```

--- a/src/admin/chimera_admin/cli.py
+++ b/src/admin/chimera_admin/cli.py
@@ -75,9 +75,11 @@ def _add_crud_commands(sub, noun: str, label: str) -> None:
 def _add_export_commands(sub) -> None:
     """Add the ``export`` resource commands.
 
-    Exports follow the generic name+path CRUD shape but grow an
-    export-specific ``--export-id`` create option, so they get their own
-    builder rather than sharing _add_crud_commands with shares/buckets.
+    Exports follow the generic name+path CRUD shape but grow
+    export-specific create options (``--export-id``, ``--access``,
+    ``--squash``, ``--anonuid``, ``--anongid``, ``--sec``), so they get
+    their own builder rather than sharing _add_crud_commands with
+    shares/buckets.
     """
     res = sub.add_parser("export", help="Manage NFS exports")
     actions = res.add_subparsers(dest="action", required=True)
@@ -94,16 +96,26 @@ def _add_export_commands(sub) -> None:
     p.add_argument("path", help="VFS path for the resource")
     p.add_argument(
         "--export-id", type=int, dest="export_id",
-        help="Stable export id (1-4095, default: auto-assigned)")
+        help="Stable export id (1-65535, default: auto-assigned)")
     p.add_argument(
-        "--options", choices=["ro", "rw"],
+        "--access", choices=["ro", "rw"],
         help="Access mode (default: rw)")
     p.add_argument(
         "--squash", choices=["none", "root", "all"],
         help="Squash policy (default: none)")
+    p.add_argument(
+        "--anonuid", type=int,
+        help="Anonymous uid squashed callers are mapped to (default: 65534)")
+    p.add_argument(
+        "--anongid", type=int,
+        help="Anonymous gid squashed callers are mapped to (default: 65534)")
+    p.add_argument(
+        "--sec", action="append", choices=["sys", "krb5", "krb5i", "krb5p"],
+        help="Allowed RPC security flavor; repeat for several "
+             "(default: any flavor)")
     p.set_defaults(func=lambda c, a: c.create_export(
-        a.name, a.path, export_id=a.export_id, options=a.options,
-        squash=a.squash))
+        a.name, a.path, export_id=a.export_id, access=a.access,
+        squash=a.squash, anonuid=a.anonuid, anongid=a.anongid, sec=a.sec))
 
     p = actions.add_parser("delete", help="Delete a NFS export")
     p.add_argument("name")

--- a/src/admin/chimera_admin/client.py
+++ b/src/admin/chimera_admin/client.py
@@ -45,6 +45,25 @@ class ChimeraAdminClient:
         self._base_url = f"{scheme}://{host}:{port}"
         self._session = requests.Session()
 
+    @staticmethod
+    def _http_error_message(e: requests.exceptions.HTTPError) -> str:
+        """Build an error string that keeps the server's explanation.
+
+        The server returns ``{"error": ..., "message": ...}`` bodies whose
+        message distinguishes causes that share a status code (e.g. a 409
+        for a duplicate export name vs a duplicate export_id). Reporting
+        only the requests exception would discard that and leave the user
+        guessing which validation failed.
+        """
+        if e.response is not None:
+            try:
+                message = e.response.json().get("message")
+            except ValueError:
+                message = None
+            if message:
+                return f"HTTP error: {e}: {message}"
+        return f"HTTP error: {e}"
+
     def _request(
         self,
         method: str,
@@ -78,7 +97,7 @@ class ChimeraAdminClient:
             raise ChimeraAdminError(f"Request timed out: {e}") from e
         except requests.exceptions.HTTPError as e:
             raise ChimeraAdminError(
-                f"HTTP error: {e}",
+                self._http_error_message(e),
                 status_code=e.response.status_code
                 if e.response is not None
                 else None,
@@ -242,37 +261,53 @@ class ChimeraAdminClient:
         name: str,
         path: str,
         export_id: Optional[int] = None,
-        options: Optional[str] = None,
+        access: Optional[str] = None,
         squash: Optional[str] = None,
+        anonuid: Optional[int] = None,
+        anongid: Optional[int] = None,
+        sec: Optional[list] = None,
     ) -> dict:
         """Create a new NFS export.
 
         Args:
             name: Export name.
             path: VFS path for the export.
-            export_id: Optional stable export id (1-4095), embedded in NFS
+            export_id: Optional stable export id (1-65535), embedded in NFS
                 file handles; auto-assigned when omitted. Clustered servers
                 exporting the same directory must pin the same id so file
                 handles stay valid across failover.
-            options: Optional access mode, "ro" or "rw" (server default: rw).
+            access: Optional access mode, "ro" or "rw" (server default: rw).
             squash: Optional squash policy, "none", "root", or "all"
                 (server default: none).
+            anonuid: Optional anonymous uid squashed callers are mapped to
+                (server default: 65534).
+            anongid: Optional anonymous gid squashed callers are mapped to
+                (server default: 65534).
+            sec: Optional list of allowed RPC security flavors ("sys",
+                "krb5", "krb5i", "krb5p"); other flavors are rejected.
+                Omitted or empty permits any flavor (the server default).
 
         Returns:
             Response message.
 
         Raises:
             ChimeraAdminError: If the request fails (e.g. 400 for an
-                out-of-range export_id, 409 if the name or export_id is
-                already in use).
+                out-of-range export_id or an unknown sec flavor, 409 if the
+                name or export_id is already in use).
         """
         data = {"name": name, "path": path}
         if export_id is not None:
             data["export_id"] = export_id
-        if options is not None:
-            data["options"] = options
+        if access is not None:
+            data["access"] = access
         if squash is not None:
             data["squash"] = squash
+        if anonuid is not None:
+            data["anonuid"] = anonuid
+        if anongid is not None:
+            data["anongid"] = anongid
+        if sec is not None:
+            data["sec"] = sec
         return self._request("POST", "/api/v1/exports", json=data)
 
     def delete_export(self, name: str) -> None:
@@ -490,7 +525,7 @@ class ChimeraAdminClient:
             raise ChimeraAdminError(f"Request timed out: {e}") from e
         except requests.exceptions.HTTPError as e:
             raise ChimeraAdminError(
-                f"HTTP error: {e}",
+                self._http_error_message(e),
                 status_code=e.response.status_code
                 if e.response is not None
                 else None,

--- a/src/admin/tests/test_api.py
+++ b/src/admin/tests/test_api.py
@@ -73,6 +73,39 @@ class TestUsersAPI:
 class TestExportsAPI:
     """Test the NFS Exports API endpoints."""
 
+    # Every export name these tests create, for the pre-clean fixture below.
+    _TEST_EXPORTS = [
+        "sdk_test_export",
+        "sdk_test_export_id",
+        "sdk_test_export_access",
+        "sdk_test_export_anon",
+        "sdk_test_export_sec",
+        "sdk_test_export_dup",
+        "sdk_test_export_dup2",
+        "sdk_test_export_bad",
+        "sdk_test_export_bad_ac",
+        "sdk_test_export_auto1",
+        "sdk_test_export_pinned",
+        "sdk_test_export_auto2",
+        "sdk_test_export_free",
+        "sdk_test_export_reuse",
+    ]
+
+    @pytest.fixture(autouse=True)
+    def _clean_exports(self, client):
+        """Best-effort removal of leftovers from a previous killed run.
+
+        The tests pin fixed names and export ids (4000-4004); a run killed
+        before its finally-blocks would otherwise leave exports behind and
+        turn every later run into 409 conflicts until the server restarts.
+        """
+        for name in self._TEST_EXPORTS:
+            try:
+                client.delete_export(name)
+            except ChimeraAdminError:
+                pass
+        yield
+
     def test_list_exports(self, client):
         """Test listing NFS exports."""
         exports = client.list_exports()
@@ -124,25 +157,66 @@ class TestExportsAPI:
         finally:
             client.delete_export(name)
 
-    def test_create_export_options_round_trip(self, client):
-        """Access options given at create time are echoed back."""
-        name = "sdk_test_export_opts"
+    def test_create_export_access_round_trip(self, client):
+        """Access control given at create time is echoed back."""
+        name = "sdk_test_export_access"
         try:
             client.create_export(
                 name, "/testshare", export_id=4003,
-                options="ro", squash="none")
+                access="ro", squash="none")
 
             export = client.get_export(name)
             assert export["export_id"] == 4003
-            assert export["options"] == "ro"
+            assert export["access"] == "ro"
             assert export["squash"] == "none"
 
             # The running config round-trips them for chimera.json.
             config = client.get_config()
-            assert config["exports"][name]["options"] == "ro"
+            assert config["exports"][name]["access"] == "ro"
             assert config["exports"][name]["squash"] == "none"
         finally:
             client.delete_export(name)
+
+    def test_create_export_anon_ids_round_trip(self, client):
+        """anonuid/anongid given at create time are echoed back."""
+        name = "sdk_test_export_anon"
+        try:
+            client.create_export(
+                name, "/testshare", export_id=4004,
+                squash="all", anonuid=1234, anongid=5678)
+
+            export = client.get_export(name)
+            assert export["squash"] == "all"
+            assert export["anonuid"] == 1234
+            assert export["anongid"] == 5678
+        finally:
+            client.delete_export(name)
+
+    def test_create_export_sec_round_trip(self, client):
+        """A sec restriction given at create time is echoed back."""
+        name = "sdk_test_export_sec"
+        try:
+            client.create_export(name, "/testshare", sec=["krb5", "krb5i"])
+
+            export = client.get_export(name)
+            assert export["sec"] == ["krb5", "krb5i"]
+
+            # The running config round-trips it for chimera.json.
+            config = client.get_config()
+            assert config["exports"][name]["sec"] == ["krb5", "krb5i"]
+        finally:
+            client.delete_export(name)
+
+    def test_create_export_invalid_sec(self, client):
+        """Unknown sec flavors are rejected with 400, not widened to any."""
+        name = "sdk_test_export_sec"
+        with pytest.raises(ChimeraAdminError) as exc_info:
+            client.create_export(name, "/testshare", sec=["krb5x"])
+        assert exc_info.value.status_code == 400
+
+        with pytest.raises(ChimeraAdminError) as exc_info:
+            client.get_export(name)
+        assert exc_info.value.status_code == 404
 
     def test_create_export_duplicate_id(self, client):
         """A second export reusing an export_id is rejected with 409."""
@@ -166,7 +240,7 @@ class TestExportsAPI:
 
     def test_create_export_invalid_id(self, client):
         """Out-of-range export ids are rejected with 400."""
-        for bad_id in (0, 4096, -5):
+        for bad_id in (0, 65536, -5):
             with pytest.raises(ChimeraAdminError) as exc_info:
                 client.create_export(
                     "sdk_test_export_bad", "/testshare", export_id=bad_id)
@@ -174,6 +248,22 @@ class TestExportsAPI:
 
         with pytest.raises(ChimeraAdminError) as exc_info:
             client.get_export("sdk_test_export_bad")
+        assert exc_info.value.status_code == 404
+
+    def test_create_export_invalid_access_control(self, client):
+        """Unrecognized access/squash values are rejected with 400 rather
+        than silently replaced with the (more permissive) defaults."""
+        name = "sdk_test_export_bad_ac"
+        for bad_kwargs in (
+            {"access": "readonly"},
+            {"squash": "rootsquash"},
+        ):
+            with pytest.raises(ChimeraAdminError) as exc_info:
+                client.create_export(name, "/testshare", **bad_kwargs)
+            assert exc_info.value.status_code == 400
+
+        with pytest.raises(ChimeraAdminError) as exc_info:
+            client.get_export(name)
         assert exc_info.value.status_code == 404
 
     def test_auto_assign_skips_explicit_id(self, client):
@@ -186,7 +276,7 @@ class TestExportsAPI:
             client.create_export(auto1, "/testshare")
             created.append(auto1)
             base = client.get_export(auto1)["export_id"]
-            if base + 2 > 4095:
+            if base + 2 > 65535:
                 pytest.skip("export id space nearly exhausted")
 
             client.create_export(pinned, "/testshare", export_id=base + 1)

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -208,7 +208,7 @@ client_test_init(
 
         // Create NFSv3 server export entry
         if (env->use_nfs) {
-            chimera_server_create_export(env->server, "/share", "/share", 0);
+            chimera_server_create_export(env->server, "/share", "/share", 0, NULL);
         }
 
         chimera_server_start(env->server);

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -206,9 +206,15 @@ client_test_init(
             exit(EXIT_FAILURE);
         }
 
-        // Create NFSv3 server export entry
+        // Create NFSv3 server export entry.  Pin an id above the default
+        // count cap (4096) so the tests exercise pinned-id file-handle
+        // attribution across the full 16-bit id space.
         if (env->use_nfs) {
-            chimera_server_create_export(env->server, "/share", "/share", 0, NULL);
+            if (chimera_server_create_export(env->server, "/share", "/share",
+                                             4242, NULL) != 0) {
+                fprintf(stderr, "Failed to create /share export\n");
+                exit(EXIT_FAILURE);
+            }
         }
 
         chimera_server_start(env->server);

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -14,3 +14,5 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/daemon.h
 )
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_subdirectory(tests)

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1094,7 +1094,7 @@ main(
                 continue;
             }
 
-            json_t     *opt_j     = json_object_get(export, "options");
+            json_t     *access_j  = json_object_get(export, "access");
             json_t     *squash_j  = json_object_get(export, "squash");
             json_t     *rsq_j     = json_object_get(export, "root_squash");
             json_t     *norsq_j   = json_object_get(export, "no_root_squash");
@@ -1102,24 +1102,34 @@ main(
             json_t     *anonuid_j = json_object_get(export, "anonuid");
             json_t     *anongid_j = json_object_get(export, "anongid");
             uint32_t    export_id = 0;
-            const char *opt_s     = json_string_value(opt_j);
+            const char *access_s  = json_string_value(access_j);
             const char *squash_s  = json_string_value(squash_j);
-            uint32_t    options   = CHIMERA_NFS_EXPORT_OPT_RW;
+            uint32_t    access    = CHIMERA_NFS_EXPORT_ACCESS_RW;
             uint32_t    squash    = CHIMERA_NFS_SQUASH_NONE;
             uint32_t    anonuid   = chimera_server_config_get_anonuid(server_config);
             uint32_t    anongid   = chimera_server_config_get_anongid(server_config);
 
             path = json_string_value(json_object_get(export, "path"));
 
+            /* The access mode key was renamed from "options" to "access".
+             * Ignoring the old key would silently turn an "options": "ro"
+             * export read-write, so reject it outright. */
+            if (json_object_get(export, "options")) {
+                chimera_server_error("Export '%s': \"options\" has been "
+                                     "renamed to \"access\"; update the config",
+                                     name);
+                exit(1);
+            }
+
             /* Access mode: "ro" | "rw" (default rw). */
-            if (opt_s) {
-                if (strcasecmp(opt_s, "ro") == 0) {
-                    options = CHIMERA_NFS_EXPORT_OPT_RO;
-                } else if (strcasecmp(opt_s, "rw") == 0) {
-                    options = CHIMERA_NFS_EXPORT_OPT_RW;
+            if (access_s) {
+                if (strcasecmp(access_s, "ro") == 0) {
+                    access = CHIMERA_NFS_EXPORT_ACCESS_RO;
+                } else if (strcasecmp(access_s, "rw") == 0) {
+                    access = CHIMERA_NFS_EXPORT_ACCESS_RW;
                 } else {
-                    chimera_server_error("Invalid export '%s' options value '%s' "
-                                         "(expected ro/rw)", name, opt_s);
+                    chimera_server_error("Invalid export '%s' access value '%s' "
+                                         "(expected ro/rw)", name, access_s);
                 }
             }
 
@@ -1212,7 +1222,7 @@ main(
 
             chimera_server_info("Adding NFS export %s -> %s (%s, %s, export_id %s)",
                                 name, path,
-                                options & CHIMERA_NFS_EXPORT_OPT_RO ? "ro" : "rw",
+                                access & CHIMERA_NFS_EXPORT_ACCESS_RO ? "ro" : "rw",
                                 squash == CHIMERA_NFS_SQUASH_ALL ? "all_squash" :
                                 squash == CHIMERA_NFS_SQUASH_NONE ? "no_root_squash" :
                                 "root_squash",
@@ -1225,7 +1235,7 @@ main(
                 chimera_server_error("Failed to create export '%s'", name);
                 exit(1);
             }
-            chimera_server_export_set_options(server, name, options, squash,
+            chimera_server_export_set_options(server, name, access, squash,
                                               anonuid, anongid);
             if (sec_mask) {
                 chimera_server_export_set_sec(server, name, sec_mask);

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1129,6 +1129,15 @@ main(
 
             path = json_string_value(json_object_get(export, "path"));
 
+            /* A missing or non-string path would otherwise flow into the
+             * export as the literal string "(null)" and boot an export that
+             * fails only when clients try to mount it. */
+            if (!path) {
+                chimera_server_error("Export '%s': missing or non-string "
+                                     "\"path\"", name);
+                exit(1);
+            }
+
             /* The access mode key was renamed from "options" to "access".
              * Ignoring the old key would silently turn an "options": "ro"
              * export read-write, so reject it outright. */
@@ -1139,34 +1148,40 @@ main(
                 exit(1);
             }
 
-            /* Access mode: "ro" | "rw" (default rw). */
-            if (access_s) {
-                if (strcasecmp(access_s, "ro") == 0) {
+            /* Access mode: "ro" | "rw" (default rw).  A value that doesn't
+             * parse is fatal: booting anyway would silently turn a requested
+             * read-only export read-write. */
+            if (access_j) {
+                if (access_s && strcasecmp(access_s, "ro") == 0) {
                     access = CHIMERA_NFS_EXPORT_ACCESS_RO;
-                } else if (strcasecmp(access_s, "rw") == 0) {
+                } else if (access_s && strcasecmp(access_s, "rw") == 0) {
                     access = CHIMERA_NFS_EXPORT_ACCESS_RW;
                 } else {
                     chimera_server_error("Invalid export '%s' access value '%s' "
-                                         "(expected ro/rw)", name, access_s);
+                                         "(expected ro/rw)", name,
+                                         access_s ? access_s : "(not a string)");
+                    exit(1);
                 }
             }
 
             /* Squash policy.  Default is no squashing.  An explicit "squash"
              * string takes precedence; otherwise the all_squash / root_squash /
              * no_root_squash booleans act as aliases. */
-            if (squash_s) {
-                if (strcasecmp(squash_s, "none") == 0 ||
-                    strcasecmp(squash_s, "no_root_squash") == 0) {
+            if (squash_j) {
+                if (squash_s && (strcasecmp(squash_s, "none") == 0 ||
+                                 strcasecmp(squash_s, "no_root_squash") == 0)) {
                     squash = CHIMERA_NFS_SQUASH_NONE;
-                } else if (strcasecmp(squash_s, "root") == 0 ||
-                           strcasecmp(squash_s, "root_squash") == 0) {
+                } else if (squash_s && (strcasecmp(squash_s, "root") == 0 ||
+                                        strcasecmp(squash_s, "root_squash") == 0)) {
                     squash = CHIMERA_NFS_SQUASH_ROOT;
-                } else if (strcasecmp(squash_s, "all") == 0 ||
-                           strcasecmp(squash_s, "all_squash") == 0) {
+                } else if (squash_s && (strcasecmp(squash_s, "all") == 0 ||
+                                        strcasecmp(squash_s, "all_squash") == 0)) {
                     squash = CHIMERA_NFS_SQUASH_ALL;
                 } else {
                     chimera_server_error("Invalid export '%s' squash value '%s' "
-                                         "(expected none/root/all)", name, squash_s);
+                                         "(expected none/root/all)", name,
+                                         squash_s ? squash_s : "(not a string)");
+                    exit(1);
                 }
             } else if (allsq_j && json_is_true(allsq_j)) {
                 squash = CHIMERA_NFS_SQUASH_ALL;
@@ -1176,11 +1191,30 @@ main(
                 squash = CHIMERA_NFS_SQUASH_NONE;
             }
 
+            /* Anon ids must be validated before the unsigned cast: a
+             * non-integer json value reads as 0, which would silently map
+             * squashed callers to uid/gid 0 (root). */
             if (anonuid_j) {
-                anonuid = (uint32_t) json_integer_value(anonuid_j);
+                json_int_t v = json_integer_value(anonuid_j);
+
+                if (!json_is_integer(anonuid_j) || v < 0 || v > UINT32_MAX) {
+                    chimera_server_error("Export '%s': invalid anonuid "
+                                         "(expected integer 0..%u)",
+                                         name, UINT32_MAX);
+                    exit(1);
+                }
+                anonuid = (uint32_t) v;
             }
             if (anongid_j) {
-                anongid = (uint32_t) json_integer_value(anongid_j);
+                json_int_t v = json_integer_value(anongid_j);
+
+                if (!json_is_integer(anongid_j) || v < 0 || v > UINT32_MAX) {
+                    chimera_server_error("Export '%s': invalid anongid "
+                                         "(expected integer 0..%u)",
+                                         name, UINT32_MAX);
+                    exit(1);
+                }
+                anongid = (uint32_t) v;
             }
 
             /* Stable export id: the id is embedded in wire file handles, so
@@ -1204,10 +1238,19 @@ main(
             /* Allowed security flavors: an optional array of
              * "sys"/"krb5"/"krb5i"/"krb5p".  Absent (mask 0) permits any
              * flavor, preserving historical behavior; a non-empty list
-             * restricts the export and rejects others with NFS4ERR_WRONGSEC. */
+             * restricts the export and rejects others with NFS4ERR_WRONGSEC.
+             * Every malformed shape is fatal: a typo'd flavor, non-string
+             * entry, or non-array value silently dropped would leave the
+             * mask at 0 -- "any flavor allowed" -- turning a requested
+             * Kerberos-only export wide open to AUTH_SYS. */
             json_t  *sec_j    = json_object_get(export, "sec");
             uint32_t sec_mask = 0;
-            if (sec_j && json_is_array(sec_j)) {
+            if (sec_j && !json_is_array(sec_j)) {
+                chimera_server_error("Export '%s': \"sec\" must be an array "
+                                     "of flavor strings", name);
+                exit(1);
+            }
+            if (sec_j) {
                 size_t  si;
                 json_t *flavor_j;
                 json_array_foreach(sec_j, si, flavor_j)
@@ -1215,7 +1258,9 @@ main(
                     const char *f = json_string_value(flavor_j);
 
                     if (!f) {
-                        continue;
+                        chimera_server_error("Export '%s': \"sec\" entry %zu "
+                                             "is not a string", name, si);
+                        exit(1);
                     }
                     if (strcasecmp(f, "sys") == 0 || strcasecmp(f, "auth_sys") == 0) {
                         sec_mask |= CHIMERA_NFS_SEC_SYS;
@@ -1228,6 +1273,7 @@ main(
                     } else {
                         chimera_server_error("Invalid export '%s' sec flavor '%s' "
                                              "(expected sys/krb5/krb5i/krb5p)", name, f);
+                        exit(1);
                     }
                 }
             }

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <string.h>
@@ -388,6 +389,23 @@ main(
     if (json_is_integer(json_value)) {
         int_value = json_integer_value(json_value);
         chimera_server_config_set_max_open_files(server_config, int_value);
+    }
+
+    /* Concurrent NFS export count cap.  A misconfigured limit silently
+     * ignored would defeat its purpose, so reject bad values outright.  The
+     * cap may not exceed the export id space (ids are unique per export, so
+     * a larger count could never be reached anyway). */
+    json_value = json_object_get(server_params, "nfs_max_exports");
+    if (json_value) {
+        json_int_t v = json_is_integer(json_value) ?
+            json_integer_value(json_value) : -1;
+
+        if (v < 1 || v > CHIMERA_NFS_EXPORT_ID_MAX) {
+            chimera_server_error("Invalid nfs_max_exports (expected integer "
+                                 "1..%u)", CHIMERA_NFS_EXPORT_ID_MAX);
+            exit(1);
+        }
+        chimera_server_config_set_nfs_max_exports(server_config, (uint32_t) v);
     }
 
     json_value = json_object_get(server_params, "sync_delegation");

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1245,18 +1245,30 @@ main(
                                 squash == CHIMERA_NFS_SQUASH_NONE ? "no_root_squash" :
                                 "root_squash",
                                 export_id_str);
-            if (chimera_server_create_export(server, name, path, export_id) != 0) {
-                /* Duplicate or unusable export_id: proceeding would mint file
-                 * handles under a different id than the operator pinned, which
-                 * breaks cluster failover in a way clients only notice later.
-                 * Fail hard like the mount-path errors above. */
+            /* All validated settings are applied atomically at creation, so
+             * the export is never live with permissive defaults while a
+             * follow-up set_options/set_sec call is pending. */
+            struct chimera_nfs_export_opts opts = {
+                .has_access  = 1,
+                .has_squash  = 1,
+                .has_anonuid = 1,
+                .has_anongid = 1,
+                .has_sec     = 1,
+                .access      = access,
+                .squash      = squash,
+                .anonuid     = anonuid,
+                .anongid     = anongid,
+                .sec_allowed = sec_mask,
+            };
+
+            if (chimera_server_create_export(server, name, path, export_id,
+                                             &opts) != 0) {
+                /* Duplicate name or unusable export_id: proceeding would mint
+                 * file handles under a different id than the operator pinned,
+                 * which breaks cluster failover in a way clients only notice
+                 * later.  Fail hard like the mount-path errors above. */
                 chimera_server_error("Failed to create export '%s'", name);
                 exit(1);
-            }
-            chimera_server_export_set_options(server, name, access, squash,
-                                              anonuid, anongid);
-            if (sec_mask) {
-                chimera_server_export_set_sec(server, name, sec_mask);
             }
         }
     }

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -1183,12 +1183,34 @@ main(
                                          squash_s ? squash_s : "(not a string)");
                     exit(1);
                 }
-            } else if (allsq_j && json_is_true(allsq_j)) {
-                squash = CHIMERA_NFS_SQUASH_ALL;
-            } else if (rsq_j && json_is_true(rsq_j)) {
-                squash = CHIMERA_NFS_SQUASH_ROOT;
-            } else if (norsq_j && json_is_true(norsq_j)) {
-                squash = CHIMERA_NFS_SQUASH_NONE;
+            } else {
+                /* The aliases must actually be booleans: a value like
+                 * "root_squash": "true" (a string) or "all_squash": 1
+                 * silently ignored would leave the export unsquashed -- the
+                 * same silent-permissive fallback the string form above
+                 * rejects. */
+                if (allsq_j && !json_is_boolean(allsq_j)) {
+                    chimera_server_error("Export '%s': \"all_squash\" must be "
+                                         "a boolean", name);
+                    exit(1);
+                }
+                if (rsq_j && !json_is_boolean(rsq_j)) {
+                    chimera_server_error("Export '%s': \"root_squash\" must be "
+                                         "a boolean", name);
+                    exit(1);
+                }
+                if (norsq_j && !json_is_boolean(norsq_j)) {
+                    chimera_server_error("Export '%s': \"no_root_squash\" must "
+                                         "be a boolean", name);
+                    exit(1);
+                }
+                if (allsq_j && json_is_true(allsq_j)) {
+                    squash = CHIMERA_NFS_SQUASH_ALL;
+                } else if (rsq_j && json_is_true(rsq_j)) {
+                    squash = CHIMERA_NFS_SQUASH_ROOT;
+                } else if (norsq_j && json_is_true(norsq_j)) {
+                    squash = CHIMERA_NFS_SQUASH_NONE;
+                }
             }
 
             /* Anon ids must be validated before the unsigned cast: a

--- a/src/daemon/tests/CMakeLists.txt
+++ b/src/daemon/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# Daemon configuration validation test: export settings that must fail
+# startup, two-pass export_id assignment, and sec config round-trip.
+add_test(NAME chimera/daemon/config_test
+    COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+            ${CMAKE_CURRENT_SOURCE_DIR}/daemon_config_test.sh
+            $<TARGET_FILE:chimera>)
+set_tests_properties(chimera/daemon/config_test PROPERTIES
+    ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/src/server/smb/tests/suppressions.txt")

--- a/src/daemon/tests/daemon_config_test.sh
+++ b/src/daemon/tests/daemon_config_test.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+#
+# Daemon configuration validation test
+#
+# Exercises the export-related startup validation in src/daemon/daemon.c,
+# which has no other test coverage:
+#   1. Malformed export settings (legacy "options" key, bad access/squash,
+#      out-of-range/non-integer/duplicate export_id, bad sec shapes, missing
+#      path, bad anonuid, bad nfs_max_exports) must fail startup with a
+#      nonzero exit rather than booting with silently-corrected values.
+#   2. A valid config must start; explicit export_ids are honored and
+#      auto-assignment must not collide with an id pinned by a lexically
+#      later entry (the two-pass parse), verified through the REST API.
+#   3. A per-export sec restriction round-trips through GET /api/v1/config.
+#
+# Expected to run under scripts/netns_test_wrapper.sh (isolated network).
+#
+
+set -u
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <chimera-daemon-binary>"
+    exit 1
+fi
+
+DAEMON=$1
+REST_PORT=18095
+
+TMPDIR=$(mktemp -d)
+DAEMON_PID=""
+
+cleanup() {
+    if [ -n "${DAEMON_PID}" ]; then
+        kill -9 "${DAEMON_PID}" 2>/dev/null
+        wait "${DAEMON_PID}" 2>/dev/null
+    fi
+    rm -rf "${TMPDIR}"
+}
+
+trap cleanup EXIT
+
+mkdir -p "${TMPDIR}/state"
+
+PASSED=0
+FAILED=0
+
+pass() {
+    echo "  PASS: $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAILED=$((FAILED + 1))
+}
+
+# Write a config with the given exports object (and optional extra server
+# keys) to stdout.
+write_config() {
+    local exports_json=$1
+    local extra_server=${2:-}
+
+    cat <<EOF
+{
+    "server": {
+        "threads": 2,
+        "rest_http_port": ${REST_PORT},
+        "rest_auth_enabled": false,
+        "state_dir": "${TMPDIR}/state"${extra_server}
+    },
+    "mounts": {
+        "data": { "module": "memfs", "path": "/" }
+    },
+    "exports": ${exports_json}
+}
+EOF
+}
+
+# A bad config must make the daemon exit nonzero on its own, quickly.  A
+# timeout kill (rc 124) means the daemon booted despite the bad config,
+# which is exactly the silent-fallback failure these checks exist to catch.
+expect_startup_failure() {
+    local name=$1
+    local exports_json=$2
+    local extra_server=${3:-}
+    local rc
+
+    write_config "${exports_json}" "${extra_server}" > "${TMPDIR}/bad.json"
+
+    timeout 30 "${DAEMON}" -c "${TMPDIR}/bad.json" > /dev/null 2>&1
+    rc=$?
+
+    if [ ${rc} -ne 0 ] && [ ${rc} -ne 124 ]; then
+        pass "${name}"
+    else
+        fail "${name} (exit ${rc})"
+    fi
+}
+
+echo "========================================"
+echo "Daemon Config Validation Test"
+echo "========================================"
+
+if ! command -v curl > /dev/null 2>&1; then
+    echo "ERROR: curl not found in PATH"
+    exit 1
+fi
+
+echo
+echo "  Test: malformed export settings are fatal at startup..."
+
+expect_startup_failure "legacy \"options\" key rejected" \
+    '{ "/e": { "path": "/data", "options": "ro" } }'
+
+expect_startup_failure "invalid access value rejected" \
+    '{ "/e": { "path": "/data", "access": "readonly" } }'
+
+expect_startup_failure "invalid squash value rejected" \
+    '{ "/e": { "path": "/data", "squash": "rootsquash" } }'
+
+expect_startup_failure "export_id 0 rejected" \
+    '{ "/e": { "path": "/data", "export_id": 0 } }'
+
+expect_startup_failure "export_id 65536 rejected" \
+    '{ "/e": { "path": "/data", "export_id": 65536 } }'
+
+expect_startup_failure "non-integer export_id rejected" \
+    '{ "/e": { "path": "/data", "export_id": "abc" } }'
+
+expect_startup_failure "duplicate export_id rejected" \
+    '{ "/e1": { "path": "/data", "export_id": 7 },
+       "/e2": { "path": "/data", "export_id": 7 } }'
+
+expect_startup_failure "unknown sec flavor rejected" \
+    '{ "/e": { "path": "/data", "sec": ["krb5x"] } }'
+
+expect_startup_failure "non-array sec rejected" \
+    '{ "/e": { "path": "/data", "sec": "krb5" } }'
+
+expect_startup_failure "non-string sec entry rejected" \
+    '{ "/e": { "path": "/data", "sec": [5] } }'
+
+expect_startup_failure "missing export path rejected" \
+    '{ "/e": { } }'
+
+expect_startup_failure "negative anonuid rejected" \
+    '{ "/e": { "path": "/data", "anonuid": -1 } }'
+
+expect_startup_failure "nfs_max_exports 0 rejected" \
+    '{ "/e": { "path": "/data" } }' \
+    ',
+        "nfs_max_exports": 0'
+
+echo
+echo "  Test: valid config starts; auto-assignment skips pinned ids..."
+
+# The auto entry sorts lexically before the pinned one, so a regression to a
+# single ordered pass would hand the auto export id 1 and then fail startup
+# on the pinned entry's conflict; the two-pass parse must give the pinned
+# entry id 1 and the auto entry id 2.  The sec restriction on the pinned
+# entry must round-trip through GET /api/v1/config.
+write_config '{
+    "/a_auto":   { "path": "/data" },
+    "/b_pinned": { "path": "/data", "export_id": 1, "sec": ["krb5"] }
+}' > "${TMPDIR}/good.json"
+
+"${DAEMON}" -c "${TMPDIR}/good.json" > "${TMPDIR}/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+BODY=""
+for _ in $(seq 1 60); do
+    if ! kill -0 "${DAEMON_PID}" 2>/dev/null; then
+        break
+    fi
+    BODY=$(curl -s "http://localhost:${REST_PORT}/api/v1/exports" 2>/dev/null)
+    if [ -n "${BODY}" ]; then
+        break
+    fi
+    sleep 0.5
+done
+
+if ! kill -0 "${DAEMON_PID}" 2>/dev/null; then
+    fail "daemon stayed up with valid config"
+    echo "---- daemon log ----"
+    cat "${TMPDIR}/daemon.log"
+    echo "--------------------"
+    DAEMON_PID=""
+elif [ -z "${BODY}" ]; then
+    fail "REST API answered on valid config"
+else
+    pass "daemon started and REST API answered"
+
+    # Flat objects (no nested braces in this config), so split and match
+    # per export.
+    if echo "${BODY}" | grep -o '{[^}]*}' | grep '"name":"/b_pinned"' |
+        grep -q '"export_id":1,'; then
+        pass "pinned export got export_id 1"
+    else
+        fail "pinned export got export_id 1 (body: ${BODY})"
+    fi
+
+    if echo "${BODY}" | grep -o '{[^}]*}' | grep '"name":"/a_auto"' |
+        grep -q '"export_id":2,'; then
+        pass "auto export skipped pinned id, got export_id 2"
+    else
+        fail "auto export skipped pinned id, got export_id 2 (body: ${BODY})"
+    fi
+
+    if echo "${BODY}" | grep -o '{[^}]*}' | grep '"name":"/b_pinned"' |
+        grep -q '"sec":\["krb5"\]'; then
+        pass "sec restriction shown in /api/v1/exports"
+    else
+        fail "sec restriction shown in /api/v1/exports (body: ${BODY})"
+    fi
+
+    CONFIG_BODY=$(curl -s "http://localhost:${REST_PORT}/api/v1/config" \
+        2>/dev/null)
+    if echo "${CONFIG_BODY}" | grep -q '"sec":\["krb5"\]'; then
+        pass "sec restriction round-trips through /api/v1/config"
+    else
+        fail "sec restriction round-trips through /api/v1/config (body: ${CONFIG_BODY})"
+    fi
+fi
+
+if [ -n "${DAEMON_PID}" ]; then
+    kill -TERM "${DAEMON_PID}" 2>/dev/null
+    SHUTDOWN_RC=1
+    for _ in $(seq 1 60); do
+        if ! kill -0 "${DAEMON_PID}" 2>/dev/null; then
+            wait "${DAEMON_PID}"
+            SHUTDOWN_RC=$?
+            break
+        fi
+        sleep 0.5
+    done
+    if [ ${SHUTDOWN_RC} -eq 0 ]; then
+        pass "daemon shut down cleanly on SIGTERM"
+    else
+        fail "daemon shut down cleanly on SIGTERM (exit ${SHUTDOWN_RC})"
+    fi
+    DAEMON_PID=""
+fi
+
+echo
+echo "========================================"
+echo "Passed: ${PASSED}"
+echo "Failed: ${FAILED}"
+echo "========================================"
+
+if [ ${FAILED} -gt 0 ]; then
+    echo "Some tests FAILED"
+    exit 1
+fi
+
+echo "All tests PASSED"
+exit 0

--- a/src/daemon/tests/daemon_config_test.sh
+++ b/src/daemon/tests/daemon_config_test.sh
@@ -123,6 +123,17 @@ expect_startup_failure "invalid access value rejected" \
 expect_startup_failure "invalid squash value rejected" \
     '{ "/e": { "path": "/data", "squash": "rootsquash" } }'
 
+# The boolean squash aliases silently ignored on a non-boolean value would
+# leave the export unsquashed (the permissive default).
+expect_startup_failure "string root_squash rejected" \
+    '{ "/e": { "path": "/data", "root_squash": "true" } }'
+
+expect_startup_failure "integer all_squash rejected" \
+    '{ "/e": { "path": "/data", "all_squash": 1 } }'
+
+expect_startup_failure "string no_root_squash rejected" \
+    '{ "/e": { "path": "/data", "no_root_squash": "yes" } }'
+
 expect_startup_failure "export_id 0 rejected" \
     '{ "/e": { "path": "/data", "export_id": 0 } }'
 
@@ -163,9 +174,10 @@ echo "  Test: valid config starts; auto-assignment skips pinned ids..."
 # single ordered pass would hand the auto export id 1 and then fail startup
 # on the pinned entry's conflict; the two-pass parse must give the pinned
 # entry id 1 and the auto entry id 2.  The sec restriction on the pinned
-# entry must round-trip through GET /api/v1/config.
+# entry must round-trip through GET /api/v1/config.  The boolean root_squash
+# alias on the auto entry must parse (and serialize as the canonical "root").
 write_config '{
-    "/a_auto":   { "path": "/data" },
+    "/a_auto":   { "path": "/data", "root_squash": true },
     "/b_pinned": { "path": "/data", "export_id": 1, "sec": ["krb5"] }
 }' > "${TMPDIR}/good.json"
 
@@ -209,6 +221,13 @@ else
         pass "auto export skipped pinned id, got export_id 2"
     else
         fail "auto export skipped pinned id, got export_id 2 (body: ${BODY})"
+    fi
+
+    if echo "${BODY}" | grep -o '{[^}]*}' | grep '"name":"/a_auto"' |
+        grep -q '"squash":"root"'; then
+        pass "boolean root_squash alias parsed to squash=root"
+    else
+        fail "boolean root_squash alias parsed to squash=root (body: ${BODY})"
     fi
 
     if echo "${BODY}" | grep -o '{[^}]*}' | grep '"name":"/b_pinned"' |

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -4023,8 +4023,13 @@ main(
                 exit(100);
             }
 
-            // Create NFSv3 server export entry
-            chimera_server_create_export(chimera_server, "/share", "/share", 0, NULL);
+            // Create NFSv3 server export entry (pinned id, see
+            // posix_test_common.h)
+            if (chimera_server_create_export(chimera_server, "/share",
+                                             "/share", 4242, NULL) != 0) {
+                fprintf(stderr, "Failed to create /share export\n");
+                exit(100);
+            }
 
             chimera_server_start(chimera_server);
 

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -4024,7 +4024,7 @@ main(
             }
 
             // Create NFSv3 server export entry
-            chimera_server_create_export(chimera_server, "/share", "/share", 0);
+            chimera_server_create_export(chimera_server, "/share", "/share", 0, NULL);
 
             chimera_server_start(chimera_server);
 

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -470,7 +470,7 @@ posix_test_start_nfs_server(struct posix_test_env *env)
     chimera_server_mount(env->server, "share", share_module, share_module_path,
                          NULL);
 
-    chimera_server_create_export(env->server, "/share", "/share", 0);
+    chimera_server_create_export(env->server, "/share", "/share", 0, NULL);
 
     if (posix_test_ro_export) {
         /* Second, read-only mount of the same backend rooted at the subdir.
@@ -486,7 +486,7 @@ posix_test_start_nfs_server(struct posix_test_env *env)
             exit(EXIT_FAILURE);
         }
 
-        chimera_server_create_export(env->server, "/roshare", "/roshare", 0);
+        chimera_server_create_export(env->server, "/roshare", "/roshare", 0, NULL);
     }
 
     chimera_server_start(env->server);

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -306,6 +306,11 @@ static int posix_test_ro_export __attribute__ ((unused)) = 0;
  * export is mounted at; the read-write export sees it as "/share/ro". */
 #define POSIX_TEST_RO_SUBDIR "ro"
 
+/* Explicit export id above the default nfs_max_exports count cap (4096),
+ * so tests cover pinned-id file-handle attribution across the whole 16-bit
+ * id space rather than only small auto-assigned ids. */
+#define POSIX_TEST_EXPORT_ID 4242
+
 // Helper to configure diskfs backend
 static inline void
 posix_test_configure_diskfs(
@@ -470,7 +475,16 @@ posix_test_start_nfs_server(struct posix_test_env *env)
     chimera_server_mount(env->server, "share", share_module, share_module_path,
                          NULL);
 
-    chimera_server_create_export(env->server, "/share", "/share", 0, NULL);
+    /* Pin an export id above the default count cap (4096) so every posix
+     * test exercises an explicitly-pinned id on the NFS wire path: the id
+     * is stamped into each file handle and resolved per request, and a
+     * regression bounding the id lookup by the count cap instead of the id
+     * space would pass any test using auto-assigned (small) ids. */
+    if (chimera_server_create_export(env->server, "/share", "/share",
+                                     POSIX_TEST_EXPORT_ID, NULL) != 0) {
+        fprintf(stderr, "Failed to create /share export\n");
+        exit(EXIT_FAILURE);
+    }
 
     if (posix_test_ro_export) {
         /* Second, read-only mount of the same backend rooted at the subdir.
@@ -486,7 +500,11 @@ posix_test_start_nfs_server(struct posix_test_env *env)
             exit(EXIT_FAILURE);
         }
 
-        chimera_server_create_export(env->server, "/roshare", "/roshare", 0, NULL);
+        if (chimera_server_create_export(env->server, "/roshare", "/roshare",
+                                         POSIX_TEST_EXPORT_ID + 1, NULL) != 0) {
+            fprintf(stderr, "Failed to create /roshare export\n");
+            exit(EXIT_FAILURE);
+        }
     }
 
     chimera_server_start(env->server);

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -921,13 +921,15 @@ nfs_server_thread_destroy(void *data)
 
 SYMBOL_EXPORT int
 chimera_nfs_add_export(
-    void       *nfs_shared,
-    const char *name,
-    const char *path,
-    uint32_t    export_id)
+    void                                 *nfs_shared,
+    const char                           *name,
+    const char                           *path,
+    uint32_t                              export_id,
+    const struct chimera_nfs_export_opts *opts)
 {
     struct chimera_server_nfs_shared *shared = nfs_shared;
     struct chimera_nfs_export        *export;
+    struct chimera_nfs_export        *existing;
 
     if (export_id > CHIMERA_NFS_EXPORT_ID_MAX) {
         chimera_nfs_error("Export '%s' id %u out of range (1..%u)",
@@ -935,15 +937,25 @@ chimera_nfs_add_export(
         return -EINVAL;
     }
 
+    /* This path is reachable from a runtime REST request, not just startup,
+     * so an allocation failure must surface as an error to the caller rather
+     * than crash the daemon on the dereference below. */
     export = calloc(1, sizeof(*export));
+
+    if (!export) {
+        chimera_nfs_error("Failed to allocate export '%s'", name);
+        return -ENOMEM;
+    }
 
     snprintf(export->name, sizeof(export->name), "%s", name);
     snprintf(export->path, sizeof(export->path), "%s", path);
 
     /* Defaults: read-write, no squashing (preserving historical behavior where
      * a client's credentials pass through unchanged); anon = configured global
-     * anonuid/anongid (65534 by default).  root_squash / all_squash are opt-in
-     * per export via chimera_nfs_export_set_options(). */
+     * anonuid/anongid (65534 by default); any security flavor.  Callers
+     * override individual fields via opts so the export is published fully
+     * configured; a post-create set_options call would leave a window where
+     * NFS request threads see the permissive defaults. */
     export->access  = CHIMERA_NFS_EXPORT_ACCESS_RW;
     export->squash  = CHIMERA_NFS_SQUASH_NONE;
     export->anonuid = shared->config ?
@@ -951,7 +963,40 @@ chimera_nfs_add_export(
     export->anongid = shared->config ?
         chimera_server_config_get_anongid(shared->config) : CHIMERA_VFS_ANON_GID;
 
+    if (opts) {
+        if (opts->has_access) {
+            export->access = opts->access;
+        }
+        if (opts->has_squash) {
+            export->squash = opts->squash;
+        }
+        if (opts->has_anonuid) {
+            export->anonuid = opts->anonuid;
+        }
+        if (opts->has_anongid) {
+            export->anongid = opts->anongid;
+        }
+        if (opts->has_sec) {
+            export->sec_allowed = opts->sec_allowed;
+        }
+    }
+
     pthread_mutex_lock(&shared->exports_lock);
+
+    /* Name uniqueness must be decided here, under the same lock as the
+     * insert: a caller-side check-then-create is a race in which two
+     * concurrent creates of the same name both succeed, leaving the second
+     * export unreachable (name lookups stop at the first match) and its id
+     * leaked. */
+    LL_FOREACH(shared->exports, existing)
+    {
+        if (strcmp(existing->name, name) == 0) {
+            pthread_mutex_unlock(&shared->exports_lock);
+            chimera_nfs_error("Export '%s' already exists", name);
+            free(export);
+            return -EEXIST;
+        }
+    }
 
     /* Enforce the configured concurrent-export count cap (nfs_max_exports)
      * before either id path, so explicitly-pinned ids are bounded too. */
@@ -977,7 +1022,7 @@ chimera_nfs_add_export(
                               shared->exports_by_id[export_id]->name);
             pthread_mutex_unlock(&shared->exports_lock);
             free(export);
-            return -EEXIST;
+            return -EADDRINUSE;
         }
         export->id = (uint16_t) export_id;
     } else {

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -1369,6 +1369,12 @@ chimera_nfs_export_get_anongid(const struct chimera_nfs_export *export)
     return export->anongid;
 } /* chimera_nfs_export_get_anongid */
 
+SYMBOL_EXPORT uint32_t
+chimera_nfs_export_get_sec(const struct chimera_nfs_export *export)
+{
+    return export->sec_allowed;
+} /* chimera_nfs_export_get_sec */
+
 SYMBOL_EXPORT struct chimera_server_protocol nfs_protocol = {
     .init           = nfs_server_init,
     .destroy        = nfs_server_destroy,

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -937,7 +937,7 @@ chimera_nfs_add_export(
      * a client's credentials pass through unchanged); anon = configured global
      * anonuid/anongid (65534 by default).  root_squash / all_squash are opt-in
      * per export via chimera_nfs_export_set_options(). */
-    export->options = CHIMERA_NFS_EXPORT_OPT_RW;
+    export->access  = CHIMERA_NFS_EXPORT_ACCESS_RW;
     export->squash  = CHIMERA_NFS_SQUASH_NONE;
     export->anonuid = shared->config ?
         chimera_server_config_get_anonuid(shared->config) : CHIMERA_VFS_ANON_UID;
@@ -1000,7 +1000,7 @@ SYMBOL_EXPORT int
 chimera_nfs_export_set_options(
     void       *nfs_shared,
     const char *name,
-    uint32_t    options,
+    uint32_t    access,
     uint32_t    squash,
     uint32_t    anonuid,
     uint32_t    anongid)
@@ -1013,7 +1013,7 @@ chimera_nfs_export_set_options(
     LL_FOREACH(shared->exports, export)
     {
         if (strcmp(export->name, name) == 0) {
-            export->options = options;
+            export->access  = access;
             export->squash  = squash;
             export->anonuid = anonuid;
             export->anongid = anongid;
@@ -1278,10 +1278,10 @@ chimera_nfs_export_get_id(const struct chimera_nfs_export *export)
 } /* chimera_nfs_export_get_id */
 
 SYMBOL_EXPORT uint32_t
-chimera_nfs_export_get_options(const struct chimera_nfs_export *export)
+chimera_nfs_export_get_access(const struct chimera_nfs_export *export)
 {
-    return export->options;
-} /* chimera_nfs_export_get_options */
+    return export->access;
+} /* chimera_nfs_export_get_access */
 
 SYMBOL_EXPORT uint32_t
 chimera_nfs_export_get_squash(const struct chimera_nfs_export *export)

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -38,11 +38,14 @@
 
 #include "common/macros.h"
 
-/* nfs.h defines the public id range without seeing nfs_common.h; if the two
- * constants ever drift apart, the range check in chimera_nfs_add_export()
- * would index exports_by_id[] out of bounds. */
-_Static_assert(CHIMERA_NFS_EXPORT_ID_MAX == CHIMERA_NFS_MAX_EXPORTS - 1,
-               "CHIMERA_NFS_EXPORT_ID_MAX must match the exports_by_id table size");
+/* Export ids are held in uint16_t fields and stamped into a 16-bit wire
+ * file-handle field; exports_by_id[] is sized by that id space, so any
+ * uint16_t value indexes it safely.  The count cap must fit in the id space
+ * or add_export() could admit more exports than there are ids to assign. */
+_Static_assert(CHIMERA_NFS_EXPORT_ID_MAX == 65535u,
+               "export id space must match the 16-bit wire file-handle field");
+_Static_assert(CHIMERA_NFS_MAX_EXPORTS_DEFAULT <= CHIMERA_NFS_EXPORT_ID_MAX,
+               "default export count cap must fit in the id space");
 
 #define NFS_PROGIDX_PORTMAP_V2 0
 #define NFS_PROGIDX_MOUNT_V3   1
@@ -182,6 +185,10 @@ nfs_server_init(
     shared = calloc(1, sizeof(*shared));
 
     shared->config = config;
+
+    /* Concurrent-export count cap (distinct from the id space; see
+     * exports_by_id commentary in nfs_common.h). */
+    shared->max_exports = chimera_server_config_get_nfs_max_exports(config);
 
     nfs_fh_key_init(shared, config);
 
@@ -946,6 +953,16 @@ chimera_nfs_add_export(
 
     pthread_mutex_lock(&shared->exports_lock);
 
+    /* Enforce the configured concurrent-export count cap (nfs_max_exports)
+     * before either id path, so explicitly-pinned ids are bounded too. */
+    if ((uint32_t) shared->num_exports >= shared->max_exports) {
+        pthread_mutex_unlock(&shared->exports_lock);
+        chimera_nfs_error("Export limit reached (%u); cannot create export '%s'",
+                          shared->max_exports, name);
+        free(export);
+        return -ENOSPC;
+    }
+
     /* Assign a stable, non-zero id and publish into the direct index used for
      * per-request attribution.  Ids start at 1 (slot 0 reserved as invalid).
      * An explicit id is honored verbatim (or rejected if taken); auto
@@ -966,20 +983,24 @@ chimera_nfs_add_export(
     } else {
         uint16_t id = shared->next_export_id;
 
-        if (id == 0 || id >= CHIMERA_NFS_MAX_EXPORTS) {
+        /* id 0 means "unset" (startup) or a wrap of the uint16_t cursor past
+         * the end of the id space; either way restart at 1. */
+        if (id == 0) {
             id = 1;
         }
-        for (int probes = 0; probes < CHIMERA_NFS_MAX_EXPORTS - 1; probes++) {
+        for (uint32_t probes = 0; probes < CHIMERA_NFS_EXPORT_ID_MAX; probes++) {
             if (!shared->exports_by_id[id]) {
                 break;
             }
-            id = (id == CHIMERA_NFS_MAX_EXPORTS - 1) ? 1 : id + 1;
+            id = (id == CHIMERA_NFS_EXPORT_ID_MAX) ? 1 : id + 1;
         }
         if (shared->exports_by_id[id]) {
+            /* Unreachable while max_exports <= the id space (asserted for the
+             * default, validated for configured values); kept as a backstop. */
             pthread_mutex_unlock(&shared->exports_lock);
-            chimera_nfs_error("Export id space exhausted (max %d); cannot "
+            chimera_nfs_error("Export id space exhausted (max %u); cannot "
                               "create export '%s'",
-                              CHIMERA_NFS_MAX_EXPORTS, name);
+                              CHIMERA_NFS_EXPORT_ID_MAX, name);
             free(export);
             return -ENOSPC;
         }
@@ -1057,7 +1078,9 @@ chimera_nfs_get_export_by_id(
 {
     struct chimera_server_nfs_shared *shared = nfs_shared;
 
-    if (id == 0 || id >= CHIMERA_NFS_MAX_EXPORTS) {
+    /* exports_by_id[] covers the full uint16_t id space, so any id indexes it
+     * safely; slot 0 is reserved as invalid. */
+    if (id == 0) {
         return NULL;
     }
 
@@ -1079,7 +1102,7 @@ chimera_nfs_remove_export(
     LL_FOREACH(shared->exports, export)
     {
         if (strcmp(export->name, name) == 0) {
-            if (export->id != 0 && export->id < CHIMERA_NFS_MAX_EXPORTS) {
+            if (export->id != 0) {
                 shared->exports_by_id[export->id] = NULL;
             }
             LL_DELETE(shared->exports, export);

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -14,12 +14,12 @@ struct chimera_nfs_export;
  * Declared here so the daemon JSON config parser can translate user-supplied
  * option strings into these values.
  */
-#define CHIMERA_NFS_EXPORT_OPT_RO 0x00000001u
-#define CHIMERA_NFS_EXPORT_OPT_RW 0x00000002u
+#define CHIMERA_NFS_EXPORT_ACCESS_RO 0x00000001u
+#define CHIMERA_NFS_EXPORT_ACCESS_RW 0x00000002u
 
-#define CHIMERA_NFS_SQUASH_NONE   0u   /* no_root_squash: credentials pass through */
-#define CHIMERA_NFS_SQUASH_ROOT   1u   /* root_squash (default): uid 0 -> anon      */
-#define CHIMERA_NFS_SQUASH_ALL    2u   /* all_squash: every caller -> anon          */
+#define CHIMERA_NFS_SQUASH_NONE      0u /* no_root_squash: credentials pass through */
+#define CHIMERA_NFS_SQUASH_ROOT      1u /* root_squash (default): uid 0 -> anon      */
+#define CHIMERA_NFS_SQUASH_ALL       2u /* all_squash: every caller -> anon          */
 
 /*
  * Per-export allowed RPC security flavors, as a bitmask.  sec_allowed == 0
@@ -27,10 +27,10 @@ struct chimera_nfs_export;
  * restricts the export to exactly those flavors (others -> NFS4ERR_WRONGSEC).
  * krb5/krb5i/krb5p all ride RPCSEC_GSS, distinguished by the GSS service.
  */
-#define CHIMERA_NFS_SEC_SYS       0x01u  /* AUTH_SYS (and AUTH_NONE)         */
-#define CHIMERA_NFS_SEC_KRB5      0x02u  /* RPCSEC_GSS, service = none       */
-#define CHIMERA_NFS_SEC_KRB5I     0x04u  /* RPCSEC_GSS, service = integrity  */
-#define CHIMERA_NFS_SEC_KRB5P     0x08u  /* RPCSEC_GSS, service = privacy    */
+#define CHIMERA_NFS_SEC_SYS          0x01u /* AUTH_SYS (and AUTH_NONE)         */
+#define CHIMERA_NFS_SEC_KRB5         0x02u /* RPCSEC_GSS, service = none       */
+#define CHIMERA_NFS_SEC_KRB5I        0x04u /* RPCSEC_GSS, service = integrity  */
+#define CHIMERA_NFS_SEC_KRB5P        0x08u /* RPCSEC_GSS, service = privacy    */
 #define CHIMERA_NFS_SEC_ALL \
         (CHIMERA_NFS_SEC_SYS | CHIMERA_NFS_SEC_KRB5 | \
          CHIMERA_NFS_SEC_KRB5I | CHIMERA_NFS_SEC_KRB5P)
@@ -40,7 +40,7 @@ struct chimera_nfs_export;
  * handles as a 16-bit field; id 0 is reserved as invalid/pseudo-root and the
  * id space is bounded by CHIMERA_NFS_MAX_EXPORTS (4096) internally.
  */
-#define CHIMERA_NFS_EXPORT_ID_MAX 4095u
+#define CHIMERA_NFS_EXPORT_ID_MAX    4095u
 
 /**
  * @brief Adds a new NFS export to the shared context.
@@ -167,11 +167,11 @@ chimera_nfs_export_get_path(
     const struct chimera_nfs_export *export);
 
 /**
- * @brief Sets per-export access options (RO/RW, squash, anon uid/gid).
+ * @brief Sets per-export options (RO/RW access mode, squash, anon uid/gid).
  *
  * @param nfs_shared Pointer to the NFS shared context.
  * @param name       Name of the export.
- * @param options    CHIMERA_NFS_EXPORT_OPT_* bitmask.
+ * @param access     CHIMERA_NFS_EXPORT_ACCESS_* bitmask.
  * @param squash     CHIMERA_NFS_SQUASH_* policy.
  * @param anonuid    Anonymous uid squashed callers are mapped to.
  * @param anongid    Anonymous gid squashed callers are mapped to.
@@ -181,7 +181,7 @@ int
 chimera_nfs_export_set_options(
     void       *nfs_shared,
     const char *name,
-    uint32_t    options,
+    uint32_t    access,
     uint32_t    squash,
     uint32_t    anonuid,
     uint32_t    anongid);
@@ -212,7 +212,7 @@ chimera_nfs_export_get_id(
     const struct chimera_nfs_export *export);
 
 uint32_t
-chimera_nfs_export_get_options(
+chimera_nfs_export_get_access(
     const struct chimera_nfs_export *export);
 
 uint32_t

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -10,15 +10,15 @@ extern struct chimera_server_protocol nfs_protocol;
 struct chimera_nfs_export;
 
 /*
- * Per-export access-control option constants (see struct chimera_nfs_export).
+ * Per-export access-control constants (see struct chimera_nfs_export).
  * Declared here so the daemon JSON config parser can translate user-supplied
- * option strings into these values.
+ * access strings into these values.
  */
 #define CHIMERA_NFS_EXPORT_ACCESS_RO    0x00000001u
 #define CHIMERA_NFS_EXPORT_ACCESS_RW    0x00000002u
 
-#define CHIMERA_NFS_SQUASH_NONE         0u /* no_root_squash: credentials pass through */
-#define CHIMERA_NFS_SQUASH_ROOT         1u /* root_squash (default): uid 0 -> anon      */
+#define CHIMERA_NFS_SQUASH_NONE         0u /* no_root_squash (default): pass through   */
+#define CHIMERA_NFS_SQUASH_ROOT         1u /* root_squash: uid 0 -> anon                */
 #define CHIMERA_NFS_SQUASH_ALL          2u /* all_squash: every caller -> anon          */
 
 /*
@@ -237,7 +237,7 @@ chimera_nfs_get_export_by_id(
     uint16_t id);
 
 /**
- * @brief Per-export option accessors.
+ * @brief Per-export attribute accessors.
  */
 uint16_t
 chimera_nfs_export_get_id(
@@ -257,4 +257,8 @@ chimera_nfs_export_get_anonuid(
 
 uint32_t
 chimera_nfs_export_get_anongid(
+    const struct chimera_nfs_export *export);
+
+uint32_t
+chimera_nfs_export_get_sec(
     const struct chimera_nfs_export *export);

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -14,12 +14,12 @@ struct chimera_nfs_export;
  * Declared here so the daemon JSON config parser can translate user-supplied
  * option strings into these values.
  */
-#define CHIMERA_NFS_EXPORT_ACCESS_RO 0x00000001u
-#define CHIMERA_NFS_EXPORT_ACCESS_RW 0x00000002u
+#define CHIMERA_NFS_EXPORT_ACCESS_RO    0x00000001u
+#define CHIMERA_NFS_EXPORT_ACCESS_RW    0x00000002u
 
-#define CHIMERA_NFS_SQUASH_NONE      0u /* no_root_squash: credentials pass through */
-#define CHIMERA_NFS_SQUASH_ROOT      1u /* root_squash (default): uid 0 -> anon      */
-#define CHIMERA_NFS_SQUASH_ALL       2u /* all_squash: every caller -> anon          */
+#define CHIMERA_NFS_SQUASH_NONE         0u /* no_root_squash: credentials pass through */
+#define CHIMERA_NFS_SQUASH_ROOT         1u /* root_squash (default): uid 0 -> anon      */
+#define CHIMERA_NFS_SQUASH_ALL          2u /* all_squash: every caller -> anon          */
 
 /*
  * Per-export allowed RPC security flavors, as a bitmask.  sec_allowed == 0
@@ -27,20 +27,26 @@ struct chimera_nfs_export;
  * restricts the export to exactly those flavors (others -> NFS4ERR_WRONGSEC).
  * krb5/krb5i/krb5p all ride RPCSEC_GSS, distinguished by the GSS service.
  */
-#define CHIMERA_NFS_SEC_SYS          0x01u /* AUTH_SYS (and AUTH_NONE)         */
-#define CHIMERA_NFS_SEC_KRB5         0x02u /* RPCSEC_GSS, service = none       */
-#define CHIMERA_NFS_SEC_KRB5I        0x04u /* RPCSEC_GSS, service = integrity  */
-#define CHIMERA_NFS_SEC_KRB5P        0x08u /* RPCSEC_GSS, service = privacy    */
+#define CHIMERA_NFS_SEC_SYS             0x01u /* AUTH_SYS (and AUTH_NONE)         */
+#define CHIMERA_NFS_SEC_KRB5            0x02u /* RPCSEC_GSS, service = none       */
+#define CHIMERA_NFS_SEC_KRB5I           0x04u /* RPCSEC_GSS, service = integrity  */
+#define CHIMERA_NFS_SEC_KRB5P           0x08u /* RPCSEC_GSS, service = privacy    */
 #define CHIMERA_NFS_SEC_ALL \
         (CHIMERA_NFS_SEC_SYS | CHIMERA_NFS_SEC_KRB5 | \
          CHIMERA_NFS_SEC_KRB5I | CHIMERA_NFS_SEC_KRB5P)
 
 /*
  * Largest export id an operator may assign.  Ids are embedded in wire file
- * handles as a 16-bit field; id 0 is reserved as invalid/pseudo-root and the
- * id space is bounded by CHIMERA_NFS_MAX_EXPORTS (4096) internally.
+ * handles as a 16-bit field, so the id space is the full uint16_t range with
+ * id 0 reserved as invalid/pseudo-root.  The id space is distinct from the
+ * concurrent-export count cap (server config nfs_max_exports, default
+ * CHIMERA_NFS_MAX_EXPORTS_DEFAULT): any id in 1..65535 may be pinned
+ * regardless of how many exports the cap allows to exist at once.
  */
-#define CHIMERA_NFS_EXPORT_ID_MAX    4095u
+#define CHIMERA_NFS_EXPORT_ID_MAX       65535u
+
+/* Default concurrent-export count cap (server config nfs_max_exports). */
+#define CHIMERA_NFS_MAX_EXPORTS_DEFAULT 4096u
 
 /**
  * @brief Adds a new NFS export to the shared context.

--- a/src/server/nfs/nfs.h
+++ b/src/server/nfs/nfs.h
@@ -48,6 +48,27 @@ struct chimera_nfs_export;
 /* Default concurrent-export count cap (server config nfs_max_exports). */
 #define CHIMERA_NFS_MAX_EXPORTS_DEFAULT 4096u
 
+/*
+ * Optional per-export settings applied atomically at creation time, so an
+ * export is never visible to NFS request threads half-configured (an export
+ * published with defaults and tightened afterward would be briefly rw and
+ * unsquashed).  Each field is applied only when its has_ flag is set; a NULL
+ * pointer or zeroed struct leaves every field at its default (rw, no
+ * squashing, configured global anon ids, any security flavor).
+ */
+struct chimera_nfs_export_opts {
+    unsigned has_access  : 1;
+    unsigned has_squash  : 1;
+    unsigned has_anonuid : 1;
+    unsigned has_anongid : 1;
+    unsigned has_sec     : 1;
+    uint32_t access;       /* CHIMERA_NFS_EXPORT_ACCESS_* */
+    uint32_t squash;       /* CHIMERA_NFS_SQUASH_*        */
+    uint32_t anonuid;
+    uint32_t anongid;
+    uint32_t sec_allowed;  /* CHIMERA_NFS_SEC_* bitmask   */
+};
+
 /**
  * @brief Adds a new NFS export to the shared context.
  *
@@ -58,14 +79,19 @@ struct chimera_nfs_export;
  *                   to auto-assign the next free id.  The id is embedded in
  *                   wire file handles, so clustered servers exporting the
  *                   same directory must pin identical ids.
- * @return 0 on success, -EINVAL if export_id is out of range, -EEXIST if the
- *         id is already in use, -ENOSPC if the id space is exhausted.
+ * @param opts       Optional per-export settings (may be NULL); see
+ *                   struct chimera_nfs_export_opts.
+ * @return 0 on success, -EINVAL if export_id is out of range, -EEXIST if an
+ *         export with the same name exists, -EADDRINUSE if the id is already
+ *         in use, -ENOSPC if the configured export limit (nfs_max_exports)
+ *         is reached, -ENOMEM on allocation failure.
  */
 int chimera_nfs_add_export(
-    void       *nfs_shared,
-    const char *name,
-    const char *path,
-    uint32_t    export_id);
+    void                                 *nfs_shared,
+    const char                           *name,
+    const char                           *path,
+    uint32_t                              export_id,
+    const struct chimera_nfs_export_opts *opts);
 
 
 /**

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -221,8 +221,6 @@ struct nfs_request {
  * declared in the public nfs.h (included below) so the daemon config parser can
  * reach them.
  */
-#define CHIMERA_NFS_MAX_EXPORTS 4096
-
 struct chimera_nfs_export {
     char                       name[CHIMERA_VFS_NAME_MAX];
     char                       path[CHIMERA_VFS_PATH_MAX];
@@ -301,13 +299,18 @@ struct chimera_server_nfs_shared {
     struct chimera_nfs_export          *exports;
     pthread_mutex_t                     exports_lock;
     int                                 num_exports;
-    /* Direct id -> export index for O(1) per-request attribution.  Slot 0 is
-     * unused (id 0 is reserved as "invalid"); ids are assigned sequentially
-     * starting at 1.  Reads on the request hot path are lockless (entries are
-     * stable once published; removal is a rare REST operation guarded by
-     * exports_lock). */
+    /* Concurrent-export count cap, snapshotted from the server config
+     * (nfs_max_exports) at init; enforced in chimera_nfs_add_export(). */
+    uint32_t                            max_exports;
+    /* Direct id -> export index for O(1) per-request attribution.  Sized by
+     * the wire-format id space (16-bit id in every file handle), not by the
+     * count cap, so any id in 1..CHIMERA_NFS_EXPORT_ID_MAX may be pinned.
+     * Slot 0 is unused (id 0 is reserved as "invalid"); ids are assigned
+     * sequentially starting at 1.  Reads on the request hot path are lockless
+     * (entries are stable once published; removal is a rare REST operation
+     * guarded by exports_lock). */
     uint16_t                            next_export_id;
-    struct chimera_nfs_export          *exports_by_id[CHIMERA_NFS_MAX_EXPORTS];
+    struct chimera_nfs_export          *exports_by_id[CHIMERA_NFS_EXPORT_ID_MAX + 1];
 
     /* File-handle signing.  fh_sign gates the SipHash MAC appended to every
      * wire file handle (default on); fh_key is the 128-bit server secret used

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -206,7 +206,7 @@ struct nfs_request {
 /*
  * Per-export access-control options.
  *
- * options : RO/RW access mode (CHIMERA_NFS_EXPORT_OPT_*).
+ * access  : RO/RW access mode (CHIMERA_NFS_EXPORT_ACCESS_*).
  * squash  : credential squashing policy (CHIMERA_NFS_SQUASH_*).  Default is
  *           SQUASH_NONE (no squashing), preserving chimera's historical
  *           pass-through behavior; root_squash / all_squash are opt-in.
@@ -217,7 +217,7 @@ struct nfs_request {
  *
  * Per-client (IP/network) access control is tracked separately (issue #69).
  *
- * The CHIMERA_NFS_EXPORT_OPT_* / CHIMERA_NFS_SQUASH_* option constants are
+ * The CHIMERA_NFS_EXPORT_ACCESS_* / CHIMERA_NFS_SQUASH_* constants are
  * declared in the public nfs.h (included below) so the daemon config parser can
  * reach them.
  */
@@ -227,7 +227,7 @@ struct chimera_nfs_export {
     char                       name[CHIMERA_VFS_NAME_MAX];
     char                       path[CHIMERA_VFS_PATH_MAX];
     uint16_t                   id;
-    uint32_t                   options;
+    uint32_t                   access;
     uint32_t                   squash;
     uint32_t                   anonuid;
     uint32_t                   anongid;

--- a/src/server/rest/CMakeLists.txt
+++ b/src/server/rest/CMakeLists.txt
@@ -9,7 +9,9 @@ pkg_check_modules(JANSSON REQUIRED jansson)
 add_library(chimera_rest SHARED
     rest.c
     rest_users.c
+    rest_exports.c
     rest_shares.c
+    rest_buckets.c
     rest_mounts.c
     rest_config.c
     rest_swagger.c

--- a/src/server/rest/rest_buckets.c
+++ b/src/server/rest/rest_buckets.c
@@ -11,89 +11,92 @@
 #include "evpl/evpl.h"
 #include "evpl/evpl_http.h"
 #include "server/server.h"
-#include "server/smb/smb.h"
+#include "server/s3/s3.h"
 #include "rest_internal.h"
 
 
-struct share_list_ctx {
+struct bucket_list_ctx {
     json_t *array;
 };
 
 static int
-share_to_json_callback(
-    const struct chimera_smb_share *share,
-    void                           *data)
+bucket_to_json_callback(
+    const struct s3_bucket *bucket,
+    void                   *data)
 {
-    struct share_list_ctx *ctx = data;
-    json_t                *obj;
+    struct bucket_list_ctx *ctx = data;
+    json_t                 *obj;
 
     obj = json_object();
     json_object_set_new(obj, "name",
-                        json_string(chimera_smb_share_get_name(share)));
+                        json_string(chimera_s3_bucket_get_name(bucket)));
     json_object_set_new(obj, "path",
-                        json_string(chimera_smb_share_get_path(share)));
+                        json_string(chimera_s3_bucket_get_path(bucket)));
 
     json_array_append_new(ctx->array, obj);
 
     return 0;
-} /* share_to_json_callback */
+} /* bucket_to_json_callback */
 
 void
-chimera_rest_handle_shares_list(
+chimera_rest_handle_buckets_list(
     struct evpl                *evpl,
     struct evpl_http_request   *request,
     struct chimera_rest_thread *thread)
 {
-    struct share_list_ctx ctx;
+    struct bucket_list_ctx ctx;
 
     ctx.array = json_array();
 
-    chimera_server_iterate_shares(thread->shared->server,
-                                  share_to_json_callback, &ctx);
+    chimera_server_iterate_buckets(thread->shared->server,
+                                   bucket_to_json_callback, &ctx);
 
     chimera_rest_send_json(evpl, request, 200, ctx.array);
-} /* chimera_rest_handle_shares_list */
+} /* chimera_rest_handle_buckets_list */
 
 void
-chimera_rest_handle_shares_get(
+chimera_rest_handle_buckets_get(
     struct evpl                *evpl,
     struct evpl_http_request   *request,
     struct chimera_rest_thread *thread,
     const char                 *name)
 {
-    const struct chimera_smb_share *share;
-    json_t                         *obj;
+    const struct s3_bucket *bucket;
+    json_t                 *obj;
 
-    share = chimera_server_get_share(thread->shared->server, name);
-    if (!share) {
+    bucket = chimera_server_get_bucket(thread->shared->server, name);
+    if (!bucket) {
         chimera_rest_send_error(evpl, request, 404, "Not Found",
-                                "Share does not exist");
+                                "Bucket does not exist");
         return;
     }
 
     obj = json_object();
     json_object_set_new(obj, "name",
-                        json_string(chimera_smb_share_get_name(share)));
+                        json_string(chimera_s3_bucket_get_name(bucket)));
     json_object_set_new(obj, "path",
-                        json_string(chimera_smb_share_get_path(share)));
+                        json_string(chimera_s3_bucket_get_path(bucket)));
+
+    chimera_server_release_bucket(thread->shared->server);
 
     chimera_rest_send_json(evpl, request, 200, obj);
-} /* chimera_rest_handle_shares_get */
+} /* chimera_rest_handle_buckets_get */
 
 void
-chimera_rest_handle_shares_create(
+chimera_rest_handle_buckets_create(
     struct evpl                *evpl,
     struct evpl_http_request   *request,
     struct chimera_rest_thread *thread,
     const char                 *body,
     int                         body_len)
 {
-    json_t      *root;
-    json_error_t error;
-    const char  *name;
-    const char  *path;
-    int          rc;
-    json_t      *obj;
+    json_t                 *root;
+    json_error_t            error;
+    const char             *name;
+    const char             *path;
+    const struct s3_bucket *existing;
+    int                     rc;
+    json_t                 *obj;
 
     root = json_loadb(body, body_len, 0, &error);
     if (!root) {
@@ -112,30 +115,34 @@ chimera_rest_handle_shares_create(
         return;
     }
 
-    if (chimera_server_get_share(thread->shared->server, name)) {
+    /* chimera_server_get_bucket holds a read lock until released, so release it
+     * unconditionally before acting on the result. */
+    existing = chimera_server_get_bucket(thread->shared->server, name);
+    chimera_server_release_bucket(thread->shared->server);
+    if (existing) {
         json_decref(root);
         chimera_rest_send_error(evpl, request, 409, "Conflict",
-                                "Share with that name already exists");
+                                "Bucket with that name already exists");
         return;
     }
 
-    rc = chimera_server_create_share(thread->shared->server, name, path, 0);
+    rc = chimera_server_create_bucket(thread->shared->server, name, path);
 
     json_decref(root);
 
     if (rc != 0) {
         chimera_rest_send_error(evpl, request, 500, "Internal Server Error",
-                                "Failed to create share");
+                                "Failed to create bucket");
         return;
     }
 
     obj = json_object();
-    json_object_set_new(obj, "message", json_string("Share created"));
+    json_object_set_new(obj, "message", json_string("Bucket created"));
     chimera_rest_send_json(evpl, request, 201, obj);
-} /* chimera_rest_handle_shares_create */
+} /* chimera_rest_handle_buckets_create */
 
 void
-chimera_rest_handle_shares_delete(
+chimera_rest_handle_buckets_delete(
     struct evpl                *evpl,
     struct evpl_http_request   *request,
     struct chimera_rest_thread *thread,
@@ -143,13 +150,13 @@ chimera_rest_handle_shares_delete(
 {
     int rc;
 
-    rc = chimera_server_remove_share(thread->shared->server, name);
+    rc = chimera_server_remove_bucket(thread->shared->server, name);
 
     if (rc != 0) {
         chimera_rest_send_error(evpl, request, 404, "Not Found",
-                                "Share does not exist");
+                                "Bucket does not exist");
         return;
     }
 
     evpl_http_server_dispatch_default(request, 204);
-} /* chimera_rest_handle_shares_delete */
+} /* chimera_rest_handle_buckets_delete */

--- a/src/server/rest/rest_config.c
+++ b/src/server/rest/rest_config.c
@@ -67,9 +67,9 @@ config_export_callback(
                         json_string(chimera_nfs_export_get_path(export)));
     json_object_set_new(obj, "export_id",
                         json_integer(chimera_nfs_export_get_id(export)));
-    json_object_set_new(obj, "options",
-                        json_string(chimera_nfs_export_get_options(export) &
-                                    CHIMERA_NFS_EXPORT_OPT_RO ? "ro" : "rw"));
+    json_object_set_new(obj, "access",
+                        json_string(chimera_nfs_export_get_access(export) &
+                                    CHIMERA_NFS_EXPORT_ACCESS_RO ? "ro" : "rw"));
     switch (chimera_nfs_export_get_squash(export)) {
         case CHIMERA_NFS_SQUASH_ALL:
             json_object_set_new(obj, "squash", json_string("all"));

--- a/src/server/rest/rest_config.c
+++ b/src/server/rest/rest_config.c
@@ -62,29 +62,12 @@ config_export_callback(
     json_t *exports = data;
     json_t *obj;
 
+    /* Shared with the /api/v1/exports handlers; includes the sec restriction
+     * so a captured config regenerates chimera.json faithfully (omitting it
+     * would silently drop a security restriction on the next boot).  The
+     * name is the entry's key rather than a field, matching chimera.json. */
     obj = json_object();
-    json_object_set_new(obj, "path",
-                        json_string(chimera_nfs_export_get_path(export)));
-    json_object_set_new(obj, "export_id",
-                        json_integer(chimera_nfs_export_get_id(export)));
-    json_object_set_new(obj, "access",
-                        json_string(chimera_nfs_export_get_access(export) &
-                                    CHIMERA_NFS_EXPORT_ACCESS_RO ? "ro" : "rw"));
-    switch (chimera_nfs_export_get_squash(export)) {
-        case CHIMERA_NFS_SQUASH_ALL:
-            json_object_set_new(obj, "squash", json_string("all"));
-            break;
-        case CHIMERA_NFS_SQUASH_NONE:
-            json_object_set_new(obj, "squash", json_string("none"));
-            break;
-        default:
-            json_object_set_new(obj, "squash", json_string("root"));
-            break;
-    } /* switch */
-    json_object_set_new(obj, "anonuid",
-                        json_integer(chimera_nfs_export_get_anonuid(export)));
-    json_object_set_new(obj, "anongid",
-                        json_integer(chimera_nfs_export_get_anongid(export)));
+    chimera_rest_export_options_to_json(export, obj);
 
     json_object_set_new(exports, chimera_nfs_export_get_name(export), obj);
 

--- a/src/server/rest/rest_exports.c
+++ b/src/server/rest/rest_exports.c
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+#include "server/server.h"
+#include "server/nfs/nfs.h"
+#include "rest_internal.h"
+
+
+struct export_list_ctx {
+    json_t *array;
+};
+
+/* Populate the per-export access options (mode, squash, anon ids) into obj. */
+static void
+export_options_to_json(
+    const struct chimera_nfs_export *export,
+    json_t                          *obj)
+{
+    json_object_set_new(obj, "options",
+                        json_string(chimera_nfs_export_get_options(export) &
+                                    CHIMERA_NFS_EXPORT_OPT_RO ? "ro" : "rw"));
+    switch (chimera_nfs_export_get_squash(export)) {
+        case CHIMERA_NFS_SQUASH_ALL:
+            json_object_set_new(obj, "squash", json_string("all"));
+            break;
+        case CHIMERA_NFS_SQUASH_NONE:
+            json_object_set_new(obj, "squash", json_string("none"));
+            break;
+        default:
+            json_object_set_new(obj, "squash", json_string("root"));
+            break;
+    } /* switch */
+    json_object_set_new(obj, "anonuid",
+                        json_integer(chimera_nfs_export_get_anonuid(export)));
+    json_object_set_new(obj, "anongid",
+                        json_integer(chimera_nfs_export_get_anongid(export)));
+} /* export_options_to_json */
+
+static int
+export_to_json_callback(
+    const struct chimera_nfs_export *export,
+    void                            *data)
+{
+    struct export_list_ctx *ctx = data;
+    json_t                 *obj;
+
+    obj = json_object();
+    json_object_set_new(obj, "name",
+                        json_string(chimera_nfs_export_get_name(export)));
+    json_object_set_new(obj, "path",
+                        json_string(chimera_nfs_export_get_path(export)));
+    json_object_set_new(obj, "export_id",
+                        json_integer(chimera_nfs_export_get_id(export)));
+    export_options_to_json(export, obj);
+
+    json_array_append_new(ctx->array, obj);
+
+    return 0;
+} /* export_to_json_callback */
+
+void
+chimera_rest_handle_exports_list(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread)
+{
+    struct export_list_ctx ctx;
+
+    ctx.array = json_array();
+
+    chimera_server_iterate_exports(thread->shared->server,
+                                   export_to_json_callback, &ctx);
+
+    chimera_rest_send_json(evpl, request, 200, ctx.array);
+} /* chimera_rest_handle_exports_list */
+
+void
+chimera_rest_handle_exports_get(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *name)
+{
+    const struct chimera_nfs_export *export;
+    json_t                          *obj;
+
+    export = chimera_server_get_export(thread->shared->server, name);
+    if (!export) {
+        chimera_rest_send_error(evpl, request, 404, "Not Found",
+                                "Export does not exist");
+        return;
+    }
+
+    obj = json_object();
+    json_object_set_new(obj, "name",
+                        json_string(chimera_nfs_export_get_name(export)));
+    json_object_set_new(obj, "path",
+                        json_string(chimera_nfs_export_get_path(export)));
+    json_object_set_new(obj, "export_id",
+                        json_integer(chimera_nfs_export_get_id(export)));
+    export_options_to_json(export, obj);
+
+    chimera_rest_send_json(evpl, request, 200, obj);
+} /* chimera_rest_handle_exports_get */
+
+void
+chimera_rest_handle_exports_create(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *body,
+    int                         body_len)
+{
+    json_t      *root;
+    json_error_t error;
+    const char  *name;
+    const char  *path;
+    json_t      *exp_id_j;
+    uint32_t     export_id = 0;
+    int          rc;
+    json_t      *obj;
+
+    root = json_loadb(body, body_len, 0, &error);
+    if (!root) {
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                error.text);
+        return;
+    }
+
+    name = json_string_value(json_object_get(root, "name"));
+    path = json_string_value(json_object_get(root, "path"));
+
+    if (!name || !path) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                "Missing required fields: name, path");
+        return;
+    }
+
+    /* Optional stable export id.  Validate the signed json value before any
+     * unsigned cast so negatives and non-integers are rejected rather than
+     * silently becoming auto-assignment (0) or wrapping into range. */
+    exp_id_j = json_object_get(root, "export_id");
+    if (exp_id_j) {
+        json_int_t v = json_integer_value(exp_id_j);
+
+        if (!json_is_integer(exp_id_j) ||
+            v < 1 || v > CHIMERA_NFS_EXPORT_ID_MAX) {
+            json_decref(root);
+            chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                    "export_id must be an integer in range 1..4095");
+            return;
+        }
+        export_id = (uint32_t) v;
+    }
+
+    if (chimera_server_get_export(thread->shared->server, name)) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "Export with that name already exists");
+        return;
+    }
+
+    rc = chimera_server_create_export(thread->shared->server, name, path,
+                                      export_id);
+
+    if (rc == -EEXIST) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "export_id already in use");
+        return;
+    }
+
+    if (rc == -EINVAL) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                "export_id out of range");
+        return;
+    }
+
+    if (rc != 0) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 500, "Internal Server Error",
+                                "Failed to create export");
+        return;
+    }
+
+    /* Apply optional access options.  create_export seeded secure defaults
+     * (root_squash, rw, configured anon); seed from those and override only the
+     * fields present in the request body. */
+    {
+        const struct chimera_nfs_export *created =
+            chimera_server_get_export(thread->shared->server, name);
+        const char                      *opt_s     = json_string_value(json_object_get(root, "options"));
+        const char                      *squash_s  = json_string_value(json_object_get(root, "squash"));
+        json_t                          *anonuid_j = json_object_get(root, "anonuid");
+        json_t                          *anongid_j = json_object_get(root, "anongid");
+        uint32_t                         options   = chimera_nfs_export_get_options(created);
+        uint32_t                         squash    = chimera_nfs_export_get_squash(created);
+        uint32_t                         anonuid   = chimera_nfs_export_get_anonuid(created);
+        uint32_t                         anongid   = chimera_nfs_export_get_anongid(created);
+
+        if (opt_s) {
+            if (strcasecmp(opt_s, "ro") == 0) {
+                options = CHIMERA_NFS_EXPORT_OPT_RO;
+            } else if (strcasecmp(opt_s, "rw") == 0) {
+                options = CHIMERA_NFS_EXPORT_OPT_RW;
+            }
+        }
+        if (squash_s) {
+            if (strcasecmp(squash_s, "none") == 0 ||
+                strcasecmp(squash_s, "no_root_squash") == 0) {
+                squash = CHIMERA_NFS_SQUASH_NONE;
+            } else if (strcasecmp(squash_s, "all") == 0 ||
+                       strcasecmp(squash_s, "all_squash") == 0) {
+                squash = CHIMERA_NFS_SQUASH_ALL;
+            } else if (strcasecmp(squash_s, "root") == 0 ||
+                       strcasecmp(squash_s, "root_squash") == 0) {
+                squash = CHIMERA_NFS_SQUASH_ROOT;
+            }
+        }
+        if (anonuid_j) {
+            anonuid = (uint32_t) json_integer_value(anonuid_j);
+        }
+        if (anongid_j) {
+            anongid = (uint32_t) json_integer_value(anongid_j);
+        }
+
+        chimera_server_export_set_options(thread->shared->server, name, options,
+                                          squash, anonuid, anongid);
+    }
+
+    json_decref(root);
+
+    obj = json_object();
+    json_object_set_new(obj, "message", json_string("Export created"));
+    chimera_rest_send_json(evpl, request, 201, obj);
+} /* chimera_rest_handle_exports_create */
+
+void
+chimera_rest_handle_exports_delete(
+    struct evpl                *evpl,
+    struct evpl_http_request   *request,
+    struct chimera_rest_thread *thread,
+    const char                 *name)
+{
+    int rc;
+
+    rc = chimera_server_remove_export(thread->shared->server, name);
+
+    if (rc != 0) {
+        chimera_rest_send_error(evpl, request, 404, "Not Found",
+                                "Export does not exist");
+        return;
+    }
+
+    evpl_http_server_dispatch_default(request, 204);
+} /* chimera_rest_handle_exports_delete */

--- a/src/server/rest/rest_exports.c
+++ b/src/server/rest/rest_exports.c
@@ -159,7 +159,7 @@ chimera_rest_handle_exports_create(
             v < 1 || v > CHIMERA_NFS_EXPORT_ID_MAX) {
             json_decref(root);
             chimera_rest_send_error(evpl, request, 400, "Bad Request",
-                                    "export_id must be an integer in range 1..4095");
+                                    "export_id must be an integer in range 1..65535");
             return;
         }
         export_id = (uint32_t) v;
@@ -196,6 +196,13 @@ chimera_rest_handle_exports_create(
         json_decref(root);
         chimera_rest_send_error(evpl, request, 400, "Bad Request",
                                 "export_id out of range");
+        return;
+    }
+
+    if (rc == -ENOSPC) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 409, "Conflict",
+                                "Export limit reached (server nfs_max_exports)");
         return;
     }
 

--- a/src/server/rest/rest_exports.c
+++ b/src/server/rest/rest_exports.c
@@ -4,6 +4,7 @@
 
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
@@ -21,12 +22,22 @@ struct export_list_ctx {
     json_t *array;
 };
 
-/* Populate the per-export options (access mode, squash, anon ids) into obj. */
-static void
-export_options_to_json(
+/* Populate every export field except the name (path, export_id, access
+ * mode, squash, anon ids, sec) into obj.  Shared with the config serializer
+ * (rest_config.c), whose entries are keyed by export name, so the export
+ * objects returned by /api/v1/exports and the exports section of
+ * /api/v1/config cannot drift apart. */
+void
+chimera_rest_export_options_to_json(
     const struct chimera_nfs_export *export,
     json_t                          *obj)
 {
+    uint32_t sec_mask = chimera_nfs_export_get_sec(export);
+
+    json_object_set_new(obj, "path",
+                        json_string(chimera_nfs_export_get_path(export)));
+    json_object_set_new(obj, "export_id",
+                        json_integer(chimera_nfs_export_get_id(export)));
     json_object_set_new(obj, "access",
                         json_string(chimera_nfs_export_get_access(export) &
                                     CHIMERA_NFS_EXPORT_ACCESS_RO ? "ro" : "rw"));
@@ -45,7 +56,27 @@ export_options_to_json(
                         json_integer(chimera_nfs_export_get_anonuid(export)));
     json_object_set_new(obj, "anongid",
                         json_integer(chimera_nfs_export_get_anongid(export)));
-} /* export_options_to_json */
+
+    /* Absent (mask 0) means any flavor is permitted, matching the config
+     * file semantics; emit the restriction only when one is set. */
+    if (sec_mask) {
+        json_t *sec = json_array();
+
+        if (sec_mask & CHIMERA_NFS_SEC_SYS) {
+            json_array_append_new(sec, json_string("sys"));
+        }
+        if (sec_mask & CHIMERA_NFS_SEC_KRB5) {
+            json_array_append_new(sec, json_string("krb5"));
+        }
+        if (sec_mask & CHIMERA_NFS_SEC_KRB5I) {
+            json_array_append_new(sec, json_string("krb5i"));
+        }
+        if (sec_mask & CHIMERA_NFS_SEC_KRB5P) {
+            json_array_append_new(sec, json_string("krb5p"));
+        }
+        json_object_set_new(obj, "sec", sec);
+    }
+} /* chimera_rest_export_options_to_json */
 
 static int
 export_to_json_callback(
@@ -53,16 +84,11 @@ export_to_json_callback(
     void                            *data)
 {
     struct export_list_ctx *ctx = data;
-    json_t                 *obj;
+    json_t                 *obj = json_object();
 
-    obj = json_object();
     json_object_set_new(obj, "name",
                         json_string(chimera_nfs_export_get_name(export)));
-    json_object_set_new(obj, "path",
-                        json_string(chimera_nfs_export_get_path(export)));
-    json_object_set_new(obj, "export_id",
-                        json_integer(chimera_nfs_export_get_id(export)));
-    export_options_to_json(export, obj);
+    chimera_rest_export_options_to_json(export, obj);
 
     json_array_append_new(ctx->array, obj);
 
@@ -105,11 +131,7 @@ chimera_rest_handle_exports_get(
     obj = json_object();
     json_object_set_new(obj, "name",
                         json_string(chimera_nfs_export_get_name(export)));
-    json_object_set_new(obj, "path",
-                        json_string(chimera_nfs_export_get_path(export)));
-    json_object_set_new(obj, "export_id",
-                        json_integer(chimera_nfs_export_get_id(export)));
-    export_options_to_json(export, obj);
+    chimera_rest_export_options_to_json(export, obj);
 
     chimera_rest_send_json(evpl, request, 200, obj);
 } /* chimera_rest_handle_exports_get */
@@ -131,6 +153,7 @@ chimera_rest_handle_exports_create(
     json_t                        *squash_j;
     json_t                        *anonuid_j;
     json_t                        *anongid_j;
+    json_t                        *sec_j;
     uint32_t                       export_id = 0;
     struct chimera_nfs_export_opts opts      = { 0 };
     int                            rc;
@@ -249,6 +272,48 @@ chimera_rest_handle_exports_create(
         }
         opts.has_anongid = 1;
         opts.anongid     = (uint32_t) v;
+    }
+
+    /* Allowed security flavors: an optional array of
+     * "sys"/"krb5"/"krb5i"/"krb5p" strings, matching the config file.  An
+     * absent key or empty array permits any flavor.  Every malformed shape
+     * is rejected: a typo'd flavor, non-string entry, or non-array value
+     * silently dropped would leave the mask at 0 -- "any flavor allowed" --
+     * turning a requested Kerberos-only export wide open to AUTH_SYS. */
+    sec_j = json_object_get(root, "sec");
+    if (sec_j) {
+        size_t  si;
+        json_t *flavor_j;
+
+        if (!json_is_array(sec_j)) {
+            json_decref(root);
+            chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                    "sec must be an array of flavor strings");
+            return;
+        }
+
+        opts.has_sec = 1;
+        json_array_foreach(sec_j, si, flavor_j)
+        {
+            const char *f = json_string_value(flavor_j);
+
+            if (f && (strcasecmp(f, "sys") == 0 ||
+                      strcasecmp(f, "auth_sys") == 0)) {
+                opts.sec_allowed |= CHIMERA_NFS_SEC_SYS;
+            } else if (f && strcasecmp(f, "krb5") == 0) {
+                opts.sec_allowed |= CHIMERA_NFS_SEC_KRB5;
+            } else if (f && strcasecmp(f, "krb5i") == 0) {
+                opts.sec_allowed |= CHIMERA_NFS_SEC_KRB5I;
+            } else if (f && strcasecmp(f, "krb5p") == 0) {
+                opts.sec_allowed |= CHIMERA_NFS_SEC_KRB5P;
+            } else {
+                json_decref(root);
+                chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                        "sec flavors must be \"sys\", \"krb5\", "
+                                        "\"krb5i\", or \"krb5p\"");
+                return;
+            }
+        }
     }
 
     /* Create the export with the validated options applied atomically, so it

--- a/src/server/rest/rest_exports.c
+++ b/src/server/rest/rest_exports.c
@@ -21,15 +21,15 @@ struct export_list_ctx {
     json_t *array;
 };
 
-/* Populate the per-export access options (mode, squash, anon ids) into obj. */
+/* Populate the per-export options (access mode, squash, anon ids) into obj. */
 static void
 export_options_to_json(
     const struct chimera_nfs_export *export,
     json_t                          *obj)
 {
-    json_object_set_new(obj, "options",
-                        json_string(chimera_nfs_export_get_options(export) &
-                                    CHIMERA_NFS_EXPORT_OPT_RO ? "ro" : "rw"));
+    json_object_set_new(obj, "access",
+                        json_string(chimera_nfs_export_get_access(export) &
+                                    CHIMERA_NFS_EXPORT_ACCESS_RO ? "ro" : "rw"));
     switch (chimera_nfs_export_get_squash(export)) {
         case CHIMERA_NFS_SQUASH_ALL:
             json_object_set_new(obj, "squash", json_string("all"));
@@ -165,6 +165,16 @@ chimera_rest_handle_exports_create(
         export_id = (uint32_t) v;
     }
 
+    /* The access mode field was renamed from "options" to "access".  Reject
+     * the old key before creating anything: silently ignoring it would turn
+     * a requested read-only export read-write. */
+    if (json_object_get(root, "options")) {
+        json_decref(root);
+        chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                "\"options\" has been renamed to \"access\"");
+        return;
+    }
+
     if (chimera_server_get_export(thread->shared->server, name)) {
         json_decref(root);
         chimera_rest_send_error(evpl, request, 409, "Conflict",
@@ -196,26 +206,26 @@ chimera_rest_handle_exports_create(
         return;
     }
 
-    /* Apply optional access options.  create_export seeded secure defaults
-     * (root_squash, rw, configured anon); seed from those and override only the
-     * fields present in the request body. */
+    /* Apply optional export options.  create_export seeded the defaults
+     * (rw, no squashing, configured anon); seed from those and override only
+     * the fields present in the request body. */
     {
         const struct chimera_nfs_export *created =
             chimera_server_get_export(thread->shared->server, name);
-        const char                      *opt_s     = json_string_value(json_object_get(root, "options"));
+        const char                      *access_s  = json_string_value(json_object_get(root, "access"));
         const char                      *squash_s  = json_string_value(json_object_get(root, "squash"));
         json_t                          *anonuid_j = json_object_get(root, "anonuid");
         json_t                          *anongid_j = json_object_get(root, "anongid");
-        uint32_t                         options   = chimera_nfs_export_get_options(created);
+        uint32_t                         access    = chimera_nfs_export_get_access(created);
         uint32_t                         squash    = chimera_nfs_export_get_squash(created);
         uint32_t                         anonuid   = chimera_nfs_export_get_anonuid(created);
         uint32_t                         anongid   = chimera_nfs_export_get_anongid(created);
 
-        if (opt_s) {
-            if (strcasecmp(opt_s, "ro") == 0) {
-                options = CHIMERA_NFS_EXPORT_OPT_RO;
-            } else if (strcasecmp(opt_s, "rw") == 0) {
-                options = CHIMERA_NFS_EXPORT_OPT_RW;
+        if (access_s) {
+            if (strcasecmp(access_s, "ro") == 0) {
+                access = CHIMERA_NFS_EXPORT_ACCESS_RO;
+            } else if (strcasecmp(access_s, "rw") == 0) {
+                access = CHIMERA_NFS_EXPORT_ACCESS_RW;
             }
         }
         if (squash_s) {
@@ -237,7 +247,7 @@ chimera_rest_handle_exports_create(
             anongid = (uint32_t) json_integer_value(anongid_j);
         }
 
-        chimera_server_export_set_options(thread->shared->server, name, options,
+        chimera_server_export_set_options(thread->shared->server, name, access,
                                           squash, anonuid, anongid);
     }
 

--- a/src/server/rest/rest_exports.c
+++ b/src/server/rest/rest_exports.c
@@ -122,14 +122,19 @@ chimera_rest_handle_exports_create(
     const char                 *body,
     int                         body_len)
 {
-    json_t      *root;
-    json_error_t error;
-    const char  *name;
-    const char  *path;
-    json_t      *exp_id_j;
-    uint32_t     export_id = 0;
-    int          rc;
-    json_t      *obj;
+    json_t                        *root;
+    json_error_t                   error;
+    const char                    *name;
+    const char                    *path;
+    json_t                        *exp_id_j;
+    json_t                        *access_j;
+    json_t                        *squash_j;
+    json_t                        *anonuid_j;
+    json_t                        *anongid_j;
+    uint32_t                       export_id = 0;
+    struct chimera_nfs_export_opts opts      = { 0 };
+    int                            rc;
+    json_t                        *obj;
 
     root = json_loadb(body, body_len, 0, &error);
     if (!root) {
@@ -175,90 +180,116 @@ chimera_rest_handle_exports_create(
         return;
     }
 
-    if (chimera_server_get_export(thread->shared->server, name)) {
-        json_decref(root);
+    /* Validate the optional export options before creating anything:
+     * an unrecognized value silently falling back to the defaults would turn
+     * a requested read-only or squashed export into an open one, and a
+     * non-integer anonuid/anongid would map squashed callers to uid/gid 0. */
+    access_j = json_object_get(root, "access");
+    if (access_j) {
+        const char *s = json_string_value(access_j);
+
+        opts.has_access = 1;
+        if (s && strcasecmp(s, "ro") == 0) {
+            opts.access = CHIMERA_NFS_EXPORT_ACCESS_RO;
+        } else if (s && strcasecmp(s, "rw") == 0) {
+            opts.access = CHIMERA_NFS_EXPORT_ACCESS_RW;
+        } else {
+            json_decref(root);
+            chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                    "access must be \"ro\" or \"rw\"");
+            return;
+        }
+    }
+
+    squash_j = json_object_get(root, "squash");
+    if (squash_j) {
+        const char *s = json_string_value(squash_j);
+
+        opts.has_squash = 1;
+        if (s && (strcasecmp(s, "none") == 0 ||
+                  strcasecmp(s, "no_root_squash") == 0)) {
+            opts.squash = CHIMERA_NFS_SQUASH_NONE;
+        } else if (s && (strcasecmp(s, "all") == 0 ||
+                         strcasecmp(s, "all_squash") == 0)) {
+            opts.squash = CHIMERA_NFS_SQUASH_ALL;
+        } else if (s && (strcasecmp(s, "root") == 0 ||
+                         strcasecmp(s, "root_squash") == 0)) {
+            opts.squash = CHIMERA_NFS_SQUASH_ROOT;
+        } else {
+            json_decref(root);
+            chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                    "squash must be \"none\", \"root\", or \"all\"");
+            return;
+        }
+    }
+
+    anonuid_j = json_object_get(root, "anonuid");
+    if (anonuid_j) {
+        json_int_t v = json_integer_value(anonuid_j);
+
+        if (!json_is_integer(anonuid_j) || v < 0 || v > UINT32_MAX) {
+            json_decref(root);
+            chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                    "anonuid must be an integer in range 0..4294967295");
+            return;
+        }
+        opts.has_anonuid = 1;
+        opts.anonuid     = (uint32_t) v;
+    }
+
+    anongid_j = json_object_get(root, "anongid");
+    if (anongid_j) {
+        json_int_t v = json_integer_value(anongid_j);
+
+        if (!json_is_integer(anongid_j) || v < 0 || v > UINT32_MAX) {
+            json_decref(root);
+            chimera_rest_send_error(evpl, request, 400, "Bad Request",
+                                    "anongid must be an integer in range 0..4294967295");
+            return;
+        }
+        opts.has_anongid = 1;
+        opts.anongid     = (uint32_t) v;
+    }
+
+    /* Create the export with the validated options applied atomically, so it
+     * is never live half-configured.  Name and id uniqueness are decided
+     * inside create_export under its lock: a handler-side check-then-create
+     * would race a concurrent create/delete of the same name (REST handlers
+     * run one per core thread). */
+    rc = chimera_server_create_export(thread->shared->server, name, path,
+                                      export_id, &opts);
+
+    json_decref(root);
+
+    if (rc == -EEXIST) {
         chimera_rest_send_error(evpl, request, 409, "Conflict",
                                 "Export with that name already exists");
         return;
     }
 
-    rc = chimera_server_create_export(thread->shared->server, name, path,
-                                      export_id);
-
-    if (rc == -EEXIST) {
-        json_decref(root);
+    if (rc == -EADDRINUSE) {
         chimera_rest_send_error(evpl, request, 409, "Conflict",
                                 "export_id already in use");
         return;
     }
 
     if (rc == -EINVAL) {
-        json_decref(root);
         chimera_rest_send_error(evpl, request, 400, "Bad Request",
                                 "export_id out of range");
         return;
     }
 
     if (rc == -ENOSPC) {
-        json_decref(root);
         chimera_rest_send_error(evpl, request, 409, "Conflict",
                                 "Export limit reached (server nfs_max_exports)");
         return;
     }
 
     if (rc != 0) {
-        json_decref(root);
         chimera_rest_send_error(evpl, request, 500, "Internal Server Error",
                                 "Failed to create export");
         return;
     }
-
-    /* Apply optional export options.  create_export seeded the defaults
-     * (rw, no squashing, configured anon); seed from those and override only
-     * the fields present in the request body. */
-    {
-        const struct chimera_nfs_export *created =
-            chimera_server_get_export(thread->shared->server, name);
-        const char                      *access_s  = json_string_value(json_object_get(root, "access"));
-        const char                      *squash_s  = json_string_value(json_object_get(root, "squash"));
-        json_t                          *anonuid_j = json_object_get(root, "anonuid");
-        json_t                          *anongid_j = json_object_get(root, "anongid");
-        uint32_t                         access    = chimera_nfs_export_get_access(created);
-        uint32_t                         squash    = chimera_nfs_export_get_squash(created);
-        uint32_t                         anonuid   = chimera_nfs_export_get_anonuid(created);
-        uint32_t                         anongid   = chimera_nfs_export_get_anongid(created);
-
-        if (access_s) {
-            if (strcasecmp(access_s, "ro") == 0) {
-                access = CHIMERA_NFS_EXPORT_ACCESS_RO;
-            } else if (strcasecmp(access_s, "rw") == 0) {
-                access = CHIMERA_NFS_EXPORT_ACCESS_RW;
-            }
-        }
-        if (squash_s) {
-            if (strcasecmp(squash_s, "none") == 0 ||
-                strcasecmp(squash_s, "no_root_squash") == 0) {
-                squash = CHIMERA_NFS_SQUASH_NONE;
-            } else if (strcasecmp(squash_s, "all") == 0 ||
-                       strcasecmp(squash_s, "all_squash") == 0) {
-                squash = CHIMERA_NFS_SQUASH_ALL;
-            } else if (strcasecmp(squash_s, "root") == 0 ||
-                       strcasecmp(squash_s, "root_squash") == 0) {
-                squash = CHIMERA_NFS_SQUASH_ROOT;
-            }
-        }
-        if (anonuid_j) {
-            anonuid = (uint32_t) json_integer_value(anonuid_j);
-        }
-        if (anongid_j) {
-            anongid = (uint32_t) json_integer_value(anongid_j);
-        }
-
-        chimera_server_export_set_options(thread->shared->server, name, access,
-                                          squash, anonuid, anongid);
-    }
-
-    json_decref(root);
 
     obj = json_object();
     json_object_set_new(obj, "message", json_string("Export created"));

--- a/src/server/rest/rest_internal.h
+++ b/src/server/rest/rest_internal.h
@@ -9,6 +9,7 @@
 #include "common/logging.h"
 
 struct chimera_vfs_thread;
+struct chimera_nfs_export;
 struct evpl;
 struct evpl_http_request;
 
@@ -93,3 +94,19 @@ chimera_rest_send_json_response(
     struct evpl_http_request *request,
     int                       status,
     const char               *json_body);
+
+/**
+ * Populate every export field except the name (path, export_id, access
+ * mode, squash, anon ids, and the sec restriction when one is set) into a
+ * JSON object.  Shared between the export handlers (rest_exports.c), which
+ * add a "name" field, and the config serializer (rest_config.c), which keys
+ * its entries by name, so the two representations cannot drift apart.
+ *
+ * @param export Export to serialize
+ * @param obj    JSON object to add the fields to
+ */
+void
+chimera_rest_export_options_to_json(
+    const struct chimera_nfs_export *export,
+    json_t *obj);
+

--- a/src/server/rest/tests/rest_exports_test.c
+++ b/src/server/rest/tests/rest_exports_test.c
@@ -305,9 +305,9 @@ main(
                "{\"name\":\"bad1\",\"path\":\"/share\",\"export_id\":0}",
                400, &failures);
 
-    check_code("export_id 4096 returns 400",
+    check_code("export_id 65536 returns 400",
                "POST", "/api/v1/exports",
-               "{\"name\":\"bad2\",\"path\":\"/share\",\"export_id\":4096}",
+               "{\"name\":\"bad2\",\"path\":\"/share\",\"export_id\":65536}",
                400, &failures);
 
     check_code("Negative export_id returns 400",

--- a/src/server/rest/tests/rest_exports_test.c
+++ b/src/server/rest/tests/rest_exports_test.c
@@ -5,29 +5,41 @@
 /*
  * REST API NFS Exports Test
  *
- * Exercises the /api/v1/exports endpoints in rest_shares.c with REST
+ * Exercises the /api/v1/exports endpoints in rest_exports.c with REST
  * authentication disabled, focusing on the export_id support:
  *   1. Create an export with an explicit export_id returns 201
  *   2. GET the export echoes the export_id back
  *   3. List exports includes the export_id on the matching entry
  *   4. GET /api/v1/config round-trips the export_id
  *   5. A duplicate export_id returns 409 and the export is not created
- *   6. Out-of-range or non-integer export_id returns 400
+ *   6. Out-of-range or non-integer export_id returns 400; the id space
+ *      boundary (65535) is accepted
  *   7. Auto-assignment skips slots pinned by explicit ids
  *   8. Delete frees the id so it can be pinned again
  *   9. Missing required fields return 400; a duplicate name returns 409
+ *  10. The access mode round-trips; the legacy "options" key and invalid
+ *      access/squash/anonuid/anongid values are rejected with 400 rather
+ *      than silently ignored; squash aliases are accepted
+ *  11. A sec restriction round-trips; no/empty restriction omits the field;
+ *      malformed sec shapes are rejected with 400
+ *  12. Creating past the configured nfs_max_exports cap returns 409 and a
+ *      delete frees a slot under the cap again
  */
 
 #include "common/logging.h"
 #include "prometheus-c.h"
 #include "server/server.h"
+#include <jansson.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define REST_PORT 18082
+#define REST_PORT        18082
+
+/* Concurrent-export cap configured for this test (nfs_max_exports). */
+#define TEST_MAX_EXPORTS 8
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -155,6 +167,35 @@ curl_get_body(
     return 0;
 } /* curl_get_body */
 
+/* Return the number of live exports per GET /api/v1/exports, or -1 on any
+ * request/parse failure.  Used so the count-cap test fills from the actual
+ * live count instead of hard-coding how many exports earlier tests left. */
+static long
+count_exports(void)
+{
+    char    response[8192];
+    long    http_code = 0;
+    json_t *array;
+    long    count;
+
+    if (curl_get_body("GET", "/api/v1/exports", NULL, response,
+                      sizeof(response), &http_code) != 0 ||
+        http_code != 200) {
+        return -1;
+    }
+
+    array = json_loads(response, 0, NULL);
+    if (!array || !json_is_array(array)) {
+        json_decref(array);
+        return -1;
+    }
+
+    count = (long) json_array_size(array);
+    json_decref(array);
+
+    return count;
+} /* count_exports */
+
 /* Assert that a request returns the expected status code. */
 static void
 check_code(
@@ -251,6 +292,10 @@ main(
     /* Disable auth so the export endpoints can be exercised directly,
      * mirroring the admin pytest setup. */
     chimera_server_config_set_rest_auth_enabled(config, 0);
+    /* Small concurrent-export cap so the nfs_max_exports enforcement can be
+     * exercised without thousands of creates; test 11 queries the live
+     * export count and fills the remaining slots up to this cap. */
+    chimera_server_config_set_nfs_max_exports(config, TEST_MAX_EXPORTS);
 
     server = chimera_server_init(config, metrics);
     if (!server) {
@@ -276,17 +321,17 @@ main(
     fprintf(stderr, "\n  Test: export_id is echoed on read...\n");
     check_body_contains("GET /api/v1/exports/exp1 echoes export_id",
                         "GET", "/api/v1/exports/exp1", NULL,
-                        200, "\"export_id\":42", 1, &failures);
+                        200, "\"export_id\":42,", 1, &failures);
 
     /* ===== Test 3: List includes the export_id ===== */
     check_body_contains("GET /api/v1/exports lists export_id",
                         "GET", "/api/v1/exports", NULL,
-                        200, "\"export_id\":42", 1, &failures);
+                        200, "\"export_id\":42,", 1, &failures);
 
     /* ===== Test 4: Config round-trips the export_id ===== */
     check_body_contains("GET /api/v1/config round-trips export_id",
                         "GET", "/api/v1/config", NULL,
-                        200, "\"export_id\":42", 1, &failures);
+                        200, "\"export_id\":42,", 1, &failures);
 
     /* ===== Test 5: Duplicate export_id is rejected with 409 ===== */
     fprintf(stderr, "\n  Test: Duplicate export_id rejected with 409...\n");
@@ -332,6 +377,17 @@ main(
     check_code("Rejected export bad4 does not exist (404)",
                "GET", "/api/v1/exports/bad4", NULL, 404, &failures);
 
+    /* The top of the id space is valid: 65535 is the largest id that fits the
+     * 16-bit wire file-handle field. */
+    check_code("export_id 65535 (id space boundary) returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expmax\",\"path\":\"/share\",\"export_id\":65535}",
+               201, &failures);
+
+    check_body_contains("GET /api/v1/exports/expmax echoes export_id",
+                        "GET", "/api/v1/exports/expmax", NULL,
+                        200, "\"export_id\":65535,", 1, &failures);
+
     /* ===== Test 7: Auto-assignment skips explicit ids =====
      * On this fresh server the auto counter is at 1.  Pin id 1, then an auto
      * export must skip to 2; pin 3, and the next auto export must skip over
@@ -349,7 +405,7 @@ main(
 
     check_body_contains("Auto export skipped pinned id 1, got 2",
                         "GET", "/api/v1/exports/expb", NULL,
-                        200, "\"export_id\":2", 1, &failures);
+                        200, "\"export_id\":2,", 1, &failures);
 
     check_code("POST export pinned to id 3 returns 201",
                "POST", "/api/v1/exports",
@@ -363,7 +419,7 @@ main(
 
     check_body_contains("Auto export skipped pinned id 3, got 4",
                         "GET", "/api/v1/exports/expd", NULL,
-                        200, "\"export_id\":4", 1, &failures);
+                        200, "\"export_id\":4,", 1, &failures);
 
     /* ===== Test 8: Delete frees the id for reuse ===== */
     fprintf(stderr, "\n  Test: Delete frees the export_id...\n");
@@ -385,10 +441,186 @@ main(
                "{\"name\":\"nopath\"}",
                400, &failures);
 
-    check_code("Duplicate export name returns 409",
+    /* The name-conflict message distinguishes this 409 from a duplicate
+     * export_id (the uniqueness check runs inside create, under the exports
+     * lock, so it cannot be raced by a concurrent create of the same name). */
+    check_body_contains("Duplicate export name returns 409",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"exp1b\",\"path\":\"/share\"}",
+                        409, "already exists", 1, &failures);
+
+    /* ===== Test 10: access mode round-trip; legacy "options" rejected ===== */
+    fprintf(stderr, "\n  Test: access mode round-trip and legacy key...\n");
+    check_code("POST export with access=ro returns 201",
                "POST", "/api/v1/exports",
-               "{\"name\":\"exp1b\",\"path\":\"/share\"}",
-               409, &failures);
+               "{\"name\":\"expro\",\"path\":\"/share\",\"access\":\"ro\"}",
+               201, &failures);
+
+    check_body_contains("GET echoes access=ro",
+                        "GET", "/api/v1/exports/expro", NULL,
+                        200, "\"access\":\"ro\"", 1, &failures);
+
+    check_body_contains("Legacy \"options\" key returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expleg\",\"path\":\"/share\",\"options\":\"ro\"}",
+                        400, "has been renamed", 1, &failures);
+
+    check_code("Rejected legacy export does not exist (404)",
+               "GET", "/api/v1/exports/expleg", NULL, 404, &failures);
+
+    check_code("DELETE access round-trip export returns 204",
+               "DELETE", "/api/v1/exports/expro", NULL, 204, &failures);
+
+    /* Unrecognized or mistyped export option values must be rejected, not
+     * silently replaced with the (more permissive) defaults. */
+    check_body_contains("Invalid access value returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"access\":\"readonly\"}",
+                        400, "access must be", 1, &failures);
+
+    check_body_contains("Non-string access value returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"access\":1}",
+                        400, "access must be", 1, &failures);
+
+    check_body_contains("Invalid squash value returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"squash\":\"rootsquash\"}",
+                        400, "squash must be", 1, &failures);
+
+    check_body_contains("String anonuid returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"anonuid\":\"1000\"}",
+                        400, "anonuid must be", 1, &failures);
+
+    check_body_contains("Negative anonuid returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"anonuid\":-1}",
+                        400, "anonuid must be", 1, &failures);
+
+    check_body_contains("Out-of-range anongid returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"anongid\":4294967296}",
+                        400, "anongid must be", 1, &failures);
+
+    check_code("Rejected export expbad does not exist (404)",
+               "GET", "/api/v1/exports/expbad", NULL, 404, &failures);
+
+    /* Squash aliases parse to the canonical value. */
+    check_code("POST export with squash=root_squash returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expsq\",\"path\":\"/share\",\"squash\":\"root_squash\",\"anonuid\":1000}",
+               201, &failures);
+
+    check_body_contains("GET echoes canonical squash=root",
+                        "GET", "/api/v1/exports/expsq", NULL,
+                        200, "\"squash\":\"root\"", 1, &failures);
+
+    check_body_contains("GET echoes anonuid=1000",
+                        "GET", "/api/v1/exports/expsq", NULL,
+                        200, "\"anonuid\":1000,", 1, &failures);
+
+    check_code("DELETE squash alias export returns 204",
+               "DELETE", "/api/v1/exports/expsq", NULL, 204, &failures);
+
+    /* ===== Test 11: sec restriction round-trip and validation ===== */
+    fprintf(stderr, "\n  Test: sec restriction round-trip...\n");
+    check_code("POST export with sec returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expsec\",\"path\":\"/share\",\"sec\":[\"krb5\",\"krb5i\"]}",
+               201, &failures);
+
+    check_body_contains("GET echoes the sec array",
+                        "GET", "/api/v1/exports/expsec", NULL,
+                        200, "\"sec\":[\"krb5\",\"krb5i\"]", 1, &failures);
+
+    /* No restriction (or an empty one) means any flavor: the field must be
+    * absent so a captured config round-trips the config-file semantics. */
+    check_body_contains("Export without a restriction omits sec",
+                        "GET", "/api/v1/exports/expa", NULL,
+                        200, "\"sec\"", 0, &failures);
+
+    check_code("POST export with empty sec returns 201",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"expsece\",\"path\":\"/share\",\"sec\":[]}",
+               201, &failures);
+
+    check_body_contains("Empty sec restriction omits the field",
+                        "GET", "/api/v1/exports/expsece", NULL,
+                        200, "\"sec\"", 0, &failures);
+
+    /* Malformed sec shapes are rejected, not silently widened to "any". */
+    check_body_contains("Unknown sec flavor returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"sec\":[\"krb5x\"]}",
+                        400, "sec flavors must be", 1, &failures);
+
+    check_body_contains("Non-array sec returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"sec\":\"krb5\"}",
+                        400, "sec must be an array", 1, &failures);
+
+    check_body_contains("Non-string sec entry returns 400",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"expbad\",\"path\":\"/share\",\"sec\":[5]}",
+                        400, "sec flavors must be", 1, &failures);
+
+    check_code("Rejected sec export expbad does not exist (404)",
+               "GET", "/api/v1/exports/expbad", NULL, 404, &failures);
+
+    check_code("DELETE sec export returns 204",
+               "DELETE", "/api/v1/exports/expsec", NULL, 204, &failures);
+
+    check_code("DELETE empty-sec export returns 204",
+               "DELETE", "/api/v1/exports/expsece", NULL, 204, &failures);
+
+    /* ===== Test 12: nfs_max_exports count cap =====
+     * Fill from the live export count (queried, so inserting a create in an
+     * earlier test cannot break the arithmetic here) up to the configured
+     * cap of 8; the next create is rejected, and deleting one frees a slot
+     * under the cap again. */
+    fprintf(stderr, "\n  Test: nfs_max_exports cap enforcement...\n");
+    {
+        long live = count_exports();
+
+        if (live < 1 || live >= TEST_MAX_EXPORTS) {
+            test_fail("Live export count within cap before fill");
+            fprintf(stderr, "    Expected 1..%d live exports, found %ld\n",
+                    TEST_MAX_EXPORTS - 1, live);
+            failures++;
+        } else {
+            test_pass("Live export count within cap before fill");
+        }
+
+        for (long i = live; i < TEST_MAX_EXPORTS; i++) {
+            char label[64];
+            char fill_body[128];
+
+            snprintf(label, sizeof(label),
+                     "Create below the cap returns 201 (%ld/%d)",
+                     i + 1, TEST_MAX_EXPORTS);
+            snprintf(fill_body, sizeof(fill_body),
+                     "{\"name\":\"fill%ld\",\"path\":\"/share\"}", i);
+            check_code(label, "POST", "/api/v1/exports", fill_body,
+                       201, &failures);
+        }
+    }
+
+    check_body_contains("Create past the cap returns 409",
+                        "POST", "/api/v1/exports",
+                        "{\"name\":\"fillover\",\"path\":\"/share\"}",
+                        409, "Export limit reached", 1, &failures);
+
+    check_code("Rejected export fillover does not exist (404)",
+               "GET", "/api/v1/exports/fillover", NULL, 404, &failures);
+
+    check_code("DELETE frees a slot under the cap",
+               "DELETE", "/api/v1/exports/exp1b", NULL, 204, &failures);
+
+    check_code("Create succeeds again after delete",
+               "POST", "/api/v1/exports",
+               "{\"name\":\"fillafter\",\"path\":\"/share\"}",
+               201, &failures);
 
     fprintf(stderr, "\n========================================\n");
     fprintf(stderr, "Test Summary\n");

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2222,7 +2222,7 @@ SYMBOL_EXPORT int
 chimera_server_export_set_options(
     struct chimera_server *server,
     const char            *name,
-    uint32_t               options,
+    uint32_t               access,
     uint32_t               squash,
     uint32_t               anonuid,
     uint32_t               anongid)
@@ -2231,7 +2231,7 @@ chimera_server_export_set_options(
         return -1;
     }
 
-    return chimera_nfs_export_set_options(server->nfs_shared, name, options,
+    return chimera_nfs_export_set_options(server->nfs_shared, name, access,
                                           squash, anonuid, anongid);
 } /* chimera_server_export_set_options */
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2236,16 +2236,18 @@ chimera_server_share_set_force_level2_oplock(
 
 SYMBOL_EXPORT int
 chimera_server_create_export(
-    struct chimera_server *server,
-    const char            *name,
-    const char            *path,
-    uint32_t               export_id)
+    struct chimera_server                *server,
+    const char                           *name,
+    const char                           *path,
+    uint32_t                              export_id,
+    const struct chimera_nfs_export_opts *opts)
 {
     if (!server->nfs_shared) {
         return -1;
     }
 
-    return chimera_nfs_add_export(server->nfs_shared, name, path, export_id);
+    return chimera_nfs_add_export(server->nfs_shared, name, path, export_id,
+                                  opts);
 } /* chimera_server_create_export */
 
 SYMBOL_EXPORT int

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -100,6 +100,7 @@ struct chimera_server_config {
     int                                   smb_num_nic_info;
     uint32_t                              anonuid;
     uint32_t                              anongid;
+    uint32_t                              nfs_max_exports;   /* concurrent-export count cap */
     int                                   nfs_fh_sign;       /* sign wire file handles (default on) */
     char                                  nfs_fh_key[33];    /* optional 32-hex-char (128-bit) signing key */
     enum chimera_tcp_flavor               tcp_flavor;
@@ -242,6 +243,11 @@ chimera_server_config_init(void)
 
     config->anonuid = 65534;
     config->anongid = 65534;
+
+    /* Concurrent NFS export count cap; distinct from the export id space
+     * (1..CHIMERA_NFS_EXPORT_ID_MAX), which is fixed by the 16-bit wire
+     * file-handle field regardless of this cap. */
+    config->nfs_max_exports = CHIMERA_NFS_MAX_EXPORTS_DEFAULT;
 
     /* Sign NFS wire file handles by default (unforgeable handles); the key is
      * generated/persisted at NFS init unless nfs_fh_key is configured. */
@@ -1198,6 +1204,30 @@ chimera_server_config_set_anonuid(
 {
     config->anonuid = anonuid;
 } /* chimera_server_config_set_anonuid */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs_max_exports(
+    struct chimera_server_config *config,
+    uint32_t                      nfs_max_exports)
+{
+    /* Clamp rather than trust the caller: 0 would reject every export create
+    * with a baffling "limit reached (0)", and a cap beyond the id space
+    * could never be reached (ids are unique per export).  The daemon config
+    * parser validates before calling; this guards direct library callers. */
+    if (nfs_max_exports < 1 || nfs_max_exports > CHIMERA_NFS_EXPORT_ID_MAX) {
+        chimera_server_error("nfs_max_exports %u out of range (1..%u); clamping",
+                             nfs_max_exports, CHIMERA_NFS_EXPORT_ID_MAX);
+        nfs_max_exports = nfs_max_exports < 1 ?
+            1 : CHIMERA_NFS_EXPORT_ID_MAX;
+    }
+    config->nfs_max_exports = nfs_max_exports;
+} /* chimera_server_config_set_nfs_max_exports */
+
+SYMBOL_EXPORT uint32_t
+chimera_server_config_get_nfs_max_exports(const struct chimera_server_config *config)
+{
+    return config->nfs_max_exports;
+} /* chimera_server_config_get_nfs_max_exports */
 
 SYMBOL_EXPORT uint32_t
 chimera_server_config_get_anonuid(const struct chimera_server_config *config)

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -693,16 +693,21 @@ chimera_server_share_set_force_level2_oplock(
 /*
  * Create an NFS export.  export_id pins the stable id embedded in wire file
  * handles (1..CHIMERA_NFS_EXPORT_ID_MAX); 0 auto-assigns the next free id.
- * Returns 0 on success, -EINVAL for an out-of-range id, -EEXIST if the id is
- * already in use, -ENOSPC if the id space is exhausted, -1 if the NFS
- * protocol is not initialized.
+ * opts (may be NULL) applies per-export settings atomically at creation, so
+ * the export is never live half-configured; see struct chimera_nfs_export_opts
+ * in nfs/nfs.h.  Returns 0 on success, -EINVAL for an out-of-range id,
+ * -EEXIST if an export with the same name exists, -EADDRINUSE if the id is
+ * already in use, -ENOSPC if the configured export limit (nfs_max_exports)
+ * is reached, -ENOMEM on allocation failure, -1 if the NFS protocol is not
+ * initialized.
  */
 int
 chimera_server_create_export(
-    struct chimera_server *server,
-    const char            *share_name,
-    const char            *share_path,
-    uint32_t               export_id);
+    struct chimera_server                *server,
+    const char                           *share_name,
+    const char                           *share_path,
+    uint32_t                              export_id,
+    const struct chimera_nfs_export_opts *opts);
 
 int
 chimera_server_export_set_options(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -693,7 +693,7 @@ int
 chimera_server_export_set_options(
     struct chimera_server *server,
     const char            *name,
-    uint32_t               options,
+    uint32_t               access,
     uint32_t               squash,
     uint32_t               anonuid,
     uint32_t               anongid);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -551,6 +551,21 @@ uint32_t
 chimera_server_config_get_anonuid(
     const struct chimera_server_config *config);
 
+/* Concurrent NFS export count cap (default CHIMERA_NFS_MAX_EXPORTS_DEFAULT).
+ * Bounds how many exports may exist at once; the export id space
+ * (1..CHIMERA_NFS_EXPORT_ID_MAX) is fixed by the wire format and unaffected.
+ * Values outside 1..CHIMERA_NFS_EXPORT_ID_MAX are clamped into range with an
+ * error logged (0 would reject every create; a larger cap could never be
+ * reached, ids being unique per export). */
+void
+chimera_server_config_set_nfs_max_exports(
+    struct chimera_server_config *config,
+    uint32_t                      nfs_max_exports);
+
+uint32_t
+chimera_server_config_get_nfs_max_exports(
+    const struct chimera_server_config *config);
+
 void
 chimera_server_config_set_anongid(
     struct chimera_server_config *config,


### PR DESCRIPTION
## Summary

This series separates the NFS export id space from the concurrent-export cap,
makes export creation atomic, and hardens export configuration end to end
(config file, REST API, admin client/CLI).

### Export id space vs. count cap

Export ids are embedded in a 16-bit wire file-handle field, but the usable id
range was previously bounded by the in-memory export table size (4096). The id
space is now the full 1..65535 range, independent of a new `nfs_max_exports`
server setting (default 4096) that caps how many exports may exist at once.
Clustered servers can pin any 16-bit id so file handles stay valid across
failover.

### Atomic export creation

`chimera_server_create_export()` now takes an options struct
(access/squash/anonuid/anongid/sec) applied under the exports lock at creation
time. Previously an export was published with permissive defaults and
tightened by follow-up `set_options`/`set_sec` calls, leaving a window where
NFS request threads could see a requested read-only or Kerberos-only export as
rw/unsquashed/any-flavor. Name uniqueness and the count cap are also decided
inside the create path under the same lock, removing the REST handler's
check-then-create race, and distinct error codes (name conflict, id conflict,
cap reached) map to precise HTTP responses.

### Fail-fast configuration

The daemon now refuses to start on malformed export settings rather than
booting with silently-corrected values: a missing path, an unrecognized
access/squash value, an out-of-range or duplicate export_id, a non-integer
anonuid/anongid (which previously read as 0 - root), a malformed `sec` shape
(which previously widened a Kerberos-only export to any flavor), or a bad
`nfs_max_exports`. The access-mode key was renamed from `options` to `access`;
the old key is rejected explicitly so an `"options": "ro"` export cannot
silently become read-write.

### REST / admin surface

- `rest_shares.c` split into per-resource files (`rest_exports.c`,
  `rest_buckets.c`); export serialization is shared between
  `/api/v1/exports` and `/api/v1/config` so the two cannot drift.
- The exports API now exposes and validates the full option set, including
  the per-export `sec` restriction (present only when configured).
- The Python admin client/CLI grew `--access`, `--anonuid`, `--anongid`, and
  repeatable `--sec` options, and surfaces the server's error message on
  failures so a 409 for a duplicate name is distinguishable from a duplicate
  export_id.

### Tests

- New daemon config-validation test (startup must fail on each malformed
  shape; two-pass export_id assignment; sec round-trip through the REST API).
- REST exports test extended to the new validation, the 65535 id boundary,
  and `nfs_max_exports` cap enforcement.
- Client/posix/fsx test harnesses pin export id 4242 (above the default count
  cap) so the wire path exercises pinned-id file-handle attribution across
  the full id space.

### Breaking changes

- Config file: exports key `options` renamed to `access`; the old key now
  fails startup with a pointer to the rename.
- REST: `POST /api/v1/exports` rejects `options` with 400; responses include
  the new fields.
- CLI: `export create --options` renamed to `--access`.
- C API: `chimera_server_create_export()` gained an options parameter;
  `-EADDRINUSE` now distinguishes an id conflict from a name conflict
  (`-EEXIST`).
