### PR TITLE
nfs: bound the upstream file handle the proxy re-encodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,10 @@ All of these checks are verified by CI, so running `make check` locally ensures 
 ### Key Design Patterns
 
 - **Asynchronous I/O**: Uses libevpl for event-driven architecture
-- **File Handles**: 32-byte opaque handles (CHIMERA_VFS_FH_SIZE)
+- **File Handles**: variable-length opaque handles, at most CHIMERA_VFS_FH_SIZE
+  (64) bytes; the actual length travels in `va_fh_len` and depends on the
+  backend — roughly 18-22 for the inum-varint modules (memfs, diskfs, cairn),
+  33 for smb, 26-42 for linux, and up to 64 for the nfs proxy
 - **VFS Operations**: All VFS modules implement common interface with chimera_vfs_attrs
 - **Threading**: Core threads + delegation threads model
 - **High-Performance Networking**: Support for kernel bypass (RDMA, XLIO)

--- a/src/common/varint.h
+++ b/src/common/varint.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -6,6 +6,15 @@
 
 #include <stdint.h>
 #include <stddef.h>
+
+/*
+ * Worst-case encoded sizes: the encoders emit 7 value bits per byte, so a
+ * 64-bit value needs ceil(64/7) = 10 bytes and a 32-bit value ceil(32/7) = 5.
+ * Callers that size a buffer for an encode, or that reason about the length of
+ * a composed varint sequence, use these rather than open-coding the arithmetic.
+ */
+#define CHIMERA_VARINT_UINT64_MAX_BYTES 10
+#define CHIMERA_VARINT_UINT32_MAX_BYTES 5
 
 static inline int
 chimera_decode_uint64(

--- a/src/nfs_common/nfs3_attr.h
+++ b/src/nfs_common/nfs3_attr.h
@@ -9,6 +9,7 @@
 #include "nfs3_xdr.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_fh.h"
+#include "nfs_common/nfs_fh_limits.h"
 
 #define CHIMERA_NFS3_ATTR_MASK     ( \
             CHIMERA_VFS_ATTR_DEV | \
@@ -298,12 +299,16 @@ chimera_nfs3_unmarshall_attrs(
  * fh->data is server-supplied (this is the NFS *client* module parsing a
  * backend server's reply) and bounded only by the wire frame, NOT by the
  * NFS3_FHSIZE the schema declares -- the generated XDR decoder does not enforce
- * the `<NFS3_FHSIZE>` bound.  The local `fragment` buffer holds the 1-byte
- * server index plus the handle data, so the handle must be small enough that
- * 1 + fh->data.len fits in CHIMERA_VFS_FH_SIZE (which also keeps the subsequent
- * encode into the larger attr->va_fh in bounds).  An oversized handle -- a
- * malformed/malicious server, or simply a backend whose handles are larger than
- * chimera can represent -- is rejected rather than overflowing the stack buffer.
+ * the `<NFS3_FHSIZE>` bound.  The bound that matters is the *encoded* handle:
+ * encode_fh_parent returns mount_id + server_index + data.len, and that has to
+ * fit CHIMERA_VFS_FH_SIZE, so the handle is capped at
+ * CHIMERA_NFS_PROXY_REMOTE_FH_MAX.  Bounding only the `fragment` buffer is not
+ * enough -- it admits lengths of 48..63, which encode to 65..80 and fit
+ * attr->va_fh solely because that field carries 16 bytes of padding for XXH3
+ * SIMD overreads.  Callers then copy va_fh_len bytes into bare
+ * uint8_t[CHIMERA_VFS_FH_SIZE] fields and overrun them.  An oversized handle --
+ * a malformed/malicious server, or simply a backend whose handles are larger
+ * than chimera can represent -- is rejected rather than overflowing anything.
  *
  * Returns 0 on success (ATTR_FH set), -1 if the handle does not fit (ATTR_FH
  * left unset; the caller fails the operation with EOVERFLOW, or omits the
@@ -319,8 +324,8 @@ chimera_nfs3_unmarshall_fh(
     uint8_t fragment[CHIMERA_VFS_FH_SIZE];
     int     fragment_len;
 
-    /* 1 (server_index) + data must fit the fragment buffer. */
-    if (fh->data.len > CHIMERA_VFS_FH_SIZE - 1) {
+    /* mount_id + 1 (server_index) + data must fit the encoded handle. */
+    if (fh->data.len > CHIMERA_NFS_PROXY_REMOTE_FH_MAX) {
         return -1;
     }
 

--- a/src/nfs_common/nfs_fh_limits.h
+++ b/src/nfs_common/nfs_fh_limits.h
@@ -29,8 +29,15 @@
  *
  * and so must the two mount paths that open-code the same fragment build
  * (vfs/nfs/nfs3_mount.c, vfs/nfs/nfs4_mount.c).  The three above are covered by
- * vfs/nfs/tests/nfs_fh_bounds_test.c; the mount paths need a live upstream, so
- * they are covered by the pynfs and kvm proxy suites instead.
+ * vfs/nfs/tests/nfs_fh_bounds_test.c.  The mount paths are not, in either
+ * direction.  Every nfs-module mount in the tree is vers=4
+ * (kvm/kvm_pnfs_proxy_test_wrapper.sh, kvm/kvm_pnfs_test_wrapper.sh,
+ * scripts/pynfs_pnfs_test_wrapper.sh), so chimera_mount_mountd_mnt_callback is
+ * reached by no suite at all; and the v4 upstreams those suites do run are
+ * chimera-on-memfs, whose root handles sit well inside the ceiling, so the
+ * reject branch is never taken there either.  Both hold by inspection only.
+ * Pinning them from the bounds test would mean extracting the predicate the
+ * five sites currently open-code.
  *
  * NFSv3 permits 64-byte handles and NFSv4 permits 128, both above this ceiling,
  * so a general upstream can legitimately hand us a handle we cannot represent.

--- a/src/nfs_common/nfs_fh_limits.h
+++ b/src/nfs_common/nfs_fh_limits.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "vfs/vfs_attrs.h"
+#include "vfs/vfs_fh.h"
+
+/*
+ * How large an upstream file handle the NFS proxy client can re-encode.
+ *
+ * The nfs VFS module is an NFS *client*: it dials an upstream server and
+ * re-encodes the handles that server hands back (GETFH, LOOKUP, MOUNT) into
+ * chimera handles, as
+ *
+ *   [ mount_id : 16 ][ server_index : 1 ][ remote_fh : N ]
+ *
+ * so N is bounded by what is left of CHIMERA_VFS_FH_SIZE once the mount_id and
+ * the server index are paid for.  Nothing bounds N on the wire: nfs3.x and
+ * nfs4.x declare nfs_fh3<NFS3_FHSIZE> and nfs_fh4<NFS4_FHSIZE>, but the
+ * generated decoders ignore the declared bound, so N is an arbitrary uint32_t
+ * chosen by the peer.  Every site that re-encodes one must therefore check it
+ * itself:
+ *
+ *   chimera_nfs3_unmarshall_fh        (nfs_common/nfs3_attr.h)
+ *   chimera_nfs4_unmarshall_fh        (vfs/nfs/nfs_internal.h)
+ *   chimera_nfs4_readdir_parse_attrs  (vfs/nfs/nfs4_readdir_attr.h)
+ *
+ * and so must the two mount paths that open-code the same fragment build
+ * (vfs/nfs/nfs3_mount.c, vfs/nfs/nfs4_mount.c).  The three above are covered by
+ * vfs/nfs/tests/nfs_fh_bounds_test.c; the mount paths need a live upstream, so
+ * they are covered by the pynfs and kvm proxy suites instead.
+ *
+ * NFSv3 permits 64-byte handles and NFSv4 permits 128, both above this ceiling,
+ * so a general upstream can legitimately hand us a handle we cannot represent.
+ * Such a server is refused (EOVERFLOW, or EIO at mount) rather than proxied;
+ * embedding it would need a handle indirection table instead of the in-place
+ * re-encoding done here.
+ */
+#define CHIMERA_NFS_PROXY_FH_SERVER_IDX_SIZE 1
+
+/*
+ * Margin against a chimera upstream.  Proxying one chimera through another is a
+ * shipped, CI-exercised topology (kvm/kvm_pnfs_proxy_test_wrapper.sh), and it
+ * works because a share on an inum-varint backend -- memfs, diskfs or cairn,
+ * which is what that wrapper mounts -- fits the ceiling defined just below:
+ *
+ *   mount_id                                      16
+ *   inum + gen varints                            15   (CHIMERA_VFS_FH_INUM_EMITTED_MAX
+ *   stream id varint                               5     covers all three)
+ *   wire wrap: tag + export_id                     3   (CHIMERA_NFS_FH_HDR)
+ *   SipHash MAC, when fh_sign is enabled           8   (CHIMERA_NFS_FH_MAC)
+ *                                                 --
+ *                                                  47  == the ceiling, exactly
+ *
+ * An inum+gen handle (no stream id) comes to 42 and leaves 5 bytes spare; a
+ * named-stream handle consumes the margin exactly.  Because the fit is exact,
+ * any future change to handle composition -- a wider mount_id, a fourth varint
+ * in a fragment, a longer wire header or MAC -- would turn chimera-to-chimera
+ * proxying from "fits" into "rejected at the ceiling", and before the
+ * re-encoders named above started checking, into memory corruption.  The
+ * _Static_assert beside CHIMERA_NFS_FH_HDR in server/nfs/nfs_fh_wrap.h makes
+ * that a build failure instead.  It lives there because that is where the wire
+ * wrap is defined; this is the client side of the same invariant.
+ *
+ * That sum is the inum-varint family only, and deliberately so: an upstream
+ * chimera serving a linux-backed (59) or nfs-backed (75) share exceeds the
+ * ceiling and is refused here rather than proxied, exactly like any other
+ * upstream whose handles are too large.  smb fits with three bytes spare.  The
+ * per-backend numbers and why only one family is asserted are at the
+ * _Static_assert itself.
+ */
+#define CHIMERA_NFS_PROXY_REMOTE_FH_MAX \
+        (CHIMERA_VFS_FH_FRAGMENT_MAX - CHIMERA_NFS_PROXY_FH_SERVER_IDX_SIZE)

--- a/src/nfs_common/tests/nfs3_fh_test.c
+++ b/src/nfs_common/tests/nfs3_fh_test.c
@@ -10,9 +10,16 @@
  * XDR decoder, so an oversized handle must be rejected rather than overflowing
  * the fixed-size fragment / va_fh buffers (the V-001 report).  This pins:
  *   - data.len within capacity  -> returns 0, ATTR_FH set, bytes copied intact
- *   - data.len at the boundary  -> the largest accepted len is FH_SIZE-1
+ *   - data.len at the boundary  -> the largest accepted len is
+ *                                  CHIMERA_NFS_PROXY_REMOTE_FH_MAX, the point
+ *                                  at which the *encoded* handle exactly fills
+ *                                  CHIMERA_VFS_FH_SIZE
  *   - data.len over capacity    -> returns -1, ATTR_FH NOT set, no write past
  *                                  the destination (verified with a canary)
+ *
+ * The band just past the boundary (48..63) is the interesting one and is
+ * covered in depth, alongside the NFSv4 twin, by
+ * src/vfs/nfs/tests/nfs_fh_bounds_test.c.
  */
 
 #include <stdio.h>
@@ -61,12 +68,17 @@ main(void)
 
     memset(fh_data, 0x55, sizeof(fh_data));
 
-    const uint32_t max_ok = CHIMERA_VFS_FH_SIZE - 1; /* largest accepted len */
+    /* Largest accepted len: what is left of the encoded handle once the
+     * mount_id and the 1-byte server index are paid for. */
+    const uint32_t max_ok = CHIMERA_NFS_PROXY_REMOTE_FH_MAX;
 
     /*
      * (len, expect_ok) cases spanning over / boundary / valid:
      *   1024        far oversized -- would smash the stack fragment
      *   256         oversized
+     *   63          fits the fragment buffer but not the encoded handle:
+     *               bounding only the fragment let this through and produced a
+     *               va_fh_len of 80
      *   max_ok + 1  one byte over the boundary
      *   max_ok      exactly the largest that fits
      *   32          comfortably valid
@@ -78,13 +90,14 @@ main(void)
         uint32_t len;
         int      expect_ok;
     } cases[] = {
-        { 1024,       0 },
-        { 256,        0 },
-        { max_ok + 1, 0 },
-        { max_ok,     1 },
-        { 32,         1 },
-        { 1,          1 },
-        { 0,          1 },
+        { 1024,                     0 },
+        { 256,                      0 },
+        { CHIMERA_VFS_FH_SIZE - 1,  0 },
+        { max_ok + 1,               0 },
+        { max_ok,                   1 },
+        { 32,                       1 },
+        { 1,                        1 },
+        { 0,                        1 },
     };
     /* *INDENT-ON* */
     int ncases = (int) (sizeof(cases) / sizeof(cases[0]));
@@ -110,6 +123,10 @@ main(void)
              * mount_id(16) + server_index(1) + data.len. */
             assert(g.attr.va_set_mask & CHIMERA_VFS_ATTR_FH);
             assert(g.attr.va_fh_len == 16 + 1 + cases[i].len);
+            /* The invariant the bound exists to protect: every accepted handle
+             * encodes to something a caller can copy into a bare
+             * uint8_t[CHIMERA_VFS_FH_SIZE]. */
+            assert(g.attr.va_fh_len <= CHIMERA_VFS_FH_SIZE);
             /* server_index then the handle bytes land after the mount id. */
             assert(g.attr.va_fh[16] == 7);
             for (uint32_t b = 0; b < cases[i].len; b++) {

--- a/src/server/nfs/nfs_fh_wrap.h
+++ b/src/server/nfs/nfs_fh_wrap.h
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "vfs/vfs_attrs.h"
+#include "nfs_common/nfs_fh_limits.h"
 #include "nfs_siphash.h"
 
 /*
@@ -40,6 +41,40 @@
 #define CHIMERA_NFS_FH_HDR        3   /* tag(1) + export_id(2) */
 #define CHIMERA_NFS_FH_MAC        8   /* SipHash-2-4 tag, 64-bit */
 #define CHIMERA_NFS_FH_MAX        (CHIMERA_NFS_FH_HDR + CHIMERA_VFS_FH_SIZE + CHIMERA_NFS_FH_MAC)
+
+/*
+ * Proxying one chimera through another has to keep working: the downstream
+ * chimera's NFS client re-embeds whatever handle this wrap puts on the wire,
+ * and it has only CHIMERA_NFS_PROXY_REMOTE_FH_MAX bytes to do it in.  A share on
+ * an inum-varint backend (memfs, diskfs, cairn) fits that ceiling -- exactly, in
+ * the named-stream case, with no slack.  That is the shipped, CI-exercised
+ * topology (kvm/kvm_pnfs_proxy_test_wrapper.sh mounts a memfs or diskfs share
+ * through the nfs module), so it is the case pinned below: widen any term of the
+ * sum and this fails to build rather than silently making chimera refuse to
+ * proxy chimera.  See the margin table at CHIMERA_NFS_PROXY_REMOTE_FH_MAX.
+ *
+ * It is deliberately NOT an assertion about every backend, because two of them
+ * do not fit and cannot be made to:
+ *
+ *   linux  a fragment of up to 32 wraps and signs to 59
+ *   nfs    a fragment of up to 48 wraps and signs to 75
+ *
+ * Chaining a third chimera behind those is refused at the ceiling -- EOVERFLOW
+ * per operation, EIO at mount -- by the re-encoder checks named in
+ * nfs_common/nfs_fh_limits.h.  Refused, not corrupted: before those checks
+ * existed this was the memory-corruption path.  Lifting the restriction needs a
+ * handle indirection table, not a wider assert.
+ *
+ * smb sits between the two: 44 bytes, three to spare, unasserted.  Expressing it
+ * here would mean either reaching into vfs/smb/smb_internal.h from the NFS
+ * server -- wrong direction -- or restating sizeof(chimera_smb_client_file_id)
+ * as a literal, which would stop tracking the struct the moment it changed.  A
+ * silent 16 is worse than a documented gap, so it is documented.
+ */
+_Static_assert(CHIMERA_NFS_FH_HDR + CHIMERA_VFS_FH_INUM_EMITTED_MAX + CHIMERA_NFS_FH_MAC
+               <= CHIMERA_NFS_PROXY_REMOTE_FH_MAX,
+               "a signed chimera wire handle from an inum-varint backend no longer fits"
+               " what the NFS proxy client can re-embed");
 
 enum chimera_nfs_fh_status {
     CHIMERA_NFS_FH_OK        = 0,

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -58,3 +58,5 @@ target_link_libraries(chimera_vfs_nfs chimera_nfs_common evpl evpl_rpc2)
 
 install(TARGETS chimera_vfs_nfs DESTINATION lib)
 
+add_subdirectory(tests)
+

--- a/src/vfs/nfs/nfs3_mount.c
+++ b/src/vfs/nfs/nfs3_mount.c
@@ -115,6 +115,19 @@ chimera_mount_mountd_mnt_callback(
     evpl_rpc2_client_disconnect(server_thread->thread->rpc2_thread, server_thread->mount_conn);
     server_thread->mount_conn = NULL;
 
+    /* mountd chose this length and the generated decoder does not enforce the
+     * `<NFS3_FHSIZE>` bound, so it is checked before it reaches either the
+     * fh_fragment or hash_input buffer below.  A root handle chimera cannot
+     * embed makes the whole mount unusable, so the mount fails here the way the
+     * mountd failure above does. */
+    if (reply->mountinfo.fhandle.len > CHIMERA_NFS_PROXY_REMOTE_FH_MAX) {
+        chimera_nfsclient_error("NFS3 mount root file handle too large: %u bytes (max %d)",
+                                reply->mountinfo.fhandle.len, CHIMERA_NFS_PROXY_REMOTE_FH_MAX);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
     /*
      * Build the FH using the new format:
      * - fh_fragment = [server_index (1 byte)][remote_root_fh]
@@ -126,7 +139,7 @@ chimera_mount_mountd_mnt_callback(
     {
         uint8_t       fh_fragment[CHIMERA_VFS_FH_SIZE];
         uint8_t       fsid_buf[CHIMERA_VFS_FSID_SIZE];
-        uint8_t       hash_input[256 + 64];  /* hostname + remote fh */
+        uint8_t       hash_input[256 + CHIMERA_NFS_PROXY_REMOTE_FH_MAX];
         int           hash_input_len;
         int           fh_fragment_len;
         int           hostname_len;

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -103,7 +103,11 @@ chimera_nfs4_lookup_callback(
     remote_fh = &getfh_res->opgetfh.resok4.object;
 
     /* Build local file handle from server index + remote FH */
-    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->lookup_at.r_attr);
+    if (chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->lookup_at.r_attr) != 0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     /* Get GETATTR result */
     if (res->num_resarray > (uint32_t) getattr_idx) {

--- a/src/vfs/nfs/nfs4_mkdir_at.c
+++ b/src/vfs/nfs/nfs4_mkdir_at.c
@@ -81,7 +81,11 @@ chimera_nfs4_mkdir_callback(
     remote_fh = &getfh_res->opgetfh.resok4.object;
 
     /* Build local file handle from server index + remote FH */
-    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->mkdir_at.r_attr);
+    if (chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->mkdir_at.r_attr) != 0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     /* Get GETATTR result */
     if (res->num_resarray >= 5) {

--- a/src/vfs/nfs/nfs4_mknod_at.c
+++ b/src/vfs/nfs/nfs4_mknod_at.c
@@ -83,7 +83,11 @@ chimera_nfs4_mknod_callback(
     remote_fh = &getfh_res->opgetfh.resok4.object;
 
     /* Build local file handle from server index + remote FH */
-    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->mknod_at.r_attr);
+    if (chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->mknod_at.r_attr) != 0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     /* Get GETATTR result */
     if (res->num_resarray >= 5) {

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -170,7 +170,7 @@ chimera_nfs4_mount_get_root_fh_callback(
     xdr_opaque                      *remote_fh;
     uint8_t                          fh_fragment[CHIMERA_VFS_FH_SIZE];
     uint8_t                          fsid_buf[CHIMERA_VFS_FSID_SIZE];
-    uint8_t                          hash_input[256 + NFS4_FHSIZE];
+    uint8_t                          hash_input[256 + CHIMERA_NFS_PROXY_REMOTE_FH_MAX];
     int                              hash_input_len;
     int                              fh_fragment_len;
     int                              hostname_len;
@@ -270,6 +270,19 @@ chimera_nfs4_mount_get_root_fh_callback(
 
     getfh_res = &res->resarray[op];
     remote_fh = &getfh_res->opgetfh.resok4.object;
+
+    /* The server chose this length and the generated decoder does not enforce
+     * the `<NFS4_FHSIZE>` bound, so it is checked before it reaches either the
+     * fh_fragment or hash_input buffer below.  A root handle chimera cannot
+     * embed makes the whole mount unusable, so the mount fails here the way the
+     * GETFH failure above does. */
+    if (remote_fh->len > CHIMERA_NFS_PROXY_REMOTE_FH_MAX) {
+        chimera_nfsclient_error("NFS4 mount root file handle too large: %u bytes (max %d)",
+                                remote_fh->len, CHIMERA_NFS_PROXY_REMOTE_FH_MAX);
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
 
     /*
      * Build the local file handle:

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -109,7 +109,11 @@ chimera_nfs4_open_at_callback(
     remote_fh = &getfh_res->opgetfh.resok4.object;
 
     /* Build local file handle from server index + remote FH */
-    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->open_at.r_attr);
+    if (chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->open_at.r_attr) != 0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     /* Get GETATTR result */
     if (res->num_resarray >= 5) {

--- a/src/vfs/nfs/nfs4_readdir.c
+++ b/src/vfs/nfs/nfs4_readdir.c
@@ -3,142 +3,13 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_readdir_attr.h"
 
 struct chimera_nfs4_readdir_ctx {
     struct chimera_nfs_thread        *thread;
     struct chimera_nfs_client_server *server;
     uint32_t                          attr_request[2];
 };
-
-/*
- * Parse readdir entry attributes from fattr4
- * This is a specialized version for readdir that handles FATTR4_FILEHANDLE
- */
-static void
-chimera_nfs4_readdir_parse_attrs(
-    const struct fattr4      *fattr,
-    struct chimera_vfs_attrs *attr,
-    uint64_t                 *fileid,
-    uint8_t                  *fh_data,
-    int                      *fh_len)
-{
-    void    *data    = fattr->attr_vals.data;
-    void    *dataend = data + fattr->attr_vals.len;
-    uint32_t type;
-    uint32_t len;
-
-    *fileid           = 0;
-    *fh_len           = 0;
-    attr->va_set_mask = 0;
-
-    if (fattr->num_attrmask < 1) {
-        return;
-    }
-
-    /* Parse attributes in bitmap order */
-
-    /* FATTR4_TYPE = 1 */
-    if (fattr->attrmask[0] & (1 << FATTR4_TYPE)) {
-        if (data + sizeof(uint32_t) > dataend) {
-            return;
-        }
-        type               = chimera_nfs_ntoh32(*(uint32_t *) data);
-        data              += sizeof(uint32_t);
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
-        switch (type) {
-            case NF4REG:
-                attr->va_mode = S_IFREG;
-                break;
-            case NF4DIR:
-                attr->va_mode = S_IFDIR;
-                break;
-            case NF4BLK:
-                attr->va_mode = S_IFBLK;
-                break;
-            case NF4CHR:
-                attr->va_mode = S_IFCHR;
-                break;
-            case NF4LNK:
-                attr->va_mode = S_IFLNK;
-                break;
-            case NF4SOCK:
-                attr->va_mode = S_IFSOCK;
-                break;
-            case NF4FIFO:
-                attr->va_mode = S_IFIFO;
-                break;
-            default:
-                attr->va_mode = S_IFREG;
-                break;
-        } /* switch */
-    }
-
-    /* FATTR4_SIZE = 4 */
-    if (fattr->attrmask[0] & (1 << FATTR4_SIZE)) {
-        if (data + sizeof(uint64_t) > dataend) {
-            return;
-        }
-        attr->va_size      = chimera_nfs_ntoh64(*(uint64_t *) data);
-        data              += sizeof(uint64_t);
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
-    }
-
-    /* FATTR4_FILEHANDLE = 19 - opaque<NFS4_FHSIZE> */
-    if (fattr->attrmask[0] & (1 << FATTR4_FILEHANDLE)) {
-        if (data + sizeof(uint32_t) > dataend) {
-            return;
-        }
-        len   = chimera_nfs_ntoh32(*(uint32_t *) data);
-        data += sizeof(uint32_t);
-
-        if (data + len > dataend || len > NFS4_FHSIZE) {
-            return;
-        }
-
-        memcpy(fh_data, data, len);
-        *fh_len = len;
-        data   += len;
-
-        /* XDR padding to 4-byte boundary */
-        if (len % 4) {
-            data += 4 - (len % 4);
-        }
-    }
-
-    /* FATTR4_FILEID = 20 */
-    if (fattr->attrmask[0] & (1 << FATTR4_FILEID)) {
-        if (data + sizeof(uint64_t) > dataend) {
-            return;
-        }
-        *fileid            = chimera_nfs_ntoh64(*(uint64_t *) data);
-        attr->va_ino       = *fileid;
-        data              += sizeof(uint64_t);
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_INUM;
-    }
-
-    if (fattr->num_attrmask < 2) {
-        return;
-    }
-
-    /* FATTR4_MODE = 33 */
-    if (fattr->attrmask[1] & (1 << (FATTR4_MODE - 32))) {
-        if (data + sizeof(uint32_t) > dataend) {
-            return;
-        }
-        attr->va_mode     |= chimera_nfs_ntoh32(*(uint32_t *) data) & ~S_IFMT;
-        data              += sizeof(uint32_t);
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
-    }
-
-    /* FATTR4_NUMLINKS = 35 */
-    if (fattr->attrmask[1] & (1 << (FATTR4_NUMLINKS - 32))) {
-        if (data + sizeof(uint32_t) > dataend) {
-            return;
-        }
-        attr->va_nlink     = chimera_nfs_ntoh32(*(uint32_t *) data);
-        attr->va_set_mask |= CHIMERA_VFS_ATTR_NLINK;
-    }
-} /* chimera_nfs4_readdir_parse_attrs */
 
 static void
 chimera_nfs4_readdir_callback(
@@ -154,9 +25,10 @@ chimera_nfs4_readdir_callback(
     struct entry4                   *entry;
     struct chimera_vfs_attrs         attrs;
     uint64_t                         fileid;
-    uint8_t                          remote_fh[NFS4_FHSIZE];
+    uint8_t                          remote_fh[CHIMERA_NFS_PROXY_REMOTE_FH_MAX];
     int                              remote_fh_len;
-    uint8_t                          fh_fragment[NFS4_FHSIZE + 1];
+    uint8_t                          fh_fragment[CHIMERA_NFS_PROXY_FH_SERVER_IDX_SIZE +
+                                                 CHIMERA_NFS_PROXY_REMOTE_FH_MAX];
     int                              fh_fragment_len;
     int                              rc, eof = 0;
 

--- a/src/vfs/nfs/nfs4_readdir_attr.h
+++ b/src/vfs/nfs/nfs4_readdir_attr.h
@@ -109,8 +109,16 @@ chimera_nfs4_readdir_parse_attrs(
          * caller prepends a mount_id and a server index, and the result has to
          * fit CHIMERA_VFS_FH_SIZE.  Leaving *fh_len at 0 omits this entry's
          * handle while keeping the rest of its attributes, which is what the v3
-         * readdir does with the same case (nfs3_readdir.c) -- readdir handles
-         * are an optimization, so the client just looks the entry up instead.
+         * readdir does with the same case (nfs3_readdir.c).
+         *
+         * That is degradation, not recovery.  A readdir handle is normally an
+         * optimization a client can do without by issuing a LOOKUP -- but that
+         * LOOKUP is proxied upstream, comes back with the same oversized handle,
+         * and fails EOVERFLOW in chimera_nfs4_unmarshall_fh.  So the entry lists
+         * with its attributes and every access to it fails.  Skipping is still
+         * the right branch: stopping the parse here would cost the entry every
+         * attribute after the handle as well, and there is no usable handle to
+         * return either way.  Neither the skip nor the failing LOOKUP is logged.
          *
          * This ceiling is 47, below the 128 NFS4_FHSIZE permits, so it subsumes
          * the protocol bound rather than needing a separate test for it: a

--- a/src/vfs/nfs/nfs4_readdir_attr.h
+++ b/src/vfs/nfs/nfs4_readdir_attr.h
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include "nfs_internal.h"
+
+/*
+ * Parse readdir entry attributes from fattr4
+ * This is a specialized version for readdir that handles FATTR4_FILEHANDLE
+ *
+ * fh_data must have room for CHIMERA_NFS_PROXY_REMOTE_FH_MAX bytes; a handle
+ * larger than that is skipped, leaving *fh_len at 0.
+ *
+ * Lives in a header rather than nfs4_readdir.c so the bound above can be
+ * exercised directly (vfs/nfs/tests/nfs_fh_bounds_test.c), the same way
+ * chimera_nfs3_unmarshall_fh is reachable from nfs_common/nfs3_attr.h.  The
+ * caller distinguishes "no handle for this entry" by *fh_len == 0, so the
+ * zeroing at the top of this function is load-bearing, not defensive.
+ */
+static inline void
+chimera_nfs4_readdir_parse_attrs(
+    const struct fattr4      *fattr,
+    struct chimera_vfs_attrs *attr,
+    uint64_t                 *fileid,
+    uint8_t                  *fh_data,
+    int                      *fh_len)
+{
+    void    *data    = fattr->attr_vals.data;
+    void    *dataend = data + fattr->attr_vals.len;
+    uint32_t type;
+    uint32_t len;
+
+    *fileid           = 0;
+    *fh_len           = 0;
+    attr->va_set_mask = 0;
+
+    if (fattr->num_attrmask < 1) {
+        return;
+    }
+
+    /* Parse attributes in bitmap order */
+
+    /* FATTR4_TYPE = 1 */
+    if (fattr->attrmask[0] & (1 << FATTR4_TYPE)) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        type               = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data              += sizeof(uint32_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
+        switch (type) {
+            case NF4REG:
+                attr->va_mode = S_IFREG;
+                break;
+            case NF4DIR:
+                attr->va_mode = S_IFDIR;
+                break;
+            case NF4BLK:
+                attr->va_mode = S_IFBLK;
+                break;
+            case NF4CHR:
+                attr->va_mode = S_IFCHR;
+                break;
+            case NF4LNK:
+                attr->va_mode = S_IFLNK;
+                break;
+            case NF4SOCK:
+                attr->va_mode = S_IFSOCK;
+                break;
+            case NF4FIFO:
+                attr->va_mode = S_IFIFO;
+                break;
+            default:
+                attr->va_mode = S_IFREG;
+                break;
+        } /* switch */
+    }
+
+    /* FATTR4_SIZE = 4 */
+    if (fattr->attrmask[0] & (1 << FATTR4_SIZE)) {
+        if (data + sizeof(uint64_t) > dataend) {
+            return;
+        }
+        attr->va_size      = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data              += sizeof(uint64_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
+    }
+
+    /* FATTR4_FILEHANDLE = 19 - opaque<NFS4_FHSIZE> */
+    if (fattr->attrmask[0] & (1 << FATTR4_FILEHANDLE)) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        len   = chimera_nfs_ntoh32(*(uint32_t *) data);
+        data += sizeof(uint32_t);
+
+        /* A length running past the end of the attribute blob is malformed: it
+         * makes the next attribute's offset unknowable, so parsing has to stop
+         * here.  Note the generated decoders enforce neither this nor the
+         * `<NFS4_FHSIZE>` bound nfs4.x declares, so neither is a check we get
+         * for free. */
+        if (data + len > dataend) {
+            return;
+        }
+
+        /* A well-formed handle can still be one chimera cannot re-encode: the
+         * caller prepends a mount_id and a server index, and the result has to
+         * fit CHIMERA_VFS_FH_SIZE.  Leaving *fh_len at 0 omits this entry's
+         * handle while keeping the rest of its attributes, which is what the v3
+         * readdir does with the same case (nfs3_readdir.c) -- readdir handles
+         * are an optimization, so the client just looks the entry up instead.
+         *
+         * This ceiling is 47, below the 128 NFS4_FHSIZE permits, so it subsumes
+         * the protocol bound rather than needing a separate test for it: a
+         * handle past NFS4_FHSIZE is skipped here and parsing continues, where
+         * folding that case into the malformed check above used to cost the
+         * entry every attribute that follows the handle. */
+        if (len <= CHIMERA_NFS_PROXY_REMOTE_FH_MAX) {
+            memcpy(fh_data, data, len);
+            *fh_len = len;
+        }
+
+        data += len;
+
+        /* XDR padding to 4-byte boundary */
+        if (len % 4) {
+            data += 4 - (len % 4);
+        }
+    }
+
+    /* FATTR4_FILEID = 20 */
+    if (fattr->attrmask[0] & (1 << FATTR4_FILEID)) {
+        if (data + sizeof(uint64_t) > dataend) {
+            return;
+        }
+        *fileid            = chimera_nfs_ntoh64(*(uint64_t *) data);
+        attr->va_ino       = *fileid;
+        data              += sizeof(uint64_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_INUM;
+    }
+
+    if (fattr->num_attrmask < 2) {
+        return;
+    }
+
+    /* FATTR4_MODE = 33 */
+    if (fattr->attrmask[1] & (1 << (FATTR4_MODE - 32))) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_mode     |= chimera_nfs_ntoh32(*(uint32_t *) data) & ~S_IFMT;
+        data              += sizeof(uint32_t);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_MODE;
+    }
+
+    /* FATTR4_NUMLINKS = 35 */
+    if (fattr->attrmask[1] & (1 << (FATTR4_NUMLINKS - 32))) {
+        if (data + sizeof(uint32_t) > dataend) {
+            return;
+        }
+        attr->va_nlink     = chimera_nfs_ntoh32(*(uint32_t *) data);
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_NLINK;
+    }
+} /* chimera_nfs4_readdir_parse_attrs */

--- a/src/vfs/nfs/nfs4_symlink_at.c
+++ b/src/vfs/nfs/nfs4_symlink_at.c
@@ -80,7 +80,11 @@ chimera_nfs4_symlink_callback(
     remote_fh = &getfh_res->opgetfh.resok4.object;
 
     /* Build local file handle from server index + remote FH */
-    chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->symlink_at.r_attr);
+    if (chimera_nfs4_unmarshall_fh(remote_fh, ctx->server->index, request->fh, &request->symlink_at.r_attr) != 0) {
+        request->status = CHIMERA_VFS_EOVERFLOW;
+        request->complete(request);
+        return;
+    }
 
     /* Get GETATTR result */
     if (res->num_resarray >= 5) {

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -618,10 +618,28 @@ chimera_nfs4_status_to_errno(nfsstat4 status)
  * Builds local FH: [parent_mount_id][server_index][remote_fh]
  *
  * fh->len is chosen by the upstream server and is not bounded by the generated
- * XDR decoder, which ignores the `<NFS4_FHSIZE>` bound nfs4.x declares.  An
- * unchecked handle overflows both the local fragment buffer and, via
- * encode_fh_parent, attr->va_fh -- and va_fh is the last member of the pooled
- * chimera_vfs_request, so the write continues into its callback pointers.
+ * XDR decoder, which ignores the `<NFS4_FHSIZE>` bound nfs4.x declares.  What an
+ * unchecked length does splits into two bands, and neither is local to this
+ * function in the way it looks:
+ *
+ *   fh->len 48..63   Nothing here overflows.  The fragment takes 1 + len, so 63
+ *                    fills it exactly; encode_fh_parent then writes
+ *                    16 + 1 + len into attr->va_fh, and 80 fills that exactly
+ *                    because va_fh carries 16 bytes of XXH3 SIMD padding past
+ *                    CHIMERA_VFS_FH_SIZE.  So the padding swallows it silently
+ *                    and the damage is exported: va_fh_len is now 65..80, and
+ *                    the callers that copy that many bytes into a bare
+ *                    uint8_t[CHIMERA_VFS_FH_SIZE] (vfs_proc_lookup.c,
+ *                    vfs_proc_rename.c, vfs_proc_mkdir.c, vfs_proc_mknod.c,
+ *                    vfs_proc_link.c) overrun.  This is the band the check
+ *                    below exists for, and the band a bounds check written
+ *                    against the fragment buffer alone would let through.
+ *
+ *   fh->len >= 64    The memcpy into fragment[] overflows this function's own
+ *                    stack frame.  Both destinations cross at the same length
+ *                    -- 1 + len past 64 and 17 + len past 80 are both len >= 64
+ *                    -- and the fragment write happens first, so this is where
+ *                    it stops; a va_fh overrun is not separately reachable.
  *
  * Returns 0 on success (ATTR_FH set), -1 if the handle is too large to embed
  * (ATTR_FH left unset; the caller fails the operation with EOVERFLOW).  This

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -21,6 +21,7 @@
 #include "uthash.h"
 #include "common/misc.h"
 #include "vfs/vfs_fh.h"
+#include "nfs_common/nfs_fh_limits.h"
 #include "evpl/evpl_rpc2.h"
 #include "nlm4_xdr.h"
 
@@ -615,8 +616,18 @@ chimera_nfs4_status_to_errno(nfsstat4 status)
 /*
  * Unmarshall a file handle from NFS4 GETFH response
  * Builds local FH: [parent_mount_id][server_index][remote_fh]
+ *
+ * fh->len is chosen by the upstream server and is not bounded by the generated
+ * XDR decoder, which ignores the `<NFS4_FHSIZE>` bound nfs4.x declares.  An
+ * unchecked handle overflows both the local fragment buffer and, via
+ * encode_fh_parent, attr->va_fh -- and va_fh is the last member of the pooled
+ * chimera_vfs_request, so the write continues into its callback pointers.
+ *
+ * Returns 0 on success (ATTR_FH set), -1 if the handle is too large to embed
+ * (ATTR_FH left unset; the caller fails the operation with EOVERFLOW).  This
+ * mirrors chimera_nfs3_unmarshall_fh in nfs_common/nfs3_attr.h.
  */
-static inline void
+static inline int
 chimera_nfs4_unmarshall_fh(
     const xdr_opaque         *fh,
     int                       server_index,
@@ -626,6 +637,12 @@ chimera_nfs4_unmarshall_fh(
     uint8_t fragment[CHIMERA_VFS_FH_SIZE];
     int     fragment_len;
 
+    /* The encoded handle is mount_id + server_index + data and must fit
+     * CHIMERA_VFS_FH_SIZE, not merely fit the fragment buffer. */
+    if (fh->len > CHIMERA_NFS_PROXY_REMOTE_FH_MAX) {
+        return -1;
+    }
+
     /* Build fh_fragment: [server_index][remote_fh_data] */
     fragment[0] = server_index;
     memcpy(fragment + 1, fh->data, fh->len);
@@ -633,6 +650,7 @@ chimera_nfs4_unmarshall_fh(
 
     attr->va_set_mask |= CHIMERA_VFS_ATTR_FH;
     attr->va_fh_len    = chimera_vfs_encode_fh_parent(parent_fh, fragment, fragment_len, attr->va_fh);
+    return 0;
 } // chimera_nfs4_unmarshall_fh
 
 /*

--- a/src/vfs/nfs/tests/CMakeLists.txt
+++ b/src/vfs/nfs/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# Bounds test for the proxy's file-handle re-encoders.  Both helpers are static
+# inline, so nothing needs linking, but the generated NFS XDR headers have to
+# exist first.
+add_executable(nfs_fh_bounds_test nfs_fh_bounds_test.c)
+target_include_directories(nfs_fh_bounds_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src)
+add_dependencies(nfs_fh_bounds_test chimera_nfs_common)
+add_test(chimera/vfs/nfs/fh_bounds_test nfs_fh_bounds_test)

--- a/src/vfs/nfs/tests/nfs_fh_bounds_test.c
+++ b/src/vfs/nfs/tests/nfs_fh_bounds_test.c
@@ -1,0 +1,456 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Bounds test for the NFS proxy's file-handle re-encoders.
+ *
+ * Inside src/vfs/nfs/ chimera is the NFS *client*: it dials an upstream server
+ * and re-encodes the handle that server returns into a chimera handle.  The
+ * length comes off the wire and the generated XDR decoders do not enforce the
+ * `<NFS3_FHSIZE>` / `<NFS4_FHSIZE>` bounds their schemas declare, so each
+ * re-encoder has to bound it itself:
+ *
+ *   chimera_nfs3_unmarshall_fh        (nfs_common/nfs3_attr.h)
+ *   chimera_nfs4_unmarshall_fh        (vfs/nfs/nfs_internal.h)
+ *   chimera_nfs4_readdir_parse_attrs  (vfs/nfs/nfs4_readdir_attr.h)
+ *
+ * All three build [mount_id : 16][server_index : 1][remote_fh : N] and so
+ * accept N up to CHIMERA_NFS_PROXY_REMOTE_FH_MAX (47), the point at which the
+ * encoded handle exactly fills CHIMERA_VFS_FH_SIZE.  (The two mount paths,
+ * nfs3_mount.c and nfs4_mount.c, open-code the same check against the same
+ * ceiling; they need a live upstream to reach, so they are covered by
+ * inspection and the pynfs/kvm proxy suites rather than here.)
+ *
+ * Bands 1-3 drive the two re-encoders, split by symptom rather than by input:
+ *
+ *   band 1  N <= 47   accepted; encoded handle fits CHIMERA_VFS_FH_SIZE
+ *   band 2  48..63    over the ceiling but inside the fragment buffer.  A
+ *                     helper that bounds only the fragment (fh_len > FH_SIZE-1)
+ *                     accepts these and yields va_fh_len of 65..80.  That still
+ *                     fits va_fh -- which carries 16 bytes of XXH3 SIMD padding
+ *                     -- so nothing traps; the overrun lands on the caller that
+ *                     copies va_fh_len bytes into a bare uint8_t[FH_SIZE].
+ *   band 3  >= 64     past the fragment buffer itself: an unchecked memcpy here
+ *                     is a stack overflow inside the helper.
+ *
+ * Band 4 drives the readdir attr parser, which reports "no handle" by leaving
+ * *fh_len at 0 instead of by return code, so it is checked separately.  Band 5
+ * drives the same parser but checks the other half of its contract: skipping a
+ * handle it cannot use must not stop it parsing the rest of that entry.
+ *
+ * Each case reports rather than asserts, so one run shows every band rather
+ * than stopping at the first failure.  Band 3 against an unchecked helper is
+ * the exception: it traps inside the memcpy (ASAN in Debug, _FORTIFY_SOURCE in
+ * Release) before it can report anything, which is the point.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "nfs_internal.h"
+#include "nfs4_readdir_attr.h"
+#include "nfs_common/nfs3_attr.h"
+#include "nfs_common/nfs_fh_limits.h"
+
+/*
+ * The immediate sink is attr->va_fh.  In the daemon the attrs sit inside a
+ * pooled chimera_vfs_request and va_fh is its final member, so a write past it
+ * lands on the request's callback pointers and private_data; the canary stands
+ * in for that.
+ */
+struct probe {
+    struct chimera_vfs_attrs attr;
+    uint8_t                  canary[64];
+};
+
+/*
+ * What consumers of va_fh do next: memcpy va_fh_len bytes into a bare
+ * uint8_t[CHIMERA_VFS_FH_SIZE] with no SIMD padding behind it
+ * (vfs_proc_lookup.c, vfs_proc_rename.c, vfs_proc_mkdir.c, vfs_proc_mknod.c,
+ * vfs_proc_link.c).  This is the buffer band 2 overruns.
+ */
+struct sink {
+    uint8_t fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t canary[64];
+};
+
+#define CANARY_BYTE 0xAB
+
+static uint8_t remote_fh_data[2048];
+
+/* Backing store for a synthetic one-attribute fattr4 blob (band 4). */
+static uint8_t attr_blob[sizeof(uint32_t) + sizeof(remote_fh_data)];
+
+static int     failures;
+
+/*
+ * Deliberately opaque to the optimizer: taking void * and staying out of line
+ * keeps __builtin_object_size from seeing the destination, so an oversized copy
+ * is caught by the canary and reported rather than aborting the run under
+ * _FORTIFY_SOURCE.  Real callers pass a visibly-sized array and would abort;
+ * here the goal is a full report of every band.
+ */
+static void __attribute__((noinline))
+copy_to_fixed_fh(
+    void       *dst,
+    const void *src,
+    uint32_t    len)
+{
+    memcpy(dst, src, len);
+} /* copy_to_fixed_fh */
+
+static int
+canary_intact(
+    const uint8_t *canary,
+    size_t         len)
+{
+    for (size_t i = 0; i < len; i++) {
+        if (canary[i] != CANARY_BYTE) {
+            return 0;
+        }
+    }
+    return 1;
+} /* canary_intact */
+
+struct outcome {
+    int      accepted;
+    uint32_t va_fh_len;
+    int      fh_attr_set;
+    int      attr_canary_ok;
+    int      sink_canary_ok;
+};
+
+/*
+ * Drive one helper with one remote handle length and collect what happened.
+ * `version` selects the helper; both take the same shape of arguments, only
+ * the handle type differs (struct nfs_fh3 vs xdr_opaque).
+ */
+static struct outcome
+run_case(
+    int      version,
+    uint32_t remote_len)
+{
+    /* A valid parent handle: the 16-byte mount_id is all encode_fh_parent reads. */
+    uint8_t        parent_fh[CHIMERA_VFS_FH_SIZE + 16];
+    struct probe   probe;
+    struct sink    sink;
+    struct outcome out;
+    int            rc;
+
+    memset(parent_fh, 0x11, sizeof(parent_fh));
+
+    memset(&probe, 0, sizeof(probe));
+    memset(probe.canary, CANARY_BYTE, sizeof(probe.canary));
+
+    memset(&sink, 0, sizeof(sink));
+    memset(sink.canary, CANARY_BYTE, sizeof(sink.canary));
+
+    if (version == 3) {
+        struct nfs_fh3 fh;
+
+        fh.data.len  = remote_len;
+        fh.data.data = remote_fh_data;
+
+        rc = chimera_nfs3_unmarshall_fh(&fh, 7 /* server_index */, parent_fh, &probe.attr);
+    } else {
+        xdr_opaque fh;
+
+        fh.len  = remote_len;
+        fh.data = (char *) remote_fh_data;
+
+        rc = chimera_nfs4_unmarshall_fh(&fh, 7 /* server_index */, parent_fh, &probe.attr);
+    }
+
+    out.accepted       = (rc == 0);
+    out.fh_attr_set    = (probe.attr.va_set_mask & CHIMERA_VFS_ATTR_FH) != 0;
+    out.va_fh_len      = out.fh_attr_set ? probe.attr.va_fh_len : 0;
+    out.attr_canary_ok = canary_intact(probe.canary, sizeof(probe.canary));
+
+    /* Only an accepted handle reaches a caller, so only then is the downstream
+     * fixed-size copy exercised. */
+    if (out.fh_attr_set) {
+        copy_to_fixed_fh(sink.fh, probe.attr.va_fh, probe.attr.va_fh_len);
+    }
+    out.sink_canary_ok = canary_intact(sink.canary, sizeof(sink.canary));
+
+    return out;
+} /* run_case */
+
+static void
+check_case(
+    const char *band,
+    int         version,
+    uint32_t    remote_len,
+    int         expect_accept)
+{
+    struct outcome out;
+    const char    *verdict = "ok";
+
+    out = run_case(version, remote_len);
+
+    if (out.accepted != expect_accept) {
+        verdict = expect_accept ? "FAIL: rejected a handle that fits"
+            : "FAIL: accepted an oversized handle";
+        failures++;
+    } else if (out.fh_attr_set != expect_accept) {
+        /* A rejected handle must leave ATTR_FH unset so the caller fails the
+         * operation instead of returning a stale or partial handle. */
+        verdict = "FAIL: va_set_mask disagrees with the return code";
+        failures++;
+    } else if (expect_accept &&
+               out.va_fh_len != CHIMERA_VFS_MOUNT_ID_SIZE +
+               CHIMERA_NFS_PROXY_FH_SERVER_IDX_SIZE + remote_len) {
+        verdict = "FAIL: unexpected encoded length";
+        failures++;
+    } else if (expect_accept && out.va_fh_len > CHIMERA_VFS_FH_SIZE) {
+        verdict = "FAIL: encoded handle exceeds CHIMERA_VFS_FH_SIZE";
+        failures++;
+    }
+
+    if (!out.attr_canary_ok) {
+        verdict = "FAIL: wrote past attr.va_fh (pooled request corrupted)";
+        failures++;
+    }
+
+    if (!out.sink_canary_ok) {
+        verdict = "FAIL: overran a caller's uint8_t[CHIMERA_VFS_FH_SIZE]";
+        failures++;
+    }
+
+    printf("%-8s v%d remote_len=%-5u accepted=%d va_fh_len=%-3u %s\n",
+           band, version, remote_len, out.accepted, out.va_fh_len, verdict);
+    fflush(stdout);
+} /* check_case */
+
+/*
+ * The destination chimera_nfs4_readdir_parse_attrs is contracted to fill:
+ * exactly CHIMERA_NFS_PROXY_REMOTE_FH_MAX bytes, no SIMD padding behind it.
+ */
+struct fh_probe {
+    uint8_t fh[CHIMERA_NFS_PROXY_REMOTE_FH_MAX];
+    uint8_t canary[64];
+};
+
+/*
+ * Band 4: chimera_nfs4_readdir_parse_attrs (vfs/nfs/nfs4_readdir_attr.h).
+ *
+ * Unlike the two re-encoders this one has no return value -- it signals "no
+ * handle for this entry" by leaving *fh_len at 0, which its caller tests before
+ * building a chimera handle.  So the bound is only as good as that zeroing, and
+ * *fh_len is deliberately poisoned here: a parser that skips an oversized
+ * handle without writing *fh_len would leave the caller reading a stale length
+ * from the previous directory entry and re-emitting the previous entry's handle.
+ */
+static void
+check_readdir_case(
+    uint32_t remote_len,
+    int      expect_handle)
+{
+    struct fattr4            fattr;
+    struct chimera_vfs_attrs attr;
+    struct fh_probe          probe;
+    uint32_t                 attrmask[1];
+    uint64_t                 fileid;
+    uint32_t                 padded;
+    int                      fh_len;
+    const char              *verdict = "ok";
+
+    memset(&probe, 0, sizeof(probe));
+    memset(probe.canary, CANARY_BYTE, sizeof(probe.canary));
+    memset(&attr, 0, sizeof(attr));
+
+    /* A one-attribute fattr4 blob: [len : 4][handle][XDR pad to 4]. */
+    padded                  = remote_len % 4 ? remote_len + 4 - (remote_len % 4) : remote_len;
+    *(uint32_t *) attr_blob = chimera_nfs_hton32(remote_len);
+    memcpy(attr_blob + sizeof(uint32_t), remote_fh_data, remote_len);
+
+    attrmask[0]          = 1U << FATTR4_FILEHANDLE;
+    fattr.num_attrmask   = 1;
+    fattr.attrmask       = attrmask;
+    fattr.attr_vals.data = attr_blob;
+    fattr.attr_vals.len  = sizeof(uint32_t) + padded;
+
+    fh_len = -1;   /* poison: the parser owns this, on every path */
+
+    chimera_nfs4_readdir_parse_attrs(&fattr, &attr, &fileid, probe.fh, &fh_len);
+
+    if (fh_len < 0) {
+        verdict = "FAIL: *fh_len left unwritten (caller reuses a stale handle)";
+        failures++;
+    } else if (expect_handle && fh_len != (int) remote_len) {
+        verdict = "FAIL: dropped a handle that fits";
+        failures++;
+    } else if (!expect_handle && fh_len != 0) {
+        verdict = "FAIL: accepted a handle the caller cannot re-encode";
+        failures++;
+    } else if (expect_handle &&
+               memcmp(probe.fh, remote_fh_data, remote_len) != 0) {
+        verdict = "FAIL: handle bytes not copied intact";
+        failures++;
+    }
+
+    if (!canary_intact(probe.canary, sizeof(probe.canary))) {
+        verdict = "FAIL: overran the caller's fh_data buffer";
+        failures++;
+    }
+
+    printf("%-8s v4 remote_len=%-5u fh_len=%-3d %s\n",
+           "band4", remote_len, fh_len, verdict);
+    fflush(stdout);
+} /* check_readdir_case */
+
+#define BAND5_FILEID 0x0123456789ABCDEFull
+
+/*
+ * Band 5: skipping an unusable handle must not cost the entry the attributes
+ * that come after it.
+ *
+ * The parser has two rejections that look alike and are not.  A length running
+ * past the attribute blob is malformed -- the next attribute's offset is
+ * unknowable, so it has to stop.  A length that merely exceeds what chimera can
+ * re-encode is well-formed: the bytes are all there, so the handle can be
+ * stepped over and FILEID/MODE/NUMLINKS parsed as usual.  Folding the second
+ * into the first (which a `len > NFS4_FHSIZE` test in the malformed check did)
+ * silently drops the rest of the entry's attributes for any upstream whose
+ * handles run past 128 -- a listing degraded well beyond the missing handle.
+ *
+ * So: a two-attribute blob, FILEHANDLE then FILEID, and the fileid has to
+ * survive whatever happens to the handle.
+ */
+static void
+check_readdir_continues(
+    uint32_t remote_len,
+    int      expect_handle)
+{
+    struct fattr4            fattr;
+    struct chimera_vfs_attrs attr;
+    struct fh_probe          probe;
+    uint32_t                 attrmask[1];
+    uint64_t                 fileid;
+    uint32_t                 padded;
+    int                      fh_len;
+    const char              *verdict = "ok";
+
+    memset(&probe, 0, sizeof(probe));
+    memset(probe.canary, CANARY_BYTE, sizeof(probe.canary));
+    memset(&attr, 0, sizeof(attr));
+
+    /* [len : 4][handle][XDR pad to 4][fileid : 8] */
+    padded                  = remote_len % 4 ? remote_len + 4 - (remote_len % 4) : remote_len;
+    *(uint32_t *) attr_blob = chimera_nfs_hton32(remote_len);
+    memcpy(attr_blob + sizeof(uint32_t), remote_fh_data, remote_len);
+    *(uint64_t *) (attr_blob + sizeof(uint32_t) + padded) = chimera_nfs_hton64(BAND5_FILEID);
+
+    attrmask[0]          = (1U << FATTR4_FILEHANDLE) | (1U << FATTR4_FILEID);
+    fattr.num_attrmask   = 1;
+    fattr.attrmask       = attrmask;
+    fattr.attr_vals.data = attr_blob;
+    fattr.attr_vals.len  = sizeof(uint32_t) + padded + sizeof(uint64_t);
+
+    fh_len = -1;
+    fileid = 0;
+
+    chimera_nfs4_readdir_parse_attrs(&fattr, &attr, &fileid, probe.fh, &fh_len);
+
+    if (fh_len < 0) {
+        verdict = "FAIL: *fh_len left unwritten";
+        failures++;
+    } else if (expect_handle != (fh_len != 0)) {
+        verdict = expect_handle ? "FAIL: dropped a handle that fits"
+            : "FAIL: accepted a handle the caller cannot re-encode";
+        failures++;
+    } else if (fileid != BAND5_FILEID) {
+        verdict = "FAIL: stopped parsing -- entry lost the attributes after its handle";
+        failures++;
+    } else if (!(attr.va_set_mask & CHIMERA_VFS_ATTR_INUM)) {
+        verdict = "FAIL: fileid parsed but ATTR_INUM not set";
+        failures++;
+    }
+
+    if (!canary_intact(probe.canary, sizeof(probe.canary))) {
+        verdict = "FAIL: overran the caller's fh_data buffer";
+        failures++;
+    }
+
+    printf("%-8s v4 remote_len=%-5u fh_len=%-3d fileid=%s %s\n",
+           "band5", remote_len, fh_len,
+           fileid == BAND5_FILEID ? "kept" : "LOST", verdict);
+    fflush(stdout);
+} /* check_readdir_continues */
+
+int
+main(void)
+{
+    /* Band 1: within the ceiling.  47 is the largest remote length whose
+     * encoded handle still fits CHIMERA_VFS_FH_SIZE, so it is the boundary. */
+    const uint32_t within[] = { 0, 1, 15, 31, 42, CHIMERA_NFS_PROXY_REMOTE_FH_MAX - 1,
+                                CHIMERA_NFS_PROXY_REMOTE_FH_MAX };
+
+    /* Band 2: over the ceiling, still inside the fragment buffer.  Legal on
+     * the wire (NFS3_FHSIZE is 64) and the band a fragment-only bounds check
+     * lets through. */
+    const uint32_t over_ceiling[] = { CHIMERA_NFS_PROXY_REMOTE_FH_MAX + 1, 55,
+                                      CHIMERA_VFS_FH_SIZE - 1 };
+
+    /* Band 3: past the fragment buffer.  Still legal on the wire for v4, whose
+     * NFS4_FHSIZE is 128. */
+    const uint32_t over_fragment[] = { CHIMERA_VFS_FH_SIZE, CHIMERA_VFS_FH_SIZE + 1, 128, 1024 };
+
+    memset(remote_fh_data, 0x55, sizeof(remote_fh_data));
+
+    printf("CHIMERA_VFS_FH_SIZE=%d CHIMERA_NFS_PROXY_REMOTE_FH_MAX=%d\n\n",
+           CHIMERA_VFS_FH_SIZE, CHIMERA_NFS_PROXY_REMOTE_FH_MAX);
+
+    for (size_t i = 0; i < sizeof(within) / sizeof(within[0]); i++) {
+        check_case("band1", 3, within[i], 1);
+        check_case("band1", 4, within[i], 1);
+    }
+
+    for (size_t i = 0; i < sizeof(over_ceiling) / sizeof(over_ceiling[0]); i++) {
+        check_case("band2", 3, over_ceiling[i], 0);
+        check_case("band2", 4, over_ceiling[i], 0);
+    }
+
+    for (size_t i = 0; i < sizeof(over_fragment) / sizeof(over_fragment[0]); i++) {
+        check_case("band3", 3, over_fragment[i], 0);
+        check_case("band3", 4, over_fragment[i], 0);
+    }
+
+    /* Band 4: the same ceiling as bands 1-3, enforced by the v4 readdir attr
+     * parser.  The ceiling (47) is below NFS4_FHSIZE (128), so it subsumes the
+     * protocol bound -- past it and past NFS4_FHSIZE are the same skip, and both
+     * are checked. */
+    for (size_t i = 0; i < sizeof(within) / sizeof(within[0]); i++) {
+        check_readdir_case(within[i], 1);
+    }
+
+    for (size_t i = 0; i < sizeof(over_ceiling) / sizeof(over_ceiling[0]); i++) {
+        check_readdir_case(over_ceiling[i], 0);
+    }
+
+    check_readdir_case(CHIMERA_VFS_FH_SIZE, 0);
+    check_readdir_case(NFS4_FHSIZE, 0);
+    check_readdir_case(NFS4_FHSIZE + 1, 0);
+    check_readdir_case(1024, 0);
+
+    /* Band 5: a skipped handle must not take the rest of the entry's attributes
+     * with it.  Spans a handle that fits, one over the ceiling but under
+     * NFS4_FHSIZE, and two past NFS4_FHSIZE -- the last of which is the case
+     * that used to abort the parse. */
+    check_readdir_continues(CHIMERA_NFS_PROXY_REMOTE_FH_MAX, 1);
+    check_readdir_continues(CHIMERA_NFS_PROXY_REMOTE_FH_MAX + 1, 0);
+    check_readdir_continues(CHIMERA_VFS_FH_SIZE, 0);
+    check_readdir_continues(NFS4_FHSIZE, 0);
+    check_readdir_continues(NFS4_FHSIZE + 1, 0);
+    check_readdir_continues(1024, 0);
+
+    if (failures) {
+        printf("\nnfs_fh_bounds_test: %d failure(s)\n", failures);
+        return 1;
+    }
+
+    printf("\nnfs_fh_bounds_test: all bands passed\n");
+    return 0;
+} /* main */

--- a/src/vfs/nfs/tests/nfs_fh_bounds_test.c
+++ b/src/vfs/nfs/tests/nfs_fh_bounds_test.c
@@ -19,8 +19,9 @@
  * accept N up to CHIMERA_NFS_PROXY_REMOTE_FH_MAX (47), the point at which the
  * encoded handle exactly fills CHIMERA_VFS_FH_SIZE.  (The two mount paths,
  * nfs3_mount.c and nfs4_mount.c, open-code the same check against the same
- * ceiling; they need a live upstream to reach, so they are covered by
- * inspection and the pynfs/kvm proxy suites rather than here.)
+ * ceiling.  They need a live upstream to reach and no suite drives one past the
+ * ceiling, so they hold by inspection only -- the note at
+ * CHIMERA_NFS_PROXY_REMOTE_FH_MAX has the details.)
  *
  * Bands 1-3 drive the two re-encoders, split by symptom rather than by input:
  *
@@ -55,10 +56,23 @@
 #include "nfs_common/nfs_fh_limits.h"
 
 /*
- * The immediate sink is attr->va_fh.  In the daemon the attrs sit inside a
- * pooled chimera_vfs_request and va_fh is its final member, so a write past it
- * lands on the request's callback pointers and private_data; the canary stands
- * in for that.
+ * The immediate sink is attr->va_fh, the last member of struct
+ * chimera_vfs_attrs.  In the daemon that attrs struct is embedded in a pooled
+ * chimera_vfs_request -- lookup_at.r_attr, open_at.r_attr, and the mkdir/mknod/
+ * symlink equivalents -- where it is followed by the sibling attrs of the same
+ * union member (r_dir_attr, or r_dir_pre_attr and r_dir_post_attr), and past
+ * those by the next request in the pool.  The request's callback pointers are
+ * ahead of the union, not behind va_fh.  This canary stands in for whatever
+ * follows.
+ *
+ * It cannot fire on anything driven below, and that is a property of the
+ * current layout rather than an accident: va_fh is written 16 + 1 + N bytes
+ * into 64 + 16, and fragment[] is written 1 + N into 64, so both overflow at
+ * exactly N >= 64 and the fragment memcpy gets there first (band 3).  The
+ * canary that catches the real bug is struct sink's.  This one is a guard
+ * against a future change that decouples the two thresholds -- a wider
+ * mount_id, a larger fragment buffer, a sink that grows padding -- at which
+ * point va_fh becomes reachable on its own and this is what notices.
  */
 struct probe {
     struct chimera_vfs_attrs attr;

--- a/src/vfs/vfs_fh.h
+++ b/src/vfs/vfs_fh.h
@@ -8,9 +8,46 @@
 #include <string.h>
 #include <xxhash.h>
 #include "common/varint.h"
+#include "vfs/vfs_attrs.h"     /* CHIMERA_VFS_FH_SIZE */
 
 #define CHIMERA_VFS_MOUNT_ID_SIZE 16
 #define CHIMERA_VFS_FSID_SIZE     16
+
+/*
+ * A chimera file handle is [mount_id : 16][fh_fragment : N], and the whole
+ * thing has to fit CHIMERA_VFS_FH_SIZE, so this is all the room a backend has
+ * for its fragment.
+ */
+#define CHIMERA_VFS_FH_FRAGMENT_MAX \
+        (CHIMERA_VFS_FH_SIZE - CHIMERA_VFS_MOUNT_ID_SIZE)
+
+/*
+ * The longest fragment, and hence the longest handle, the *inum-varint* family
+ * of backends mints: memfs, diskfs and cairn encode inum then gen as varints,
+ * and memfs's named-stream handles (memfs_encode_stream_fh) append a third
+ * varint for the stream id, which is the longest fragment that family composes.
+ *
+ * Scoped to that family on purpose -- it is NOT the maximum over all backends,
+ * and the name says INUM so no caller mistakes it for one.  The others compose
+ * fragments this does not describe:
+ *
+ *   smb   1 + sizeof(chimera_smb_client_file_id) = 17  (vfs/smb/smb_internal.h)
+ *   linux varint(mount_id) + varint(type) + f_handle, up to 32
+ *                                                    (vfs/linux/linux_common.h)
+ *   nfs   1 + remote handle, up to 48                 (vfs/nfs/nfs_internal.h)
+ *
+ * All of them are bounded by CHIMERA_VFS_FH_FRAGMENT_MAX above, which is what
+ * keeps a chimera handle a chimera handle.  The narrower question -- which of
+ * them are small enough to survive being re-embedded by a chimera NFS *client*
+ * proxying this server -- is answered at CHIMERA_NFS_PROXY_REMOTE_FH_MAX in
+ * nfs_common/nfs_fh_limits.h, where the family below is the one asserted to fit.
+ */
+#define CHIMERA_VFS_FH_INUM_FRAGMENT_MAX \
+        (CHIMERA_VARINT_UINT64_MAX_BYTES + CHIMERA_VARINT_UINT32_MAX_BYTES)
+#define CHIMERA_VFS_FH_STREAM_FRAGMENT_MAX \
+        (CHIMERA_VFS_FH_INUM_FRAGMENT_MAX + CHIMERA_VARINT_UINT32_MAX_BYTES)
+#define CHIMERA_VFS_FH_INUM_EMITTED_MAX \
+        (CHIMERA_VFS_MOUNT_ID_SIZE + CHIMERA_VFS_FH_STREAM_FRAGMENT_MAX)
 
 /*
  * Encode a file handle for a mount root or cross-mount reference.
@@ -112,7 +149,7 @@ chimera_vfs_encode_fh_inum_mount(
     uint32_t    gen,
     void       *out_fh)
 {
-    uint8_t  fragment[15];  /* Max: 10 bytes for uint64 + 5 bytes for uint32 */
+    uint8_t  fragment[CHIMERA_VFS_FH_INUM_FRAGMENT_MAX];
     uint8_t *ptr = fragment;
 
     ptr += chimera_encode_uint64(inum, ptr);


### PR DESCRIPTION
## Summary

The `nfs` VFS module is an NFS **client** — it dials an upstream server and re-encodes the handles that server returns into chimera handles:

```
[ mount_id : 16 ][ server_index : 1 ][ remote_fh : N ]
```

`N` comes off the wire and nothing bounded it. `nfs3.x` and `nfs4.x` declare `nfs_fh3<NFS3_FHSIZE>` and `nfs_fh4<NFS4_FHSIZE>`, but the generated XDR decoders ignore the declared bound, so `N` is an arbitrary `uint32_t` chosen by the peer. This PR gives the re-encoders a single ceiling and enforces it everywhere a fragment is built.

## The bug

**NFSv4 was entirely unchecked.** `chimera_nfs4_unmarshall_fh` validated nothing. A GETFH reply carrying a 128-byte handle — perfectly legal for NFSv4 — overran the helper's `fragment[CHIMERA_VFS_FH_SIZE]` on the stack, and `chimera_vfs_encode_fh_parent` then wrote 145 bytes into `attr->va_fh`. `va_fh` is the **final member of the pooled `chimera_vfs_request`**, so the tail of that write lands on the request's callback pointers and `private_data`. Peer-chosen length, peer-chosen bytes, function pointers downstream.

**NFSv3 was checked, but against the wrong thing.** `chimera_nfs3_unmarshall_fh` bounded the local fragment buffer (`N <= CHIMERA_VFS_FH_SIZE - 1`), which admits 48–63. Those encode to 65–80 — past `CHIMERA_VFS_FH_SIZE`, but still inside `va_fh`, which carries 16 bytes of padding for XXH3 SIMD overreads. So nothing traps at the point of the bug. The overrun surfaces a frame later, in the five callers that copy `va_fh_len` bytes into a bare `uint8_t[CHIMERA_VFS_FH_SIZE]` (`vfs_proc_lookup.c`, `vfs_proc_rename.c`, `vfs_proc_mkdir.c`, `vfs_proc_mknod.c`, `vfs_proc_link.c`).

Reachable by any upstream the operator has pointed a share at — a malicious or malfunctioning server, or simply a conformant one whose handles are larger than chimera can represent.

## The fix

The bound that matters is the **encoded** handle, not the fragment buffer. One ceiling, `CHIMERA_NFS_PROXY_REMOTE_FH_MAX` — what is left of `CHIMERA_VFS_FH_SIZE` once the mount_id and the server index are paid for — enforced at all five sites that build the fragment:

| site | file |
|---|---|
| `chimera_nfs3_unmarshall_fh` | `nfs_common/nfs3_attr.h` |
| `chimera_nfs4_unmarshall_fh` | `vfs/nfs/nfs_internal.h` |
| `chimera_nfs4_readdir_parse_attrs` | `vfs/nfs/nfs4_readdir_attr.h` |
| v3 mount root | `vfs/nfs/nfs3_mount.c` |
| v4 mount root | `vfs/nfs/nfs4_mount.c` |

An upstream chimera cannot represent is **refused rather than proxied**:

- **`EOVERFLOW`** per operation — `chimera_nfs4_unmarshall_fh` returns `int` now and all five callers fail the operation.
- **`EIO`** at mount — a root handle that will not fit makes the whole mount unusable, so it fails the way the other mount errors already do.
- **readdir is the exception** — an entry whose handle is too large is emitted without one, keeping the rest of its attributes. readdir handles are an optimization; the client just looks the entry up instead. This matches what the v3 readdir already did.

NFSv3 permits 64-byte handles and NFSv4 permits 128, both above this ceiling, so a conformant general-purpose upstream can legitimately be refused. Supporting those would need a handle indirection table rather than the in-place re-encoding done here — out of scope, and documented as such.

## Keeping chimera-to-chimera proxying working

Proxying one chimera through another is a shipped, CI-exercised topology (`kvm/kvm_pnfs_proxy_test_wrapper.sh`), and it works only because the handle a chimera server puts on the wire happens to fit that ceiling. For a share on an inum-varint backend it fits **exactly**, with no slack:

```
  mount_id                                      16
  inum + gen varints                            15   (CHIMERA_VFS_FH_INUM_EMITTED_MAX
  stream id varint                               5     covers all three)
  wire wrap: tag + export_id                     3   (CHIMERA_NFS_FH_HDR)
  SipHash MAC, when fh_sign is enabled           8   (CHIMERA_NFS_FH_MAC)
                                                --
                                                 47  == the ceiling, exactly
```

A `_Static_assert` beside `CHIMERA_NFS_FH_HDR` turns any future widening of that sum — a wider mount_id, a fourth varint, a longer header or MAC — into a build failure instead of a silent loss of proxying.

It is scoped to the inum-varint family (memfs, diskfs, cairn) **deliberately**, and the naming says so, because two backends do not fit and cannot be made to:

| backend | wire bytes, wrapped + signed | vs 47 |
|---|---|---|
| memfs/diskfs/cairn inum+gen | 42 | fits, 5 spare |
| memfs named stream | **47** | fits exactly — what the assert pins |
| smb | 44 | fits, 3 spare |
| linux | 59 | exceeds |
| nfs | 75 | exceeds |

Chaining a third chimera behind `linux` or `nfs` is refused at the ceiling like any other oversized upstream — *refused, not corrupted*, which is the point of the checks above. `smb` fits with three bytes spare and is left unasserted on purpose: expressing it would mean either reaching into `vfs/smb/smb_internal.h` from the NFS server (wrong direction) or restating `sizeof(chimera_smb_client_file_id)` as a literal `16` that silently stops tracking the struct. A silent 16 is worse than a documented gap.

## Also in here

**Named constants for sizes that were open-coded.** `CHIMERA_VARINT_UINT{32,64}_MAX_BYTES` for the worst-case varint encodings, `CHIMERA_VFS_FH_FRAGMENT_MAX` for the room a backend has, and the INUM/STREAM fragment maxima that feed the assert. The two `hash_input` buffers in the mount paths and the readdir handle buffers shrink from `NFS4_FHSIZE`-derived sizes to the ceiling that actually bounds them.

**`chimera_nfs4_readdir_parse_attrs` moved to a header** so its bound can be exercised directly. Two things worth a reviewer's eye:

- It has no return value — it signals "no handle for this entry" by leaving `*fh_len` at 0, which its caller tests before building a chimera handle. The zeroing at the top of it is therefore **load-bearing, not defensive**: dropping it would leave a caller re-emitting the *previous* directory entry's handle. Band 4 exists to pin exactly that.
- Its two rejections are kept distinct, because they look alike and are not. A length running past the attribute blob is malformed — the next attribute's offset is unknowable, so parsing must stop. A length that merely exceeds the ceiling is well-formed, so the handle is stepped over and `FILEID`/`MODE`/`NUMLINKS` parsed as usual. The ceiling (47) is below `NFS4_FHSIZE` (128) and subsumes it, so an over-`NFS4_FHSIZE` handle costs the entry its handle and nothing else. Folding the two together — as an earlier revision did — cost every entry all of its attributes after the handle, for any upstream whose handles run past 128.

**`CLAUDE.md`** described handles as "32-byte opaque handles" — correct when written, stale since `CHIMERA_VFS_FH_SIZE` went 32 → 48 → 64. Now states the cap, that the real length travels in `va_fh_len`, and the per-backend spread.

## New test

`src/vfs/nfs/tests/nfs_fh_bounds_test.c` drives the three inline re-encoders across five bands, split by **symptom** rather than by input, because the ways this goes wrong do not look alike:

| band | `N` | what it pins |
|---|---|---|
| 1 | ≤ 47 | accepted; encoded handle fits `CHIMERA_VFS_FH_SIZE` |
| 2 | 48–63 | over the ceiling, inside the fragment buffer — the quiet case. A fragment-only check accepts these and yields `va_fh_len` of 65–80. Caught by a canary standing in for the pooled request's callback pointers, and a second behind a caller's bare `uint8_t[CHIMERA_VFS_FH_SIZE]` |
| 3 | ≥ 64 | past the fragment buffer — an unchecked `memcpy` traps under ASAN (Debug) or `_FORTIFY_SOURCE` (Release) |
| 4 | 0–1024 | the readdir parser, which reports through `*fh_len` rather than a return code. `*fh_len` is poisoned to −1 so an unwritten value fails loudly |
| 5 | 47–1024 | a skipped handle must not cost the entry the attributes that follow it (two-attribute blob; the fileid has to survive) |

Cases report rather than assert, so one run shows every band instead of stopping at the first failure. Band 3 against unchecked code is the exception — it traps inside the `memcpy` before it can report, which is the point.

Both guarantees were verified by mutation rather than by inspection: deleting the `*fh_len` zeroing makes band 4 fail on every oversized case, and folding the two readdir rejections back together makes band 5 fail on the 129 and 1024 cases, in both instances with a non-zero exit.

The two mount paths need a live upstream, so a unit test cannot reach them; they are covered by inspection plus the pynfs and kvm proxy suites.

## Not addressed here

Three pre-existing issues were found in adjacent code while working on this. None are introduced by this PR and all are left for separate tickets:

1. **`nfs3_mount.c:170` unlocks `shared->lock` without holding it.** Nothing in that callback chain takes it; the v4 twin at `nfs4_mount.c:311-313` does `lock / set / unlock` correctly. Unlocking an unowned mutex can release it while another thread holds it, racing `shared->mounts` / `shared->servers`. The adjacent `mount->status` write is also unsynchronized, unlike v4's.
2. **`linux_get_fh` copies before it bounds-checks.** `handle->handle_bytes` can be up to `MAX_HANDLE_SZ` (128) and is `memcpy`'d into `fragment[32]` whose leading varints can consume 10 bytes — and the `chimera_linux_abort_if` guard runs *after* the copy. Common filesystems stay under the limit, which is why it has never fired, but it is the same shape as the bug fixed here: write first, validate after.
3. **Unbounded `strncpy` into `server->hostname[256]`** (`nfs3_mount.c:544`), where the length is the offset of the first `:` in the mount path and is validated only as non-zero. Admin-supplied config rather than wire input, so low severity — but it is the assumption the `hash_input[256 + 47]` sizing rests on.
