### PR TITLE
nfs3/vfs: memfs remove-path deadlock fixes, ESYMLINK mapping, remove type flags

### DIFF
--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -248,6 +248,7 @@ struct chimera_client_request {
             int                             parent_len;
             int                             name_offset;
             int                             child_fh_len;
+            unsigned int                    flags; /* CHIMERA_VFS_REMOVE_* */
             uint8_t                         child_fh[CHIMERA_VFS_FH_SIZE];
             char                            path[CHIMERA_VFS_PATH_MAX];
         } remove;

--- a/src/client/client_remove.c
+++ b/src/client/client_remove.c
@@ -20,6 +20,7 @@ chimera_remove(
     request = chimera_client_request_alloc(thread);
 
     request->opcode              = CHIMERA_CLIENT_OP_REMOVE;
+    request->remove.flags        = 0; /* generic remove: no type assertion */
     request->remove.callback     = callback;
     request->remove.private_data = private_data;
     request->remove.path_len     = path_len;

--- a/src/client/client_remove.h
+++ b/src/client/client_remove.h
@@ -40,6 +40,7 @@ chimera_dispatch_remove(
         thread->client->root_fh_len,
         request->remove.path,
         request->remove.path_len,
+        request->remove.flags,
         chimera_remove_vfs_complete,
         request);
 } /* chimera_dispatch_remove */
