### PR TITLE
nfs: enforce per-export read-only access

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -302,6 +302,38 @@ add_posix_erofs_test(nfs3 memfs)
 add_posix_erofs_test(nfs4 memfs)
 
 # ============================================================================
+# NFS export-level read-only ("access": "ro") test
+# Exposes the SAME writable VFS mount through a rw and an access-ro export and
+# asserts that mutations through the ro export fail with EROFS while the rw
+# export stays writable.  Unlike the EROFS test above (which read-only-flags a
+# separate VFS mount), the backing mount here is read-write, so this exercises
+# the NFS server's per-export access enforcement in isolation.  Registered
+# explicitly because it requires the extra export the standard harness does
+# not create, and is only meaningful over an NFS backend.  Any backend works
+# (the gate keys on the export id in the wire file handle, not the mount);
+# registered for linux and memfs over both NFS3 and NFS4.
+# ============================================================================
+add_posix_testprog(test_export_ro)
+
+macro(add_posix_export_ro_test nfs_prefix nfs_backend)
+    if(CHIMERA_NETNS_TESTING)
+        add_test(NAME chimera/posix/export_ro_${nfs_prefix}_${nfs_backend}
+            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_export_ro -b ${nfs_prefix}_${nfs_backend}
+        )
+        get_target_property(test_file posix_test_export_ro TEST_FILE)
+        set_tests_properties(chimera/posix/export_ro_${nfs_prefix}_${nfs_backend} PROPERTIES
+            ENVIRONMENT "TEST_FILE=${test_file}"
+            TIMEOUT 60
+        )
+    endif()
+endmacro()
+
+add_posix_export_ro_test(nfs3 linux)
+add_posix_export_ro_test(nfs4 linux)
+add_posix_export_ro_test(nfs3 memfs)
+add_posix_export_ro_test(nfs4 memfs)
+
+# ============================================================================
 # NFSv4 pseudo-fs root mount test
 # Mounts the bare pseudo-fs root ("server:/") instead of an export and lists
 # it, exercising nfs4_root_readdir's asynchronous per-export lookup walk (a

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -302,6 +302,15 @@ static int         posix_test_diskfs_reuse_devices __attribute__ ((unused)) = 0;
  * read-only gate keys on. */
 static int posix_test_ro_export __attribute__ ((unused)) = 0;
 
+/* When non-zero (set before posix_test_init), posix_test_start_nfs_server also
+ * creates a SECOND export "/roaccess" of the SAME writable "/share" mount,
+ * configured with the export-level access "ro" option.  Unlike
+ * posix_test_ro_export above (which read-only-flags a separate VFS mount), the
+ * backing mount here stays read-write, so a test using this flag isolates the
+ * NFS per-export access enforcement from the VFS-mount read-only gate: any
+ * EROFS seen through "/roaccess" can only come from the export policy. */
+static int posix_test_ro_access_export __attribute__ ((unused)) = 0;
+
 /* Name of the subdirectory (relative to the backend root) that the read-only
  * export is mounted at; the read-write export sees it as "/share/ro". */
 #define POSIX_TEST_RO_SUBDIR             "ro"
