### PR TITLE
nfs4: fix stack-use-after-return in pseudo-root READDIR

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -302,6 +302,33 @@ add_posix_erofs_test(nfs3 memfs)
 add_posix_erofs_test(nfs4 memfs)
 
 # ============================================================================
+# NFSv4 pseudo-fs root mount test
+# Mounts the bare pseudo-fs root ("server:/") instead of an export and lists
+# it, exercising nfs4_root_readdir's asynchronous per-export lookup walk (a
+# stack-use-after-return regression) plus entry into an export via
+# nfs4_root_lookup.  Registered explicitly because the standard harness always
+# mounts the "/share" export.  NFS4-only: the pseudo-fs root is an NFSv4
+# concept.
+# ============================================================================
+add_posix_testprog(test_pseudo_root)
+
+macro(add_posix_pseudo_root_test nfs_backend)
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/pseudo_root_nfs4_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_pseudo_root -b nfs4_${nfs_backend}
+        )
+        get_target_property(test_file posix_test_pseudo_root TEST_FILE)
+        set_tests_properties(chimera/posix/pseudo_root_nfs4_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+        )
+    endif()
+endmacro()
+
+add_posix_pseudo_root_test(memfs)
+add_posix_pseudo_root_test(linux)
+
+# ============================================================================
 # NFS3 over TCP-RDMA Backend Tests
 # These tests run the POSIX tests through the Chimera NFS client using TCP-RDMA,
 # connecting to a Chimera NFS server in the same process.

