### PR TITLE
nfs4: validate pseudo-root READDIR cookies and report per-op mount errors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,4 +9,5 @@ The following individuals and organizations have contributed to this project:
 Ben Jarvis
 Alain Renaud
 Joe Habermann
+Peter Dunlap
 Quantum Corporation

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -304,12 +304,54 @@ static int posix_test_ro_export __attribute__ ((unused)) = 0;
 
 /* Name of the subdirectory (relative to the backend root) that the read-only
  * export is mounted at; the read-write export sees it as "/share/ro". */
-#define POSIX_TEST_RO_SUBDIR "ro"
+#define POSIX_TEST_RO_SUBDIR             "ro"
 
 /* Explicit export id above the default nfs_max_exports count cap (4096),
  * so tests cover pinned-id file-handle attribution across the whole 16-bit
  * id space rather than only small auto-assigned ids. */
-#define POSIX_TEST_EXPORT_ID 4242
+#define POSIX_TEST_EXPORT_ID             4242
+
+/* When non-zero (set before posix_test_init), posix_test_start_nfs_server
+ * creates this many EXTRA exports alongside "/share", each its own mount of
+ * the same backend rooted at its own subdirectory.
+ *
+ * The pseudo-root test uses them to make an NFSv4 pseudo-fs root listing span
+ * multiple READDIR pages, reaching the page-boundary path where the server
+ * fills a page and returns eof=0.  The client's maxcount is fixed at 8192 and
+ * each entry costs a 256-byte attr_vals allocation plus its entry4, name and
+ * attrmask, which fits 23 entries per page in practice; see the bound in
+ * test_pseudo_root.c.
+ *
+ * Export names are fixed width ("page00", "page01", ...) so no name is a
+ * string prefix of another: chimera_nfs_find_export_path matches export names
+ * by prefix, the same collision the "roshare" note below avoids. */
+static int posix_test_extra_exports __attribute__ ((unused)) = 0;
+
+/* Name of the i'th extra export and its mount (fixed width, see above). */
+#define POSIX_TEST_EXTRA_EXPORT_NAME_FMT "page%02d"
+
+/* Pinned ids for the extra exports, clear of POSIX_TEST_EXPORT_ID and the
+ * read-only export's POSIX_TEST_EXPORT_ID + 1. */
+#define POSIX_TEST_EXTRA_EXPORT_ID_BASE  (POSIX_TEST_EXPORT_ID + 100)
+
+/* Build the i'th extra export's module_path for the given backend, matching
+ * how the "/share" mount roots itself: passthrough backends live under the
+ * host session dir, everything else at the backend root. */
+static inline void
+posix_test_extra_export_module_path(
+    const char *nfs_backend_name,
+    const char *session_dir,
+    const char *name,
+    char       *out,
+    size_t      out_size)
+{
+    if (strcmp(nfs_backend_name, "linux") == 0 ||
+        strcmp(nfs_backend_name, "io_uring") == 0) {
+        snprintf(out, out_size, "%s/%s", session_dir, name);
+    } else {
+        snprintf(out, out_size, "/%s", name);
+    }
+} // posix_test_extra_export_module_path
 
 // Helper to configure diskfs backend
 static inline void
@@ -472,6 +514,39 @@ posix_test_start_nfs_server(struct posix_test_env *env)
         }
     }
 
+    /* Create every extra export's backing subdirectory before any mount of
+     * this backend exists: for the in-backend case chimera_server_mkpath does a
+     * transient mount of the backend root, which would otherwise collide in the
+     * mount table with the "/share" mount below.  Same reason the read-only
+     * subdir is created up here. */
+    for (int i = 0; i < posix_test_extra_exports; i++) {
+        char name[32], module_path[400];
+
+        snprintf(name, sizeof(name), POSIX_TEST_EXTRA_EXPORT_NAME_FMT, i);
+        posix_test_extra_export_module_path(nfs_backend_name, env->session_dir,
+                                            name, module_path,
+                                            sizeof(module_path));
+
+        /* For the passthrough backends the subdirectory is a real host
+         * directory under the session dir, so create it directly:
+         * chimera_server_mkpath transiently mounts the backend at "/", and the
+         * linux/io_uring mount derives a file handle via name_to_handle_at(),
+         * which the container's overlayfs root rejects with EOPNOTSUPP. */
+        if (strcmp(nfs_backend_name, "linux") == 0 ||
+            strcmp(nfs_backend_name, "io_uring") == 0) {
+            if (mkdir(module_path, 0777) != 0 && errno != EEXIST) {
+                fprintf(stderr, "Failed to create extra export subdir %s: %s\n",
+                        module_path, strerror(errno));
+                exit(EXIT_FAILURE);
+            }
+        } else if (chimera_server_mkpath(env->server, share_module, module_path,
+                                         0777) != 0) {
+            fprintf(stderr, "Failed to create extra export subdir %s in %s\n",
+                    module_path, share_module);
+            exit(EXIT_FAILURE);
+        }
+    }
+
     chimera_server_mount(env->server, "share", share_module, share_module_path,
                          NULL);
 