@@ -559,6 +568,24 @@ posix_test_start_nfs_server(struct posix_test_env *env)
                                      POSIX_TEST_EXPORT_ID, NULL) != 0) {
         fprintf(stderr, "Failed to create /share export\n");
         exit(EXIT_FAILURE);
+    }
+
+    if (posix_test_ro_access_export) {
+        /* Second export of the SAME writable "/share" mount, differing only in
+         * the export-level access option (this creates no new mount).  The
+         * export name must not be a string prefix of "share" nor have "share"
+         * as its prefix (see the "roshare" note below). */
+        struct chimera_nfs_export_opts ro_opts = {
+            .has_access = 1,
+            .access     = CHIMERA_NFS_EXPORT_ACCESS_RO,
+        };
+
+        if (chimera_server_create_export(env->server, "/roaccess", "/share",
+                                         POSIX_TEST_EXPORT_ID + 2,
+                                         &ro_opts) != 0) {
+            fprintf(stderr, "Failed to create /roaccess export\n");
+            exit(EXIT_FAILURE);
+        }
     }
 
     if (posix_test_ro_export) {

--- a/src/posix/tests/test_export_ro.c
+++ b/src/posix/tests/test_export_ro.c
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFS export-level read-only ("access": "ro") enforcement.
+ *
+ * The harness exposes the SAME writable VFS mount through two exports:
+ *   - "/share"     access rw (the default)
+ *   - "/roaccess"  access ro (export option only; the backing mount stays rw)
+ *
+ * Because the backing mount is read-write, the VFS-mount read-only gate never
+ * fires: any EROFS observed through "/roaccess" can only come from the NFS
+ * server's per-export access enforcement.  This test creates fixtures through
+ * the writable export, then mounts the read-only export and asserts:
+ *   - reads / stat / lookup / readdir / readlink still work,
+ *   - every mutating operation fails with EROFS, and
+ *   - the fixtures still exist afterwards with their original mode and size.
+ *
+ * The server also masks the write-class bits out of the NFS ACCESS reply on a
+ * read-only export, but that is not observable here: this client answers
+ * faccessat from stat mode bits without issuing ACCESS (see the note further
+ * down).  Only a kernel NFS client exercises the masking.
+ *
+ * TAP-style output is emitted on stderr ("ok"/"not ok") so the suite can be
+ * scanned for failures.
+ */
+
+#define _GNU_SOURCE 1
+#include <sys/sysmacros.h>
+#include "posix_test_common.h"
+
+static int test_num   = 0;
+static int test_fails = 0;
+
+static void
+tap(
+    int         ok,
+    const char *desc)
+{
+    test_num++;
+    if (!ok) {
+        test_fails++;
+    }
+    fprintf(stderr, "%s %d - %s\n", ok ? "ok" : "not ok", test_num, desc);
+} /* tap */
+
+/* Run `expr` (which sets rc<0 + errno on failure) and assert it failed with
+ * EROFS. */
+#define EXPECT_EROFS(desc, expr) \
+        do { \
+            errno = 0; \
+            long _rc = (long) (expr); \
+            int  _en = errno; \
+            tap(_rc < 0 && _en == EROFS, desc); \
+            if (!(_rc < 0 && _en == EROFS)) { \
+                fprintf(stderr, "  # %s: rc=%ld errno=%d (%s), wanted EROFS\n", \
+                        desc, _rc, _en, strerror(_en)); \
+            } \
+        } while (0)
+
+/* Run `expr` and assert it succeeded (rc >= 0). */
+#define EXPECT_OK(desc, expr) \
+        do { \
+            errno = 0; \
+            long _rc = (long) (expr); \
+            int  _en = errno; \
+            tap(_rc >= 0, desc); \
+            if (_rc < 0) { \
+                fprintf(stderr, "  # %s: rc=%ld errno=%d (%s), wanted success\n", \
+                        desc, _rc, _en, strerror(_en)); \
+            } \
+        } while (0)
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    int                   rc;
+    int                   fd;
+    struct stat           st;
+    char                  buf[64];
+
+    /* Ask the harness to also create the access-ro export of the rw mount. */
+    posix_test_ro_access_export = 1;
+
+    posix_test_init(&env, argv, argc);
+
+    if (env.nfs_version <= 0) {
+        fprintf(stderr, "test_export_ro requires an NFS backend\n");
+        posix_test_fail(&env);
+    }
+
+    const char *vers = (env.nfs_version == 4) ? "vers=4" : "vers=3";
+
+    /* Phase 1: mount the writable export and create the fixtures at the mount
+     * root (the very same inodes "/roaccess" exposes), then unmount it. */
+    rc = chimera_posix_mount_with_options("/test", "nfs", "127.0.0.1:/share",
+                                          vers);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount /share (rw): %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    fd = chimera_posix_open("/test/file", O_CREAT | O_RDWR, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to create fixture file: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+    /* Checked here rather than left to the size assertion at the end, so a
+     * setup failure is not misreported as a read-only enforcement bug. */
+    if (chimera_posix_write(fd, "hello\n", 6) != 6) {
+        fprintf(stderr, "Failed to write fixture file: %s\n", strerror(errno));
+        chimera_posix_close(fd);
+        posix_test_fail(&env);
+    }
+    chimera_posix_close(fd);
+
+    if (chimera_posix_mkdir("/test/dir", 0755) != 0) {
+        fprintf(stderr, "Failed to create fixture dir: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    if (chimera_posix_symlink("file", "/test/link") != 0) {
+        fprintf(stderr, "Failed to create fixture symlink: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* The rw export must stay fully writable while the access-ro export of the
+     * same mount exists (both exports are created before any mount, so the ro
+     * policy is already live here): the export policy must not bleed across
+     * exports the way the VFS-mount "ro" flag would. */
+    EXPECT_OK("rw export writable alongside ro export (chmod)",
+              chimera_posix_chmod("/test/file", 0644));
+    EXPECT_OK("rw export writable alongside ro export (create+unlink)",
+              ((fd = chimera_posix_open("/test/scratch", O_CREAT | O_RDWR,
+                                        0644)) >= 0 ?
+               (chimera_posix_close(fd), chimera_posix_unlink("/test/scratch")) :
+               -1));
+
+    if (chimera_posix_umount("/test") != 0) {
+        fprintf(stderr, "Failed to unmount /share (rw): %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* Phase 2: mount the access-ro export and run the assertions against it. */
+    rc = chimera_posix_mount_with_options("/test_ro", "nfs",
+                                          "127.0.0.1:/roaccess", vers);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount /roaccess (ro): %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* ---- Read-side operations must still succeed on the RO export. ---- */
+    EXPECT_OK("stat regular file (ro)", chimera_posix_stat("/test_ro/file", &st));
+    EXPECT_OK("lstat symlink (ro)", chimera_posix_lstat("/test_ro/link", &st));
+    EXPECT_OK("stat directory (ro)", chimera_posix_stat("/test_ro/dir", &st));
+
+    EXPECT_OK("open O_RDONLY (ro)",
+              (fd = chimera_posix_open("/test_ro/file", O_RDONLY, 0)));
+    if (fd >= 0) {
+        EXPECT_OK("read file contents (ro)",
+                  chimera_posix_read(fd, buf, sizeof(buf)));
+        chimera_posix_close(fd);
+    } else {
+        tap(0, "read file contents (ro)");
+    }
+
+    EXPECT_OK("readlink (ro)",
+              chimera_posix_readlink("/test_ro/link", buf, sizeof(buf)));
+
+    {
+        CHIMERA_DIR *d = chimera_posix_opendir("/test_ro");
+        tap(d != NULL, "opendir (ro)");
+        if (d) {
+            int saw = 0;
+            errno = 0;
+            while (chimera_posix_readdir(d) != NULL) {
+                saw++;
+            }
+            /* A NULL return is end-of-directory only if errno is untouched;
+             * otherwise the listing was cut short by an error. */
+            tap(saw > 0 && errno == 0, "readdir returns entries (ro)");
+            if (errno != 0) {
+                fprintf(stderr, "  # readdir failed after %d entries: "
+                        "errno=%d (%s)\n", saw, errno, strerror(errno));
+            }
+            chimera_posix_closedir(d);
+        } else {
+            tap(0, "readdir returns entries (ro)");
+        }
+    }
+
+    /* Note: the server also masks the write-class bits out of the NFS ACCESS
+     * reply on a read-only export, but the chimera posix client computes
+     * faccessat locally from stat mode bits rather than issuing ACCESS, so
+     * that masking is only observable with a kernel NFS client. */
+    EXPECT_OK("faccessat R_OK (ro)",
+              chimera_posix_faccessat(AT_FDCWD, "/test_ro/file", R_OK, 0));
+
+    /* ---- Mutating operations must all fail with EROFS on the RO export. ---- */
+    EXPECT_EROFS("chmod", chimera_posix_chmod("/test_ro/file", 0600));
+    EXPECT_EROFS("chown", chimera_posix_chown("/test_ro/file", 1, 1));
+    EXPECT_EROFS("mkdir", chimera_posix_mkdir("/test_ro/newdir", 0755));
+    EXPECT_EROFS("mkfifo",
+                 chimera_posix_mknod("/test_ro/fifo", S_IFIFO | 0644, 0));
+    EXPECT_EROFS("mknod (char device)",
+                 chimera_posix_mknod("/test_ro/dev", S_IFCHR | 0644,
+                                     makedev(1, 3)));
+    EXPECT_EROFS("open O_CREAT",
+                 chimera_posix_open("/test_ro/created", O_CREAT | O_RDWR, 0644));
+    EXPECT_EROFS("creat",
+                 chimera_posix_open("/test_ro/creatfile",
+                                    O_CREAT | O_WRONLY | O_TRUNC, 0644));
+    EXPECT_EROFS("rename",
+                 chimera_posix_rename("/test_ro/file", "/test_ro/file2"));
+    EXPECT_EROFS("rmdir", chimera_posix_rmdir("/test_ro/dir"));
+    EXPECT_EROFS("symlink",
+                 chimera_posix_symlink("file", "/test_ro/newlink"));
+    EXPECT_EROFS("link",
+                 chimera_posix_link("/test_ro/file", "/test_ro/hardlink"));
+    EXPECT_EROFS("unlink", chimera_posix_unlink("/test_ro/file"));
+    EXPECT_EROFS("truncate", chimera_posix_truncate("/test_ro/file", 0));
+
+    {
+        struct timespec ts[2];
+        ts[0].tv_sec  = ts[1].tv_sec = 0;
+        ts[0].tv_nsec = ts[1].tv_nsec = 0;
+        EXPECT_EROFS("utimensat",
+                     chimera_posix_utimensat(AT_FDCWD, "/test_ro/file", ts, 0));
+    }
+
+    /* A writable open of an existing file is granted locally under both
+     * versions here, so enforcement surfaces on the first mutating op.
+     *
+     * That is a property of this client, not of the protocol.  NFSv3 has no
+     * server-side open at all.  On NFSv4 the server does reject OPEN with
+     * share_access WRITE on a read-only export (RFC 7530 section 16.16.5), but
+     * this client never sends that OPEN for an existing file: chimera_nfs4_open_fh
+     * returns success without a wire OPEN and lets I/O run on an anonymous
+     * stateid (see src/vfs/nfs/nfs4_open_fh.c), so only a create reaches the
+     * server's OPEN path.  The OPEN branch of the gate is covered instead by
+     * chimera/server/nfs/rofs_gate, which drives the decision logic directly.
+     *
+     * Accept either outcome, but a granted handle must fail every mutation. */
+    errno = 0;
+    fd    = chimera_posix_open("/test_ro/file", O_WRONLY, 0);
+    if (fd < 0) {
+        tap(errno == EROFS, "open O_WRONLY denied with EROFS (ro)");
+        tap(1, "write (denied at open)");
+        tap(1, "ftruncate (denied at open)");
+        tap(1, "futimens (denied at open)");
+    } else {
+        tap(1, "open O_WRONLY allowed; mutations must fail (ro)");
+        EXPECT_EROFS("write", chimera_posix_write(fd, "x", 1));
+        EXPECT_EROFS("ftruncate", chimera_posix_ftruncate(fd, 0));
+        struct timespec ts2[2] = { { 0, 0 }, { 0, 0 } };
+        EXPECT_EROFS("futimens", chimera_posix_futimens(fd, ts2));
+        chimera_posix_close(fd);
+    }
+
+    /* Confirm the fixtures are intact (no mutation slipped through): the file
+     * still exists, keeps its original mode and non-zero size, and the
+     * directory still exists -- all read via the read-only export. */
+    EXPECT_OK("fixture file still present (ro)",
+              chimera_posix_stat("/test_ro/file", &st));
+    tap(S_ISREG(st.st_mode) && (st.st_mode & 0777) == 0644 && st.st_size == 6,
+        "fixture file unchanged (ro)");
+    EXPECT_OK("fixture dir still present (ro)",
+              chimera_posix_stat("/test_ro/dir", &st));
+
+    (void) chimera_posix_umount("/test_ro");
+
+    fprintf(stderr, "1..%d\n", test_num);
+
+    if (test_fails) {
+        fprintf(stderr, "%d/%d export-ro subtests FAILED\n", test_fails,
+                test_num);
+        posix_test_fail(&env);
+    }
+
+    posix_test_success(&env);
+    return 0;
+} /* main */

--- a/src/server/nfs/nfs3_proc_access.c
+++ b/src/server/nfs/nfs3_proc_access.c
@@ -86,6 +86,12 @@ chimera_nfs3_access_complete(
         if ((args->access & ACCESS3_EXECUTE) && (granted & CHIMERA_ACE_EXECUTE)) {
             res.resok.access |= ACCESS3_EXECUTE;
         }
+
+        /* A read-only export never grants write-class access, regardless of
+         * what the ACL/mode would allow. */
+        if (chimera_nfs_export_id_is_ro(shared, req->export_id)) {
+            res.resok.access &= ~(ACCESS3_MODIFY | ACCESS3_EXTEND | ACCESS3_DELETE);
+        }
     } else {
         chimera_nfs3_set_post_op_attr(&res.resfail.obj_attributes, attr);
     }

--- a/src/server/nfs/nfs3_proc_create.c
+++ b/src/server/nfs/nfs3_proc_create.c
@@ -223,6 +223,9 @@ chimera_nfs3_create(
     req->args_create = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_proc_link.c
+++ b/src/server/nfs/nfs3_proc_link.c
@@ -53,7 +53,7 @@ chimera_nfs3_link(
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct nfs_request               *req;
     struct LINK3res                   res;
-    uint16_t                          linkdir_export_id;
+    uint16_t                          linkdir_export_id = 0;
     int                               rc;
 
     req = nfs_request_alloc(thread, conn, encoding);
@@ -67,11 +67,19 @@ chimera_nfs3_link(
      * target handle must outlive this (async) call, so it lives in the request
      * rather than on the stack (saved_fh is unused by NFSv3). */
     res.status = chimera_nfs3_decode_fh(req, args->file.data.data, args->file.data.len);
-    if (res.status != NFS3_OK ||
+    if (res.status == NFS3_OK &&
         chimera_nfs_fh_unwrap(args->link.dir.data.data, args->link.dir.data.len,
                               &linkdir_export_id, req->saved_fh, &req->saved_fhlen,
                               shared->fh_key, shared->fh_sign) != CHIMERA_NFS_FH_OK) {
-        nfsstat3 fh_status = res.status != NFS3_OK ? res.status : NFS3ERR_BADHANDLE;
+        res.status = NFS3ERR_BADHANDLE;
+    }
+    /* The link directory gains an entry and the file's nlink changes, so
+     * both exports must be writable. */
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs2(req, linkdir_export_id);
+    }
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
         res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_LINK(evpl, NULL, &res, req->encoding);

--- a/src/server/nfs/nfs3_proc_mkdir.c
+++ b/src/server/nfs/nfs3_proc_mkdir.c
@@ -127,6 +127,9 @@ chimera_nfs3_mkdir(
     req->args_mkdir = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_proc_mknod.c
+++ b/src/server/nfs/nfs3_proc_mknod.c
@@ -156,6 +156,9 @@ chimera_nfs3_mknod(
     req->args_mknod = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -168,6 +168,9 @@ chimera_nfs3_remove(
     req->args_remove = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->object.dir.data.data, args->object.dir.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -127,7 +127,7 @@ chimera_nfs3_rename(
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct nfs_request               *req;
     struct RENAME3res                 res;
-    uint16_t                          todir_export_id;
+    uint16_t                          todir_export_id = 0;
     int                               rc;
 
     req = nfs_request_alloc(thread, conn, encoding);
@@ -140,11 +140,18 @@ chimera_nfs3_rename(
      * squash); the destination is authenticated into req->saved_fh.  Both must
      * outlive this (async) call, so they go in the request, not on the stack. */
     res.status = chimera_nfs3_decode_fh(req, args->from.dir.data.data, args->from.dir.data.len);
-    if (res.status != NFS3_OK ||
+    if (res.status == NFS3_OK &&
         chimera_nfs_fh_unwrap(args->to.dir.data.data, args->to.dir.data.len,
                               &todir_export_id, req->saved_fh, &req->saved_fhlen,
                               shared->fh_key, shared->fh_sign) != CHIMERA_NFS_FH_OK) {
-        nfsstat3 fh_status = res.status != NFS3_OK ? res.status : NFS3ERR_BADHANDLE;
+        res.status = NFS3ERR_BADHANDLE;
+    }
+    /* Both directories are mutated, so both exports must be writable. */
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs2(req, todir_export_id);
+    }
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
         res.status = fh_status;
         rc         = shared->nfs_v3.send_reply_NFSPROC3_RENAME(evpl, NULL, &res, req->encoding);

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -157,6 +157,9 @@ chimera_nfs3_rmdir(
     req->args_rmdir = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->object.dir.data.data, args->object.dir.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_proc_setattr.c
+++ b/src/server/nfs/nfs3_proc_setattr.c
@@ -161,6 +161,9 @@ chimera_nfs3_setattr(
     req->args_setattr = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->object.data.data, args->object.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_proc_symlink.c
+++ b/src/server/nfs/nfs3_proc_symlink.c
@@ -127,6 +127,9 @@ chimera_nfs3_symlink(
     req->args_symlink = args;
 
     res.status = chimera_nfs3_decode_fh(req, args->where.dir.data.data, args->where.dir.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_proc_write.c
+++ b/src/server/nfs/nfs3_proc_write.c
@@ -138,6 +138,9 @@ chimera_nfs3_write(
     evpl_rpc2_encoding_take_read_chunk(req->encoding, NULL, NULL);
 
     res.status = chimera_nfs3_decode_fh(req, args->file.data.data, args->file.data.len);
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_check_rofs(req, req->export_id);
+    }
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));

--- a/src/server/nfs/nfs3_procs.h
+++ b/src/server/nfs/nfs3_procs.h
@@ -31,6 +31,46 @@ chimera_nfs3_decode_fh(
     } /* switch */
 } /* chimera_nfs3_decode_fh */
 
+/*
+ * Per-export read-only gate for mutating NFSv3 procedures.  Call after a
+ * successful chimera_nfs3_decode_fh with the export id the mutation targets.
+ * RENAME and LINK mutate through two handles and use chimera_nfs3_check_rofs2
+ * below instead.
+ */
+static inline nfsstat3
+chimera_nfs3_check_rofs(
+    struct nfs_request *req,
+    uint16_t            export_id)
+{
+    return chimera_nfs_export_id_is_ro(req->thread->shared, export_id) ?
+           NFS3ERR_ROFS : NFS3_OK;
+} /* chimera_nfs3_check_rofs */
+
+/*
+ * Per-export read-only gate for the two-directory mutating procedures, RENAME
+ * and LINK.  Both handles' exports must be writable: two exports may share one
+ * backing VFS mount, so a cross-export operation would otherwise succeed at
+ * the VFS layer.  The first side is the request's own export (stamped by
+ * chimera_nfs3_decode_fh on the first handle) and is read from the request
+ * here rather than passed in, so a call site cannot accidentally check the
+ * same export twice; dir2_export_id is the second handle's export as recovered
+ * by chimera_nfs_fh_unwrap.  The cross-export combinations are unreachable
+ * through a POSIX client (cross-mount RENAME/LINK fails client-side with
+ * EXDEV), so tests/test_nfs3_rofs.c drives them directly.
+ */
+static inline nfsstat3
+chimera_nfs3_check_rofs2(
+    struct nfs_request *req,
+    uint16_t            dir2_export_id)
+{
+    nfsstat3 status = chimera_nfs3_check_rofs(req, req->export_id);
+
+    if (status == NFS3_OK) {
+        status = chimera_nfs3_check_rofs(req, dir2_export_id);
+    }
+    return status;
+} /* chimera_nfs3_check_rofs2 */
+
 void chimera_nfs3_null(
     struct evpl               *evpl,
     struct evpl_rpc2_conn     *conn,

--- a/src/server/nfs/nfs4_op_matrix.h
+++ b/src/server/nfs/nfs4_op_matrix.h
@@ -20,6 +20,11 @@
 /* Behavioral flags applied during dispatch. */
 #define NFS4_OP_FLAG_MUST_BE_FIRST  0x01 /* SEQUENCE in 4.1+: must be at op_index 0 */
 #define NFS4_OP_FLAG_NO_REQ_SESSION 0x02 /* allowed in 4.1+ even without a preceding SEQUENCE */
+/* Always mutates, so it unconditionally fails NFS4ERR_ROFS on a read-only
+ * export.  Ops that mutate only for certain arguments (OPEN, OPENATTR) or that
+ * need a different error (LAYOUTGET) are gated explicitly in nfs4_rofs_gate
+ * instead -- do not flag those here. */
+#define NFS4_OP_FLAG_MUTATES        0x04
 
 struct nfs4_op_info {
     uint8_t minors;
@@ -34,7 +39,7 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_COMMIT] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
-    [OP_CREATE] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    [OP_CREATE] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, NFS4_OP_FLAG_MUTATES
     },
     [OP_DELEGPURGE] =           { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
@@ -44,7 +49,7 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_GETFH] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
-    [OP_LINK] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    [OP_LINK] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, NFS4_OP_FLAG_MUTATES
     },
     [OP_LOCK] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
@@ -60,6 +65,7 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_OPEN] =                 { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
+    /* OPENATTR mutates only when createdir is set; gated conditionally. */
     [OP_OPENATTR] =             { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
     [OP_OPEN_DOWNGRADE] =       { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
@@ -76,9 +82,9 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_READLINK] =             { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
-    [OP_REMOVE] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    [OP_REMOVE] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, NFS4_OP_FLAG_MUTATES
     },
-    [OP_RENAME] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    [OP_RENAME] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, NFS4_OP_FLAG_MUTATES
     },
     [OP_RESTOREFH] =            { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
@@ -86,11 +92,11 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_SECINFO] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
-    [OP_SETATTR] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    [OP_SETATTR] =              { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, NFS4_OP_FLAG_MUTATES
     },
     [OP_VERIFY] =               { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
     },
-    [OP_WRITE] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, 0
+    [OP_WRITE] =                { NFS4_OP_V40 | NFS4_OP_V41 | NFS4_OP_V42, NFS4_OP_FLAG_MUTATES
     },
 
     /* 4.0-only ops (RFC 7530); MNI in 4.1+ per RFC 5661 / 8881. */
@@ -125,7 +131,7 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_GETDEVICELIST] =        { NFS4_OP_V41 | NFS4_OP_V42,               0
     },
-    [OP_LAYOUTCOMMIT] =         { NFS4_OP_V41 | NFS4_OP_V42,               0
+    [OP_LAYOUTCOMMIT] =         { NFS4_OP_V41 | NFS4_OP_V42,               NFS4_OP_FLAG_MUTATES
     },
     [OP_LAYOUTGET] =            { NFS4_OP_V41 | NFS4_OP_V42,               0
     },
@@ -151,13 +157,13 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
 
     /* 4.2-only ops. */
-    [OP_ALLOCATE] =             { NFS4_OP_V42,                             0
+    [OP_ALLOCATE] =             { NFS4_OP_V42,                             NFS4_OP_FLAG_MUTATES
     },
-    [OP_COPY] =                 { NFS4_OP_V42,                             0
+    [OP_COPY] =                 { NFS4_OP_V42,                             NFS4_OP_FLAG_MUTATES
     },
     [OP_COPY_NOTIFY] =          { NFS4_OP_V42,                             0
     },
-    [OP_DEALLOCATE] =           { NFS4_OP_V42,                             0
+    [OP_DEALLOCATE] =           { NFS4_OP_V42,                             NFS4_OP_FLAG_MUTATES
     },
     [OP_IO_ADVISE] =            { NFS4_OP_V42,                             0
     },
@@ -171,19 +177,19 @@ static const struct nfs4_op_info nfs4_op_support[NFS4_OP_MAX + 1] = {
     },
     [OP_SEEK] =                 { NFS4_OP_V42,                             0
     },
-    [OP_WRITE_SAME] =           { NFS4_OP_V42,                             0
+    [OP_WRITE_SAME] =           { NFS4_OP_V42,                             NFS4_OP_FLAG_MUTATES
     },
-    [OP_CLONE] =                { NFS4_OP_V42,                             0
+    [OP_CLONE] =                { NFS4_OP_V42,                             NFS4_OP_FLAG_MUTATES
     },
 
     /* RFC 8276 extended attribute ops (NFSv4.2 only) */
     [OP_GETXATTR] =             { NFS4_OP_V42,                             0
     },
-    [OP_SETXATTR] =             { NFS4_OP_V42,                             0
+    [OP_SETXATTR] =             { NFS4_OP_V42,                             NFS4_OP_FLAG_MUTATES
     },
     [OP_LISTXATTRS] =           { NFS4_OP_V42,                             0
     },
-    [OP_REMOVEXATTR] =          { NFS4_OP_V42,                             0
+    [OP_REMOVEXATTR] =          { NFS4_OP_V42,                             NFS4_OP_FLAG_MUTATES
     },
 };
 

--- a/src/server/nfs/nfs4_proc_access.c
+++ b/src/server/nfs/nfs4_proc_access.c
@@ -53,6 +53,14 @@ chimera_nfs4_access_complete(
     res->resok4.supported = requested;
     res->resok4.access    = chimera_nfs4_access_from_granted(requested, granted);
 
+    /* A read-only export never grants write-class access, regardless of what
+     * the ACL/mode would allow.  `supported` stays unmasked: the bits were
+     * evaluated, just not granted (RFC 7530 sec 16.1). */
+    if (chimera_nfs_export_id_is_ro(req->thread->shared, req->export_id)) {
+        res->resok4.access &= ~(ACCESS4_MODIFY | ACCESS4_EXTEND |
+                                ACCESS4_DELETE | ACCESS4_XAWRITE);
+    }
+
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_access_complete */
 
@@ -96,13 +104,14 @@ chimera_nfs4_access(
 
     if (fh_is_nfs4_root(req->fh, req->fhlen)) {
         /* The pseudo-root is a directory with no backing store (no xattrs):
-         * report only the directory-meaningful bits the client asked for, and
-         * grant them all. */
+         * report only the directory-meaningful bits the client asked for.
+         * It is immutable, so the write-class bits are never granted. */
         uint32_t meaningful = chimera_nfs4_access_meaningful(1, 0);
 
         res->status           = NFS4_OK;
         res->resok4.supported = args->access & meaningful;
-        res->resok4.access    = args->access & meaningful;
+        res->resok4.access    = args->access & meaningful &
+            ~(ACCESS4_MODIFY | ACCESS4_EXTEND | ACCESS4_DELETE);
         chimera_nfs4_compound_complete(req, NFS4_OK);
         return;
     }

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -12,6 +12,7 @@
 #include "nfs4_dump.h"
 #include "nfs4_trace.h"
 #include "nfs4_op_matrix.h"
+#include "nfs4_rofs.h"
 #include "nfs_drc_reply.h"
 
 static int
@@ -41,6 +42,51 @@ nfs4_release_write_args(
         }
     }
 } /* nfs4_release_write_args */
+
+/*
+ * Enforce per-export read-only policy at dispatch time.  Extracts the inputs
+ * nfs4_rofs_check needs from the request and the op's arguments; that header
+ * carries the policy itself and the reasoning behind each branch.
+ *
+ * This gate covers only mutations reached through the current filehandle.  Ops
+ * that mutate a handle carried by a stateid cannot use it to escape: ALLOCATE,
+ * DEALLOCATE, and COPY call nfs_state_check_write_for_fh, and SETATTR performs
+ * the same stateid-vs-current-filehandle check inline, so the stateid must
+ * name the gated filehandle.  WRITE instead relies on its NFS4ERR_OPENMODE
+ * check: a write-mode open can only have been granted through a writable
+ * export.  (After a runtime flip to read-only, existing write-mode opens keep
+ * writing -- the same window the COMMIT rationale in nfs4_rofs.h accepts.)
+ *
+ * Only call this after nfs4_op_check_minor has accepted the op (argop is then a
+ * valid matrix index).
+ */
+static nfsstat4
+nfs4_rofs_gate(
+    struct nfs_request      *req,
+    const struct nfs_argop4 *argop)
+{
+    struct chimera_server_nfs_shared *shared = req->thread->shared;
+    struct nfs4_rofs_input            in     = {
+        .op            = argop->argop,
+        .export_ro     = chimera_nfs_export_id_is_ro(shared, req->export_id),
+        .have_saved_fh = req->saved_fhlen != 0,
+    };
+
+    if (in.have_saved_fh) {
+        in.saved_export_ro = chimera_nfs_export_id_is_ro(shared,
+                                                         req->saved_export_id);
+    }
+
+    if (argop->argop == OP_OPEN) {
+        in.open_writes =
+            (argop->opopen.share_access & OPEN4_SHARE_ACCESS_WRITE) != 0 ||
+            argop->opopen.openhow.opentype == OPEN4_CREATE;
+    } else if (argop->argop == OP_OPENATTR) {
+        in.openattr_creates = argop->opopenattr.createdir != 0;
+    }
+
+    return nfs4_rofs_check(&in);
+} /* nfs4_rofs_gate */
 
 /*
  * Prepare the result slot of an op that failed before any handler ran.
@@ -181,6 +227,10 @@ chimera_nfs4_compound_process(
                                        req->minorversion,
                                        (uint32_t) req->index,
                                        req->seen_sequence);
+
+            if (gate == NFS4_OK) {
+                gate = nfs4_rofs_gate(req, argop);
+            }
         }
 
         if (gate != NFS4_OK) {
@@ -496,9 +546,13 @@ chimera_nfs4_compound(
     /* RFC 7530 §16.2.4: the server MUST echo the request tag back to the
      * client unchanged. xdr_opaque .data is owned by the request msg buffer
      * which lives until the response is sent. */
-    req->res_compound.tag            = args->tag;
-    req->fhlen                       = 0;
-    req->saved_fhlen                 = 0;
+    req->res_compound.tag = args->tag;
+    req->fhlen            = 0;
+    req->saved_fhlen      = 0;
+    /* Requests are recycled from a per-thread free list without being zeroed,
+     * and only SAVEFH ever writes saved_export_id -- reset it so a policy
+     * check on the saved side cannot read a previous compound's export. */
+    req->saved_export_id             = 0;
     req->minorversion                = (uint8_t) args->minorversion;
     req->seen_sequence               = false;
     req->current_stateid_valid       = false;

--- a/src/server/nfs/nfs4_rofs.h
+++ b/src/server/nfs/nfs4_rofs.h
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * Per-export read-only policy decision for one NFSv4 operation.
+ *
+ * The decision is kept here as a pure function of already-extracted inputs,
+ * separate from the dispatch-time adapter in nfs4_proc_compound.c that fills
+ * them in from the request.  Most of these branches cannot be reached through
+ * the chimera posix client -- it never sends a wire OPEN for an existing file,
+ * and cross-mount RENAME/LINK fails client-side with EXDEV -- so keeping the
+ * logic callable lets the unit test cover them directly.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "nfs4_xdr.h"
+#include "nfs4_op_matrix.h"
+
+struct nfs4_rofs_input {
+    uint32_t op;
+
+    /* The current filehandle's export is configured read-only. */
+    bool     export_ro;
+
+    /* The saved filehandle's export is configured read-only.  Only consulted
+     * for RENAME and LINK, and only when have_saved_fh is set. */
+    bool     saved_export_ro;
+    bool     have_saved_fh;
+
+    /* OPEN: share_access carries WRITE, or opentype is OPEN4_CREATE. */
+    bool     open_writes;
+
+    /* OPENATTR: createdir is set. */
+    bool     openattr_creates;
+};
+
+/*
+ * Returns NFS4_OK when the op may proceed, or the error to fail it with.
+ *
+ * Ops flagged NFS4_OP_FLAG_MUTATES always fail on a read-only export.  OPEN and
+ * OPENATTR mutate only for some arguments, so they are decided from the flags
+ * the caller extracted.  LAYOUTGET is refused with NFS4ERR_LAYOUTUNAVAILABLE
+ * rather than NFS4ERR_ROFS: a read-only export hands out no layouts (a RW-iomode
+ * layout would grant direct out-of-band write authority, and even an RO-iomode
+ * LAYOUTGET creates the backing file on the metadata server), and
+ * LAYOUTUNAVAILABLE is the error clients answer by falling back to I/O through
+ * the metadata server, so reads keep working.
+ *
+ * RENAME and LINK also mutate the saved-filehandle side -- removal of the source
+ * directory entry for RENAME, the source file's nlink for LINK -- and two exports
+ * may share one backing VFS mount, so both sides must be writable.  With no
+ * SAVEFH the saved side is not consulted at all; on a writable current export
+ * the handler then reports NFS4ERR_NOFILEHANDLE (RFC 7530 section 13.1.2.5).
+ *
+ * COMMIT is deliberately never gated: it writes no new data, and refusing it
+ * would strand unstable WRITE data written before a runtime flip to read-only or
+ * through a read-write sibling export of the same mount.
+ *
+ * Ops outside the matrix range (NFS4_OP_MIN..NFS4_OP_MAX) are not gated: they
+ * are not dispatchable, so the caller rejects them as illegal regardless.
+ */
+static inline nfsstat4
+nfs4_rofs_check(const struct nfs4_rofs_input *in)
+{
+    if (in->op < NFS4_OP_MIN || in->op > NFS4_OP_MAX) {
+        return NFS4_OK;
+    }
+
+    if (in->export_ro) {
+        if (nfs4_op_support[in->op].flags & NFS4_OP_FLAG_MUTATES) {
+            return NFS4ERR_ROFS;
+        }
+
+        if (in->op == OP_OPEN && in->open_writes) {
+            return NFS4ERR_ROFS;
+        }
+
+        if (in->op == OP_OPENATTR && in->openattr_creates) {
+            return NFS4ERR_ROFS;
+        }
+
+        if (in->op == OP_LAYOUTGET) {
+            return NFS4ERR_LAYOUTUNAVAILABLE;
+        }
+    }
+
+    if ((in->op == OP_RENAME || in->op == OP_LINK) &&
+        in->have_saved_fh && in->saved_export_ro) {
+        return NFS4ERR_ROFS;
+    }
+
+    return NFS4_OK;
+} /* nfs4_rofs_check */

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -640,6 +640,8 @@ nfs_open_state_check_principal(
  * server makes against the current filehandle is only meaningful if the
  * operation actually acts on that filehandle.  An op that instead mutated some
  * other handle carried by its stateid would slip past such a check entirely.
+ * The per-export read-only gate (nfs4_rofs_gate) is exactly such a check, and
+ * relies on this one to stay a dispatch-time decision.
  *
  * Delegation and layout stateids are rejected rather than misinterpreted:
  * neither carries an open_state, and callers that support them (see WRITE)

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -547,6 +547,34 @@ chimera_nfs_export_sec_ok(
 } /* chimera_nfs_export_sec_ok */
 
 /*
+ * True iff export_id names a live export configured read-only.
+ *
+ * Export id 0 (pseudo-root / no export) returns false; the pseudo-root's own
+ * immutability is enforced elsewhere.  An unknown id also returns false, which
+ * is fail-open for this gate: the handle either fails at the VFS layer because
+ * its mount is gone, or -- if the mount survives because another export still
+ * references it -- is treated as unrestricted.  Removing an export unlinks only
+ * the export record (chimera_nfs_remove_export) and unmounts nothing, so a
+ * client holding handles minted under a deleted read-only export keeps them
+ * usable.  The same fail-open applies to the squash and sec policies; closing
+ * it means rejecting well-formed handles that name an unknown export at decode
+ * time, not patching each policy check.
+ */
+static inline int
+chimera_nfs_export_id_is_ro(
+    struct chimera_server_nfs_shared *shared,
+    uint16_t                          export_id)
+{
+    const struct chimera_nfs_export *export =
+        chimera_nfs_get_export_by_id(shared, export_id);
+
+    /* access is a CHIMERA_NFS_EXPORT_ACCESS_* bitmask (see nfs.h); test the RO
+     * bit rather than comparing the whole mask so an over-set value such as
+     * RO|RW fails closed instead of silently granting write access. */
+    return export && (export->access & CHIMERA_NFS_EXPORT_ACCESS_RO) != 0;
+} /* chimera_nfs_export_id_is_ro */
+
+/*
  * Map the RPC credential into a request and snapshot it as the pre-squash
  * original.  Use this from every proc/compound entry instead of calling
  * chimera_nfs_map_cred directly so that file-handle decoding can recompute the

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -82,6 +82,32 @@ target_link_libraries(test_protocol_advertise chimera_vfs chimera_common evpl ev
 add_dependencies(test_protocol_advertise chimera_nfs_common)
 add_test(NAME chimera/server/nfs/protocol_advertise COMMAND test_protocol_advertise)
 
+# Unit test for the per-export read-only gate decision logic (nfs4_rofs.h) and
+# the NFS4_OP_FLAG_MUTATES set it keys on.  Header logic only, but nfs4_rofs.h
+# pulls in the generated nfs4_xdr.h, hence the chimera_nfs_common dependency.
+add_executable(test_rofs_gate test_rofs_gate.c)
+target_include_directories(test_rofs_gate PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src
+    ${NFS_COMMON_INCLUDE_DIR})
+target_link_libraries(test_rofs_gate chimera_vfs chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
+add_dependencies(test_rofs_gate chimera_nfs_common)
+add_test(NAME chimera/server/nfs/rofs_gate COMMAND test_rofs_gate)
+
+# Unit test for the NFSv3 per-export read-only gate (nfs3_procs.h): the single-
+# and two-handle (RENAME/LINK) checks against a fixture export table, including
+# the cross-export directions a POSIX client cannot reach (cross-mount
+# RENAME/LINK fails client-side with EXDEV).  Links chimera_nfs for the export
+# id lookup (chimera_nfs_get_export_by_id).
+add_executable(test_nfs3_rofs test_nfs3_rofs.c)
+target_link_libraries(test_nfs3_rofs chimera_nfs chimera_server chimera_vfs chimera_nfs_common chimera_common evpl evpl_rpc2 pthread uuid urcu-qsbr urcu-common)
+target_include_directories(test_nfs3_rofs PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/server/nfs
+    ${NFS_COMMON_INCLUDE_DIR})
+add_test(NAME chimera/server/nfs/nfs3_rofs
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_nfs3_rofs)
+
 # Unit test for the shared xattr name translation helpers (vfs/vfs_xattr_name.h).
 add_executable(test_xattr_name test_xattr_name.c)
 target_include_directories(test_xattr_name PRIVATE

--- a/src/server/nfs/tests/test_nfs3_rofs.c
+++ b/src/server/nfs/tests/test_nfs3_rofs.c
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Per-export read-only ("access": "ro") enforcement for NFSv3: the gate
+ * helpers in nfs3_procs.h, driven against a fixture export table.
+ *
+ * The end-to-end half (src/posix/tests/test_export_ro.c) covers every mutating
+ * procedure same-export, but the POSIX client cannot reach the cross-export
+ * side of chimera_nfs3_check_rofs2 -- cross-mount RENAME/LINK fails
+ * client-side with EXDEV -- so both directions (read-only source into a
+ * writable directory and the reverse) are driven here, the NFSv3 counterpart
+ * of test_rofs_gate.c's saved-filehandle checks.  The lookup contract of
+ * chimera_nfs_export_id_is_ro is pinned as well: fail-open for export id 0 and
+ * unknown ids (documented in nfs_common.h -- a deleted export must not brick
+ * handles that stay valid through a surviving sibling export), and fail-closed
+ * for an over-set access mask such as RO|RW, which must read as read-only
+ * rather than silently granting write access.
+ *
+ * Checks are explicit rather than assert()-based: release builds define NDEBUG,
+ * which would compile an assert-only test down to nothing.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "nfs3_procs.h"
+
+#define RO_EXPORT_ID      3
+#define RW_EXPORT_ID      4
+#define OVERSET_EXPORT_ID 5
+#define UNKNOWN_EXPORT_ID 6
+
+static int                              failures = 0;
+
+/* exports_by_id spans the full uint16_t id space, so the shared fixture is
+ * large; keep it static rather than on the stack. */
+static struct chimera_server_nfs_shared shared;
+static struct chimera_server_nfs_thread thread;
+static struct nfs_request               request;
+
+static struct chimera_nfs_export        export_ro = {
+    .id     = RO_EXPORT_ID,
+    .access = CHIMERA_NFS_EXPORT_ACCESS_RO,
+};
+
+static struct chimera_nfs_export        export_rw = {
+    .id     = RW_EXPORT_ID,
+    .access = CHIMERA_NFS_EXPORT_ACCESS_RW,
+};
+
+/* The access field is copied verbatim from the public API with no validation,
+ * so an over-set mask is representable; it must fail closed. */
+static struct chimera_nfs_export        export_overset = {
+    .id     = OVERSET_EXPORT_ID,
+    .access = CHIMERA_NFS_EXPORT_ACCESS_RO | CHIMERA_NFS_EXPORT_ACCESS_RW,
+};
+
+static void
+expect_single(
+    uint16_t    export_id,
+    nfsstat3    want,
+    const char *desc)
+{
+    nfsstat3 got = chimera_nfs3_check_rofs(&request, export_id);
+
+    if (got != want) {
+        failures++;
+        fprintf(stderr, "FAIL: %s: got %d, expected %d\n", desc, got, want);
+    }
+} /* expect_single */
+
+static void
+expect_dual(
+    uint16_t    export_id,
+    uint16_t    dir2_export_id,
+    nfsstat3    want,
+    const char *desc)
+{
+    nfsstat3 got;
+
+    request.export_id = export_id;
+    got               = chimera_nfs3_check_rofs2(&request, dir2_export_id);
+
+    if (got != want) {
+        failures++;
+        fprintf(stderr, "FAIL: %s: got %d, expected %d\n", desc, got, want);
+    }
+} /* expect_dual */
+
+/* Single-handle gate: the shape every mutating one-directory proc calls. */
+static void
+test_single_handle_gate(void)
+{
+    expect_single(RO_EXPORT_ID, NFS3ERR_ROFS,
+                  "read-only export must be gated");
+    expect_single(RW_EXPORT_ID, NFS3_OK,
+                  "read-write export must not be gated");
+    expect_single(OVERSET_EXPORT_ID, NFS3ERR_ROFS,
+                  "over-set access mask (RO|RW) must fail closed as read-only");
+    expect_single(0, NFS3_OK,
+                  "export id 0 (pseudo-root / none) is fail-open by contract");
+    expect_single(UNKNOWN_EXPORT_ID, NFS3_OK,
+                  "unknown export id is fail-open by contract");
+} /* test_single_handle_gate */
+
+/* Two-handle gate (RENAME/LINK): both sides must be writable, in both
+ * cross-export directions.  A regression that consults req->export_id twice
+ * or drops the second handle's export fails here. */
+static void
+test_dual_handle_gate(void)
+{
+    expect_dual(RW_EXPORT_ID, RO_EXPORT_ID, NFS3ERR_ROFS,
+                "writable current export into read-only second export");
+    expect_dual(RO_EXPORT_ID, RW_EXPORT_ID, NFS3ERR_ROFS,
+                "read-only current export into writable second export");
+    expect_dual(RO_EXPORT_ID, RO_EXPORT_ID, NFS3ERR_ROFS,
+                "both exports read-only");
+    expect_dual(RW_EXPORT_ID, RW_EXPORT_ID, NFS3_OK,
+                "both exports writable must not be gated");
+    expect_dual(RW_EXPORT_ID, UNKNOWN_EXPORT_ID, NFS3_OK,
+                "unknown second export id is fail-open by contract");
+} /* test_dual_handle_gate */
+
+int
+main(void)
+{
+    shared.exports_by_id[RO_EXPORT_ID]      = &export_ro;
+    shared.exports_by_id[RW_EXPORT_ID]      = &export_rw;
+    shared.exports_by_id[OVERSET_EXPORT_ID] = &export_overset;
+    thread.shared                           = &shared;
+    request.thread                          = &thread;
+
+    test_single_handle_gate();
+    test_dual_handle_gate();
+
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+
+    return 0;
+} /* main */

--- a/src/server/nfs/tests/test_rofs_gate.c
+++ b/src/server/nfs/tests/test_rofs_gate.c
@@ -1,0 +1,350 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Per-export read-only ("access": "ro") enforcement for NFSv4: the decision
+ * logic in nfs4_rofs.h and the NFS4_OP_FLAG_MUTATES set that drives it.
+ *
+ * Two things are checked here that no end-to-end test can reach.  First, the
+ * flag set is pinned exactly, in both directions: a new mutating op added to
+ * nfs4_op_matrix.h without the flag is a silent enforcement hole rather than a
+ * failure anywhere else, and a conditionally-mutating op flagged by mistake
+ * would reject reads.  Second, the gate branches that the chimera posix client
+ * cannot exercise -- the OPEN and OPENATTR argument-dependent cases, LAYOUTGET,
+ * and the cross-export saved-filehandle side of RENAME/LINK -- are driven
+ * directly.  See src/posix/tests/test_export_ro.c for the end-to-end half.
+ *
+ * Checks are explicit rather than assert()-based: release builds define NDEBUG,
+ * which would compile an assert-only test down to nothing.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "nfs_internal.h"
+#include "nfs4_xdr.h"
+#include "nfs4_op_matrix.h"
+#include "nfs4_rofs.h"
+
+#define ARRAY_COUNT(a) (sizeof(a) / sizeof((a)[0]))
+
+static int       failures = 0;
+
+/* Every op that mutates unconditionally, whatever its arguments. */
+static const int expect_mutates[] = {
+    OP_CREATE,
+    OP_LINK,
+    OP_REMOVE,
+    OP_RENAME,
+    OP_SETATTR,
+    OP_WRITE,
+    OP_LAYOUTCOMMIT,
+    OP_ALLOCATE,
+    OP_COPY,
+    OP_DEALLOCATE,
+    OP_WRITE_SAME,
+    OP_CLONE,
+    OP_SETXATTR,
+    OP_REMOVEXATTR,
+};
+
+/*
+ * Ops that mutate only for some arguments, or that need an error other than
+ * NFS4ERR_ROFS.  These are gated explicitly in nfs4_rofs_gate and must NOT
+ * carry the flag -- flagging them would reject reads:
+ *   OPEN       mutates only for share_access WRITE or OPEN4_CREATE
+ *   OPENATTR   mutates only when createdir is set
+ *   LAYOUTGET  answers NFS4ERR_LAYOUTUNAVAILABLE so clients fall back to the
+ *              metadata server instead of failing the read outright
+ */
+static const int expect_conditional[] = {
+    OP_OPEN,
+    OP_OPENATTR,
+    OP_LAYOUTGET,
+};
+
+static int
+in_list(
+    const int *list,
+    size_t     count,
+    int        op)
+{
+    size_t i;
+
+    for (i = 0; i < count; i++) {
+        if (list[i] == op) {
+            return 1;
+        }
+    }
+    return 0;
+} /* in_list */
+
+static void
+test_mutates_set_is_exact(void)
+{
+    int op;
+
+    for (op = NFS4_OP_MIN; op <= NFS4_OP_MAX; op++) {
+        int flagged = (nfs4_op_support[op].flags & NFS4_OP_FLAG_MUTATES) != 0;
+        int expect  = in_list(expect_mutates, ARRAY_COUNT(expect_mutates), op);
+
+        if (flagged == expect) {
+            continue;
+        }
+
+        failures++;
+        if (expect) {
+            fprintf(stderr,
+                    "FAIL: op %d expected NFS4_OP_FLAG_MUTATES but does not "
+                    "have it -- it would escape the read-only export gate\n",
+                    op);
+        } else {
+            fprintf(stderr,
+                    "FAIL: op %d has NFS4_OP_FLAG_MUTATES unexpectedly -- if "
+                    "it only mutates conditionally, gate it in nfs4_rofs_gate "
+                    "instead so reads are not rejected\n",
+                    op);
+        }
+    }
+} /* test_mutates_set_is_exact */
+
+static void
+test_conditionally_gated_ops_are_not_flagged(void)
+{
+    size_t i;
+
+    for (i = 0; i < ARRAY_COUNT(expect_conditional); i++) {
+        int op = expect_conditional[i];
+
+        if (nfs4_op_support[op].flags & NFS4_OP_FLAG_MUTATES) {
+            failures++;
+            fprintf(stderr,
+                    "FAIL: conditionally-mutating op %d must not carry "
+                    "NFS4_OP_FLAG_MUTATES\n", op);
+        }
+
+        /* Sanity: still a supported op, not a hole in the matrix. */
+        if (nfs4_op_support[op].minors == 0) {
+            failures++;
+            fprintf(stderr,
+                    "FAIL: op %d is not supported in any minor version; the "
+                    "expected-conditional list is stale\n", op);
+        }
+    }
+} /* test_conditionally_gated_ops_are_not_flagged */
+
+/* COMMIT writes no new data and is deliberately never gated -- gating it would
+ * strand unstable WRITE data written through a read-write sibling export of the
+ * same mount, or before a runtime flip to read-only. */
+static void
+test_commit_is_not_flagged(void)
+{
+    if (nfs4_op_support[OP_COMMIT].flags & NFS4_OP_FLAG_MUTATES) {
+        failures++;
+        fprintf(stderr, "FAIL: OP_COMMIT must not be gated read-only\n");
+    }
+} /* test_commit_is_not_flagged */
+
+/* The flag must not collide with the dispatch flags sharing the same field. */
+static void
+test_flag_bits_are_distinct(void)
+{
+    if ((NFS4_OP_FLAG_MUTATES & NFS4_OP_FLAG_MUST_BE_FIRST) ||
+        (NFS4_OP_FLAG_MUTATES & NFS4_OP_FLAG_NO_REQ_SESSION)) {
+        failures++;
+        fprintf(stderr,
+                "FAIL: NFS4_OP_FLAG_MUTATES overlaps another dispatch flag\n");
+    }
+} /* test_flag_bits_are_distinct */
+
+static void
+expect_status(
+    const struct nfs4_rofs_input *in,
+    nfsstat4                      want,
+    const char                   *desc)
+{
+    nfsstat4 got = nfs4_rofs_check(in);
+
+    if (got != want) {
+        failures++;
+        fprintf(stderr, "FAIL: %s: got %d, expected %d\n", desc, got, want);
+    }
+} /* expect_status */
+
+/* A read-write export must never be gated, whatever the op. */
+static void
+test_rw_export_is_never_gated(void)
+{
+    int op;
+
+    for (op = NFS4_OP_MIN; op <= NFS4_OP_MAX; op++) {
+        struct nfs4_rofs_input in = {
+            .op               = op,
+            .export_ro        = false,
+            .open_writes      = true,
+            .openattr_creates = true,
+        };
+
+        expect_status(&in, NFS4_OK, "read-write export must not be gated");
+    }
+} /* test_rw_export_is_never_gated */
+
+static void
+test_unconditional_mutators_are_gated(void)
+{
+    size_t i;
+
+    for (i = 0; i < ARRAY_COUNT(expect_mutates); i++) {
+        struct nfs4_rofs_input in = {
+            .op        = expect_mutates[i],
+            .export_ro = true,
+        };
+
+        expect_status(&in, NFS4ERR_ROFS, "mutating op on read-only export");
+    }
+} /* test_unconditional_mutators_are_gated */
+
+/* OPEN is refused only when it would write: share_access WRITE or a create.
+ * A read-only OPEN must still be granted, or reads break entirely. */
+static void
+test_open_gated_only_when_it_writes(void)
+{
+    struct nfs4_rofs_input reading = {
+        .op          = OP_OPEN,
+        .export_ro   = true,
+        .open_writes = false,
+    };
+    struct nfs4_rofs_input writing = {
+        .op          = OP_OPEN,
+        .export_ro   = true,
+        .open_writes = true,
+    };
+
+    expect_status(&reading, NFS4_OK, "read-only OPEN on read-only export");
+    expect_status(&writing, NFS4ERR_ROFS, "write OPEN on read-only export");
+} /* test_open_gated_only_when_it_writes */
+
+/* OPENATTR mutates only when it is asked to create the attribute directory. */
+static void
+test_openattr_gated_only_when_creating(void)
+{
+    struct nfs4_rofs_input reading = {
+        .op               = OP_OPENATTR,
+        .export_ro        = true,
+        .openattr_creates = false,
+    };
+    struct nfs4_rofs_input creating = {
+        .op               = OP_OPENATTR,
+        .export_ro        = true,
+        .openattr_creates = true,
+    };
+
+    expect_status(&reading, NFS4_OK, "OPENATTR createdir=false");
+    expect_status(&creating, NFS4ERR_ROFS, "OPENATTR createdir=true");
+} /* test_openattr_gated_only_when_creating */
+
+/* LAYOUTGET must answer LAYOUTUNAVAILABLE, not ROFS: clients fall back to I/O
+ * through the metadata server on the former but can fail the read on the latter. */
+static void
+test_layoutget_reports_layoutunavailable(void)
+{
+    struct nfs4_rofs_input in = {
+        .op        = OP_LAYOUTGET,
+        .export_ro = true,
+    };
+
+    expect_status(&in, NFS4ERR_LAYOUTUNAVAILABLE, "LAYOUTGET on read-only export");
+} /* test_layoutget_reports_layoutunavailable */
+
+/*
+ * The cross-export half of RENAME/LINK: the current filehandle sits on a
+ * writable export while the saved side is read-only.  Two exports can share one
+ * backing VFS mount, so without this the mutation would succeed at the VFS
+ * layer.  Unreachable through a POSIX client (cross-mount rename returns EXDEV),
+ * which is exactly why it is checked here.
+ */
+static void
+test_saved_side_gated_for_rename_and_link(void)
+{
+    const int ops[] = { OP_RENAME, OP_LINK };
+    size_t    i;
+
+    for (i = 0; i < ARRAY_COUNT(ops); i++) {
+        struct nfs4_rofs_input cross = {
+            .op              = ops[i],
+            .export_ro       = false,
+            .saved_export_ro = true,
+            .have_saved_fh   = true,
+        };
+        /* No SAVEFH ran: the saved side must not be consulted at all, so the
+         * handler can report NFS4ERR_NOFILEHANDLE instead of ROFS. */
+        struct nfs4_rofs_input no_savefh = {
+            .op              = ops[i],
+            .export_ro       = false,
+            .saved_export_ro = true,
+            .have_saved_fh   = false,
+        };
+
+        expect_status(&cross, NFS4ERR_ROFS,
+                      "RENAME/LINK with read-only saved-side export");
+        expect_status(&no_savefh, NFS4_OK,
+                      "RENAME/LINK with no SAVEFH must not consult saved side");
+    }
+
+    /* An op that does not touch the saved filehandle ignores it entirely. */
+    struct nfs4_rofs_input unrelated = {
+        .op              = OP_READ,
+        .export_ro       = false,
+        .saved_export_ro = true,
+        .have_saved_fh   = true,
+    };
+
+    expect_status(&unrelated, NFS4_OK,
+                  "non-RENAME/LINK op ignores the saved-side export");
+} /* test_saved_side_gated_for_rename_and_link */
+
+/* Read-path ops must keep working on a read-only export. */
+static void
+test_read_ops_are_not_gated(void)
+{
+    const int ops[] = {
+        OP_ACCESS,   OP_GETATTR,     OP_GETFH,        OP_LOOKUP,        OP_LOOKUPP,
+        OP_READ,     OP_READDIR,     OP_READLINK,     OP_SECINFO,       OP_COMMIT,
+        OP_GETXATTR, OP_LISTXATTRS,  OP_SEEK,         OP_CLOSE,         OP_LOCK,
+    };
+    size_t    i;
+
+    for (i = 0; i < ARRAY_COUNT(ops); i++) {
+        struct nfs4_rofs_input in = {
+            .op        = ops[i],
+            .export_ro = true,
+        };
+
+        expect_status(&in, NFS4_OK, "read-path op on read-only export");
+    }
+} /* test_read_ops_are_not_gated */
+
+int
+main(void)
+{
+    test_mutates_set_is_exact();
+    test_conditionally_gated_ops_are_not_flagged();
+    test_commit_is_not_flagged();
+    test_flag_bits_are_distinct();
+    test_rw_export_is_never_gated();
+    test_unconditional_mutators_are_gated();
+    test_open_gated_only_when_it_writes();
+    test_openattr_gated_only_when_creating();
+    test_layoutget_reports_layoutunavailable();
+    test_saved_side_gated_for_rename_and_link();
+    test_read_ops_are_not_gated();
+
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+
+    return 0;
+} /* main */


### PR DESCRIPTION
The export "access" option accepted "ro" and stored it, and the REST and CLI paths reported it, but nothing in either protocol server consulted it: a client mounting a read-only export could still write to it.

Both servers key the gate on chimera_nfs_export_id_is_ro.  The access field is a bitmask copied verbatim from the public API, so the helper tests the RO bit rather than comparing the whole mask: an over-set value such as RO|RW fails closed instead of silently granting write access.

NFSv3 gates every mutating procedure after the file handle is decoded, via chimera_nfs3_check_rofs, returning NFS3ERR_ROFS.  RENAME and LINK check both handles' exports through chimera_nfs3_check_rofs2 -- which reads the first export from the request itself, so a call site cannot check the same export twice -- since two exports may share one backing VFS mount and a cross-export operation would otherwise succeed at the VFS layer.

NFSv4 gates at dispatch, before any handler runs.  Ops that always mutate carry NFS4_OP_FLAG_MUTATES in the op matrix and fail NFS4ERR_ROFS; ops outside the matrix range (NFS4_OP_MIN..NFS4_OP_MAX) are skipped, since they are not dispatchable and the caller rejects them as illegal regardless.  Three cases are decided from their arguments instead, in nfs4_rofs.h:

  - OPEN only when it would write -- share_access WRITE, or a create.  RFC 7530 section 16.16.5 has the server return NFS4ERR_ROFS for the former; a create writes regardless of share_access.
  - OPENATTR only when createdir is set; per RFC 7530 section 16.19 it is otherwise a pure read of the named-attribute directory.
  - LAYOUTGET always, but with NFS4ERR_LAYOUTUNAVAILABLE rather than ROFS.  A read-only export hands out no layouts: an RW-iomode layout would grant the client direct out-of-band write authority that gating LAYOUTCOMMIT alone cannot take back, and even an RO-iomode LAYOUTGET creates the backing file on the metadata server.  LAYOUTUNAVAILABLE is what clients answer by falling back to I/O through the metadata server, so reads keep working.

COMMIT is deliberately never gated: it writes no new data, and refusing it would strand unstable WRITE data written before a runtime flip to read-only or through a read-write sibling export of the same mount.

The gate keys on the current filehandle's export.  Ops that mutate a handle carried by a stateid cannot use the stateid to escape it: ALLOCATE, DEALLOCATE, and COPY call nfs_state_check_write_for_fh, and SETATTR performs the same stateid-vs-current-filehandle check inline, so the stateid must name the gated filehandle.  WRITE instead relies on its NFS4ERR_OPENMODE check: a write-mode open can only have been granted through a writable export.  RENAME and LINK also mutate the saved-filehandle side, so both exports must be writable; the saved side is consulted only once a SAVEFH has run, and on a writable current export the handler otherwise reports NFS4ERR_NOFILEHANDLE (RFC 7530 section 13.1.2.5).  saved_export_id is now reset per compound, since requests are recycled from a per-thread free list without being zeroed and only SAVEFH writes that field.

ACCESS replies stop advertising the write-class bits on a read-only export, in both versions, so a client learns up front rather than on its first failed mutation.  `supported` stays unmasked: the bits were evaluated, just not granted (RFC 7530 section 16.1).  The NFSv4 pseudo-root, which is immutable, no longer advertises them either.

Three tests.  chimera/server/nfs/rofs_gate drives the NFSv4 decision logic directly and pins the MUTATES set in both directions, covering the branches no client can reach -- the OPEN and OPENATTR argument cases, LAYOUTGET, and the cross-export saved-filehandle side.  chimera/server/nfs/nfs3_rofs pins the v3 dual-export rule: both cross-export directions (unreachable through a POSIX client, which fails with EXDEV client-side), the fail-open contract for id 0 and unknown export ids, and the fail-closed handling of an over-set access mask.  chimera/posix/export_ro exposes one writable mount through both a rw and a read-only export and checks end to end that reads still work, that every mutation fails EROFS, that the fixtures are untouched, and that the rw export stays writable -- so the policy cannot bleed across exports.