--- a/src/posix/tests/test_pseudo_root.c
+++ b/src/posix/tests/test_pseudo_root.c
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFSv4 pseudo-fs root mount ("server:/").
+ *
+ * Mounts the bare pseudo-fs root instead of an export and exercises the
+ * pseudo-root compound handlers, most importantly nfs4_root_readdir: listing
+ * the root resolves every export's backing path through an asynchronous VFS
+ * lookup per entry, a path that once assumed synchronous completion and
+ * crashed with a stack-use-after-return when a lookup completed off the
+ * request thread.
+ *
+ * Verifies that READDIR of the root lists the "/share" export, that the
+ * export can be entered by lookup from the root, and that files created
+ * through the pseudo-root path are readable back through it.
+ */
+
+#include "posix_test_common.h"
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    CHIMERA_DIR          *dir;
+    struct dirent        *entry;
+    struct stat           st;
+    int                   rc;
+    int                   fd;
+    int                   found_share = 0;
+    int                   num_entries = 0;
+    const char           *test_data   = "pseudo-root";
+    char                  buf[64];
+    ssize_t               len;
+
+    posix_test_init(&env, argv, argc);
+
+    if (env.nfs_version != 4) {
+        fprintf(stderr, "test_pseudo_root requires an NFS4 backend\n");
+        posix_test_fail(&env);
+    }
+
+    rc = chimera_posix_mount_with_options("/test", "nfs", "127.0.0.1:/",
+                                          "vers=4");
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount pseudo-fs root: %s\n",
+                strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* READDIR of the pseudo-root must list each export exactly once. */
+    dir = chimera_posix_opendir("/test");
+    if (!dir) {
+        fprintf(stderr, "Failed to open pseudo-root directory: %s\n",
+                strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    while ((entry = chimera_posix_readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 ||
+            strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        fprintf(stderr, "pseudo-root entry: %s\n", entry->d_name);
+        num_entries++;
+        if (strcmp(entry->d_name, "share") == 0) {
+            found_share++;
+        }
+    }
+
+    chimera_posix_closedir(dir);
+
+    if (found_share != 1) {
+        fprintf(stderr, "Export 'share' listed %d times in pseudo-root, "
+                "expected exactly once\n", found_share);
+        posix_test_fail(&env);
+    }
+
+    if (num_entries != 1) {
+        fprintf(stderr, "Pseudo-root listed %d entries, expected 1\n",
+                num_entries);
+        posix_test_fail(&env);
+    }
+
+    /* Entering the export from the pseudo-root (nfs4_root_lookup). */
+    rc = chimera_posix_stat("/test/share", &st);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to stat export via pseudo-root: %s\n",
+                strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        fprintf(stderr, "Export root is not a directory\n");
+        posix_test_fail(&env);
+    }
+
+    /* I/O through the pseudo-root path crosses into the export's backend. */
+    fd = chimera_posix_open("/test/share/pseudo_root_file",
+                            O_CREAT | O_RDWR, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to create file via pseudo-root: %s\n",
+                strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    len = chimera_posix_write(fd, test_data, strlen(test_data));
+    if (len != (ssize_t) strlen(test_data)) {
+        fprintf(stderr, "Failed to write via pseudo-root: %s\n",
+                strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    chimera_posix_close(fd);
+
+    fd = chimera_posix_open("/test/share/pseudo_root_file", O_RDONLY, 0);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to reopen file via pseudo-root: %s\n",
+                strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    len = chimera_posix_read(fd, buf, sizeof(buf));
+    if (len != (ssize_t) strlen(test_data) ||
+        memcmp(buf, test_data, len) != 0) {
+        fprintf(stderr, "Read-back via pseudo-root mismatched\n");
+        posix_test_fail(&env);
+    }
+
+    chimera_posix_close(fd);
+
+    rc = posix_test_umount();
+    if (rc != 0) {
+        fprintf(stderr, "Failed to unmount /test: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    fprintf(stderr, "Pseudo-root mount test passed\n");
+
+    posix_test_success(&env);
+
+    return 0;
+} /* main */

--- a/src/server/nfs/nfs4_proc_readdir.c
+++ b/src/server/nfs/nfs4_proc_readdir.c
@@ -227,7 +227,8 @@ chimera_nfs4_readdir(
      * sent by a client (0 means "start of directory"). The VFS backends emit
      * only cookie 0 or values >= 3 for regular directories, so a reserved
      * cookie here is a client error. The pseudo-root, handled above, uses its
-     * own export-index cookie space and is intentionally exempt. */
+     * own export-position cookie space (also >= 3) and applies the same check
+     * in nfs4_root_readdir. */
     if (args->cookie == 1 || args->cookie == 2) {
         res->status = NFS4ERR_BAD_COOKIE;
         chimera_nfs4_compound_complete(req, res->status);

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <sys/stat.h>
@@ -61,16 +62,6 @@ nfs4_root_getattr(
         attr->va_fsid           = 0;
     }
 } /* nfs4_getattr_root */
-
-struct nfs4_root_readdir_lookup_ctx {
-    enum chimera_vfs_error error_code;
-    struct entry4       *entry;
-    struct READDIR4args *args;
-    uint32_t             lease_time_s;
-    uint16_t             export_id;
-    const uint8_t       *fh_key;
-    int                  fh_sign;
-};
 
 static void
 nfs4_root_lookup_complete(
@@ -159,169 +150,288 @@ nfs4_root_lookup(
 
 } /* nfs4_root_lookup */
 
+/*
+ * Pseudo-fs root READDIR.
+ *
+ * Each entry's attributes require resolving the export's backing path via
+ * chimera_vfs_lookup(), which completes asynchronously, so the exports are
+ * walked one at a time by a state machine: issue the lookup for the current
+ * export, marshal its attrs in the completion callback, then advance to the
+ * next export, and complete the compound only after the walk finishes.
+ *
+ * The export list is snapshotted up front (under exports_lock, inside
+ * chimera_nfs_iterate_exports) because exports may be removed via the REST
+ * API while lookups are in flight; the walk must not retain pointers into
+ * the live list.
+ *
+ * The pseudo-root has its own cookie space: entry cookies are the export's
+ * snapshot position biased by +3 to stay clear of the reserved cookie values
+ * 0-2 (RFC 7530 §16.24.4), and a client cookie resumes the walk at the
+ * position after the entry that carried it.
+ */
+
+struct nfs4_root_readdir_export {
+    char    *name;  /* leading '/' stripped, validated single component */
+    char    *path;
+    uint16_t id;
+};
+
+struct nfs4_root_readdir_state {
+    struct nfs_request              *req;
+    struct chimera_vfs_thread       *vfs_thread;
+    uint8_t                          root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                         root_fh_len;
+    uint64_t                         attrmask;
+    struct nfs4_root_readdir_export *exports;
+    int                              num_exports;
+    int                              pos;         /* current snapshot position */
+    int                              first_pos;   /* resume position from args->cookie */
+    struct entry4                   *entry;       /* entry awaiting its lookup */
+    uint32_t                         dbuf_before; /* dbuf watermark for rollback */
+    enum chimera_vfs_error error_code;
+    int                              in_advance;  /* advance() loop is on the stack */
+    int                              lookup_done; /* current lookup completed synchronously */
+};
+
+struct nfs4_root_readdir_snap {
+    struct nfs4_root_readdir_export *exports;
+    int                              count;
+    int                              capacity;
+};
+
+static int
+nfs4_root_readdir_snap_cb(
+    const struct chimera_nfs_export *export,
+    void                            *private_data)
+{
+    struct nfs4_root_readdir_snap   *snap = private_data;
+    struct nfs4_root_readdir_export *e;
+    const char                      *export_name = export->name;
+
+    // remove leading '/' from export name if present
+    while (export_name[0] == '/') {
+        export_name++;
+    }
+
+    /* The pseudo-root lists each export as a single directory entry, so the
+     * name must be exactly one non-empty path component */
+    if (export_name[0] == '\0' || strchr(export_name, '/')) {
+        chimera_nfs_error("Invalid export name %s for export path %s: "
+                          "export name must be a single non-empty path component",
+                          export->name, export->path);
+        return 0;
+    }
+
+    if (snap->count == snap->capacity) {
+        snap->capacity = snap->capacity ? snap->capacity * 2 : 8;
+        snap->exports  = realloc(snap->exports,
+                                 snap->capacity * sizeof(*snap->exports));
+        chimera_nfs_abort_if(snap->exports == NULL, "Failed to allocate export snapshot");
+    }
+
+    e       = &snap->exports[snap->count++];
+    e->name = strdup(export_name);
+    e->path = strdup(export->path);
+    e->id   = export->id;
+    chimera_nfs_abort_if(e->name == NULL || e->path == NULL, "Failed to allocate export snapshot");
+
+    return 0;
+} /* nfs4_root_readdir_snap_cb */
+
+static void
+nfs4_root_readdir_finish(struct nfs4_root_readdir_state *state)
+{
+    struct nfs_request             *req    = state->req;
+    struct READDIR4res             *res    = &req->res_compound.resarray[req->index].opreaddir;
+    struct nfs_nfs4_readdir_cursor *cursor = &req->readdir4_cursor;
+    int                             eof    = 1;
+    int                             i;
+
+    if (state->error_code == CHIMERA_VFS_EOVERFLOW) {
+        /* Overflow means there are more entries to be read */
+        eof = 0;
+        if (cursor->entries == NULL) {
+            /* RFC 7530 §16.24.4: not even one entry fit in maxcount and we
+             * are not at end-of-directory.  Returning an empty, non-eof page
+             * would stall a paging client. */
+            res->status = NFS4ERR_TOOSMALL;
+        }
+    } else if (state->error_code != CHIMERA_VFS_OK) {
+        chimera_nfs_error("Error iterating exports for readdir: %d", state->error_code);
+        res->status = chimera_nfs4_errno_to_nfsstat4(state->error_code);
+    }
+
+    /* The pseudo-root export list has no change verifier; cookies are
+     * positional and best-effort across list mutations. */
+    memset(res->resok4.cookieverf, 0, sizeof(res->resok4.cookieverf));
+
+    res->resok4.reply.eof     = eof;
+    res->resok4.reply.entries = res->status == NFS4_OK ? cursor->entries : NULL;
+
+    for (i = 0; i < state->num_exports; i++) {
+        free(state->exports[i].name);
+        free(state->exports[i].path);
+    }
+    free(state->exports);
+
+    chimera_nfs4_compound_complete(req, res->status);
+
+    free(state);
+} /* nfs4_root_readdir_finish */
+
+static void nfs4_root_readdir_advance(
+    struct nfs4_root_readdir_state *state);
+
 static void
 nfs4_root_readdir_lookup_callback(
     enum chimera_vfs_error    error_code,
     struct chimera_vfs_attrs *attrs,
     void                     *private_data)
 {
-    struct nfs4_root_readdir_lookup_ctx *ctx   = private_data;
-    struct READDIR4args                 *args  = ctx->args;
-    struct entry4                       *entry = ctx->entry;
+    struct nfs4_root_readdir_state *state  = private_data;
+    struct nfs_request             *req    = state->req;
+    struct READDIR4args            *args   = &req->args_compound->argarray[req->index].opreaddir;
+    struct nfs_nfs4_readdir_cursor *cursor = &req->readdir4_cursor;
+    struct entry4                  *entry  = state->entry;
+    uint32_t                        dbuf_cur;
+
+    state->lookup_done = 1;
 
     if (error_code != CHIMERA_VFS_OK) {
         /* An export root that fails to resolve (deleted directory, config
-        * typo, momentarily unavailable backend) is a routine condition, not
-        * a server fault.  Record it so nfs4_root_readdir_itr_cb surfaces it
-        * as an NFS4ERR_* READDIR status instead of aborting the whole process
-        * (RFC 7530 §16.24 / RFC 8881 §18.23: report errors as status). */
-        ctx->error_code = error_code;
-        return;
+         * typo, momentarily unavailable backend) is a routine condition, not
+         * a server fault.  Surface it as an NFS4ERR_* READDIR status instead
+         * of aborting the whole process (RFC 7530 §16.24 / RFC 8881 §18.23:
+         * report errors as status). */
+        req->encoding->dbuf->used = state->dbuf_before;
+        state->error_code         = error_code;
+    } else {
+        chimera_nfs4_marshall_attrs(attrs,
+                                    args->num_attr_request,
+                                    args->attr_request,
+                                    &entry->attrs.num_attrmask,
+                                    entry->attrs.attrmask,
+                                    3,
+                                    entry->attrs.attr_vals.data,
+                                    &entry->attrs.attr_vals.len,
+                                    256,
+                                    0,
+                                    0, /* pNFS not advertised on the pseudo-fs root */
+                                    0, /* pseudo-fs root has no xattr-capable backend */
+                                    0,
+                                    req->thread->shared->nfs_lease_time_s,
+                                    state->exports[state->pos].id,
+                                    req->thread->shared->fh_key,
+                                    req->thread->shared->fh_sign);
+
+        dbuf_cur = req->encoding->dbuf->used - state->dbuf_before;
+
+        if (cursor->count + dbuf_cur > args->maxcount ||
+            req->encoding->dbuf->used + 8192 > (uint32_t) req->encoding->dbuf->size) {
+            req->encoding->dbuf->used = state->dbuf_before;
+            state->error_code         = CHIMERA_VFS_EOVERFLOW;
+        } else {
+            cursor->count += dbuf_cur;
+
+            if (cursor->entries) {
+                cursor->last->nextentry = entry;
+                cursor->last            = entry;
+            } else {
+                cursor->entries = entry;
+                cursor->last    = entry;
+            }
+            state->pos++;
+        }
     }
-    chimera_nfs4_marshall_attrs(attrs,
-                                args->num_attr_request,
-                                args->attr_request,
-                                &entry->attrs.num_attrmask,
-                                entry->attrs.attrmask,
-                                3,
-                                entry->attrs.attr_vals.data,
-                                &entry->attrs.attr_vals.len,
-                                256,
-                                0,
-                                0, /* pNFS not advertised on the pseudo-fs root */
-                                0, /* pseudo-fs root has no xattr-capable backend */
-                                0,
-                                ctx->lease_time_s,
-                                ctx->export_id,
-                                ctx->fh_key,
-                                ctx->fh_sign);
+
+    /* If the lookup completed synchronously the advance() loop is still on
+     * the stack and continues the walk itself; re-entering it here would
+     * recurse once per export. */
+    if (!state->in_advance) {
+        nfs4_root_readdir_advance(state);
+    }
 } /* nfs4_root_readdir_lookup_callback */
 
-struct nfs4_root_readdir_itr_ctx {
-    uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
-    uint32_t                        root_fh_len;
-    struct chimera_vfs_thread      *vfs_thread;
-    struct nfs_request             *req;
-    struct nfs_nfs4_readdir_cursor *cursor;
-    uint64_t                        attrmask;
-    uint64_t                        cookie;
-    int                             index;
-    enum chimera_vfs_error error_code;
-};
-
-static int
-nfs4_root_readdir_itr_cb(
-    const struct chimera_nfs_export *export,
-    void                            *private_data)
+static void
+nfs4_root_readdir_advance(struct nfs4_root_readdir_state *state)
 {
-    struct nfs4_root_readdir_itr_ctx   *ctx    = private_data;
-    struct nfs_request                 *req    = ctx->req;
-    struct READDIR4args                *args   = &req->args_compound->argarray[req->index].opreaddir;
-    struct nfs_nfs4_readdir_cursor     *cursor = ctx->cursor;
-    uint32_t                            dbuf_cur;
-    uint32_t                            dbuf_before = req->encoding->dbuf->used;
-    struct nfs4_root_readdir_lookup_ctx lookup_ctx;
-    struct entry4                      *entry;
-    const char                         *export_name = export->name;
-    int                                 rc;
+    struct nfs_request              *req = state->req;
+    struct nfs4_root_readdir_export *export;
+    struct entry4                   *entry;
+    int                              rc;
 
-    if (ctx->index < ctx->cookie) {
-        ctx->index++;
-        return 0;
-    }
-    if (ctx->error_code != CHIMERA_VFS_OK) {
-        return -1;
-    }
-    // remove leading '/' from export name if present
-    while (export_name && export_name[0] == '/') {
-        export_name++;
-    }
-    if (!export_name) {
-        chimera_nfs_error("Invalid export name %s for export path %s", export->name, export->path);
-        return 0;
-    }
+    state->in_advance = 1;
 
-    // Report error if any / character is present in the export name after removing leading /
-    if (strchr(export_name, '/')) {
-        chimera_nfs_error("Invalid export name %s for export path %s: export name cannot contain '/' character",
-                          export_name, export->path);
-        return 0;
-    }
-    /* allocate a new entry and populate it with the export name and path */
-    entry = xdr_dbuf_alloc_space(sizeof(*entry), req->encoding->dbuf);
-    if (!entry) {
-        req->encoding->dbuf->used = dbuf_before;
-        ctx->error_code           = CHIMERA_VFS_EOVERFLOW;
-        return -1;
-    }
+    while (state->error_code == CHIMERA_VFS_OK && state->pos < state->num_exports) {
 
-    rc = xdr_dbuf_opaque_copy(&entry->name, export_name, strlen(export_name), req->encoding->dbuf);
-    if (rc) {
-        // TODO: do we need to free the entry here?
-        req->encoding->dbuf->used = dbuf_before;
-        ctx->error_code           = CHIMERA_VFS_EOVERFLOW;
-        return -1;
-    }
-    entry->cookie    = ctx->index;
-    entry->nextentry = NULL;
+        if (state->pos < state->first_pos) {
+            state->pos++;
+            continue;
+        }
 
-    rc = xdr_dbuf_alloc_array(&entry->attrs, attrmask, 3, req->encoding->dbuf);
-    if (rc) {
-        req->encoding->dbuf->used = dbuf_before;
-        ctx->error_code           = CHIMERA_VFS_EOVERFLOW;
-        return -1;
-    }
+        export             = &state->exports[state->pos];
+        state->dbuf_before = req->encoding->dbuf->used;
 
-    rc = xdr_dbuf_alloc_opaque(&entry->attrs.attr_vals,
-                               256,
-                               req->encoding->dbuf);
-    if (rc) {
-        req->encoding->dbuf->used = dbuf_before;
-        ctx->error_code           = CHIMERA_VFS_EOVERFLOW;
-        return -1;
-    }
-    lookup_ctx.entry        = entry;
-    lookup_ctx.args         = args;
-    lookup_ctx.error_code   = CHIMERA_VFS_OK;
-    lookup_ctx.lease_time_s = req->thread->shared->nfs_lease_time_s;
-    lookup_ctx.export_id    = export->id;
-    lookup_ctx.fh_key       = req->thread->shared->fh_key;
-    lookup_ctx.fh_sign      = req->thread->shared->fh_sign;
-    chimera_vfs_lookup(ctx->vfs_thread,
-                       &req->cred,
-                       ctx->root_fh,
-                       ctx->root_fh_len,
-                       export->path,
-                       strlen(export->path),
-                       CHIMERA_VFS_ATTR_FH,
-                       ctx->attrmask,
-                       nfs4_root_readdir_lookup_callback,
-                       &lookup_ctx);
-    if (lookup_ctx.error_code != CHIMERA_VFS_OK) {
-        ctx->error_code           = lookup_ctx.error_code;
-        req->encoding->dbuf->used = dbuf_before;
-        return -1;
-    }
-    dbuf_cur = req->encoding->dbuf->used - dbuf_before;
+        /* allocate a new entry and populate it with the export name */
+        entry = xdr_dbuf_alloc_space(sizeof(*entry), req->encoding->dbuf);
+        if (!entry) {
+            state->error_code = CHIMERA_VFS_EOVERFLOW;
+            break;
+        }
 
-    if (cursor->count + dbuf_cur > args->maxcount ||
-        req->encoding->dbuf->used + 8192 > (uint32_t) req->encoding->dbuf->size) {
-        req->encoding->dbuf->used = dbuf_before;
-        ctx->error_code           = CHIMERA_VFS_EOVERFLOW;
-        return -1;
+        rc = xdr_dbuf_opaque_copy(&entry->name, export->name, strlen(export->name), req->encoding->dbuf);
+        if (rc) {
+            req->encoding->dbuf->used = state->dbuf_before;
+            state->error_code         = CHIMERA_VFS_EOVERFLOW;
+            break;
+        }
+
+        /* Resuming with this cookie skips every export up to and including
+         * this one; the +3 bias keeps clear of reserved cookies 0-2. */
+        entry->cookie    = state->pos + 3;
+        entry->nextentry = NULL;
+
+        rc = xdr_dbuf_alloc_array(&entry->attrs, attrmask, 3, req->encoding->dbuf);
+        if (rc) {
+            req->encoding->dbuf->used = state->dbuf_before;
+            state->error_code         = CHIMERA_VFS_EOVERFLOW;
+            break;
+        }
+
+        rc = xdr_dbuf_alloc_opaque(&entry->attrs.attr_vals,
+                                   256,
+                                   req->encoding->dbuf);
+        if (rc) {
+            req->encoding->dbuf->used = state->dbuf_before;
+            state->error_code         = CHIMERA_VFS_EOVERFLOW;
+            break;
+        }
+
+        state->entry       = entry;
+        state->lookup_done = 0;
+
+        chimera_vfs_lookup(state->vfs_thread,
+                           &req->cred,
+                           state->root_fh,
+                           state->root_fh_len,
+                           export->path,
+                           strlen(export->path),
+                           CHIMERA_VFS_ATTR_FH,
+                           state->attrmask,
+                           nfs4_root_readdir_lookup_callback,
+                           state);
+
+        if (!state->lookup_done) {
+            /* Lookup is in flight; its callback resumes the walk. */
+            state->in_advance = 0;
+            return;
+        }
     }
 
-    cursor->count += dbuf_cur;
+    state->in_advance = 0;
 
-    if (cursor->entries) {
-        cursor->last->nextentry = entry;
-        cursor->last            = entry;
-    } else {
-        cursor->entries = entry;
-        cursor->last    = entry;
-    }
-    return 0;
-} /* nfs4_root_readdir_itr_cb */
+    nfs4_root_readdir_finish(state);
+} /* nfs4_root_readdir_advance */
 
 SYMBOL_EXPORT void
 nfs4_root_readdir(
@@ -330,11 +440,18 @@ nfs4_root_readdir(
 {
     struct READDIR4args              *args   = &req->args_compound->argarray[req->index].opreaddir;
     struct chimera_server_nfs_shared *shared = nfs_thread->shared;
-    struct nfs4_root_readdir_itr_ctx  ctx;
+    struct READDIR4res               *res    = &req->res_compound.resarray[req->index].opreaddir;
     struct nfs_nfs4_readdir_cursor   *cursor;
-    struct READDIR4res               *res = &req->res_compound.resarray[req->index].opreaddir;
-    int                               eof = 1;
+    struct nfs4_root_readdir_state   *state;
+    struct nfs4_root_readdir_snap     snap = { NULL, 0, 0 };
 
+    /* Cookies 1 and 2 are reserved (RFC 7530 §16.24.4); the pseudo-root
+     * never emits them, so receiving one back is a client error. */
+    if (args->cookie == 1 || args->cookie == 2) {
+        res->status = NFS4ERR_BAD_COOKIE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
 
     cursor                    = &req->readdir4_cursor;
     res->resok4.reply.entries = NULL;
@@ -344,30 +461,20 @@ nfs4_root_readdir(
     cursor->entries = NULL;
     cursor->last    = NULL;
 
-    ctx.error_code = CHIMERA_VFS_OK;
-    ctx.vfs_thread = nfs_thread->vfs_thread;
-    ctx.req        = req;
-    ctx.cursor     = cursor;
-    ctx.index      = 0;
-    ctx.cookie     = args->cookie;
-    ctx.attrmask   = chimera_nfs4_attr2mask(args->attr_request,
-                                            args->num_attr_request);
-    chimera_vfs_get_root_fh(ctx.root_fh, &ctx.root_fh_len);
+    chimera_nfs_iterate_exports(shared, nfs4_root_readdir_snap_cb, &snap);
 
-    /* Iterate over exports and populate the readdir response */
-    chimera_nfs_iterate_exports(shared, nfs4_root_readdir_itr_cb, &ctx);
+    state = calloc(1, sizeof(*state));
+    chimera_nfs_abort_if(state == NULL, "Failed to allocate readdir state");
 
-    if (ctx.error_code == CHIMERA_VFS_EOVERFLOW) {
-        /* If we hit overflow, it means there are more entries to be read */
-        eof = 0;
-    } else if (ctx.error_code != CHIMERA_VFS_OK) {
-        /* For any other error, return the error code */
-        chimera_nfs_error("Error iterating exports for readdir: %d", ctx.error_code);
-        res->status = chimera_nfs4_errno_to_nfsstat4(ctx.error_code);
-    }
+    state->req         = req;
+    state->vfs_thread  = nfs_thread->vfs_thread;
+    state->exports     = snap.exports;
+    state->num_exports = snap.count;
+    state->first_pos   = args->cookie ? args->cookie - 2 : 0;
+    state->error_code  = CHIMERA_VFS_OK;
+    state->attrmask    = chimera_nfs4_attr2mask(args->attr_request,
+                                                args->num_attr_request);
+    chimera_vfs_get_root_fh(state->root_fh, &state->root_fh_len);
 
-    res->resok4.reply.eof     = eof;
-    res->resok4.reply.entries = cursor->entries;
-
-    chimera_nfs4_compound_complete(req, res->status);
+    nfs4_root_readdir_advance(state);
 } /* nfs4_root_readdir */

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -168,6 +168,7 @@ chimera_nfs4_mount_get_root_fh_callback(
     int                              hash_input_len;
     int                              fh_fragment_len;
     int                              hostname_len;
+    int                              op;
     XXH128_hash_t                    fsid_hash;
 
     if (status != 0) {
@@ -184,14 +185,10 @@ chimera_nfs4_mount_get_root_fh_callback(
         return;
     }
 
-    /* Check individual operation results */
-    /* res->resarray[0] = SEQUENCE */
-    /* res->resarray[1] = PUTROOTFH */
-    /* res->resarray[2] = LOOKUP */
-    /* res->resarray[3] = GETFH */
-    /* res->resarray[4] = GETATTR */
-
-    if (res->num_resarray < 5) {
+    /* Check individual operation results.  The compound is
+     * SEQUENCE + PUTROOTFH [+ LOOKUP] + GETFH + GETATTR; the LOOKUP is
+     * omitted when the mount targets the bare pseudo-fs root. */
+    if (res->num_resarray < 4) {
         chimera_nfsclient_error("NFS4 mount get_root_fh: incomplete response");
         request->status = CHIMERA_VFS_EIO;
         request->complete(request);
@@ -212,14 +209,19 @@ chimera_nfs4_mount_get_root_fh_callback(
         return;
     }
 
-    if (res->resarray[2].oplookup.status != NFS4_OK) {
-        chimera_nfsclient_error("NFS4 LOOKUP failed: %d", res->resarray[2].oplookup.status);
-        request->status = chimera_nfs4_status_to_errno(res->resarray[2].oplookup.status);
-        request->complete(request);
-        return;
+    op = 2;
+
+    if (res->num_resarray >= 5) {
+        if (res->resarray[op].oplookup.status != NFS4_OK) {
+            chimera_nfsclient_error("NFS4 LOOKUP failed: %d", res->resarray[op].oplookup.status);
+            request->status = chimera_nfs4_status_to_errno(res->resarray[op].oplookup.status);
+            request->complete(request);
+            return;
+        }
+        op++;
     }
 
-    getfh_res = &res->resarray[3];
+    getfh_res = &res->resarray[op];
     if (getfh_res->opgetfh.status != NFS4_OK) {
         chimera_nfsclient_error("NFS4 GETFH failed: %d", getfh_res->opgetfh.status);
         request->status = CHIMERA_VFS_EIO;
@@ -289,32 +291,41 @@ chimera_nfs4_mount_get_root_fh(
     }
     pathlen = strlen(path);
 
+    int op = 0;
+
     memset(&args, 0, sizeof(args));
     args.tag.len      = 0;
     args.minorversion = 1;
     args.argarray     = argarray;
-    args.num_argarray = 5;
 
-    /* Op 0: SEQUENCE (slot fields filled by chimera_nfs4_compound_call) */
-    argarray[0].argop = OP_SEQUENCE;
+    /* SEQUENCE (slot fields filled by chimera_nfs4_compound_call) */
+    argarray[op++].argop = OP_SEQUENCE;
 
-    /* Op 1: PUTROOTFH */
-    argarray[1].argop = OP_PUTROOTFH;
+    /* PUTROOTFH */
+    argarray[op++].argop = OP_PUTROOTFH;
 
-    /* Op 2: LOOKUP - lookup the export/share name */
-    argarray[2].argop                 = OP_LOOKUP;
-    argarray[2].oplookup.objname.data = (uint8_t *) path;
-    argarray[2].oplookup.objname.len  = pathlen;
+    /* LOOKUP the export/share name.  A mount of the bare pseudo-fs root
+     * ("server:/") has no name to look up; the root FH itself is the mount
+     * point. */
+    if (pathlen > 0) {
+        argarray[op].argop                 = OP_LOOKUP;
+        argarray[op].oplookup.objname.data = (uint8_t *) path;
+        argarray[op].oplookup.objname.len  = pathlen;
+        op++;
+    }
 
-    /* Op 3: GETFH */
-    argarray[3].argop = OP_GETFH;
+    /* GETFH */
+    argarray[op++].argop = OP_GETFH;
 
-    /* Op 4: GETATTR - request basic attributes */
-    argarray[4].argop                      = OP_GETATTR;
-    attr_request[0]                        = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]                        = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32));
-    argarray[4].opgetattr.attr_request     = attr_request;
-    argarray[4].opgetattr.num_attr_request = 2;
+    /* GETATTR - request basic attributes */
+    argarray[op].argop                      = OP_GETATTR;
+    attr_request[0]                         = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
+    attr_request[1]                         = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32));
+    argarray[op].opgetattr.attr_request     = attr_request;
+    argarray[op].opgetattr.num_attr_request = 2;
+    op++;
+
+    args.num_argarray = op;
 
     (void) session;
 


### PR DESCRIPTION
## Summary

Mounting the bare NFSv4 pseudo-root (`server:/`) and listing it crashed the
server with a deterministic AddressSanitizer stack-use-after-return whenever
the export was backed by a blocking VFS module (linux, io_uring, diskfs).
This PR fixes the crash, fixes two latent defects in the same loop, and adds
a wire-path regression test that reproduces the original failure.

## The bug

`nfs4_root_readdir` assumed `chimera_vfs_lookup` completes synchronously: the
per-export iterator passed a stack-allocated context as the lookup callback's
private data, read its error field immediately after the call returned, and
completed the compound right after the iteration. On blocking backends
lookups are delegated and complete via the event-loop doorbell, so the
callback fired after the iterator frame was gone and dereferenced dead stack
memory.

## The fix

The pseudo-root READDIR is restructured as an async state machine:

- The export list is snapshotted under `exports_lock`, since exports can be
  removed via REST while lookups are in flight.
- Exports are walked one lookup at a time, with each entry's attributes
  marshalled in the completion callback; the compound is completed only when
  the walk finishes.
- A trampoline flag keeps synchronous completions (memfs) from recursing once
  per export.

Two latent defects in the same loop are fixed along the way:

- The entry cookie was never incremented, so every entry carried the same
  cookie and a paginating client would loop forever on resume. Cookies are
  now the export's snapshot position biased past the reserved values 0-2
  (RFC 7530 §16.24.4), and reserved client cookies are rejected with
  `NFS4ERR_BAD_COOKIE`.
- An overflow before the first entry now returns `NFS4ERR_TOOSMALL` instead
  of an empty non-eof page that would stall the client.

## Test coverage

No existing test mounted the bare pseudo-root, which is why this path was
never exercised end to end. The second commit closes that gap:

- The NFS client's v4 mount learns to target the pseudo-root: the LOOKUP op
  is omitted from the mount compound when the mount path is empty, and the
  root FH itself becomes the mount point.
- New `posix_test_pseudo_root` mounts `127.0.0.1:/` with `vers=4`, asserts
  READDIR of the pseudo-root lists the export exactly once, enters the export
  by lookup from the root, and round-trips file I/O through the pseudo-root
  path.
- Registered for `nfs4_memfs` (inline lookup completions) and `nfs4_linux`
  (delegated, asynchronous completions — the configuration that reproduced
  the crash).

## Commits

| Commit | Description |
|---|---|
| `75ee163e` | nfs4: fix stack-use-after-return in pseudo-root READDIR |
| `51970a90` | tests: exercise the NFSv4 pseudo-root mount on the wire path |