### PR TITLE
smbtorture: make the matrix a retainable measurement

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -505,6 +505,111 @@ jobs:
               /workspace/scripts/cap_ctest_output.sh \
               ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'
 
+  # Informational measurement of the full smbtorture smb2 matrix (655 subtests x
+  # 6 VFS backends).  The gating suite only registers the subtests in the
+  # generated SMBTORTURE_ENABLED_<backend> allowlists, so 15-30% of the catalog
+  # per backend never runs in CI at all; this job runs the complement too and
+  # diffs the outcome against the checked-in baseline.
+  #
+  # It fails ONLY on a "newly failing" cell -- a subtest that is in the baseline
+  # (and therefore gated) but did not pass.  A "still failing" cell is the
+  # expected state of the exploration backlog and must not be noise, or the job
+  # would be red every night and nobody would read it.
+  #
+  # amd64 Release only: the matrix is ~3900 daemon+netns+client invocations and
+  # the baselines were measured on that configuration.
+  smbtorture-matrix:
+    name: smbtorture matrix (informational)
+    needs: [build-devcontainer]
+    runs-on: arc-amd64
+    permissions:
+      contents: read
+    # Passing cells cost ~0.6s, but a hung cell burns the full 300s timeout and
+    # there are ~880 non-passing cells across the matrix; 3h leaves headroom.
+    timeout-minutes: 180
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # --privileged: the netns wrapper needs CAP_NET_ADMIN.  smbtorture itself
+      # ships in the devcontainer image (samba-testsuite).
+      # The matrix and both compare passes run in the container (which is where
+      # python3 and smbtorture live); the runner steps only read the files it
+      # leaves behind, so publishing never depends on tooling outside the image.
+      #
+      # compare runs twice over the same results: once to render the buckets for
+      # the job summary, once to decide the exit status.  The verdict is recorded
+      # as a flag file rather than failing here, so the summary and the artifacts
+      # still publish when a gated test regressed -- exactly when they are worth
+      # reading.  "still failing" is summarized but not listed; it is ~880 cells
+      # of known backlog.
+      - name: Build and run the matrix
+        run: |
+          rm -rf smbt-report
+          mkdir -p smbt-report
+          docker run --rm --privileged \
+            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
+            -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -v "${{ github.workspace }}:/workspace" \
+            -v /build \
+            -w /build \
+            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
+            bash -euxc '\
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DREQUIRE_NETNS_TESTS=ON /workspace && \
+              ninja smbtorture_test && \
+              /workspace/tools/smbtorture/regen.sh --report-only \
+                  --build-dir /build \
+                  --out-dir /workspace/smbt-report \
+                  --parallel 32 && \
+              cd /workspace && \
+              python3 tools/smbtorture/regen.py compare \
+                  --results smbt-report/results.txt \
+                  --cmake src/server/smb/tests/CMakeLists.txt \
+                  --format markdown \
+                  --quiet-buckets "still failing" \
+                > smbt-report/drift.md && \
+              { python3 tools/smbtorture/regen.py compare \
+                  --results smbt-report/results.txt \
+                  --cmake src/server/smb/tests/CMakeLists.txt \
+                  --quiet-buckets "still failing,skipped" \
+                  --fail-on-newly-failing > /dev/null \
+                || touch smbt-report/newly-failing.flag; }'
+
+      - name: Report baseline drift
+        if: always()
+        run: |
+          if [ -f smbt-report/drift.md ]; then
+            {
+              echo '## smbtorture baseline drift'
+              cat smbt-report/drift.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## smbtorture baseline drift' >> "$GITHUB_STEP_SUMMARY"
+            echo 'The matrix did not complete; no results to compare.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload matrix results and failure logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: smbtorture-matrix-amd64
+          path: smbt-report/
+          if-no-files-found: warn
+          retention-days: 30
+
+      # Only a regression in a gated subtest turns the job red.  A missing flag
+      # file means either no regression or a matrix that never finished, and the
+      # latter already failed its own step.
+      - name: Fail on a regression in a gated subtest
+        if: always()
+        run: |
+          if [ -f smbt-report/newly-failing.flag ]; then
+            echo "a gated smbtorture subtest regressed; see the job summary" >&2
+            exit 1
+          fi
+
   static-analysis:
     name: Analyze ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer, build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,25 @@ on:
   schedule:
     - cron: '0 7 * * *'  # 07:00 UTC daily
   workflow_dispatch:     # allow manual runs
+    # Scope the smbtorture matrix for a manual run.  All three default to the
+    # full matrix, so the scheduled run is unaffected; they exist so the job can
+    # be exercised end to end (privileged container, netns, artifact upload, job
+    # summary, regression gate) in a minute rather than the hours a full ~3900
+    # cell sweep takes.  Ignored by every other job.
+    inputs:
+      smbtorture_backends:
+        description: 'smbtorture: backends to run (default: all six)'
+        required: false
+        type: string
+      smbtorture_filter:
+        description: 'smbtorture: only subtests matching this regex (default: all)'
+        required: false
+        type: string
+      smbtorture_parallel:
+        description: 'smbtorture: concurrent cells'
+        required: false
+        type: string
+        default: '32'
 
 env:
   DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
@@ -545,13 +564,32 @@ jobs:
       # still publish when a gated test regressed -- exactly when they are worth
       # reading.  "still failing" is summarized but not listed; it is ~880 cells
       # of known backlog.
+      # The scoping inputs reach regen.sh as environment variables passed through
+      # by `docker run -e NAME` (value taken from the step env), never
+      # interpolated into the container's command line -- a dispatch input is
+      # attacker-controlled text and must not be able to break out of quoting.
+      # Empty means the full matrix, which is what the scheduled run sends.
+      #
+      # compare measures against measured-catalog.txt -- the catalog the run
+      # actually covered -- and not the checked-in SMBTORTURE_SUITES.  Identical
+      # for a full run today; they diverge as soon as a dispatch scopes the
+      # matrix or a Samba upgrade changes the catalog, and then the live one is
+      # the honest denominator.  regen.sh writes that file on every run, scoped
+      # or not, so nothing here has to infer the scope from which files exist.
       - name: Build and run the matrix
+        env:
+          SMBTORTURE_BACKENDS: ${{ inputs.smbtorture_backends }}
+          SMBTORTURE_FILTER: ${{ inputs.smbtorture_filter }}
+          SMBTORTURE_PARALLEL: ${{ inputs.smbtorture_parallel || '32' }}
         run: |
           rm -rf smbt-report
           mkdir -p smbt-report
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -e SMBTORTURE_BACKENDS \
+            -e SMBTORTURE_FILTER \
+            -e SMBTORTURE_PARALLEL \
             -v "${{ github.workspace }}:/workspace" \
             -v /build \
             -w /build \
@@ -561,18 +599,19 @@ jobs:
               ninja smbtorture_test && \
               /workspace/tools/smbtorture/regen.sh --report-only \
                   --build-dir /build \
-                  --out-dir /workspace/smbt-report \
-                  --parallel 32 && \
+                  --out-dir /workspace/smbt-report && \
               cd /workspace && \
               python3 tools/smbtorture/regen.py compare \
                   --results smbt-report/results.txt \
                   --cmake src/server/smb/tests/CMakeLists.txt \
+                  --subs smbt-report/measured-catalog.txt \
                   --format markdown \
                   --quiet-buckets "still failing" \
                 > smbt-report/drift.md && \
               { python3 tools/smbtorture/regen.py compare \
                   --results smbt-report/results.txt \
                   --cmake src/server/smb/tests/CMakeLists.txt \
+                  --subs smbt-report/measured-catalog.txt \
                   --quiet-buckets "still failing,skipped" \
                   --fail-on-newly-failing > /dev/null \
                 || touch smbt-report/newly-failing.flag; }'

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1920,9 +1920,11 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.zero-data-ioctl
     # attribute-only ("stat") opens acquire their requested oplock when sole
     smb2.oplock.batch9
+    # attribute-only ("stat") opens acquire their requested oplock when sole
     smb2.oplock.batch9a
     # oplocks/leases on named streams (harness enables ADS for these subtests)
     smb2.oplock.batch26
+    # oplocks/leases on named streams (harness enables ADS for these subtests)
     smb2.lease.request
     # delete-on-close via SET_INFO marks the file delete-pending
     smb2.oplock.doc
@@ -1933,6 +1935,8 @@ set(SMBTORTURE_ENABLED_memfs
     # byte-range lock breaks a caching lease to NONE in a single shot, and a
     # fresh lease behind a lock is capped to NONE (lock-vs-caching conflict)
     smb2.lease.lock1
+    # byte-range lock breaks a caching lease to NONE in a single shot, and a
+    # fresh lease behind a lock is capped to NONE (lock-vs-caching conflict)
     smb2.lease.lease-epoch
     # batch oplock break-ack timeout duration (harness sets oplocktimeout=30)
     smb2.oplock.batch22a

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -4721,6 +4721,21 @@ set(SMBTORTURE_ENABLED_diskfs_aio
 set(SMBTORTURE_JUNIT_DIR ${CMAKE_BINARY_DIR}/smbtorture-junit
     CACHE PATH "Directory for per-subtest smbtorture JUnit XML output.")
 
+# Register the subtests the gating suite does NOT run -- everything in the
+# catalog that add_smbtorture_backend_tests() skips, i.e. the per-backend
+# complement of the generated allowlist plus the entries held back by
+# SMBTORTURE_DISABLED_SUBTESTS.  Together the two labels cover the catalog
+# exactly once per backend, so `ctest -L smbtorture_explore -R smb2_streams` is
+# a one-liner for iterating on one area without hand-running the matrix.
+#
+# OFF by default and adds nothing to the gating suite: these are the cells known
+# to fail, hang, or flake, so the label exists to make them addressable, not to
+# gate on them.  Use tools/smbtorture/regen.sh --report-only for a full matrix
+# measurement; this is for local iteration on a single family.
+option(SMBTORTURE_EXPLORE_TESTS
+       "Register the currently-unenabled smbtorture subtests under the \
+smbtorture_explore label (off by default; not part of the gating suite)." OFF)
+
 # A whole suite's subtests run in ONE server+netns+smbtorture invocation instead
 # of one each.  smbtorture is a fast C client (~0.4s startup), but that per-test
 # tax (fork+exec the daemon, set up the netns, start the client) is paid ~1800
@@ -4865,6 +4880,39 @@ function(_smbtorture_add_subtest backend subtest)
     endif()
 endfunction()
 
+# One per-subtest ctest entry for a subtest the gating suite does not run.
+# Mirrors _smbtorture_add_subtest's properties (SKIP_RETURN_CODE 77, 300s, the
+# durable-family resource lock, the LSAN suppressions) so a subtest promoted out
+# of here into the allowlist behaves identically, and reuses the JUnit converter
+# so an explore run still produces per-subtest XML.
+function(_smbtorture_add_explore backend subtest)
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" sid "${subtest}")
+    set(name chimera/server/smb/smbtorture_explore_${sid}_${backend})
+    add_test(NAME ${name}
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+                ${SMBTORTURE_CMD} -b ${backend} ${subtest})
+    set_tests_properties(${name} PROPERTIES
+        LABELS "smbtorture_explore"
+        ENVIRONMENT "${SMBTORTURE_LSAN};SMBTORTURE_JUNIT_FILE=${SMBTORTURE_JUNIT_DIR}/smbtorture_explore_${sid}_${backend}.xml;SMBTORTURE_JUNIT_CONVERTER=${CMAKE_SOURCE_DIR}/scripts/smbtorture_to_junit.py"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 300)
+    if(subtest MATCHES "^smb2\\.durable-(v2-)?open\\.")
+        set_tests_properties(${name} PROPERTIES
+            RESOURCE_LOCK smb_durable_oplock_family)
+    endif()
+endfunction()
+
+macro(add_smbtorture_explore_tests backend)
+    foreach(_sub ${SMBTORTURE_SUITES})
+        # The complement of what the gating suite registers: not enabled for this
+        # backend, or enabled but held back by the disabled list.
+        if(NOT "${_sub}" IN_LIST SMBTORTURE_ENABLED_${backend}
+           OR "${_sub}" IN_LIST SMBTORTURE_DISABLED_SUBTESTS)
+            _smbtorture_add_explore(${backend} "${_sub}")
+        endif()
+    endforeach()
+endmacro()
+
 macro(add_smbtorture_backend_tests backend)
     foreach(_parent ${SMBTORTURE_PARENTS})
         set(_pid ${SMBTORTURE_PID_${_parent}})
@@ -4959,6 +5007,22 @@ if(CHIMERA_NETNS_TESTING AND SMBTORTURE_EXECUTABLE)
     endif()
     if(IO_URING_ENABLED)
         add_smbtorture_backend_tests(io_uring)
+    endif()
+
+    # Same backend set, gated on the option so the default ctest set is unchanged.
+    if(SMBTORTURE_EXPLORE_TESTS)
+        add_smbtorture_explore_tests(memfs)
+        add_smbtorture_explore_tests(linux)
+        add_smbtorture_explore_tests(diskfs_io_uring)
+        if(HAVE_LIBAIO)
+            add_smbtorture_explore_tests(diskfs_aio)
+        endif()
+        if(CAIRN_ENABLED)
+            add_smbtorture_explore_tests(cairn)
+        endif()
+        if(IO_URING_ENABLED)
+            add_smbtorture_explore_tests(io_uring)
+        endif()
     endif()
 elseif(CHIMERA_NETNS_TESTING)
     message(STATUS "smbtorture tests: disabled (smbtorture client not found; "

--- a/tools/smbtorture/regen.py
+++ b/tools/smbtorture/regen.py
@@ -2,51 +2,135 @@
 # SPDX-FileCopyrightText: 2024-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
-"""Rewrite SMBTORTURE_SUITES + SMBTORTURE_ENABLED_<backend> blocks in
-   src/server/smb/tests/CMakeLists.txt from a smbtorture matrix run.
+"""Generate or diff the SMBTORTURE_SUITES + SMBTORTURE_ENABLED_<backend> blocks
+   in src/server/smb/tests/CMakeLists.txt from a smbtorture matrix run.
 
-   Inputs:
-       --subs       path to a one-per-line catalog of addressable subtests
-                    (output of `smbtorture --list smb2.*` w/ trailing dup
-                    stripped)
-       --results    path to a `PASS|FAIL|TIME|SKIP|<backend>|<subtest>` log
+   Modes:
+       generate   splice a freshly measured matrix into the CMake block
+       compare    diff a matrix result against the checked-in baseline
+
+   Inputs shared by both modes:
+       --results    path to a `PASS|FAIL|TIME|SKIP|<backend>|<subtest>` log as
+                    written by tools/smbtorture/regen.sh.  compare accepts the
+                    flag more than once; cells whose status disagrees between
+                    runs are reported as flaky.
        --cmake      path to src/server/smb/tests/CMakeLists.txt
 
-   The script splices a single contiguous block that contains the suite list
-   and all six per-backend allowlists, replacing whatever lies between the
-   anchor markers `# >>> SMBTORTURE_BLOCK_BEGIN` and `# >>> SMBTORTURE_BLOCK_END`.
+   generate splices a single contiguous block containing the suite list and all
+   six per-backend allowlists, replacing whatever lies between the anchor markers
+   `# >>> SMBTORTURE_BLOCK_BEGIN` and `# >>> SMBTORTURE_BLOCK_END`.  Comments
+   hand-written against an individual entry are carried across the rewrite (see
+   split_entries); the hand-curated SMBTORTURE_ISOLATE_SUITES and
+   SMBTORTURE_DISABLED_SUBTESTS blocks live outside the markers and are never
+   touched.
 """
 
-import argparse, collections, sys
+import argparse, collections, re, sys
 
 BACKENDS = ("memfs","linux","io_uring","cairn","diskfs_io_uring","diskfs_aio")
 BEGIN = "# >>> SMBTORTURE_BLOCK_BEGIN (regenerate with tools/smbtorture/regen.sh)"
 END   = "# >>> SMBTORTURE_BLOCK_END"
 
+# A comment regen.py itself emits: the `# smb2.<suite>` group header.  Anything
+# else inside a list is hand-written prose about the entry that follows it.
+GROUP_COMMENT = re.compile(r"#\s*smb2\.[\w-]+\s*$")
 
-def parse_results(path):
-    res = {}
-    with open(path) as f:
-        for line in f:
-            parts = line.rstrip().split("|")
-            if not parts or parts[0] not in ("PASS","FAIL","TIME","SKIP"):
-                continue
-            if len(parts) < 3:
-                continue
-            res[(parts[1], parts[2])] = parts[0]
+STATUSES = ("PASS","FAIL","TIME","SKIP")
+
+
+def parse_results(paths):
+    """Map (backend, subtest) -> [status, ...] in the order the runs were given."""
+    res = collections.defaultdict(list)
+    for path in paths:
+        seen = {}
+        with open(path) as f:
+            for line in f:
+                parts = line.rstrip().split("|")
+                if len(parts) < 3 or parts[0] not in STATUSES:
+                    continue
+                seen[(parts[1], parts[2])] = parts[0]
+        for cell, status in seen.items():
+            res[cell].append(status)
     return res
+
+
+LIST_OPEN = re.compile(r"set\(SMBTORTURE_(\w+)\s*$")
+
+
+def parse_cmake_lists(txt):
+    """Extract every multi-line `set(SMBTORTURE_<name>\\n ... \\n)` list.
+
+       Returns {name: [line, ...]} covering both the generated lists and the
+       hand-curated ones (DISABLED_SUBTESTS, ISOLATE_SUITES).  Scanned line by
+       line rather than with one regex: the file also holds single-line and
+       `CACHE`-decorated SMBTORTURE_* sets, and a non-greedy body pattern
+       mis-pairs their parens with a later list's closing one.
+    """
+    out, name, body = {}, None, []
+    for line in txt.splitlines():
+        if name is None:
+            m = LIST_OPEN.match(line.strip())
+            if m:
+                name, body = m.group(1), []
+            continue
+        # A list may close on its own line or on the last entry's line
+        # (`    rpc.lsalookup)`), which must still terminate the scan.  Comments
+        # are exempt: the curated prose ends in ")" often enough
+        # ("...(lock-vs-caching conflict)") to close the list 400 entries early.
+        stripped = line.rstrip()
+        if stripped.endswith(")") and not stripped.lstrip().startswith("#"):
+            last = stripped[:-1]
+            if last.strip():
+                body.append(last)
+            out[name] = body
+            name = None
+        else:
+            body.append(line)
+    return out
+
+
+def split_entries(lines):
+    """Split raw list body lines into (entries, comments-attached-to-entry).
+
+       A hand-written comment attaches to exactly the entry below it.  Prose that
+       covers several entries has to be repeated above each of them, because
+       generate re-sorts the list and any adjacency-based grouping is lost -- one
+       comment per entry is the only association that survives a rewrite (and
+       makes this parse a fixed point, so a regen of a generated block is a
+       no-op).
+
+       Group headers (`# smb2.<suite>`) are dropped; generate re-emits those.
+    """
+    entries, attached, pending = [], {}, []
+    for line in lines:
+        s = line.strip()
+        if not s:
+            continue
+        if s.startswith("#"):
+            if not GROUP_COMMENT.match(s):
+                pending.append(s)
+            continue
+        entry = s.strip('"')
+        entries.append(entry)
+        if pending:
+            attached[entry] = pending
+        pending = []
+    return entries, attached
 
 
 def cmake_quote(s):
     return f'"{s}"' if any(c in s for c in ' ()') else s
 
 
-def emit_block(subs, res):
+def parent_of(subtest):
+    bits = subtest.split(".")
+    return bits[0] + "." + bits[1]
+
+
+def emit_block(subs, res, attached):
     by_suite = collections.defaultdict(list)
     for s in subs:
-        bits = s.split(".")
-        parent = bits[0] + "." + bits[1]
-        by_suite[parent].append(s)
+        by_suite[parent_of(s)].append(s)
 
     out = []
     w = out.append
@@ -61,15 +145,17 @@ def emit_block(subs, res):
     w(")")
     w("")
     for b in BACKENDS:
-        enabled = sorted([s for s in subs if res.get((b,s)) == "PASS"])
+        enabled = sorted([s for s in subs if res.get((b,s), [None])[-1] == "PASS"])
         w(f"set(SMBTORTURE_ENABLED_{b}")
         cur = None
         for s in enabled:
-            bits = s.split(".")
-            parent = bits[0] + "." + bits[1]
+            parent = parent_of(s)
             if parent != cur:
                 cur = parent
                 w(f"    # {parent}")
+            # Carry across any rationale hand-written against this entry.
+            for c in attached.get(b, {}).get(s, ()):
+                w(f"    {c}")
             w(f"    {cmake_quote(s)}")
         w(")")
         w("")
@@ -77,27 +163,155 @@ def emit_block(subs, res):
     return "\n".join(out)
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--subs", required=True)
-    ap.add_argument("--results", required=True)
-    ap.add_argument("--cmake", required=True)
-    args = ap.parse_args()
+def log_path(results_path, backend, subtest):
+    import os
+    sid = re.sub(r"[^A-Za-z0-9]", "_", subtest)
+    return os.path.join(os.path.dirname(os.path.abspath(results_path)),
+                        f"smbt-fail.{backend}.{sid}.log")
 
+
+def do_generate(args):
     subs = [l.strip() for l in open(args.subs) if l.strip()]
     res = parse_results(args.results)
-    block = emit_block(subs, res)
 
     txt = open(args.cmake).read()
     if BEGIN not in txt or END not in txt:
         print(f"error: anchor markers not found in {args.cmake}", file=sys.stderr)
-        sys.exit(1)
+        return 1
+
+    # Preserve rationale comments hand-written against individual entries.
+    lists = parse_cmake_lists(txt)
+    attached, kept = {}, 0
+    for b in BACKENDS:
+        raw = lists.get(f"ENABLED_{b}")
+        if raw is None:
+            continue
+        _, att = split_entries(raw)
+        attached[b] = att
+        kept += sum(len(v) for v in att.values())
+
+    block = emit_block(subs, res, attached)
     head, _, rest = txt.partition(BEGIN)
     _, _, tail = rest.partition(END)
     new = head + block + tail
-    open(args.cmake, "w").write(new)
-    n_pass = sum(1 for v in res.values() if v == "PASS")
-    print(f"rewrote {args.cmake}: {len(subs)} subtests, {n_pass} pass cells")
+
+    if args.block_only:
+        new = block + "\n"
+    dest = args.output or args.cmake
+    open(dest, "w").write(new)
+
+    n_pass = sum(1 for v in res.values() if v[-1] == "PASS")
+    print(f"wrote {dest}: {len(subs)} subtests, {n_pass} pass cells, "
+          f"{kept} hand comments preserved")
+    return 0
+
+
+def do_compare(args):
+    txt = open(args.cmake).read()
+    lists = parse_cmake_lists(txt)
+    if "SUITES" not in lists:
+        print(f"error: SMBTORTURE_SUITES not found in {args.cmake}", file=sys.stderr)
+        return 1
+
+    catalog, _ = split_entries(lists["SUITES"])
+    if args.subs:
+        catalog = [l.strip() for l in open(args.subs) if l.strip()]
+    disabled = set(split_entries(lists.get("DISABLED_SUBTESTS", []))[0])
+    res = parse_results(args.results)
+
+    report, totals = [], collections.Counter()
+    for b in BACKENDS:
+        raw = lists.get(f"ENABLED_{b}")
+        if raw is None:
+            continue
+        baseline = set(split_entries(raw)[0])
+        # The gated set is what add_smbtorture_backend_tests() actually registers.
+        gated = baseline - disabled
+        buckets = collections.defaultdict(list)
+        for s in catalog:
+            statuses = res.get((b, s))
+            if not statuses:
+                buckets["not measured"].append(s)
+                continue
+            if len(set(statuses)) > 1:
+                buckets["flaky"].append(f"{s} [{'/'.join(statuses)}]")
+                continue
+            status = statuses[-1]
+            if status == "PASS":
+                if s not in baseline:
+                    buckets["newly passing"].append(s)
+            elif status == "SKIP":
+                buckets["skipped"].append(s)
+            elif s in gated:
+                buckets["newly failing"].append(
+                    f"{s} [{status}] {log_path(args.results[0], b, s)}")
+            elif s in disabled:
+                buckets["failing (disabled)"].append(f"{s} [{status}]")
+            elif status == "TIME":
+                buckets["timing out"].append(
+                    f"{s} {log_path(args.results[0], b, s)}")
+            else:
+                buckets["still failing"].append(
+                    f"{s} {log_path(args.results[0], b, s)}")
+        report.append((b, len(baseline), buckets))
+        for k, v in buckets.items():
+            totals[k] += len(v)
+
+    md = args.format == "markdown"
+    for b, n_baseline, buckets in report:
+        counts = ", ".join(f"{k} {len(buckets[k])}" for k in sorted(buckets)
+                           if k != "not measured")
+        head = f"{b}: baseline {n_baseline}/{len(catalog)}"
+        print(f"\n### {head}\n" if md else f"\n== {head}")
+        print(f"{counts or 'no cells measured'}\n")
+        for k in ("newly failing", "newly passing", "flaky", "timing out",
+                  "still failing", "failing (disabled)", "skipped"):
+            items = buckets.get(k)
+            if not items or (k in args.quiet_buckets):
+                continue
+            print(f"{'#### ' if md else '-- '}{k} ({len(items)})")
+            for s in items:
+                print(f"  {'- ' if md else ''}{s}")
+            print()
+
+    print("== totals: " + (", ".join(f"{k} {v}" for k, v in sorted(totals.items()))
+                           or "nothing measured"))
+    if totals["newly failing"] and args.fail_on_newly_failing:
+        print(f"\nerror: {totals['newly failing']} newly failing cell(s) -- "
+              "a gated test regressed", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="mode", required=True)
+
+    g = sub.add_parser("generate", help="splice a measured matrix into CMakeLists")
+    g.add_argument("--subs", required=True, help="one-per-line subtest catalog")
+    g.add_argument("--results", required=True, action="append",
+                   help="matrix results.txt")
+    g.add_argument("--cmake", required=True, help="CMakeLists.txt to read/rewrite")
+    g.add_argument("--output", help="write here instead of --cmake (leaves the "
+                                    "tree untouched)")
+    g.add_argument("--block-only", action="store_true",
+                   help="with --output, emit just the generated block")
+    g.set_defaults(func=do_generate)
+
+    c = sub.add_parser("compare", help="diff a matrix against the baseline")
+    c.add_argument("--results", required=True, action="append",
+                   help="matrix results.txt; repeat to detect flaky cells")
+    c.add_argument("--cmake", required=True, help="CMakeLists.txt holding the baseline")
+    c.add_argument("--subs", help="restrict the catalog to this list")
+    c.add_argument("--format", choices=("text","markdown"), default="text")
+    c.add_argument("--fail-on-newly-failing", action="store_true",
+                   help="exit 1 if a gated test regressed (nightly gate)")
+    c.add_argument("--quiet-buckets", default="", type=lambda s: set(filter(None, s.split(","))),
+                   help="comma separated bucket names to summarize but not list")
+    c.set_defaults(func=do_compare)
+
+    args = ap.parse_args()
+    sys.exit(args.func(args))
 
 
 if __name__ == "__main__":

--- a/tools/smbtorture/regen.py
+++ b/tools/smbtorture/regen.py
@@ -253,15 +253,24 @@ def do_compare(args):
             else:
                 buckets["still failing"].append(
                     f"{s} {log_path(args.results[0], b, s)}")
-        report.append((b, len(baseline), buckets))
+        # Report the baseline as a fraction of the catalog actually measured, not
+        # of the whole allowlist: a --backends/--filter run restricts the catalog,
+        # and "baseline 551/15" is worse than no number at all.
+        report.append((b, len(baseline & set(catalog)), buckets))
         for k, v in buckets.items():
             totals[k] += len(v)
 
     md = args.format == "markdown"
+    unmeasured = []
     for b, n_baseline, buckets in report:
+        # A --backends run leaves whole backends unmeasured; listing each as an
+        # empty section buries the ones that were actually run.
+        if len(buckets.get("not measured", ())) == len(catalog):
+            unmeasured.append(b)
+            continue
         counts = ", ".join(f"{k} {len(buckets[k])}" for k in sorted(buckets)
                            if k != "not measured")
-        head = f"{b}: baseline {n_baseline}/{len(catalog)}"
+        head = f"{b}: baseline {n_baseline}/{len(catalog)} measured"
         print(f"\n### {head}\n" if md else f"\n== {head}")
         print(f"{counts or 'no cells measured'}\n")
         for k in ("newly failing", "newly passing", "flaky", "timing out",
@@ -274,6 +283,8 @@ def do_compare(args):
                 print(f"  {'- ' if md else ''}{s}")
             print()
 
+    if unmeasured:
+        print(f"\n{'> ' if md else ''}not run: {', '.join(unmeasured)}")
     print("== totals: " + (", ".join(f"{k} {v}" for k, v in sorted(totals.items()))
                            or "nothing measured"))
     if totals["newly failing"] and args.fail_on_newly_failing:

--- a/tools/smbtorture/regen.py
+++ b/tools/smbtorture/regen.py
@@ -220,6 +220,7 @@ def do_compare(args):
     res = parse_results(args.results)
 
     report, totals = [], collections.Counter()
+    n_measured = n_cells = 0
     for b in BACKENDS:
         raw = lists.get(f"ENABLED_{b}")
         if raw is None:
@@ -253,26 +254,39 @@ def do_compare(args):
             else:
                 buckets["still failing"].append(
                     f"{s} {log_path(args.results[0], b, s)}")
+        # Count what was measured on its own, not off the buckets: the buckets
+        # hold only deviations, so a clean backend leaves every one of them empty
+        # and any total derived from them alone reports a fully green matrix of
+        # thousands of cells as "nothing measured".
+        measured = len(catalog) - len(buckets.get("not measured", ()))
+        n_measured += measured
+        n_cells += len(catalog)
         # Report the baseline as a fraction of the catalog actually measured, not
         # of the whole allowlist: a --backends/--filter run restricts the catalog,
         # and "baseline 551/15" is worse than no number at all.
-        report.append((b, len(baseline & set(catalog)), buckets))
+        report.append((b, len(baseline & set(catalog)), measured, buckets))
         for k, v in buckets.items():
-            totals[k] += len(v)
+            # "not measured" is scope, not drift, and n_measured now carries it.
+            if k != "not measured":
+                totals[k] += len(v)
 
     md = args.format == "markdown"
     unmeasured = []
-    for b, n_baseline, buckets in report:
+    for b, n_baseline, measured, buckets in report:
         # A --backends run leaves whole backends unmeasured; listing each as an
         # empty section buries the ones that were actually run.
-        if len(buckets.get("not measured", ())) == len(catalog):
+        if not measured:
             unmeasured.append(b)
             continue
         counts = ", ".join(f"{k} {len(buckets[k])}" for k in sorted(buckets)
                            if k != "not measured")
-        head = f"{b}: baseline {n_baseline}/{len(catalog)} measured"
+        # Buckets hold only deviations, so an empty bucket set means every
+        # measured cell agreed with the baseline -- report that as no drift, not
+        # as an absence of measurement.
+        head = (f"{b}: {measured}/{len(catalog)} cells measured, "
+                f"{n_baseline} in baseline")
         print(f"\n### {head}\n" if md else f"\n== {head}")
-        print(f"{counts or 'no cells measured'}\n")
+        print(f"{counts or 'no drift from the baseline'}\n")
         for k in ("newly failing", "newly passing", "flaky", "timing out",
                   "still failing", "failing (disabled)", "skipped"):
             items = buckets.get(k)
@@ -285,8 +299,9 @@ def do_compare(args):
 
     if unmeasured:
         print(f"\n{'> ' if md else ''}not run: {', '.join(unmeasured)}")
-    print("== totals: " + (", ".join(f"{k} {v}" for k, v in sorted(totals.items()))
-                           or "nothing measured"))
+    print(f"== totals: {n_measured}/{n_cells} cells measured, "
+          + (", ".join(f"{k} {v}" for k, v in sorted(totals.items()))
+             or "no drift from the baseline"))
     if totals["newly failing"] and args.fail_on_newly_failing:
         print(f"\nerror: {totals['newly failing']} newly failing cell(s) -- "
               "a gated test regressed", file=sys.stderr)

--- a/tools/smbtorture/regen.sh
+++ b/tools/smbtorture/regen.sh
@@ -10,34 +10,159 @@
 # Run after upgrading the Samba devcontainer image (which changes the subtest
 # catalog) or after adding a new backend to the smbtorture_test driver.
 #
+# With --report-only the matrix runs but the splice step is skipped, so the run
+# is a pure measurement: results.txt plus one log per failing cell, retained in
+# --out-dir for inspection or for `regen.py compare`.  Use --backends/--filter to
+# narrow a targeted investigation to a subset of the ~3900 cells.
+#
 # Pre-requisites:
 #   - smbtorture client present in PATH (e.g. apt: samba-testsuite)
-#   - chimera built in build/Release (with smbtorture_test)
+#   - chimera built with smbtorture_test (see --build-dir)
 #   - run as root (the netns wrapper needs CAP_NET_ADMIN)
 #
 # Output:
-#   - rewrites src/server/smb/tests/CMakeLists.txt in place
-#   - leaves /tmp/smbtorture_results.txt for inspection
+#   - <out-dir>/results.txt              PASS|SKIP|TIME|FAIL cell classifications
+#   - <out-dir>/subtests.txt             the full discovered catalog
+#   - <out-dir>/measured-catalog.txt     the subset this run measured (== the
+#                                        full catalog unless --filter narrowed
+#                                        it); pass to `regen.py compare --subs`
+#   - <out-dir>/smbt-fail.<b>.<s>.log    one log per non-passing cell
+#   - src/server/smb/tests/CMakeLists.txt rewritten in place (unless
+#     --report-only)
+#
+# The out-dir is reusable: everything this script generates in it is removed at
+# startup, so a later run can never be read against a leftover catalog or a
+# leftover failure log from an earlier, differently-scoped one.
 
 set -euo pipefail
 
 REPO=$(cd "$(dirname "$0")/../.." && pwd)
-RESULTS=/tmp/smbtorture_results.txt
-SUBS=/tmp/smbtorture_subtests.txt
-PAIRS=/tmp/smbtorture_pairs.bin
+ALL_BACKENDS="memfs linux io_uring cairn diskfs_io_uring diskfs_aio"
+
+BUILD_DIR=${SMBTORTURE_BUILD_DIR:-}
+OUT_DIR=${SMBTORTURE_OUT_DIR:-/tmp}
 PARALLEL=${SMBTORTURE_PARALLEL:-12}
+BACKENDS=$ALL_BACKENDS
+FILTER=
+REPORT_ONLY=0
+
+usage()
+{
+    cat <<'USAGE'
+usage: regen.sh [options]
+
+  --report-only        run the matrix and stop; do not splice CMakeLists.txt
+  --out-dir <dir>      where results.txt and per-failure logs land (default /tmp)
+  --backends <list>    comma/space separated subset of backends to run
+  --filter <regex>     only run catalog subtests matching this extended regex
+  --build-dir <dir>    build tree holding src/server/smb/tests/smbtorture_test
+                       (default: first of $SMBTORTURE_BUILD_DIR, ./build/Release,
+                       /build/Release that exists)
+  --parallel <n>       concurrent cells (default 12, $SMBTORTURE_PARALLEL)
+  -h, --help           this message
+
+Known backends: memfs linux io_uring cairn diskfs_io_uring diskfs_aio
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --report-only) REPORT_ONLY=1; shift;;
+        --out-dir)     OUT_DIR=$2; shift 2;;
+        --backends)    BACKENDS=${2//,/ }; shift 2;;
+        --filter)      FILTER=$2; shift 2;;
+        --build-dir)   BUILD_DIR=$2; shift 2;;
+        --parallel)    PARALLEL=$2; shift 2;;
+        -h|--help)     usage; exit 0;;
+        *)             echo "error: unknown option '$1'" >&2; usage >&2; exit 2;;
+    esac
+done
+
+# Canonical form for a backend set, so "is this the whole matrix" is a question
+# about the set and not about the order it happened to be typed in.
+canon_backends()
+{
+    # $1 is deliberately unquoted: the word split is what turns the list into
+    # one entry per line for sort.
+    printf '%s\n' $1 | sort -u | tr '\n' ' '
+}
+
+for b in $BACKENDS; do
+    case " $ALL_BACKENDS " in
+        *" $b "*) ;;
+        *) echo "error: unknown backend '$b' (known: $ALL_BACKENDS)" >&2; exit 2;;
+    esac
+done
+
+# xargs reads -P 0 as "unbounded", which across ~3900 cells is ~3900 concurrent
+# daemon+netns+client invocations rather than a faster run.
+case $PARALLEL in
+    ''|*[!0-9]*)
+        echo "error: --parallel wants a positive integer (got '$PARALLEL')" >&2
+        exit 2;;
+esac
+if [ "$PARALLEL" -lt 1 ]; then
+    echo "error: --parallel wants a positive integer (got '$PARALLEL'); 0 tells" >&2
+    echo "       xargs to run every cell at once" >&2
+    exit 2
+fi
+
+# Reject a scoped splice up front rather than after the matrix: the run is the
+# expensive part and the verdict does not depend on any of it.
+if [ "$REPORT_ONLY" -eq 0 ] &&
+   { [ -n "$FILTER" ] ||
+     [ "$(canon_backends "$BACKENDS")" != "$(canon_backends "$ALL_BACKENDS")" ]; }; then
+    echo "error: refusing to splice from a partial run (--backends/--filter)" >&2
+    echo "       a partial matrix would drop every unmeasured subtest from the" >&2
+    echo "       allowlists; re-run without them, or use --report-only" >&2
+    exit 1
+fi
 
 cd "$REPO"
 
-if [ ! -x build/Release/src/server/smb/tests/smbtorture_test ]; then
-    echo "error: build/Release/src/server/smb/tests/smbtorture_test not built" >&2
-    echo "       run 'make release' first" >&2
+# Build trees live in ./build/Release for worktrees and /build/Release for the
+# main tree, so there is no single relative path that works in both.
+if [ -z "$BUILD_DIR" ]; then
+    for d in build/Release /build/Release; do
+        if [ -x "$d/src/server/smb/tests/smbtorture_test" ]; then
+            BUILD_DIR=$d
+            break
+        fi
+    done
+fi
+TEST_BIN=$BUILD_DIR/src/server/smb/tests/smbtorture_test
+if [ -z "$BUILD_DIR" ] || [ ! -x "$TEST_BIN" ]; then
+    echo "error: smbtorture_test not found (looked for $TEST_BIN)" >&2
+    echo "       run 'make release' first, or pass --build-dir" >&2
     exit 1
 fi
 if ! command -v smbtorture >/dev/null; then
     echo "error: smbtorture client not in PATH (install samba-testsuite)" >&2
     exit 1
 fi
+
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd)
+RESULTS=$OUT_DIR/results.txt
+SUBS=$OUT_DIR/subtests.txt
+MEASURED=$OUT_DIR/measured-catalog.txt
+PAIRS=$OUT_DIR/pairs.bin
+
+echo "build dir: $BUILD_DIR"
+echo "out dir:   $OUT_DIR"
+
+# Clear what a previous run left here before writing any of it.  The default
+# out-dir is /tmp and the documented workflow retains the directory, so stale
+# state is the normal case, not the exotic one: a measured-catalog.txt from an
+# earlier --filter run would silently become this run's denominator, and old
+# failure logs would sit in the artifact looking like this run's failures.
+# smbt.*.log and smbt-runner.*.sh are the temporaries a killed run leaves.
+# subtests.filtered.txt is the pre-measured-catalog name for the same thing;
+# nothing reads it any more, so clear it rather than leave a file that looks
+# authoritative sitting in an out-dir that predates the rename.
+rm -f "$SUBS" "$MEASURED" "$RESULTS" "${RESULTS}.lock" "$PAIRS" \
+    "$OUT_DIR"/subtests.filtered.txt \
+    "$OUT_DIR"/smbt-fail.*.log "$OUT_DIR"/smbt.*.log "$OUT_DIR"/smbt-runner.*.sh
 
 # 1) Discover the catalog.
 smbtorture --list 2>&1 | grep -E '^smb2\.' \
@@ -53,26 +178,55 @@ for a in sorted(seen):
 ' > "$SUBS"
 echo "catalog: $(wc -l < "$SUBS") subtests"
 
+# The filter narrows only what this run measures; the catalog written to $SUBS
+# stays complete so a spliced block never drops the unmeasured subtests.  What
+# the run did measure is always written to $MEASURED, filtered or not, so a
+# consumer never has to infer the scope from which files happen to exist.
+if [ -n "$FILTER" ]; then
+    # Distinguish grep's "no lines selected" (1) from "bad regex" (2): both used
+    # to surface as "filter matched no subtests", which sends you looking for a
+    # catalog that does not contain what you asked for instead of at your regex.
+    grep -E "$FILTER" "$SUBS" > "$MEASURED" && grc=0 || grc=$?
+    if [ "$grc" -gt 1 ]; then
+        echo "error: --filter '$FILTER' is not a valid extended regex" >&2
+        exit 2
+    fi
+    echo "filter '$FILTER': $(wc -l < "$MEASURED") subtests match"
+    if [ ! -s "$MEASURED" ]; then
+        echo "error: filter matched no subtests" >&2
+        exit 1
+    fi
+else
+    cp "$SUBS" "$MEASURED"
+fi
+RUN_SUBS=$MEASURED
+
 # 2) Build (backend, subtest) pairs as null-delimited records.
 > "$PAIRS"
-for b in memfs linux io_uring cairn diskfs_io_uring diskfs_aio; do
+NCELLS=0
+for b in $BACKENDS; do
     while IFS= read -r s; do
         printf '%s\0%s\0' "$b" "$s" >> "$PAIRS"
-    done < "$SUBS"
+        NCELLS=$((NCELLS + 1))
+    done < "$RUN_SUBS"
 done
-echo "pairs: $(( $(stat -c%s "$PAIRS") )) bytes"
+echo "cells: $NCELLS ($(echo "$BACKENDS" | wc -w) backends)"
 
 # 3) Per-pair runner: flock-serialized append to results.
-RUNNER=$(mktemp /tmp/smbt-runner.XXXXXX.sh)
+RUNNER=$(mktemp "$OUT_DIR/smbt-runner.XXXXXX.sh")
 cat > "$RUNNER" <<'RUNNER_EOF'
 #!/bin/bash
+# Paths arrive as exported SMBT_* variables rather than being substituted into
+# this text.  A repository path containing "&" or the sed delimiter would
+# otherwise corrupt every cell of the run, and the failure would look like a
+# test failure rather than a quoting bug.
 set -u
 BACKEND="$1"; SUITE="$2"
-LOG=$(mktemp /var/tmp/smbt.XXXXXX.log)
-cd %REPO%
+LOG=$(mktemp "$SMBT_OUTDIR/smbt.XXXXXX.log")
+cd "$SMBT_REPO"
 timeout --signal=KILL 300 \
     scripts/netns_test_wrapper.sh \
-    build/Release/src/server/smb/tests/smbtorture_test \
+    "$SMBT_TESTBIN" \
     -b "$BACKEND" "$SUITE" > "$LOG" 2>&1
 RC=$?
 case $RC in
@@ -81,25 +235,45 @@ case $RC in
     137) STATUS="TIME|$BACKEND|$SUITE";;
     *)   STATUS="FAIL|$BACKEND|$SUITE|rc=$RC";;
 esac
-{ flock -x 9; echo "$STATUS" >> %RESULTS%; } 9>%RESULTS%.lock
+{ flock -x 9; echo "$STATUS" >> "$SMBT_RESULTS"; } 9>"$SMBT_RESULTS.lock"
 if [ "$RC" -ne 0 ] && [ "$RC" -ne 77 ]; then
-    mv "$LOG" "/var/tmp/smbt-fail.${BACKEND}.${SUITE//[^A-Za-z0-9]/_}.log" 2>/dev/null || rm -f "$LOG"
+    mv "$LOG" "$SMBT_OUTDIR/smbt-fail.${BACKEND}.${SUITE//[^A-Za-z0-9]/_}.log" 2>/dev/null || rm -f "$LOG"
 else
     rm -f "$LOG"
 fi
+# A cell's outcome belongs in results.txt, never in this script's exit status:
+# xargs returns 123 if any invocation exits non-zero, and the caller's `set -e`
+# would discard a multi-hour matrix over one unlink.
+exit 0
 RUNNER_EOF
-sed -i "s|%REPO%|$REPO|g; s|%RESULTS%|$RESULTS|g" "$RUNNER"
 chmod +x "$RUNNER"
+export SMBT_REPO=$REPO
+export SMBT_RESULTS=$RESULTS
+export SMBT_OUTDIR=$OUT_DIR
+export SMBT_TESTBIN=$TEST_BIN
 
 # 4) Drive the matrix.
 rm -f "$RESULTS" "${RESULTS}.lock"
 : > "$RESULTS"
-echo "running $(( $(stat -c%s "$PAIRS") / 2 )) cells at parallel=$PARALLEL"
+echo "running $NCELLS cells at parallel=$PARALLEL"
 xargs -0 -P "$PARALLEL" -n 2 -a "$PAIRS" "$RUNNER"
-rm -f "$RUNNER" "${RESULTS}.lock"
+rm -f "$RUNNER" "${RESULTS}.lock" "$PAIRS"
 
-# 5) Regenerate the CMakeLists block.
-python3 "$(dirname "$0")/regen.py" \
+if [ "$REPORT_ONLY" -eq 1 ]; then
+    echo "report-only: CMakeLists.txt untouched"
+    echo "results: $RESULTS"
+    # --subs keeps the comparison honest about its denominator: without it a
+    # scoped run is diffed against the whole checked-in catalog.
+    echo "compare with: python3 tools/smbtorture/regen.py compare \\"
+    echo "                  --results $RESULTS \\"
+    echo "                  --subs $MEASURED \\"
+    echo "                  --cmake src/server/smb/tests/CMakeLists.txt"
+    exit 0
+fi
+
+# 5) Regenerate the CMakeLists block.  A scoped run was rejected before the
+#    matrix ran, so what reached here measured the whole catalog.
+python3 "$(dirname "$0")/regen.py" generate \
     --subs "$SUBS" \
     --results "$RESULTS" \
     --cmake "$REPO/src/server/smb/tests/CMakeLists.txt"

--- a/tools/smbtorture/regen.sh
+++ b/tools/smbtorture/regen.sh
@@ -42,8 +42,11 @@ ALL_BACKENDS="memfs linux io_uring cairn diskfs_io_uring diskfs_aio"
 BUILD_DIR=${SMBTORTURE_BUILD_DIR:-}
 OUT_DIR=${SMBTORTURE_OUT_DIR:-/tmp}
 PARALLEL=${SMBTORTURE_PARALLEL:-12}
-BACKENDS=$ALL_BACKENDS
-FILTER=
+# Env fallbacks so a caller that cannot easily append flags -- a CI job passing
+# `docker run -e` -- can scope a run without interpolating anything into a shell
+# command line.  Unset or empty means "the whole matrix".
+BACKENDS=${SMBTORTURE_BACKENDS:-$ALL_BACKENDS}
+FILTER=${SMBTORTURE_FILTER:-}
 REPORT_ONLY=0
 
 usage()
@@ -53,8 +56,11 @@ usage: regen.sh [options]
 
   --report-only        run the matrix and stop; do not splice CMakeLists.txt
   --out-dir <dir>      where results.txt and per-failure logs land (default /tmp)
+                       ($SMBTORTURE_OUT_DIR)
   --backends <list>    comma/space separated subset of backends to run
+                       ($SMBTORTURE_BACKENDS)
   --filter <regex>     only run catalog subtests matching this extended regex
+                       ($SMBTORTURE_FILTER)
   --build-dir <dir>    build tree holding src/server/smb/tests/smbtorture_test
                        (default: first of $SMBTORTURE_BUILD_DIR, ./build/Release,
                        /build/Release that exists)
@@ -77,6 +83,11 @@ while [ $# -gt 0 ]; do
         *)             echo "error: unknown option '$1'" >&2; usage >&2; exit 2;;
     esac
 done
+
+# Normalize commas once every input source has been consumed.  --backends did it
+# on the way in, but $SMBTORTURE_BACKENDS handed its text straight to the
+# validation below, where "memfs,linux" is a single unknown backend.
+BACKENDS=${BACKENDS//,/ }
 
 # Canonical form for a backend set, so "is this the whole matrix" is a question
 # about the set and not about the order it happened to be typed in.
@@ -223,6 +234,13 @@ cat > "$RUNNER" <<'RUNNER_EOF'
 set -u
 BACKEND="$1"; SUITE="$2"
 LOG=$(mktemp "$SMBT_OUTDIR/smbt.XXXXXX.log")
+# mktemp creates 0600 regardless of umask, and this runs as root inside the
+# container while the out-dir is a bind mount the CI runner reads as an
+# unprivileged user.  Without this the kept failure logs are unreadable outside
+# the container and artifact upload dies with EACCES.  Done before the run, not
+# after the mv, so the temporaries an aborted matrix leaves behind are readable
+# too -- upload happens even when the matrix never finished.
+chmod 644 "$LOG"
 cd "$SMBT_REPO"
 timeout --signal=KILL 300 \
     scripts/netns_test_wrapper.sh \
@@ -246,7 +264,10 @@ fi
 # would discard a multi-hour matrix over one unlink.
 exit 0
 RUNNER_EOF
-chmod +x "$RUNNER"
+# 755 rather than +x for the same reason the per-cell log is 644: mktemp made it
+# 0600, and a matrix that dies before the cleanup below leaves it in an out-dir
+# that CI uploads as an unprivileged user.
+chmod 755 "$RUNNER"
 export SMBT_REPO=$REPO
 export SMBT_RESULTS=$RESULTS
 export SMBT_OUTDIR=$OUT_DIR


### PR DESCRIPTION
## Why

`tools/smbtorture/regen.sh` could do exactly one thing: run the whole 3930-cell
backend × subtest matrix and immediately collapse it into the
`SMBTORTURE_ENABLED_*` allowlists in `src/server/smb/tests/CMakeLists.txt`. The
evidence landed in `/tmp` and `/var/tmp`, where the next run overwrote it.

Because `add_smbtorture_backend_tests()` registers a ctest only for the *enabled*
set, every currently-failing subtest is invisible to ctest. So there was no way
to ask the two questions that matter for working the backlog down:

- what is still failing?
- has that set changed since last time?

This series makes the measurement a first-class output, diffs it against the
checked-in baseline, and puts both behind a nightly job.

## What changed

**`regen.sh` — the measurement is retainable and scopable**

| Flag | Effect |
|---|---|
| `--report-only` | run the matrix, skip the allowlist splice |
| `--out-dir <dir>` | `results.txt` + per-failure logs land here |
| `--backends <list>` | narrow to a subset of backends |
| `--filter <regex>` | narrow to matching subtests |
| `--build-dir <dir>` | locate `smbtorture_test` explicitly |

Splicing from a `--backends`/`--filter` run is refused outright — a partial
matrix would silently drop every unmeasured subtest from the allowlists.

The build tree is now auto-detected across `./build/Release` (worktrees) and
`/build/Release` (main tree). The previous hardcoded relative path meant the
script could not run in the main tree at all.

**`regen.py` — two named modes**

`generate` is the previous behaviour; `compare` buckets a run against the
checked-in baseline. `--output` writes somewhere other than the input
CMakeLists, `--results` may be repeated (a cell whose status disagrees between
runs is reported as flaky), and `--fail-on-newly-failing` exits non-zero only for
a regression in a gated test.

`compare` buckets on the runner's own classification rather than on "not in the
allowlist", which matters in two places: a 300s hang (`TIME`) is never filed as a
plain failure, and a subtest that is in the allowlist but excluded by
`SMBTORTURE_DISABLED_SUBTESTS` is reported separately — it is not a gated test,
so it must not trip the regression gate.

**`SMBTORTURE_EXPLORE_TESTS=ON` — the complement, addressable from ctest**

Registers, per backend, the subtests the gating suite does not run: the
complement of the generated allowlist plus the entries held back by
`SMBTORTURE_DISABLED_SUBTESTS`. The `smbtorture` and `smbtorture_explore` labels
together now cover the catalog exactly once per backend (933 explore entries
across six backends = the 879-cell complement plus 9 disabled subtests each), so

```
ctest -L smbtorture_explore -R smb2_streams
```

iterates on one family without hand-running the matrix.

The disabled subtests are included deliberately: they are excluded from gating
because they flake, which is a reason to keep them addressable, not a reason to
make them unreachable.

Explore entries mirror `_smbtorture_add_subtest`'s properties — `SKIP_RETURN_CODE
77`, 300s timeout, the durable-family `RESOURCE_LOCK`, the LSAN suppressions — so
a subtest promoted into an allowlist behaves identically before and after. Off by
default; with the option off the registered ctest set is unchanged (verified:
8135 tests, name-for-name identical to before the series).

**Nightly job `smbtorture matrix (informational)`**

Runs the full matrix with `--report-only`, publishes `results.txt` and the
per-failure logs as an artifact, and renders the compare buckets into the job
summary.

It fails only on a *newly* failing cell — a gated subtest that stopped passing. A
*still* failing cell is the expected state of the exploration backlog; gating on
it would make the job red every night and nobody would read it. The verdict is
recorded as a flag file inside the container rather than by failing the compare
step, so the summary and artifacts publish even on a regression, which is exactly
when they are worth reading.

**Manual scoping, so the first real run isn't a blind three-hour bet**

The matrix job could initially only be exercised as the full sweep, so the first
run costs hours and a trivial mistake — a bad artifact path, a mis-quoted flag —
costs another. Three `workflow_dispatch` inputs scope it, defaulting to the full
matrix so the scheduled run is unchanged:

```
gh workflow run nightly.yml --ref <branch> \
    -f smbtorture_backends=memfs -f smbtorture_filter='smb2\.streams'
```

These reach `regen.sh` as `SMBTORTURE_BACKENDS` / `SMBTORTURE_FILTER` /
`SMBTORTURE_PARALLEL`, passed through by `docker run -e NAME` from the step
environment rather than interpolated into the container command line. A dispatch
input is attacker-controlled text and must not be able to break out of quoting.
`regen.sh` grows env fallbacks for the two it lacked, which also makes scoping
available to callers that cannot easily append flags.

## Reporting fixes surfaced along the way

Three, all on the scoped path, none reachable from the full-matrix run:

- `compare` printed the whole allowlist over the measured catalog, so a scoped
  run reported nonsense like "baseline 551/15". It now reports `baseline n
  catalog` and measures against the catalog the run actually covered — the
  filtered list when scoped, else the catalog `regen.sh` just discovered from the
  live smbtorture, rather than the checked-in `SMBTORTURE_SUITES`. Identical
  today; the live list is the honest denominator once a Samba upgrade moves the
  catalog.
- An empty bucket set was read as "no cells measured", but buckets only hold
  deviations — so a backend whose every measured cell matched the baseline, the
  expected outcome, reported as though nothing had run. It now reports the
  measured count and says "no drift from the baseline".
- Backends a scoped run skipped entirely each got their own empty section,
  burying the ones actually measured. They now collapse into a single "not run"
  line.

The full-matrix path (no `--subs`) is unchanged at 551/655.

## Note on `generate` and hand-written commentary

`generate` previously destroyed hand-written rationale.
`SMBTORTURE_ENABLED_memfs` carries comments against individual entries, and
`emit_block()` only ever wrote `# smb2.<suite>` group headers — so any regen
deleted all of them. The entries survived; the reasoning did not. Comments
attached to an entry are now carried onto it across the rewrite.

One consequence worth flagging for review: because `generate` re-sorts the list,
prose covering several adjacent entries cannot survive as a group, so the three
entries that shared one comment each get their own copy in this PR. One comment
per entry is the only association a rewrite can preserve, and it makes the parse
a fixed point.

The CMake lists are parsed line by line rather than with a single non-greedy
regex, which mis-pairs its parens with `SMBTORTURE_RPC_SUITES_DISABLED` — that
list closes on its last entry rather than on its own line — and swallows
`SMBTORTURE_SUITES` entirely.
