### PR TITLE
nfs4: stateid validation and undispatched-op result handling

### DIFF
--- a/src/server/nfs/nfs4_proc_allocate.c
+++ b/src/server/nfs/nfs4_proc_allocate.c
@@ -87,18 +87,20 @@ chimera_nfs4_allocate(
     /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
     chimera_nfs4_resolve_current_stateid(req, &args->aa_stateid);
 
+    /* Every path below acts on the current filehandle: the special-stateid
+     * path opens it directly, and the state-table path must name it. */
+    if (req->fhlen == 0) {
+        res->ar_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->ar_status);
+        return;
+    }
+
     /*
      * RFC 8881 §8.2.3 requires ALLOCATE to honor the special stateids.  These
      * carry no state-table entry, so open the current FH on the fly instead of
      * consulting the state table.
      */
     if (nfs4_stateid_is_special(&args->aa_stateid)) {
-        if (req->fhlen == 0) {
-            res->ar_status = NFS4ERR_NOFILEHANDLE;
-            chimera_nfs4_compound_complete(req, res->ar_status);
-            return;
-        }
-
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,
@@ -111,6 +113,16 @@ chimera_nfs4_allocate(
     status = nfs_state_table_acquire(table, &args->aa_stateid, 0,
                                      &state_void, &state_type);
     if (status != NFS4_OK) {
+        res->ar_status = status;
+        chimera_nfs4_compound_complete(req, res->ar_status);
+        return;
+    }
+
+    status = nfs_state_check_write_for_fh(state_void, state_type,
+                                          req->fh, req->fhlen);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
         res->ar_status = status;
         chimera_nfs4_compound_complete(req, res->ar_status);
         return;

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -41,6 +41,45 @@ nfs4_release_write_args(
     }
 } /* nfs4_release_write_args */
 
+/*
+ * Prepare the result slot of an op that failed before any handler ran.
+ *
+ * The per-op result union is uninitialized dbuf memory (xdr_dbuf_alloc_space
+ * does not zero), and some result types marshal fields even on the error
+ * branch -- SETATTR4res carries num_attrsset and attrsset outside any union --
+ * so an un-zeroed slot encodes heap contents onto the wire or crashes the
+ * encoder.  Zero it and set the discriminant.
+ *
+ * A WRITE that never dispatches also still holds the +1 the XDR unmarshal
+ * cloned onto its data iovecs: chimera_nfs4_compound_complete sweeps only the
+ * WRITEs past the failed op, and the release that normally happens in the
+ * WRITE completion will never run.  Releasing here is idempotent with that
+ * sweep and with the replay path, both of which skip a niov already zeroed.
+ *
+ * WRITE is the only op needing the release: xdr_iovecr appears only on
+ * WRITE4args.data, while SETXATTR, SETATTR and CREATE payloads are xdr_opaque
+ * in dbuf memory freed with the encoding.
+ */
+static void
+nfs4_fail_undispatched_op(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop,
+    nfsstat4                          status)
+{
+    memset(resop, 0, sizeof(*resop));
+
+    /* An out-of-range argop is not a valid result discriminant. */
+    resop->resop = (status == NFS4ERR_OP_ILLEGAL) ? OP_ILLEGAL : argop->argop;
+
+    if (argop->argop == OP_WRITE && argop->opwrite.data.niov) {
+        evpl_iovecs_release(thread->evpl,
+                            argop->opwrite.data.iov,
+                            argop->opwrite.data.niov);
+        argop->opwrite.data.niov = 0;
+    }
+} /* nfs4_fail_undispatched_op */
+
 void
 chimera_nfs4_compound_process(
     struct nfs_request *req,
@@ -118,20 +157,22 @@ chimera_nfs4_compound_process(
 
     thread->active = 1;
 
-    /* If the response buffer is running low, fail early with RESOURCE
-     * rather than letting individual procs abort on allocation failure */
-    if (req->encoding->dbuf->size - req->encoding->dbuf->used < 8192) {
-        chimera_nfs4_compound_complete(req, NFS4ERR_RESOURCE);
-    } else {
-        nfsstat4 gate = nfs4_op_check_minor(argop->argop,
-                                            req->minorversion,
-                                            (uint32_t) req->index,
-                                            req->seen_sequence);
+    {
+        nfsstat4 gate;
+
+        /* If the response buffer is running low, fail early with RESOURCE
+         * rather than letting individual procs abort on allocation failure */
+        if (req->encoding->dbuf->size - req->encoding->dbuf->used < 8192) {
+            gate = NFS4ERR_RESOURCE;
+        } else {
+            gate = nfs4_op_check_minor(argop->argop,
+                                       req->minorversion,
+                                       (uint32_t) req->index,
+                                       req->seen_sequence);
+        }
 
         if (gate != NFS4_OK) {
-            if (gate == NFS4ERR_OP_ILLEGAL) {
-                resop->resop = OP_ILLEGAL;
-            }
+            nfs4_fail_undispatched_op(thread, argop, resop, gate);
             chimera_nfs4_compound_complete(req, gate);
         } else {
             /* NFS4.1 current-stateid lifecycle (RFC 8881 §16.2.3.1.2):

--- a/src/server/nfs/nfs4_proc_copy.c
+++ b/src/server/nfs/nfs4_proc_copy.c
@@ -26,15 +26,21 @@ struct nfs4_copy_state_refs {
     struct evpl_iovec   rw_iov[CHIMERA_NFS4_COPY_IOV_MAX];
 };
 
+/* Returns NULL for any state type that carries no open handle -- a delegation
+ * or layout stateid must not be reinterpreted as one of the two that do. */
 static struct chimera_vfs_open_handle *
 chimera_nfs4_copy_state_handle(
     void   *state,
     uint8_t state_type)
 {
-    if (state_type == NFS4_SLOT_TYPE_OPEN) {
-        return ((struct nfs_open_state *) state)->handle;
-    }
-    return ((struct nfs_lock_state *) state)->handle;
+    switch (state_type) {
+        case NFS4_SLOT_TYPE_OPEN:
+            return ((struct nfs_open_state *) state)->handle;
+        case NFS4_SLOT_TYPE_LOCK:
+            return ((struct nfs_lock_state *) state)->handle;
+        default:
+            return NULL;
+    } /* switch */
 } /* chimera_nfs4_copy_state_handle */
 
 static void
@@ -277,8 +283,28 @@ chimera_nfs4_copy(
         return;
     }
 
+    /* The destination stateid must name a write-capable open of the current
+     * filehandle (the saved filehandle is the source -- RFC 7862 sec 15.2).
+     * Without this the write would target whatever handle the stateid carries,
+     * rather than the object the compound named. */
+    status = nfs_state_check_write_for_fh(refs->dst_state, refs->dst_type,
+                                          req->fh, req->fhlen);
+    if (status != NFS4_OK) {
+        chimera_nfs4_copy_release_refs(req, refs);
+        res->cr_status = status;
+        chimera_nfs4_compound_complete(req, res->cr_status);
+        return;
+    }
+
     src_handle = chimera_nfs4_copy_state_handle(refs->src_state, refs->src_type);
     dst_handle = chimera_nfs4_copy_state_handle(refs->dst_state, refs->dst_type);
+
+    if (!src_handle || !dst_handle) {
+        chimera_nfs4_copy_release_refs(req, refs);
+        res->cr_status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->cr_status);
+        return;
+    }
 
     refs->req        = req;
     refs->src_offset = args->ca_src_offset;

--- a/src/server/nfs/nfs4_proc_deallocate.c
+++ b/src/server/nfs/nfs4_proc_deallocate.c
@@ -89,18 +89,20 @@ chimera_nfs4_deallocate(
     /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
     chimera_nfs4_resolve_current_stateid(req, &args->da_stateid);
 
+    /* Every path below acts on the current filehandle: the special-stateid
+     * path opens it directly, and the state-table path must name it. */
+    if (req->fhlen == 0) {
+        res->dr_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->dr_status);
+        return;
+    }
+
     /*
      * RFC 8881 §8.2.3 requires DEALLOCATE to honor the special stateids.  These
      * carry no state-table entry, so open the current FH on the fly instead of
      * consulting the state table.
      */
     if (nfs4_stateid_is_special(&args->da_stateid)) {
-        if (req->fhlen == 0) {
-            res->dr_status = NFS4ERR_NOFILEHANDLE;
-            chimera_nfs4_compound_complete(req, res->dr_status);
-            return;
-        }
-
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,
@@ -113,6 +115,16 @@ chimera_nfs4_deallocate(
     status = nfs_state_table_acquire(table, &args->da_stateid, 0,
                                      &state_void, &state_type);
     if (status != NFS4_OK) {
+        res->dr_status = status;
+        chimera_nfs4_compound_complete(req, res->dr_status);
+        return;
+    }
+
+    status = nfs_state_check_write_for_fh(state_void, state_type,
+                                          req->fh, req->fhlen);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
         res->dr_status = status;
         chimera_nfs4_compound_complete(req, res->dr_status);
         return;

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -629,6 +629,56 @@ nfs_open_state_check_principal(
 } /* nfs_open_state_check_principal */
 
 /*
+ * Validate a stateid that authorizes a mutation of the current filehandle.
+ *
+ * Returns NFS4ERR_BAD_STATEID unless `state` names an open (directly, or the
+ * open a lock state is anchored to) of the object that is the current
+ * filehandle -- required by RFC 7530 sec 9.1.4.3 / RFC 8881 sec 8.2.4 -- and
+ * NFS4ERR_OPENMODE if that open does not carry write access.
+ *
+ * The current-filehandle half matters beyond conformance: any access check the
+ * server makes against the current filehandle is only meaningful if the
+ * operation actually acts on that filehandle.  An op that instead mutated some
+ * other handle carried by its stateid would slip past such a check entirely.
+ *
+ * Delegation and layout stateids are rejected rather than misinterpreted:
+ * neither carries an open_state, and callers that support them (see WRITE)
+ * must handle them before calling this.
+ */
+static inline nfsstat4
+nfs_state_check_write_for_fh(
+    void          *state,
+    uint8_t        type,
+    const uint8_t *fh,
+    uint32_t       fh_len)
+{
+    const struct nfs_open_state *open_state;
+
+    switch (type) {
+        case NFS4_SLOT_TYPE_OPEN:
+            open_state = state;
+            break;
+        case NFS4_SLOT_TYPE_LOCK:
+            open_state = ((struct nfs_lock_state *) state)->open_state;
+            break;
+        default:
+            return NFS4ERR_BAD_STATEID;
+    } /* switch */
+
+    if (!open_state ||
+        open_state->fh_len != fh_len ||
+        memcmp(open_state->fh, fh, fh_len) != 0) {
+        return NFS4ERR_BAD_STATEID;
+    }
+
+    if ((open_state->share_access & OPEN4_SHARE_ACCESS_WRITE) == 0) {
+        return NFS4ERR_OPENMODE;
+    }
+
+    return NFS4_OK;
+} /* nfs_state_check_write_for_fh */
+
+/*
  * Public API.
  */
 


### PR DESCRIPTION
Two independent correctness fixes in the NFSv4 server, both pre-existing on `main`. They were found while auditing the per-export access-control path, but neither depends on that work.

## nfs4: validate stateids against the current filehandle

ALLOCATE, DEALLOCATE and COPY took the handle they mutate from the handle carried by their stateid, without checking that the stateid names the object that is the current filehandle, and without checking that the open carries write access. RFC 7530 sec 9.1.4.3 and RFC 8881 sec 8.2.4 both require the stateid to designate the current filehandle. SETATTR already implements this cross-check, and WRITE is covered incidentally by its `NFS4ERR_OPENMODE` check, so these three were the outliers.

Two consequences:

- **Any access check keyed on the current filehandle is bypassable**, because the operation mutates a different object than the one the compound named. A client can open a file for READ, make some unrelated handle current, and still mutate the opened file. DEALLOCATE punches holes, so this is a data-loss path, and COPY writes arbitrary bulk data through both the `copy_range` and read/write fallback paths, so every VFS backend is reachable.
- **Type confusion on delegation and layout stateids.** All three acquired state with `want_type` 0 and then treated anything that was not an open state as a lock state, so a delegation or layout stateid was read at the wrong offset and `->handle` came from unrelated memory. This one needs no unusual server configuration at all.

The fix adds `nfs_state_check_write_for_fh`, which resolves the open behind an open or lock stateid, rejects any other state type as `NFS4ERR_BAD_STATEID` rather than reinterpreting it, requires the open to name the current filehandle, and requires write share access. `chimera_nfs4_copy_state_handle` gets the same type guard for the source side.

The `NFS4ERR_NOFILEHANDLE` check in ALLOCATE and DEALLOCATE moves ahead of the special-stateid branch, since both paths now require a current filehandle — a missing one is reported as NOFILEHANDLE rather than BAD_STATEID.

## nfs4: zero the result slot and release WRITE iovecs for undispatched ops

An operation can fail before any handler runs, on two paths: the low-response-buffer early fail returning `NFS4ERR_RESOURCE`, and `nfs4_op_check_minor` rejecting the op. Neither initialized the per-op result union first.

`xdr_dbuf_alloc_space` does not zero its memory and `compound_complete` writes only `opillegal.status`, yet some result types marshal fields outside any union and so encode them whatever the status. `SETATTR4res` is one: it carries `num_attrsset` and an `attrsset` pointer. A client sending SETATTR in a 4.1+ compound with no preceding SEQUENCE takes `NFS4ERR_OP_NOT_IN_SESSION` from the minor-version gate, and the reply is then built from an uninitialized count and pointer — an out-of-bounds read that either leaks heap contents to the client or crashes the encoder.

The same paths leak WRITE payloads. Unmarshalling `WRITE4args.data` clones the iovecs with a +1 that `chimera_nfs4_write_complete` normally drops; for an op that never dispatches that completion never runs, and `compound_complete` sweeps only the WRITEs *past* the failed op, never the failed op itself. A client can repeat this to grow memory without bound.

Both failure paths now route through `nfs4_fail_undispatched_op`, which zeroes the slot, sets the discriminant, and releases the clone. The release is idempotent with the `compound_complete` sweep and the SEQUENCE replay path, since both skip a `niov` already zeroed.

WRITE is the only op needing the release: `xdr_iovecr` appears only on `WRITE4args.data`, while SETXATTR, SETATTR and CREATE payloads are `xdr_opaque` in dbuf memory freed with the encoding.

---

Release build is clean under `-Werror`, uncrustify reports no changes, and the full linux-backend ctest suite passes (1426/1426).