@@ -101,6 +102,7 @@ chimera_remove_at_lookup_complete(
         request->remove.path_len,
         request->remove.child_fh,
         request->remove.child_fh_len,
+        request->remove.flags,
         0,
         0,
         NULL,

--- a/src/nfs_common/nfs3_status.h
+++ b/src/nfs_common/nfs3_status.h
@@ -54,6 +54,13 @@ chimera_vfs_error_to_nfsstat3(enum chimera_vfs_error err)
             return NFS3ERR_BADHANDLE;
         case CHIMERA_VFS_ENOTSUP:
             return NFS3ERR_NOTSUPP;
+        case CHIMERA_VFS_ESYMLINK:
+            /* A symlink where a directory was required (e.g. LOOKUP or
+             * READDIR with a symlink file handle).  NFSv3 has no dedicated
+             * symlink error for this; RFC 1813 uses NFS3ERR_NOTDIR for a
+             * non-directory object.  (The NFSv4 mapping is separate and
+             * keeps NFS4ERR_SYMLINK, which v4 LOOKUP relies on.) */
+            return NFS3ERR_NOTDIR;
         case CHIMERA_VFS_EFAULT:
             return NFS3ERR_SERVERFAULT;
         case CHIMERA_VFS_EOVERFLOW:

--- a/src/posix/posix_rmdir.c
+++ b/src/posix/posix_rmdir.c
@@ -47,6 +47,7 @@ chimera_posix_rmdir(const char *path)
     slash = rindex(path, '/');
 
     req.opcode              = CHIMERA_CLIENT_OP_REMOVE;
+    req.remove.flags        = CHIMERA_VFS_REMOVE_ISDIR; /* rmdir(2): must be a directory */
     req.remove.callback     = chimera_posix_rmdir_callback;
     req.remove.private_data = &comp;
     req.remove.path_len     = path_len;

--- a/src/posix/posix_unlink.c
+++ b/src/posix/posix_unlink.c
@@ -47,6 +47,7 @@ chimera_posix_unlink(const char *path)
     slash = rindex(path, '/');
 
     req.opcode              = CHIMERA_CLIENT_OP_REMOVE;
+    req.remove.flags        = CHIMERA_VFS_REMOVE_ISNOTDIR; /* unlink(2): not a directory */
     req.remove.callback     = chimera_posix_remove_callback;
     req.remove.private_data = &comp;
     req.remove.path_len     = path_len;

--- a/src/posix/posix_unlinkat.c
+++ b/src/posix/posix_unlinkat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -55,10 +55,6 @@ chimera_posix_unlinkat(
     int                             path_len;
     const char                     *slash;
 
-    // Note: AT_REMOVEDIR flag is handled by the VFS layer
-    // which will enforce directory-only removal semantics
-    (void) flags;
-
     chimera_posix_completion_init(&comp, &req);
 
     // Handle AT_FDCWD case
@@ -102,7 +98,12 @@ chimera_posix_unlinkat(
         req.remove.name_offset   = 0;
     }
 
-    req.opcode              = CHIMERA_CLIENT_OP_REMOVE;
+    req.opcode = CHIMERA_CLIENT_OP_REMOVE;
+    /* AT_REMOVEDIR selects rmdir(2) semantics (directory only); its absence
+     * selects unlink(2) semantics (non-directory only).  The VFS remove op
+     * enforces the assertion in the backend. */
+    req.remove.flags = (flags & AT_REMOVEDIR) ?
+        CHIMERA_VFS_REMOVE_ISDIR : CHIMERA_VFS_REMOVE_ISNOTDIR;
     req.remove.callback     = chimera_posix_unlinkat_callback;
     req.remove.private_data = &comp;
 

--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -72,6 +72,7 @@ chimera_nfs3_remove_dispatch(
                           args->object.name.len,
                           child_fh,
                           child_fh_len,
+                          CHIMERA_VFS_REMOVE_ISNOTDIR,
                           CHIMERA_NFS3_ATTR_WCC_MASK,
                           CHIMERA_NFS3_ATTR_MASK,
                           NULL,

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -69,6 +69,7 @@ chimera_nfs3_rmdir_dispatch(
                           args->object.name.len,
                           child_fh,
                           child_fh_len,
+                          CHIMERA_VFS_REMOVE_ISDIR,
                           CHIMERA_NFS3_ATTR_WCC_MASK,
                           CHIMERA_NFS3_ATTR_MASK,
                           NULL,

--- a/src/server/nfs/nfs4_proc_remove.c
+++ b/src/server/nfs/nfs4_proc_remove.c
@@ -94,7 +94,7 @@ nfs4_remove_ds_root_opened(
     chimera_vfs_remove_at(ctx->req->thread->vfs_thread, &ctx->req->cred,
                           ctx->ds_root_handle,
                           ctx->backing_name, strlen(ctx->backing_name),
-                          NULL, 0, 0, 0, NULL,
+                          NULL, 0, 0, 0, 0, NULL,
                           nfs4_remove_ds_backing_complete, ctx);
 } /* nfs4_remove_ds_root_opened */
 
@@ -140,7 +140,7 @@ nfs4_remove_mds(struct nfs4_remove_ctx *ctx)
     chimera_vfs_remove_at(req->thread->vfs_thread, &req->cred,
                           ctx->parent_handle,
                           args->target.data, args->target.len,
-                          NULL, 0, 0, 0, NULL,
+                          NULL, 0, 0, 0, 0, NULL,
                           nfs4_remove_mds_complete, ctx);
 } /* nfs4_remove_mds */
 

--- a/src/server/rest/rest_debug.c
+++ b/src/server/rest/rest_debug.c
@@ -224,7 +224,7 @@ chimera_rest_handle_debug_fsop(
 
     if (strcmp(op, "unlink") == 0) {
         chimera_vfs_remove(ctx->vfs_thread, cred, root_fh, root_fh_len,
-                           ctx->path, strlen(ctx->path),
+                           ctx->path, strlen(ctx->path), 0,
                            rest_fsop_remove_cb, ctx);
     } else if (strcmp(op, "rename") == 0) {
         path2 = json_string_value(json_object_get(root, "path2"));

--- a/src/server/s3/s3_bucket.c
+++ b/src/server/s3/s3_bucket.c
@@ -331,7 +331,7 @@ chimera_s3_delbucket_remove_next(struct s3_delbucket_ctx *ctx)
     if (ctx->cur < ctx->ndirs) {
         chimera_vfs_remove(thread->vfs, &shared->cred,
                            ctx->bucket_fh, ctx->bucket_fhlen,
-                           ctx->dirs[ctx->cur], strlen(ctx->dirs[ctx->cur]),
+                           ctx->dirs[ctx->cur], strlen(ctx->dirs[ctx->cur]), 0,
                            chimera_s3_delbucket_dir_removed, ctx);
         return;
     }
@@ -339,7 +339,7 @@ chimera_s3_delbucket_remove_next(struct s3_delbucket_ctx *ctx)
     /* All scaffolding gone; remove the bucket directory from the bucket root. */
     chimera_vfs_remove(thread->vfs, &shared->cred,
                        shared->root_fh, shared->root_fh_len,
-                       ctx->bucket_path, ctx->bucket_path_len,
+                       ctx->bucket_path, ctx->bucket_path_len, 0,
                        chimera_s3_delbucket_root_removed, ctx);
 } /* chimera_s3_delbucket_remove_next */
 

--- a/src/server/s3/s3_delete.c
+++ b/src/server/s3/s3_delete.c
@@ -60,6 +60,7 @@ chimera_s3_delete_open_callback(
                           0,
                           0,
                           0,
+                          0,
                           NULL,
                           chimera_s3_delete_remove_callback,
                           request);

--- a/src/server/s3/s3_delete_objects.c
+++ b/src/server/s3/s3_delete_objects.c
@@ -421,7 +421,7 @@ chimera_s3_del_open_cb(
                           oh,
                           request->del.cur_name,
                           request->del.cur_name_len,
-                          NULL, 0, 0, 0,
+                          NULL, 0, 0, 0, 0,
                           NULL,
                           chimera_s3_del_remove_cb,
                           request);

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -321,6 +321,7 @@ chimera_s3_part_destroy_open_dir_callback(
         0,
         0,
         0,
+        0,
         NULL,
         chimera_s3_part_destroy_remove_callback,
         ctx);

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -164,6 +164,7 @@ chimera_smb_close_doc_open_parent_callback(
         0,
         0,
         0,
+        0,
         unlink_skip,
         chimera_smb_close_doc_remove_callback,
         request);
@@ -261,6 +262,7 @@ chimera_smb_teardown_doc_open_parent_callback(
         ctx->doc_info.name,
         ctx->doc_info.name_len,
         NULL,
+        0,
         0,
         0,
         0,
@@ -407,6 +409,7 @@ chimera_smb_close_stream_base_parent_callback(
         open_file->name,
         open_file->name_len,
         NULL,
+        0,
         0,
         0,
         0,

--- a/src/server/smb/smb_proc_reparse.c
+++ b/src/server/smb/smb_proc_reparse.c
@@ -280,6 +280,7 @@ chimera_smb_set_reparse_open_parent_cb(
         0,
         0,
         0,
+        0,
         NULL,
         chimera_smb_set_reparse_remove_cb,
         request);

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2540,6 +2540,23 @@ cairn_remove_at(
 
     inode = child_ih.inode;
 
+    /* Enforce the caller's type assertion (RMDIR/ISDIR vs REMOVE/ISNOTDIR);
+     * neither flag removes whichever kind is present.  Capture the type
+     * before releasing the handles below -- the release invalidates `inode`. */
+    {
+        int child_is_dir = S_ISDIR(inode->mode);
+
+        if (((request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) && !child_is_dir) ||
+            ((request->remove_at.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) && child_is_dir)) {
+            cairn_inode_handle_release(&parent_ih);
+            cairn_inode_handle_release(&child_ih);
+            cairn_dirent_handle_release(&dh);
+            request->status = child_is_dir ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_ENOTDIR;
+            request->complete(request);
+            return;
+        }
+    }
+
     if (S_ISDIR(inode->mode)) {
         /* Check if directory is empty (proper rmdir semantics) */
         if (!cairn_directory_is_empty(thread, inode->inum)) {

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -1247,6 +1247,15 @@ diskfs_remove_at_child_cb(
 
     p->inode_stash[1] = inode;
 
+    /* Enforce the caller's type assertion (RMDIR/ISDIR vs REMOVE/ISNOTDIR);
+     * neither flag removes whichever kind is present. */
+    if (((request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) && !S_ISDIR(inode->mode)) ||
+        ((request->remove_at.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) && S_ISDIR(inode->mode))) {
+        diskfs_op_fail(request, p->txn,
+                       S_ISDIR(inode->mode) ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
     /* rmdir of a non-empty directory: probe for any dirent record
      * (asynchronously -- the child's tree may not be cached).  "." and ".."
      * are synthesised, so one record means non-empty. */

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1702,10 +1702,19 @@ chimera_io_uring_remove_at(
         return;
     }
 
-    rc = unlinkat(fd, fullname, 0);
-
-    if (rc == -1 && errno == EISDIR) {
+    /* Use the caller's type assertion to pick unlink vs rmdir: ISDIR ->
+     * AT_REMOVEDIR (a non-directory then yields ENOTDIR), ISNOTDIR -> plain
+     * unlink (a directory then yields EISDIR).  Neither set keeps the legacy
+     * try-file-then-directory fallback. */
+    if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) {
         rc = unlinkat(fd, fullname, AT_REMOVEDIR);
+    } else if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) {
+        rc = unlinkat(fd, fullname, 0);
+    } else {
+        rc = unlinkat(fd, fullname, 0);
+        if (rc == -1 && errno == EISDIR) {
+            rc = unlinkat(fd, fullname, AT_REMOVEDIR);
+        }
     }
 
     int unlinkat_errno = errno;

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -969,10 +969,19 @@ chimera_linux_remove_at(
         return;
     }
 
-    rc = unlinkat(fd, fullname, 0);
-
-    if (rc == -1 && errno == EISDIR) {
+    /* Use the caller's type assertion to pick unlink vs rmdir: ISDIR ->
+     * AT_REMOVEDIR (a non-directory then yields ENOTDIR), ISNOTDIR -> plain
+     * unlink (a directory then yields EISDIR).  Neither set keeps the legacy
+     * try-file-then-directory fallback. */
+    if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) {
         rc = unlinkat(fd, fullname, AT_REMOVEDIR);
+    } else if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) {
+        rc = unlinkat(fd, fullname, 0);
+    } else {
+        rc = unlinkat(fd, fullname, 0);
+        if (rc == -1 && errno == EISDIR) {
+            rc = unlinkat(fd, fullname, AT_REMOVEDIR);
+        }
     }
 
     int unlinkat_errno = errno;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4993,6 +4993,20 @@ memfs_link_at(
         return;
     }
 
+    /* If the link target's handle is the parent directory itself, the
+     * memfs_inode_get_fh() below would re-lock parent_inode's non-recursive
+     * mutex and self-deadlock (wedging this thread while it holds the lock).
+     * The parent passed the S_ISDIR check above, so the target is a
+     * directory: reject it as EISDIR (as the S_ISDIR(inode->mode) path below
+     * would) without taking the lock a second time. */
+    if (request->fh_len == request->link_at.dir_fhlen &&
+        memcmp(request->fh, request->link_at.dir_fh, request->fh_len) == 0) {
+        pthread_mutex_unlock(&parent_inode->lock);
+        request->status = CHIMERA_VFS_EISDIR;
+        request->complete(request);
+        return;
+    }
+
     inode = memfs_inode_get_fh(shared, request->fh, request->fh_len);
 
     if (!inode) {

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2542,6 +2542,18 @@ memfs_remove_at(
         }
     }
 
+    /* Enforce the caller's type assertion: RMDIR/rmdir(2) sets ISDIR (a
+     * non-directory is ENOTDIR); REMOVE/unlink(2) sets ISNOTDIR (a directory
+     * is EISDIR).  Neither set removes whichever kind is present. */
+    if (((request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) && !S_ISDIR(inode->mode)) ||
+        ((request->remove_at.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) && S_ISDIR(inode->mode))) {
+        pthread_mutex_unlock(&parent_inode->lock);
+        pthread_mutex_unlock(&inode->lock);
+        request->status = S_ISDIR(inode->mode) ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
+    }
+
     if (S_ISDIR(inode->mode) && !rb_tree_empty(&inode->dir.dirents)) {
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&inode->lock);

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4864,13 +4864,40 @@ memfs_rename_at(
             return;
         }
 
-        /* Destination exists - check if we can replace it */
-        existing_inode = memfs_inode_get_inum(shared, existing_dirent->inum, existing_dirent->gen);
+        /* Destination exists - check if we can replace it.
+         *
+         * The destination name may resolve to a directory we already hold
+         * locked -- e.g. renaming X into a name that currently points at X's
+         * own parent directory.  Re-locking it via memfs_inode_get_inum()
+         * would self-deadlock (wedging this thread while it holds the parent
+         * locks).  Reuse the already-held pointer in that case.  Such an
+         * existing target is always one of the parent directories, hence a
+         * non-empty directory, so the checks below reject the rename
+         * (EISDIR/ENOTDIR on a non-directory source, ENOTEMPTY otherwise)
+         * without ever reaching the replace path -- so existing_inode is
+         * never unlinked or unlocked here when it aliases a parent (the
+         * parent-unlock sites below own that lock). */
+        int existing_is_parent = 0;
+
+        if (existing_dirent->inum == old_parent_inode->inum &&
+            existing_dirent->gen == old_parent_inode->gen) {
+            existing_inode     = old_parent_inode;
+            existing_is_parent = 1;
+        } else if (cmp != 0 &&
+                   existing_dirent->inum == new_parent_inode->inum &&
+                   existing_dirent->gen == new_parent_inode->gen) {
+            existing_inode     = new_parent_inode;
+            existing_is_parent = 1;
+        } else {
+            existing_inode = memfs_inode_get_inum(shared, existing_dirent->inum, existing_dirent->gen);
+        }
 
         if (existing_inode) {
             /* Cannot rename a directory over a non-directory or vice versa */
             if (S_ISDIR(child_inode->mode) != S_ISDIR(existing_inode->mode)) {
-                pthread_mutex_unlock(&existing_inode->lock);
+                if (!existing_is_parent) {
+                    pthread_mutex_unlock(&existing_inode->lock);
+                }
                 pthread_mutex_unlock(&child_inode->lock);
                 pthread_mutex_unlock(&old_parent_inode->lock);
                 if (cmp != 0) {
@@ -4884,7 +4911,9 @@ memfs_rename_at(
             /* Cannot replace non-empty directory */
             if (S_ISDIR(existing_inode->mode) &&
                 !rb_tree_empty(&existing_inode->dir.dirents)) {
-                pthread_mutex_unlock(&existing_inode->lock);
+                if (!existing_is_parent) {
+                    pthread_mutex_unlock(&existing_inode->lock);
+                }
                 pthread_mutex_unlock(&child_inode->lock);
                 pthread_mutex_unlock(&old_parent_inode->lock);
                 if (cmp != 0) {

--- a/src/vfs/nfs/nfs3_remove_at.c
+++ b/src/vfs/nfs/nfs3_remove_at.c
@@ -169,6 +169,80 @@ chimera_nfs3_remove_do_remove(
                                                   chimera_nfs3_remove_callback, request);
 } /* chimera_nfs3_remove_do_remove */
 
+static void
+chimera_nfs3_rmdir_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct RMDIR3res            *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS3_OK) {
+        chimera_nfs3_get_wcc_data(&request->remove_at.r_dir_pre_attr,
+                                  &request->remove_at.r_dir_post_attr,
+                                  &res->resfail.dir_wcc);
+        request->status = nfs3_client_status_to_chimera_vfs_error(res->status);
+        request->complete(request);
+        return;
+    }
+
+    chimera_nfs3_get_wcc_data(&request->remove_at.r_dir_pre_attr,
+                              &request->remove_at.r_dir_post_attr,
+                              &res->resok.dir_wcc);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs3_rmdir_callback */
+
+/*
+ * A directory removal (the caller asserted CHIMERA_VFS_REMOVE_ISDIR) maps to
+ * the RMDIR RPC, not REMOVE.  Directories are never silly-renamed, so this is
+ * a direct send with no open-cache check.
+ */
+static void
+chimera_nfs3_remove_do_rmdir(
+    struct chimera_vfs_request     *request,
+    struct chimera_nfs3_remove_ctx *ctx)
+{
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct RMDIR3args                        args;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *dir_fh;
+    int                                      dir_fhlen;
+
+    server_thread = chimera_nfs_thread_get_server_thread(ctx->thread, request->fh, request->fh_len);
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    chimera_nfs3_map_fh(request->fh, request->fh_len, &dir_fh, &dir_fhlen);
+
+    args.object.dir.data.data = dir_fh;
+    args.object.dir.data.len  = dir_fhlen;
+    args.object.name.str      = (char *) request->remove_at.name;
+    args.object.name.len      = request->remove_at.namelen;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    ctx->shared->nfs_v3.send_call_NFSPROC3_RMDIR(&ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
+                                                 server_thread->nfs_conn, &rpc2_cred, &args,
+                                                 0, 0, NULL, 0, 0,
+                                                 chimera_nfs3_rmdir_callback, request);
+} /* chimera_nfs3_remove_do_rmdir */
+
 void
 chimera_nfs3_remove_at(
     struct chimera_nfs_thread  *thread,
@@ -197,6 +271,12 @@ chimera_nfs3_remove_at(
     ctx->thread = thread;
     ctx->shared = shared;
     ctx->server = server_thread->server;
+
+    /* A directory removal maps to RMDIR (never silly-renamed). */
+    if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) {
+        chimera_nfs3_remove_do_rmdir(request, ctx);
+        return;
+    }
 
     /*
      * If no child FH provided, skip silly rename handling entirely.

--- a/src/vfs/tests/vfs_clone_range_test.c
+++ b/src/vfs/tests/vfs_clone_range_test.c
@@ -409,11 +409,11 @@ main(
     /* Unlink the files so their (and the CoW-shared) block buffers are freed
      * before the module is torn down -- keeps LeakSanitizer quiet. */
     chimera_vfs_remove_at(ctx.vfs_thread, &cred, root_handle, "src", 3,
-                          src_fh, src_fh_len, 0, 0, NULL, remove_cb, &ctx);
+                          src_fh, src_fh_len, 0, 0, 0, NULL, remove_cb, &ctx);
     wait_done(&ctx);
     assert(ctx.status == CHIMERA_VFS_OK);
     chimera_vfs_remove_at(ctx.vfs_thread, &cred, root_handle, "dst", 3,
-                          dst_fh, dst_fh_len, 0, 0, NULL, remove_cb, &ctx);
+                          dst_fh, dst_fh_len, 0, 0, 0, NULL, remove_cb, &ctx);
     wait_done(&ctx);
     assert(ctx.status == CHIMERA_VFS_OK);
     chimera_vfs_release(ctx.vfs_thread, root_handle);

--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -275,7 +275,7 @@ remove_as(
     uint32_t                        child_fh_len)
 {
     chimera_vfs_remove_at(ctx->vfs_thread, cred, dir, name, strlen(name),
-                          child_fh, child_fh_len, 0, 0, NULL, remove_cb, ctx);
+                          child_fh, child_fh_len, 0, 0, 0, NULL, remove_cb, ctx);
     wait_done(ctx);
     return ctx->status;
 } /* remove_as */

--- a/src/vfs/tests/vfs_inode_scoped_remove_test.c
+++ b/src/vfs/tests/vfs_inode_scoped_remove_test.c
@@ -184,7 +184,7 @@ do_remove(
     const char                     *name)
 {
     chimera_vfs_remove_at(ctx->vfs_thread, cred, dir, name, strlen(name),
-                          NULL, 0, 0, 0, NULL, remove_cb, ctx);
+                          NULL, 0, 0, 0, 0, NULL, remove_cb, ctx);
     wait_done(ctx);
     return ctx->status;
 } /* do_remove */

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -138,6 +138,17 @@ struct chimera_vfs_mount_options {
  * symlink-leaf semantics. */
 #define CHIMERA_VFS_OPEN_STOP_SYMLINK   (1U << 9)
 
+/* remove_at flags: an optional assertion about the target's type, letting the
+ * single VFS remove op express the rmdir(2)/RMDIR vs unlink(2)/REMOVE
+ * distinction the callers know but the op otherwise loses.  Enforcing backends
+ * (memfs, cairn, diskfs) reject a mismatch (ENOTDIR when ISDIR is set on a
+ * non-directory, EISDIR when ISNOTDIR is set on a directory); passthrough
+ * backends (linux, io_uring) use it to choose unlinkat's AT_REMOVEDIR flag.
+ * With neither set the op removes whatever the name resolves to (legacy
+ * behavior). */
+#define CHIMERA_VFS_REMOVE_ISDIR        (1U << 0)  /* target must be a directory */
+#define CHIMERA_VFS_REMOVE_ISNOTDIR     (1U << 1)  /* target must not be a directory */
+
 /* Allocate flags */
 #define CHIMERA_VFS_ALLOCATE_DEALLOCATE 0x01
 
@@ -573,6 +584,7 @@ struct chimera_vfs_request {
             int                             pathlen;
             int                             parent_len;
             int                             name_offset;
+            unsigned int                    flags; /* CHIMERA_VFS_REMOVE_* type assertion */
             struct chimera_vfs_open_handle *parent_handle;
             chimera_vfs_remove_callback_t   callback;
             void                           *private_data;
@@ -855,6 +867,7 @@ struct chimera_vfs_request {
             const char                     *name;
             int                             namelen;
             uint64_t                        name_hash;
+            uint32_t                        flags;        /* CHIMERA_VFS_REMOVE_* type assertion */
             const uint8_t                  *child_fh;     /* Optional: child FH if known */
             int                             child_fh_len; /* 0 if child_fh not provided */
             /* Inode-scoped removal: when set (with child_fh), the backend MUST

--- a/src/vfs/vfs_proc_remove.c
+++ b/src/vfs/vfs_proc_remove.c
@@ -115,6 +115,7 @@ chimera_vfs_remove_child_lookup_complete(
         request->remove.pathlen - request->remove.name_offset,
         request->remove.child_fh_len ? request->remove.child_fh : NULL,
         request->remove.child_fh_len,
+        request->remove.flags,
         0,
         0,
         NULL,
@@ -154,6 +155,7 @@ chimera_vfs_remove_parent_open_complete(
             request->remove.pathlen - request->remove.name_offset,
             NULL,
             0,
+            request->remove.flags,
             0,
             0,
             NULL,  /* parent_lease_skip: path-only mount has no parent lease */
@@ -213,6 +215,7 @@ chimera_vfs_remove(
     int                            fhlen,
     const char                    *path,
     int                            pathlen,
+    unsigned int                   flags,
     chimera_vfs_remove_callback_t  callback,
     void                          *private_data)
 {
@@ -250,6 +253,7 @@ chimera_vfs_remove(
 
     request->remove.path         = request->plugin_data;
     request->remove.pathlen      = pathlen;
+    request->remove.flags        = flags;
     request->remove.callback     = callback;
     request->remove.private_data = private_data;
 

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -129,6 +129,7 @@ chimera_vfs_remove_at_dispatch(
     const uint8_t                   *child_fh,
     int                              child_fh_len,
     int                              match_child_fh,
+    unsigned int                     flags,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,
@@ -150,6 +151,7 @@ chimera_vfs_remove_at_dispatch(
     request->remove_at.name           = name;
     request->remove_at.namelen        = namelen;
     request->remove_at.name_hash      = chimera_vfs_hash(name, namelen);
+    request->remove_at.flags          = flags;
     request->remove_at.child_fh       = child_fh;
     request->remove_at.child_fh_len   = child_fh_len;
     request->remove_at.match_child_fh = match_child_fh ? 1 : 0;
@@ -194,6 +196,7 @@ struct chimera_vfs_remove_at_gate {
     const uint8_t                   *child_fh;
     int                              child_fh_len;
     int                              match_child_fh;
+    unsigned int                     flags;
     uint64_t                         pre_attr_mask;
     uint64_t                         post_attr_mask;
     uint8_t                          parent_lease_skip[16];
@@ -218,6 +221,7 @@ chimera_vfs_remove_at_gate_complete(
     chimera_vfs_remove_at_dispatch(gate->thread, gate->cred, gate->handle,
                                    gate->name, gate->namelen, gate->child_fh,
                                    gate->child_fh_len, gate->match_child_fh,
+                                   gate->flags,
                                    gate->pre_attr_mask,
                                    gate->post_attr_mask,
                                    gate->parent_lease_skip_valid ?
@@ -237,6 +241,7 @@ chimera_vfs_remove_at_common(
     const uint8_t                   *child_fh,
     int                              child_fh_len,
     int                              match_child_fh,
+    unsigned int                     flags,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,
@@ -271,6 +276,7 @@ chimera_vfs_remove_at_common(
         gate->child_fh       = child_fh;
         gate->child_fh_len   = child_fh_len;
         gate->match_child_fh = match_child_fh;
+        gate->flags          = flags;
         gate->pre_attr_mask  = pre_attr_mask;
         gate->post_attr_mask = post_attr_mask;
         if (parent_lease_skip) {
@@ -299,7 +305,7 @@ chimera_vfs_remove_at_common(
 
     chimera_vfs_remove_at_dispatch(thread, cred, handle, name, namelen,
                                    child_fh, child_fh_len, match_child_fh,
-                                   pre_attr_mask,
+                                   flags, pre_attr_mask,
                                    post_attr_mask, parent_lease_skip,
                                    callback, private_data);
 } /* chimera_vfs_remove_at_common */
@@ -316,6 +322,7 @@ chimera_vfs_remove_at(
     int                              namelen,
     const uint8_t                   *child_fh,
     int                              child_fh_len,
+    unsigned int                     flags,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,
@@ -324,7 +331,7 @@ chimera_vfs_remove_at(
 {
     chimera_vfs_remove_at_common(thread, cred, handle, name, namelen,
                                  child_fh, child_fh_len, 0 /* match_child_fh */,
-                                 pre_attr_mask, post_attr_mask, parent_lease_skip,
+                                 flags, pre_attr_mask, post_attr_mask, parent_lease_skip,
                                  callback, private_data);
 } /* chimera_vfs_remove_at */
 
@@ -352,6 +359,6 @@ chimera_vfs_remove_at_match_fh(
 {
     chimera_vfs_remove_at_common(thread, cred, handle, name, namelen,
                                  child_fh, child_fh_len, 1 /* match_child_fh */,
-                                 pre_attr_mask, post_attr_mask, parent_lease_skip,
+                                 0 /* flags */, pre_attr_mask, post_attr_mask, parent_lease_skip,
                                  callback, private_data);
 } /* chimera_vfs_remove_at_match_fh */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -141,6 +141,7 @@ chimera_vfs_remove(
     int                            fhlen,
     const char                    *path,
     int                            pathlen,
+    unsigned int                   flags,
     chimera_vfs_remove_callback_t  callback,
     void                          *private_data);
 
@@ -492,6 +493,7 @@ chimera_vfs_remove_at(
     int                              namelen,
     const uint8_t                   *child_fh,
     int                              child_fh_len,
+    unsigned int                     flags,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,


### PR DESCRIPTION
Four fixes to the NFS3/VFS remove path, surfaced by protocol-level model-based
testing of the NFS3 server. Each is its own commit.

### memfs: LINK-of-directory self-alias deadlock
`memfs_link_at()` locks the target directory, then locks the link-target inode.
When the two handles name the same inode (a `LINK` whose object handle equals
the directory handle), the second lock re-acquires the same non-recursive mutex
and the serving thread deadlocks while holding it — a single RPC wedges the
server for all clients. Rejected up front with `EISDIR` (the intended result)
without the second lock.

### memfs: RENAME-onto-locked-parent self-deadlock
`memfs_rename_at()` holds both parent locks, then locks the existing
destination inode. When the destination name still resolves to one of the held
parents (e.g. renaming `D/f` onto `root/d` when `root/d` **is** `D`), that
re-locks a held mutex and deadlocks. The function already guarded the
same-inode-hardlink and ancestor-cycle cases; this adds the missing one,
reusing the already-held parent pointer.

### nfs3: `ESYMLINK` → `NFS3ERR_NOTDIR`
`LOOKUP`/`READDIR` on a symlink file handle returned `NFS3ERR_SERVERFAULT`
(the memfs paths report `ESYMLINK`, which had no case in
`chimera_vfs_error_to_nfsstat3()` and fell through to the default). Other
non-directories already returned `NOTDIR`. The NFSv4 mapping is untouched and
keeps `NFS4ERR_SYMLINK`.

### vfs: ISDIR/ISNOTDIR type flags on the remove op
The single VFS remove op carried no caller intent, so it removed whichever kind
of object the name resolved to — leaving `rmdir(2)`/RMDIR vs `unlink(2)`/REMOVE
unenforced (RMDIR of a file unlinked it; unlink of a directory removed it). The
same gap left the POSIX layer's `unlink`/`rmdir`/`unlinkat` (with `AT_REMOVEDIR`
discarded) funnelling into one untyped remove. Adds an optional
`CHIMERA_VFS_REMOVE_ISDIR`/`_ISNOTDIR` assertion (neither = legacy behavior):
enforcing backends (memfs/cairn/diskfs) reject a mismatch with `ENOTDIR`/
`EISDIR`, passthrough backends (linux/io_uring) use it to select
`unlinkat(AT_REMOVEDIR)`. NFS3 RMDIR/REMOVE, the NFS-client backend, and the
POSIX layer pass their intent; NFSv4/S3/SMB pass neither (unchanged).

---

The two deadlocks are availability (DoS) class. All four were found and
validated by an NFS3 model-based (Quint) test suite that replays generated RPC
sequences against the server and checks each reply against an RFC-1813 model;
that suite is a separate contribution and exercises these paths.