@@ -503,6 +578,32 @@ posix_test_start_nfs_server(struct posix_test_env *env)
         if (chimera_server_create_export(env->server, "/roshare", "/roshare",
                                          POSIX_TEST_EXPORT_ID + 1, NULL) != 0) {
             fprintf(stderr, "Failed to create /roshare export\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    /* One mount plus one pinned-id export per subdirectory created above.
+     * These exist only to give the NFSv4 pseudo-fs root enough entries to span
+     * multiple READDIR pages. */
+    for (int i = 0; i < posix_test_extra_exports; i++) {
+        char name[32], module_path[400], export_path[64];
+
+        snprintf(name, sizeof(name), POSIX_TEST_EXTRA_EXPORT_NAME_FMT, i);
+        snprintf(export_path, sizeof(export_path), "/%s", name);
+        posix_test_extra_export_module_path(nfs_backend_name, env->session_dir,
+                                            name, module_path,
+                                            sizeof(module_path));
+
+        if (chimera_server_mount(env->server, name, share_module, module_path,
+                                 NULL) != 0) {
+            fprintf(stderr, "Failed to mount extra export %s\n", name);
+            exit(EXIT_FAILURE);
+        }
+
+        if (chimera_server_create_export(env->server, export_path, export_path,
+                                         POSIX_TEST_EXTRA_EXPORT_ID_BASE + i,
+                                         NULL) != 0) {
+            fprintf(stderr, "Failed to create %s export\n", export_path);
             exit(EXIT_FAILURE);
         }
     }

--- a/src/posix/tests/test_pseudo_root.c
+++ b/src/posix/tests/test_pseudo_root.c
@@ -13,8 +13,9 @@
  * request thread.
  *
  * Verifies that READDIR of the root lists the "/share" export, that the
- * export can be entered by lookup from the root, and that files created
- * through the pseudo-root path are readable back through it.
+ * export can be entered by lookup from the root, that files created through
+ * the pseudo-root path are readable back through it, and that mounting an
+ * export the server does not have reports ENOENT.
  */
 
 #include "posix_test_common.h"
@@ -40,6 +41,23 @@ main(
 
     if (env.nfs_version != 4) {
         fprintf(stderr, "test_pseudo_root requires an NFS4 backend\n");
+        posix_test_fail(&env);
+    }
+
+    /* Mounting an export the server does not have must report ENOENT.  The
+     * mount compound's LOOKUP fails with NFS4ERR_NOENT, and the client maps
+     * that per-op status rather than collapsing it into EIO. */
+    rc = chimera_posix_mount_with_options("/badexport", "nfs",
+                                          "127.0.0.1:/nosuchexport", "vers=4");
+    if (rc == 0) {
+        fprintf(stderr, "Mount of a nonexistent export unexpectedly "
+                "succeeded\n");
+        posix_test_fail(&env);
+    }
+
+    if (errno != ENOENT) {
+        fprintf(stderr, "Mount of a nonexistent export reported %s, "
+                "expected ENOENT\n", strerror(errno));
         posix_test_fail(&env);
     }
 

--- a/src/posix/tests/test_pseudo_root.c
+++ b/src/posix/tests/test_pseudo_root.c
@@ -12,13 +12,66 @@
  * crashed with a stack-use-after-return when a lookup completed off the
  * request thread.
  *
- * Verifies that READDIR of the root lists the "/share" export, that the
- * export can be entered by lookup from the root, that files created through
- * the pseudo-root path are readable back through it, and that mounting an
- * export the server does not have reports ENOENT.
+ * The listing deliberately spans multiple READDIR pages.  Two separate paths
+ * are covered, and they do not depend on each other:
+ *
+ *   - The first_pos resume runs on essentially every entry no matter how the
+ *     server pages, because chimera's POSIX readdir consumes one entry per
+ *     call and re-issues a fresh READDIR from that entry's cookie.  A
+ *     41-entry listing costs 42 READDIR RPCs, each resuming from a cookie.
+ *   - The server's mid-walk dbuf overflow -- it fills a page, rolls the
+ *     pending entry back and returns short -- needs more exports than one page
+ *     holds.  The client's maxcount is fixed at 8192 and each entry costs a
+ *     256-byte attr_vals allocation plus its entry4, name and attrmask, which
+ *     in practice fits 23 entries per page, so the extra exports below drive
+ *     that rollback 18 times over.
+ *
+ * Every export must appear exactly once across the whole listing, which catches
+ * a first_pos resume that repeats or skips an entry.
+ *
+ * What this test cannot see is the server's eof flag.  chimera's client zeroes
+ * it whenever the caller's callback stops the entry walk
+ * (src/vfs/nfs/nfs4_readdir.c), which the one-entry-per-call POSIX readdir does
+ * on every page, and the loop below ends on an entry-less reply rather than on
+ * eof -- so a server that reported eof wrongly in either direction would still
+ * pass.  For the same reason a lost page *tail* is invisible: only entry 1 of
+ * each page is ever consumed.  Both need a raw-wire NFSv4 harness.
+ *
+ * Also verifies that the export can be entered by lookup from the root, that
+ * files created through the pseudo-root path are readable back through it, and
+ * that mounting an export the server does not have reports ENOENT.
  */
 
 #include "posix_test_common.h"
+
+/* Conservative upper bound on the entries the server fits in one READDIR page.
+ * Measured at 23 for the current entry size and the client's 8192 maxcount
+ * (set in src/vfs/nfs/nfs4_readdir.c); rounded up so a small change in entry
+ * size does not quietly invalidate the assert below.  Raising maxcount there
+ * means raising this. */
+#define PSEUDO_ROOT_MAX_PAGE_ENTRIES 27
+
+/* Enough exports that the pseudo-root listing needs more than one READDIR
+ * page -- see the page-size arithmetic above. */
+#define PSEUDO_ROOT_EXTRA_EXPORTS    40
+
+/* "share" plus the extras must exceed one page.  Note this only catches
+ * lowering PSEUDO_ROOT_EXTRA_EXPORTS: both operands are constants in this file,
+ * so it cannot notice the real per-page capacity growing past the export count
+ * and the listing quietly collapsing to a single page.  Shrinking the server's
+ * 256-byte attr_vals allocation (src/server/nfs/nfs4_root.c) or raising the
+ * client's maxcount (src/vfs/nfs/nfs4_readdir.c) both do that; both carry a
+ * comment pointing back here, and either means re-deriving
+ * PSEUDO_ROOT_MAX_PAGE_ENTRIES by hand. */
+_Static_assert(1 + PSEUDO_ROOT_EXTRA_EXPORTS > PSEUDO_ROOT_MAX_PAGE_ENTRIES,
+               "pseudo-root export count no longer spans multiple READDIR "
+               "pages; raise PSEUDO_ROOT_EXTRA_EXPORTS");
+
+/* Fixed-width export names ("page00") stay distinct only below 100 extras;
+ * past that snprintf widens the field and "page100" gains "page10" as a
+ * prefix, which chimera_nfs_find_export_path's prefix match would confuse. */
+_Static_assert(PSEUDO_ROOT_EXTRA_EXPORTS <= 100,
+               "extra export names are no longer fixed width");
 
 int
 main(
@@ -31,17 +84,36 @@ main(
     struct stat           st;
     int                   rc;
     int                   fd;
-    int                   found_share = 0;
     int                   num_entries = 0;
+    int                   num_iter    = 0;
     const char           *test_data   = "pseudo-root";
     char                  buf[64];
     ssize_t               len;
+    int                   i;
+
+    /* Every export the pseudo-root must list, and how often we saw it. */
+    struct {
+        char name[32];
+        int  seen;
+    } expect[1 + PSEUDO_ROOT_EXTRA_EXPORTS];
+    const int             num_expect = 1 + PSEUDO_ROOT_EXTRA_EXPORTS;
+
+    posix_test_extra_exports = PSEUDO_ROOT_EXTRA_EXPORTS;
 
     posix_test_init(&env, argv, argc);
 
     if (env.nfs_version != 4) {
         fprintf(stderr, "test_pseudo_root requires an NFS4 backend\n");
         posix_test_fail(&env);
+    }
+
+    snprintf(expect[0].name, sizeof(expect[0].name), "share");
+    expect[0].seen = 0;
+
+    for (i = 0; i < PSEUDO_ROOT_EXTRA_EXPORTS; i++) {
+        snprintf(expect[i + 1].name, sizeof(expect[i + 1].name),
+                 POSIX_TEST_EXTRA_EXPORT_NAME_FMT, i);
+        expect[i + 1].seen = 0;
     }
 
     /* Mounting an export the server does not have must report ENOENT.  The
@@ -69,7 +141,8 @@ main(
         posix_test_fail(&env);
     }
 
-    /* READDIR of the pseudo-root must list each export exactly once. */
+    /* READDIR of the pseudo-root must list each export exactly once, across
+     * however many pages the listing takes. */
     dir = chimera_posix_opendir("/test");
     if (!dir) {
         fprintf(stderr, "Failed to open pseudo-root directory: %s\n",
@@ -77,29 +150,75 @@ main(
         posix_test_fail(&env);
     }
 
-    while ((entry = chimera_posix_readdir(dir)) != NULL) {
+    for (;;) {
+        /* chimera_posix_readdir returns NULL for both end-of-directory and
+         * failure, setting errno only on failure, so it is cleared before every
+         * call: without that the loop would read a mid-listing RPC error as a
+         * short but successful listing, and a failure on the final eof-only
+         * READDIR would not be noticed at all.  Clearing it once before the
+         * loop is not enough -- the fprintf below can set it too. */
+        errno = 0;
+        entry = chimera_posix_readdir(dir);
+
+        if (!entry) {
+            break;
+        }
+
+        /* A broken first_pos resume re-serves the same page forever, so bound
+         * the listing: a correct one is every export plus "." and "..".
+         * Checked ahead of the "."/".." skip so no reply can spin here at all.
+         * Without this the failure is a bare ctest timeout, indistinguishable
+         * from a slow machine. */
+        if (++num_iter > num_expect + 2) {
+            fprintf(stderr, "Pseudo-root listing did not terminate after %d "
+                    "entries (still returning '%s'); a broken first_pos resume "
+                    "re-serves the same page forever\n", num_iter - 1,
+                    entry->d_name);
+            posix_test_fail(&env);
+        }
+
         if (strcmp(entry->d_name, ".") == 0 ||
             strcmp(entry->d_name, "..") == 0) {
             continue;
         }
+
         fprintf(stderr, "pseudo-root entry: %s\n", entry->d_name);
         num_entries++;
-        if (strcmp(entry->d_name, "share") == 0) {
-            found_share++;
+
+        for (i = 0; i < num_expect; i++) {
+            if (strcmp(entry->d_name, expect[i].name) == 0) {
+                expect[i].seen++;
+                break;
+            }
         }
+
+        if (i == num_expect) {
+            fprintf(stderr, "Unexpected pseudo-root entry: %s\n",
+                    entry->d_name);
+            posix_test_fail(&env);
+        }
+    }
+
+    if (errno != 0) {
+        fprintf(stderr, "READDIR of the pseudo-root failed after %d entries: "
+                "%s\n", num_entries, strerror(errno));
+        posix_test_fail(&env);
     }
 
     chimera_posix_closedir(dir);
 
-    if (found_share != 1) {
-        fprintf(stderr, "Export 'share' listed %d times in pseudo-root, "
-                "expected exactly once\n", found_share);
-        posix_test_fail(&env);
+    for (i = 0; i < num_expect; i++) {
+        if (expect[i].seen != 1) {
+            fprintf(stderr, "Export '%s' listed %d times in pseudo-root, "
+                    "expected exactly once\n", expect[i].name,
+                    expect[i].seen);
+            posix_test_fail(&env);
+        }
     }
 
-    if (num_entries != 1) {
-        fprintf(stderr, "Pseudo-root listed %d entries, expected 1\n",
-                num_entries);
+    if (num_entries != num_expect) {
+        fprintf(stderr, "Pseudo-root listed %d entries, expected %d\n",
+                num_entries, num_expect);
         posix_test_fail(&env);
     }
 

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -12,6 +12,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_attr.h"
 #include "nfs4_status.h"
+#include "nfs4_root_cookie.h"
 #include "vfs/vfs_procs.h"
 #include "common/logging.h"
 #include "common/macros.h"
@@ -167,7 +168,19 @@ nfs4_root_lookup(
  * The pseudo-root has its own cookie space: entry cookies are the export's
  * snapshot position biased by +3 to stay clear of the reserved cookie values
  * 0-2 (RFC 7530 §16.24.4), and a client cookie resumes the walk at the
- * position after the entry that carried it.
+ * position after the entry that carried it.  The cookie is validated against
+ * the snapshot (nfs4_root_cookie.h) before the walk starts; a reserved or
+ * out-of-range cookie gets NFS4ERR_BAD_COOKIE rather than truncating into the
+ * int resume position.
+ *
+ * Cookies are positional and the cookieverf is always zero, so a client
+ * mid-walk across a list mutation is not protected.  chimera_nfs_add_export
+ * prepends, so an addition shifts every position by one and the client
+ * re-reads an entry it already saw; a removal shifts the other way and an
+ * export the client has not reached yet is skipped.  Only a cookie left past
+ * the end of the shrunken snapshot is caught, as NFS4ERR_BAD_COOKIE.  Closing
+ * that needs an export-list generation counter returned as the cookieverf,
+ * which is what RFC 7530 §16.24.4 provides it for.
  */
 
 struct nfs4_root_readdir_export {
@@ -239,13 +252,27 @@ nfs4_root_readdir_snap_cb(
 } /* nfs4_root_readdir_snap_cb */
 
 static void
+nfs4_root_readdir_exports_free(
+    struct nfs4_root_readdir_export *exports,
+    int                              count)
+{
+    int i;
+
+    for (i = 0; i < count; i++) {
+        free(exports[i].name);
+        free(exports[i].path);
+    }
+
+    free(exports);
+} /* nfs4_root_readdir_exports_free */
+
+static void
 nfs4_root_readdir_finish(struct nfs4_root_readdir_state *state)
 {
     struct nfs_request             *req    = state->req;
     struct READDIR4res             *res    = &req->res_compound.resarray[req->index].opreaddir;
     struct nfs_nfs4_readdir_cursor *cursor = &req->readdir4_cursor;
     int                             eof    = 1;
-    int                             i;
 
     if (state->error_code == CHIMERA_VFS_EOVERFLOW) {
         /* Overflow means there are more entries to be read */
@@ -268,11 +295,7 @@ nfs4_root_readdir_finish(struct nfs4_root_readdir_state *state)
     res->resok4.reply.eof     = eof;
     res->resok4.reply.entries = res->status == NFS4_OK ? cursor->entries : NULL;
 
-    for (i = 0; i < state->num_exports; i++) {
-        free(state->exports[i].name);
-        free(state->exports[i].path);
-    }
-    free(state->exports);
+    nfs4_root_readdir_exports_free(state->exports, state->num_exports);
 
     chimera_nfs4_compound_complete(req, res->status);
 
@@ -387,8 +410,9 @@ nfs4_root_readdir_advance(struct nfs4_root_readdir_state *state)
         }
 
         /* Resuming with this cookie skips every export up to and including
-         * this one; the +3 bias keeps clear of reserved cookies 0-2. */
-        entry->cookie    = state->pos + 3;
+         * this one; the bias keeps clear of reserved cookies 0-2.  Paired with
+         * nfs4_root_readdir_cookie_first_pos, which inverts it. */
+        entry->cookie    = nfs4_root_readdir_pos_cookie(state->pos);
         entry->nextentry = NULL;
 
         rc = xdr_dbuf_alloc_array(&entry->attrs, attrmask, 3, req->encoding->dbuf);
@@ -443,25 +467,28 @@ nfs4_root_readdir(
     struct READDIR4res               *res    = &req->res_compound.resarray[req->index].opreaddir;
     struct nfs_nfs4_readdir_cursor   *cursor;
     struct nfs4_root_readdir_state   *state;
-    struct nfs4_root_readdir_snap     snap = { NULL, 0, 0 };
+    struct nfs4_root_readdir_snap     snap      = { NULL, 0, 0 };
+    int                               first_pos = 0;
 
-    /* Cookies 1 and 2 are reserved (RFC 7530 §16.24.4); the pseudo-root
-     * never emits them, so receiving one back is a client error. */
-    if (args->cookie == 1 || args->cookie == 2) {
-        res->status = NFS4ERR_BAD_COOKIE;
+    chimera_nfs_iterate_exports(shared, nfs4_root_readdir_snap_cb, &snap);
+
+    /* The valid cookie range depends on the export count, so the cookie is
+     * validated against the snapshot -- before any walk state is allocated. */
+    res->status = nfs4_root_readdir_cookie_first_pos(args->cookie, snap.count,
+                                                     &first_pos);
+
+    if (res->status != NFS4_OK) {
+        nfs4_root_readdir_exports_free(snap.exports, snap.count);
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }
 
     cursor                    = &req->readdir4_cursor;
     res->resok4.reply.entries = NULL;
-    res->status               = NFS4_OK;
 
     cursor->count   = 256;
     cursor->entries = NULL;
     cursor->last    = NULL;
-
-    chimera_nfs_iterate_exports(shared, nfs4_root_readdir_snap_cb, &snap);
 
     state = calloc(1, sizeof(*state));
     chimera_nfs_abort_if(state == NULL, "Failed to allocate readdir state");
@@ -470,7 +497,7 @@ nfs4_root_readdir(
     state->vfs_thread  = nfs_thread->vfs_thread;
     state->exports     = snap.exports;
     state->num_exports = snap.count;
-    state->first_pos   = args->cookie ? args->cookie - 2 : 0;
+    state->first_pos   = first_pos;
     state->error_code  = CHIMERA_VFS_OK;
     state->attrmask    = chimera_nfs4_attr2mask(args->attr_request,
                                                 args->num_attr_request);

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -422,6 +422,10 @@ nfs4_root_readdir_advance(struct nfs4_root_readdir_state *state)
             break;
         }
 
+        /* Per-entry attribute buffer.  test_pseudo_root sizes its export list
+         * off this to force a multi-page listing; shrinking it means raising
+         * that test's PSEUDO_ROOT_MAX_PAGE_ENTRIES too, or its page-boundary
+         * coverage lapses. */
         rc = xdr_dbuf_alloc_opaque(&entry->attrs.attr_vals,
                                    256,
                                    req->encoding->dbuf);

--- a/src/server/nfs/nfs4_root_cookie.h
+++ b/src/server/nfs/nfs4_root_cookie.h
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+
+#include "nfs4_xdr.h"
+
+/*
+ * Cookie policy for the NFSv4 pseudo-fs root READDIR (nfs4_root_readdir).
+ *
+ * The pseudo-root has its own cookie space: an entry's cookie is its position
+ * in the export snapshot biased by +3, staying clear of the reserved cookie
+ * values 0-2 (RFC 7530 16.24.4).  Resuming with cookie C therefore restarts
+ * the walk at position C - 2, just past the entry that carried C.
+ *
+ * Valid cookies are 0 (start of directory) and [3, num_exports + 2].  Anything
+ * else is a client error: 1 and 2 are reserved and never emitted, and a cookie
+ * above the range is either garbage or a stale cookie into a list that has
+ * since shrunk.  Both get NFS4ERR_BAD_COOKIE, which makes a client restart the
+ * directory read.  The alternative -- truncating a 64-bit cookie into the int
+ * resume position -- turns a cookie like 0x80000002 into a negative first_pos,
+ * which never trips the resume test and silently restarts the listing at 0,
+ * feeding the client duplicate entries.
+ *
+ * Bounding the cookie by num_exports is also what keeps *first_pos within
+ * [0, num_exports], so the resume position can stay a plain int.
+ *
+ * num_exports is the snapshot's entry count and must not be negative: the
+ * range check widens it to uint64_t, so a negative count would wrap and accept
+ * almost any cookie.
+ *
+ * *first_pos is written only on NFS4_OK.
+ */
+
+/* Bias applied to a snapshot position to produce its wire cookie.  Encode and
+ * decode below are the only two places that know it. */
+#define NFS4_ROOT_COOKIE_BIAS 3
+
+/* The cookie carried by the entry at snapshot position pos. */
+static inline uint64_t
+nfs4_root_readdir_pos_cookie(int pos)
+{
+    return (uint64_t) pos + NFS4_ROOT_COOKIE_BIAS;
+} /* nfs4_root_readdir_pos_cookie */
+
+/* Inverse of nfs4_root_readdir_pos_cookie, shifted by one: resuming with a
+ * cookie restarts *after* the entry that carried it. */
+static inline nfsstat4
+nfs4_root_readdir_cookie_first_pos(
+    uint64_t cookie,
+    int      num_exports,
+    int     *first_pos)
+{
+    if (cookie == 0) {
+        *first_pos = 0;
+        return NFS4_OK;
+    }
+
+    /* Reserved (RFC 7530 16.24.4); the pseudo-root never emits them, so
+     * receiving one back is a client error. */
+    if (cookie < NFS4_ROOT_COOKIE_BIAS) {
+        return NFS4ERR_BAD_COOKIE;
+    }
+
+    /* The largest cookie emitted is the last entry's, i.e. the cookie for
+     * position num_exports - 1.  Written out rather than as
+     * nfs4_root_readdir_pos_cookie(num_exports - 1) so an empty snapshot does
+     * not depend on -1 wrapping.  Compared in uint64_t so neither side is
+     * truncated. */
+    if (cookie > (uint64_t) num_exports + NFS4_ROOT_COOKIE_BIAS - 1) {
+        return NFS4ERR_BAD_COOKIE;
+    }
+
+    *first_pos = (int) (cookie - (NFS4_ROOT_COOKIE_BIAS - 1));
+
+    return NFS4_OK;
+} /* nfs4_root_readdir_cookie_first_pos */

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -114,6 +114,18 @@ target_include_directories(test_fh_security PRIVATE
 add_dependencies(test_fh_security chimera_nfs_common)
 add_test(NAME chimera/server/nfs/fh_security COMMAND test_fh_security)
 
+# Unit test for the pseudo-fs root READDIR cookie policy (nfs4_root_cookie.h):
+# reserved and out-of-range client cookies must be rejected rather than
+# truncated into the int resume position.  The header includes the generated
+# nfs4_xdr.h (for nfsstat4), hence the chimera_nfs_common dependency.
+add_executable(test_root_cookie test_root_cookie.c)
+target_include_directories(test_root_cookie PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src
+    ${NFS_COMMON_INCLUDE_DIR})
+add_dependencies(test_root_cookie chimera_nfs_common)
+add_test(NAME chimera/server/nfs/root_cookie COMMAND test_root_cookie)
+
 # Regression test: open_owner / lock_owner refcount lifetime under
 # a lease sweep racing an in-flight OPEN/LOCK.  Links the exported nfs4_state
 # API the same way as test_state_table (no production sources compiled in).

--- a/src/server/nfs/tests/test_root_cookie.c
+++ b/src/server/nfs/tests/test_root_cookie.c
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Cookie policy for the NFSv4 pseudo-fs root READDIR (nfs4_root_cookie.h).
+ *
+ * args->cookie is a 64-bit nfs_cookie4 while the export walk's resume position
+ * is an int, so a garbage cookie such as 0x80000002 once truncated to a
+ * negative first_pos, never tripped the resume test, and restarted the listing
+ * at position 0 -- the client got duplicate entries instead of
+ * NFS4ERR_BAD_COOKIE.
+ *
+ * The reserved and garbage cookies are unreachable from chimera's own NFS
+ * client: it clamps cookies below 3 to 0, synthesizes "." and ".." locally,
+ * and never sends a cookie it did not receive from the server.  An
+ * out-of-range cookie is reachable -- a client mid-walk when an export is
+ * removed holds a cookie into a list that has since shrunk -- but not
+ * deterministically.  Exercise the decision logic directly instead.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "nfs4_root_cookie.h"
+
+#define CHECK(cond)                                                 \
+        do {                                                        \
+            if (!(cond)) {                                          \
+                fprintf(stderr,                                     \
+                        "test_root_cookie: FAILED at %s:%d: %s\n",  \
+                        __FILE__, __LINE__, # cond);                \
+                return 1;                                           \
+            }                                                       \
+        } while (0)
+
+/* Cookie 0 means "start of directory" whatever the export count. */
+static int
+test_start_of_directory(void)
+{
+    int first_pos = -1;
+
+    CHECK(nfs4_root_readdir_cookie_first_pos(0, 4, &first_pos) == NFS4_OK);
+    CHECK(first_pos == 0);
+
+    first_pos = -1;
+    CHECK(nfs4_root_readdir_cookie_first_pos(0, 0, &first_pos) == NFS4_OK);
+    CHECK(first_pos == 0);
+
+    return 0;
+} /* test_start_of_directory */
+
+/* 1 and 2 are reserved; the pseudo-root never emits them. */
+static int
+test_reserved_cookies_rejected(void)
+{
+    int first_pos = 7;
+
+    CHECK(nfs4_root_readdir_cookie_first_pos(1, 4, &first_pos) ==
+          NFS4ERR_BAD_COOKIE);
+    CHECK(nfs4_root_readdir_cookie_first_pos(2, 4, &first_pos) ==
+          NFS4ERR_BAD_COOKIE);
+
+    /* first_pos is untouched on rejection. */
+    CHECK(first_pos == 7);
+
+    return 0;
+} /* test_reserved_cookies_rejected */
+
+/* Entry cookies are pos + 3, so cookie C resumes at C - 2. */
+static int
+test_resume_positions(void)
+{
+    int first_pos = -1;
+
+    /* First entry's cookie: resume just past position 0. */
+    CHECK(nfs4_root_readdir_cookie_first_pos(3, 4, &first_pos) == NFS4_OK);
+    CHECK(first_pos == 1);
+
+    /* Last entry's cookie with 4 exports: resume at end-of-directory. */
+    CHECK(nfs4_root_readdir_cookie_first_pos(6, 4, &first_pos) == NFS4_OK);
+    CHECK(first_pos == 4);
+
+    return 0;
+} /* test_resume_positions */
+
+/* The encode side (nfs4_root_readdir_pos_cookie, used by nfs4_root_readdir to
+ * stamp entry->cookie) and the decode side must stay inverses: resuming with
+ * the cookie of position p restarts at p + 1, and every emitted cookie is
+ * accepted.  They are separate functions, so pin the pairing here. */
+static int
+test_encode_decode_round_trip(void)
+{
+    const int num_exports = 8;
+    int       pos, first_pos;
+
+    for (pos = 0; pos < num_exports; pos++) {
+        uint64_t cookie = nfs4_root_readdir_pos_cookie(pos);
+
+        /* Never collides with the reserved values. */
+        CHECK(cookie > 2);
+
+        first_pos = -1;
+        CHECK(nfs4_root_readdir_cookie_first_pos(cookie, num_exports,
+                                                 &first_pos) == NFS4_OK);
+        CHECK(first_pos == pos + 1);
+    }
+
+    /* One past the last emitted cookie is out of range. */
+    first_pos = -1;
+    CHECK(nfs4_root_readdir_cookie_first_pos(
+              nfs4_root_readdir_pos_cookie(num_exports - 1) + 1,
+              num_exports, &first_pos) == NFS4ERR_BAD_COOKIE);
+
+    return 0;
+} /* test_encode_decode_round_trip */
+
+/* Anything above the last entry's cookie is garbage or stale. */
+static int
+test_out_of_range_rejected(void)
+{
+    int first_pos = -1;
+
+    /* One past the last valid cookie for 4 exports. */
+    CHECK(nfs4_root_readdir_cookie_first_pos(7, 4, &first_pos) ==
+          NFS4ERR_BAD_COOKIE);
+
+    /* Truncates to a negative int -- the original defect. */
+    CHECK(nfs4_root_readdir_cookie_first_pos(0x80000002ULL, 4, &first_pos) ==
+          NFS4ERR_BAD_COOKIE);
+
+    CHECK(nfs4_root_readdir_cookie_first_pos(UINT64_MAX, 4, &first_pos) ==
+          NFS4ERR_BAD_COOKIE);
+
+    /* An empty export list accepts only the start-of-directory cookie. */
+    CHECK(nfs4_root_readdir_cookie_first_pos(3, 0, &first_pos) ==
+          NFS4ERR_BAD_COOKIE);
+
+    return 0;
+} /* test_out_of_range_rejected */
+
+int
+main(void)
+{
+    if (test_start_of_directory() ||
+        test_reserved_cookies_rejected() ||
+        test_resume_positions() ||
+        test_encode_decode_round_trip() ||
+        test_out_of_range_rejected()) {
+        return 1;
+    }
+
+    printf("test_root_cookie: all cases passed\n");
+
+    return 0;
+} /* main */

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -25,6 +25,12 @@
 struct chimera_nfs4_mount_ctx {
     struct chimera_nfs_client_server_thread *server_thread;
     struct chimera_nfs_client_mount         *mount;
+    /* 1 when the mount compound carried an OP_LOOKUP (a path-bearing mount),
+     * 0 for a bare pseudo-fs root mount.  Recorded where the compound is
+     * built so the reply is indexed by what was requested rather than by how
+     * long the reply is: a compound stops at its first failing op, so
+     * num_resarray says nothing about which ops were sent. */
+    int                                      lookup_included;
 };
 
 /* Forward declarations */
@@ -169,6 +175,7 @@ chimera_nfs4_mount_get_root_fh_callback(
     int                              fh_fragment_len;
     int                              hostname_len;
     int                              op;
+    int                              expected_ops;
     XXH128_hash_t                    fsid_hash;
 
     if (status != 0) {
@@ -187,8 +194,11 @@ chimera_nfs4_mount_get_root_fh_callback(
 
     /* Check individual operation results.  The compound is
      * SEQUENCE + PUTROOTFH [+ LOOKUP] + GETFH + GETATTR; the LOOKUP is
-     * omitted when the mount targets the bare pseudo-fs root. */
-    if (res->num_resarray < 4) {
+     * omitted when the mount targets the bare pseudo-fs root, which
+     * ctx->lookup_included records -- do not infer it from num_resarray. */
+    expected_ops = 4 + ctx->lookup_included;
+
+    if (res->num_resarray < expected_ops) {
         chimera_nfsclient_error("NFS4 mount get_root_fh: incomplete response");
         request->status = CHIMERA_VFS_EIO;
         request->complete(request);
@@ -211,7 +221,7 @@ chimera_nfs4_mount_get_root_fh_callback(
 
     op = 2;
 
-    if (res->num_resarray >= 5) {
+    if (ctx->lookup_included) {
         if (res->resarray[op].oplookup.status != NFS4_OK) {
             chimera_nfsclient_error("NFS4 LOOKUP failed: %d", res->resarray[op].oplookup.status);
             request->status = chimera_nfs4_status_to_errno(res->resarray[op].oplookup.status);
@@ -313,6 +323,10 @@ chimera_nfs4_mount_get_root_fh(
         argarray[op].oplookup.objname.len  = pathlen;
         op++;
     }
+
+    /* Re-stamped on every slot-exhaustion replay: this function rebuilds args
+     * from scratch each time it runs, so the flag cannot go stale. */
+    ctx->lookup_included = pathlen > 0;
 
     /* GETFH */
     argarray[op++].argop = OP_GETFH;

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -185,17 +185,80 @@ chimera_nfs4_mount_get_root_fh_callback(
         return;
     }
 
-    if (res->status != NFS4_OK) {
-        chimera_nfsclient_error("NFS4 mount get_root_fh compound failed: %d", res->status);
+    /* The compound is SEQUENCE + PUTROOTFH [+ LOOKUP] + GETFH + GETATTR; the
+     * LOOKUP is omitted when the mount targets the bare pseudo-fs root, which
+     * ctx->lookup_included records -- do not infer it from num_resarray.
+     *
+     * A compound stops at its first failing op, so a partial reply carries one
+     * result per op up to and including the one that failed.  Every op present
+     * is therefore inspected in order, before falling back to the compound
+     * status; checking the compound status first would collapse every per-op
+     * failure into one error, which is what let a mount of a nonexistent export
+     * report EIO rather than ENOENT.  Each access is bounds-checked
+     * individually because a partial reply is short by construction.
+     *
+     * The filesystem-level ops carry statuses that mean something to the
+     * caller, so they go through chimera_nfs4_status_to_errno.  SEQUENCE is the
+     * exception: its failures are session-level (BADSESSION, BADSLOT,
+     * SEQ_MISORDERED) with no faithful errno, and the mapper's default would
+     * report them as EINVAL, so it stays EIO. */
+    if (res->num_resarray >= 1 &&
+        res->resarray[0].opsequence.sr_status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 SEQUENCE failed: %d", res->resarray[0].opsequence.sr_status);
         request->status = CHIMERA_VFS_EIO;
         request->complete(request);
         return;
     }
 
-    /* Check individual operation results.  The compound is
-     * SEQUENCE + PUTROOTFH [+ LOOKUP] + GETFH + GETATTR; the LOOKUP is
-     * omitted when the mount targets the bare pseudo-fs root, which
-     * ctx->lookup_included records -- do not infer it from num_resarray. */
+    if (res->num_resarray >= 2 &&
+        res->resarray[1].opputrootfh.status != NFS4_OK) {
+        /* Mapped rather than fixed at EIO for spec generality: RFC 7530 §8
+         * lets a server refuse PUTROOTFH for the client's security flavor with
+         * NFS4ERR_WRONGSEC.  chimera's own PUTROOTFH always succeeds and has no
+         * flavor check, so against chimera that status arrives on the LOOKUP
+         * below, not here. */
+        chimera_nfsclient_error("NFS4 PUTROOTFH failed: %d", res->resarray[1].opputrootfh.status);
+        request->status = chimera_nfs4_status_to_errno(res->resarray[1].opputrootfh.status);
+        request->complete(request);
+        return;
+    }
+
+    op = 2;
+
+    if (ctx->lookup_included) {
+        if (res->num_resarray >= 3 &&
+            res->resarray[2].oplookup.status != NFS4_OK) {
+            /* Mounting an export the server does not have lands here: the
+             * LOOKUP's NFS4ERR_NOENT becomes ENOENT for the caller.  This is
+             * also where a chimera server's NFS4ERR_WRONGSEC arrives, raised
+             * from its pseudo-fs root when the export disallows the client's
+             * security flavor; the mapper turns that into EPERM rather than
+             * the EINVAL its default gave. */
+            chimera_nfsclient_error("NFS4 LOOKUP failed: %d", res->resarray[2].oplookup.status);
+            request->status = chimera_nfs4_status_to_errno(res->resarray[2].oplookup.status);
+            request->complete(request);
+            return;
+        }
+        op++;
+    }
+
+    if (res->num_resarray > op &&
+        res->resarray[op].opgetfh.status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 GETFH failed: %d", res->resarray[op].opgetfh.status);
+        request->status = chimera_nfs4_status_to_errno(res->resarray[op].opgetfh.status);
+        request->complete(request);
+        return;
+    }
+
+    /* Anything the per-op checks above did not explain: a GETATTR failure, or a
+     * reply whose failing op carried no result of its own. */
+    if (res->status != NFS4_OK) {
+        chimera_nfsclient_error("NFS4 mount get_root_fh compound failed: %d", res->status);
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
     expected_ops = 4 + ctx->lookup_included;
 
     if (res->num_resarray < expected_ops) {
@@ -205,40 +268,7 @@ chimera_nfs4_mount_get_root_fh_callback(
         return;
     }
 
-    if (res->resarray[0].opsequence.sr_status != NFS4_OK) {
-        chimera_nfsclient_error("NFS4 SEQUENCE failed: %d", res->resarray[0].opsequence.sr_status);
-        request->status = CHIMERA_VFS_EIO;
-        request->complete(request);
-        return;
-    }
-
-    if (res->resarray[1].opputrootfh.status != NFS4_OK) {
-        chimera_nfsclient_error("NFS4 PUTROOTFH failed: %d", res->resarray[1].opputrootfh.status);
-        request->status = CHIMERA_VFS_EIO;
-        request->complete(request);
-        return;
-    }
-
-    op = 2;
-
-    if (ctx->lookup_included) {
-        if (res->resarray[op].oplookup.status != NFS4_OK) {
-            chimera_nfsclient_error("NFS4 LOOKUP failed: %d", res->resarray[op].oplookup.status);
-            request->status = chimera_nfs4_status_to_errno(res->resarray[op].oplookup.status);
-            request->complete(request);
-            return;
-        }
-        op++;
-    }
-
     getfh_res = &res->resarray[op];
-    if (getfh_res->opgetfh.status != NFS4_OK) {
-        chimera_nfsclient_error("NFS4 GETFH failed: %d", getfh_res->opgetfh.status);
-        request->status = CHIMERA_VFS_EIO;
-        request->complete(request);
-        return;
-    }
-
     remote_fh = &getfh_res->opgetfh.resok4.object;
 
     /*

--- a/src/vfs/nfs/nfs4_readdir.c
+++ b/src/vfs/nfs/nfs4_readdir.c
@@ -341,7 +341,9 @@ chimera_nfs4_readdir(
     argarray[1].opputfh.object.data = fh;
     argarray[1].opputfh.object.len  = fhlen;
 
-    /* Op 2: READDIR */
+    /* Op 2: READDIR.  test_pseudo_root sizes its export list off this maxcount
+     * to force a multi-page listing; raising it means raising that test's
+     * PSEUDO_ROOT_MAX_PAGE_ENTRIES too, or its page-boundary coverage lapses. */
     argarray[2].argop              = OP_READDIR;
     argarray[2].opreaddir.dircount = 8192;
     argarray[2].opreaddir.maxcount = 8192;

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -596,6 +596,11 @@ chimera_nfs4_status_to_errno(nfsstat4 status)
             return CHIMERA_VFS_EBADCOOKIE;
         case NFS4ERR_BADHANDLE:
             return CHIMERA_VFS_EBADF;
+        case NFS4ERR_WRONGSEC:
+            /* The filesystem rejects the security flavor in use (chimera's own
+             * pseudo-fs root does this).  EPERM matches what the Linux client
+             * reports; the default below would call it EINVAL. */
+            return CHIMERA_VFS_EPERM;
         case NFS4ERR_NOTSUPP:
             return CHIMERA_VFS_ENOTSUP;
         case NFS4ERR_TOOSMALL:


### PR DESCRIPTION
First PR for this project. Code change and this PR text are obviously AI generated although we iterated several times on the code. Feedback welcome, happy to review or iterate:

Three follow-ups from the review of the NFSv4 pseudo-root READDIR fix, plus one adjacent client-side status mapping found along the way.

**Pseudo-root READDIR cookies are validated against the export count**
args->cookie is a 64-bit nfs_cookie4, but the pseudo-root walk's resume position (state->first_pos) is an int, and it was computed by plain assignment. A client cookie such as 0x80000002 truncated to a negative first_pos, which never tripped the "skip up to first_pos" test, so the walk silently restarted at position 0 and the client received duplicate entries.

The cookie policy moves into a header-only helper, [nfs4_root_cookie.h](vscode-webview://1af807lq0m3990rfscqtmqm7mb611dfbo1eicq0bddp19njqaldm/src/server/nfs/nfs4_root_cookie.h), and the cookie is now validated against the export snapshot before any walk state is allocated: cookie 0 starts at the beginning, and the reserved values 1 and 2 (RFC 7530 §16.24.4) plus anything above the last entry's cookie get NFS4ERR_BAD_COOKIE. Bounding the cookie by the export count is what keeps first_pos in range, so it can stay an int. The bias between a snapshot position and its wire cookie now lives in exactly two inline functions instead of being open-coded.

A side effect: a client mid-walk while exports are removed now gets BAD_COOKIE and restarts the directory read, rather than a silently truncated listing. The positional-cookie/zero-cookieverf limitation that remains — a concurrent add or remove shifts positions under a walking client — is documented at the top of the READDIR path in [nfs4_root.c](vscode-webview://1af807lq0m3990rfscqtmqm7mb611dfbo1eicq0bddp19njqaldm/src/server/nfs/nfs4_root.c); closing it needs an export-list generation counter returned as the cookieverf.

**Mount no longer infers the compound's shape from the reply length**
chimera_nfs4_mount_get_root_fh_callback deduced whether the mount compound carried an OP_LOOKUP from the reply length (num_resarray >= 5). That only held because the res->status gate above it returned EIO first: a compound stops at its first failing op, so a successful compound has one result per requested op, but a partial one does not. If that gate were ever relaxed, a pathless 4-op mount whose GETFH failed would misread resarray[2] as the GETFH result.

The answer is now recorded in chimera_nfs4_mount_ctx where the compound is built. It is re-stamped on every call, so the slot-exhaustion replay path (which rebuilds args from scratch) cannot leave it stale, and it also gives the incomplete-response floor its correct per-mount value.

**Mounting a nonexistent export reports ENOENT, not EIO**
With the compound-status check ahead of every per-op status, all per-op failures collapsed into EIO and the LOOKUP- and GETFH-failure branches below it were unreachable — mounting an export the server does not have reported "Input/output error".

Ops that are present are now inspected in order, ahead of the compound-status check, which stays as the fallback for anything the per-op checks do not explain. Because a partial reply is short by construction, each access is bounds-checked individually rather than behind one up-front floor. PUTROOTFH, LOOKUP, GETFH and the compound fallback map their status through chimera_nfs4_status_to_errno; SEQUENCE deliberately does not, since its failures are session-level (BADSESSION, BADSLOT, SEQ_MISORDERED) and the mapper's default would call them EINVAL.

**NFS4ERR_WRONGSEC maps to EPERM**
chimera_nfs4_status_to_errno had no case for NFS4ERR_WRONGSEC, so it fell through to the EINVAL default and every operation refused for its security flavor reported "Invalid argument". Chimera's own server raises WRONGSEC from its pseudo-fs root when a client traverses into an export under a disallowed flavor, so this is reachable against chimera itself. It now maps to EPERM, matching the Linux NFS client. This changes the errno for every caller of the mapper — getattr, write, open, rename, remove, seek, link, mkdir — not just mount.

**Test coverage**
test_pseudo_root listed a single export at the default maxcount, so pseudo-root pagination was never exercised end to end. A new posix_test_extra_exports knob in [posix_test_common.h](vscode-webview://1af807lq0m3990rfscqtmqm7mb611dfbo1eicq0bddp19njqaldm/src/posix/tests/posix_test_common.h) creates N additional mounts and pinned-id exports, and the pseudo-root test asks for 40. The client's maxcount is fixed at 8192 and each entry costs at least ~300 bytes of it, so 41 entries span multiple pages and drive the server's mid-walk dbuf rollback repeatedly. The test asserts every export appears exactly once, which catches a resume that repeats or skips an entry, and bounds the listing so a resume stuck re-serving one page fails by naming the entry it was stuck on rather than by hitting the ctest timeout.

The extra subdirectories are created with mkdir for the passthrough backends: chimera_server_mkpath transiently mounts the backend at /, which the linux/io_uring modules reject with EOPNOTSUPP (it had only ever run against memfs). Export names are fixed width because chimera_nfs_find_export_path matches export names by prefix.

test_pseudo_root also now mounts 127.0.0.1:/nosuchexport and asserts ENOENT; reverting the mount reorder makes it fail with EIO.

The cookie policy itself is covered by a new unit test, [test_root_cookie.c](vscode-webview://1af807lq0m3990rfscqtmqm7mb611dfbo1eicq0bddp19njqaldm/src/server/nfs/tests/test_root_cookie.c) — reserved cookies 1 and 2, cookies past the last entry, the truncating 0x80000002 and UINT64_MAX cases, and a valid cookie resuming at cookie - 2. None of that is reachable from chimera's own client, which clamps cookies below 3 to zero, synthesizes . and .. locally, and never sends a cookie it did not receive.

**Known gaps**
NFS4ERR_TOOSMALL is uncovered: it needs a maxcount too small for a single entry, which chimera's client cannot send (8192 is hardcoded), and there is no raw-wire NFSv4 test harness in the tree.
The server's eof flag is unverifiable from the POSIX path: the client zeroes it whenever the caller's callback stops the entry walk, which one-entry-per-call POSIX readdir does on every page. A lost page tail is invisible for the same reason, so only the first_pos resume is genuinely under test.

