### PR TITLE
nfs3/vfs: move namespace-change recall into the VFS + four handle-handling fixes

### DIFF
--- a/src/server/nfs/nfs3_proc_create.c
+++ b/src/server/nfs/nfs3_proc_create.c
@@ -111,6 +111,10 @@ chimera_nfs3_create_open_at_complete(
     if (error_code == CHIMERA_VFS_EEXIST &&
         args->how.mode == EXCLUSIVE) {
         set_attr->va_set_mask = 0;
+        /* Re-open to read the existing file's attrs and verify the verifier.
+         * Request the directory WCC masks too: an idempotent EXCLUSIVE retry
+         * still owes the caller dir_wcc (RFC 1813 3.3.8), even though the
+         * directory is unchanged (before == after). */
         chimera_vfs_open_at(thread->vfs_thread, &req->cred,
                             req->handle,
                             args->where.name.str,
@@ -118,8 +122,8 @@ chimera_nfs3_create_open_at_complete(
                             CHIMERA_VFS_OPEN_INFERRED,
                             set_attr,
                             CHIMERA_NFS3_ATTR_MASK | CHIMERA_VFS_ATTR_FH,
-                            0,
-                            0,
+                            CHIMERA_NFS3_ATTR_WCC_MASK,
+                            CHIMERA_NFS3_ATTR_MASK,
                             chimera_nfs3_create_exclusive_verify,
                             req);
         return;

--- a/src/server/nfs/nfs3_proc_fsstat.c
+++ b/src/server/nfs/nfs3_proc_fsstat.c
@@ -24,7 +24,12 @@ chimera_nfs3_fsstat_complete(
 
     res.status = chimera_vfs_error_to_nfsstat3(error_code);
 
-    if ((attr->va_set_mask & CHIMERA_NFS3_FSSTAT_MASK) != CHIMERA_NFS3_FSSTAT_MASK) {
+    /* Only treat missing statfs attributes as NOTSUPP when the getattr itself
+     * succeeded -- otherwise a real error (e.g. NFS3ERR_NOENT from a stale
+     * handle, whose failed getattr leaves va_set_mask empty) would be
+     * clobbered into a misleading NFS3ERR_NOTSUPP. */
+    if (res.status == NFS3_OK &&
+        (attr->va_set_mask & CHIMERA_NFS3_FSSTAT_MASK) != CHIMERA_NFS3_FSSTAT_MASK) {
         res.status = NFS3ERR_NOTSUPP;
     }
 

--- a/src/server/nfs/nfs3_proc_pathconf.c
+++ b/src/server/nfs/nfs3_proc_pathconf.c
@@ -3,8 +3,88 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <stdint.h>
+#include <string.h>
+
 #include "nfs3_procs.h"
+#include "nfs_common/nfs3_status.h"
+#include "nfs_common/nfs3_attr.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
 #include "nfs3_dump.h"
+#include "nfs3_trace.h"
+
+/* PATHCONF's reply is entirely synthetic -- the limits are server constants,
+ * independent of the object -- but the handle is still validated the way every
+ * other file-handle-bearing procedure validates it: decoded (a bogus handle is
+ * NFS3ERR_BADHANDLE) then resolved with a GETATTR (a stale handle is
+ * NFS3ERR_NOENT).  memfs's open_fh is lazy and does not resolve the inode, so
+ * the GETATTR is what actually catches a freed object; its returned attributes
+ * are discarded and the constants are returned. */
+static void
+chimera_nfs3_pathconf_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request               *req    = private_data;
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct evpl                      *evpl   = thread->evpl;
+    struct PATHCONF3res               res;
+    int                               rc;
+
+    res.status = chimera_vfs_error_to_nfsstat3(error_code);
+
+    if (res.status == NFS3_OK) {
+        res.resok.obj_attributes.attributes_follow = 0;
+        res.resok.case_insensitive                 = 0;
+        res.resok.case_preserving                  = 1;
+        res.resok.no_trunc                         = 1;
+        res.resok.linkmax                          = UINT32_MAX;
+        res.resok.name_max                         = 255;
+        res.resok.chown_restricted                 = 1;   /* POSIX: chown is superuser-only */
+    } else {
+        res.resfail.obj_attributes.attributes_follow = 0;
+    }
+
+    chimera_vfs_release(thread->vfs_thread, req->handle);
+
+    rc = shared->nfs_v3.send_reply_NFSPROC3_PATHCONF(evpl, NULL, &res, req->encoding);
+    chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+
+    nfs_request_free(thread, req);
+} /* chimera_nfs3_pathconf_complete */
+
+static void
+chimera_nfs3_pathconf_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request               *req    = private_data;
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct evpl                      *evpl   = thread->evpl;
+    struct PATHCONF3res               res;
+    int                               rc;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        req->handle = handle;
+
+        chimera_vfs_getattr(thread->vfs_thread, &req->cred,
+                            handle,
+                            CHIMERA_NFS3_ATTR_MASK,
+                            chimera_nfs3_pathconf_complete,
+                            req);
+    } else {
+        res.status                                   = chimera_vfs_error_to_nfsstat3(error_code);
+        res.resfail.obj_attributes.attributes_follow = 0;
+        rc                                           = shared->nfs_v3.send_reply_NFSPROC3_PATHCONF(evpl, NULL, &res,
+                                                                                                   req->encoding);
+        chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+        nfs_request_free(thread, req);
+    }
+} /* chimera_nfs3_pathconf_open_callback */
 
 void
 chimera_nfs3_pathconf(
@@ -17,22 +97,31 @@ chimera_nfs3_pathconf(
 {
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
+    struct nfs_request               *req;
     struct PATHCONF3res               res;
     int                               rc;
 
-    nfs3_dump_pathconf(NULL, args);
+    req = nfs_request_alloc(thread, conn, encoding);
+    chimera_nfs_map_cred_req(req, cred);
 
-    res.status = NFS3_OK;
+    nfs3_dump_pathconf(req, args);
+    nfs3_trace_pathconf(req, args);
 
-    res.resok.obj_attributes.attributes_follow = 0;
+    res.status = chimera_nfs3_decode_fh(req, args->object.data.data, args->object.data.len);
+    if (res.status != NFS3_OK) {
+        nfsstat3 fh_status = res.status;
+        memset(&res, 0, sizeof(res));
+        res.status = fh_status;
+        rc         = shared->nfs_v3.send_reply_NFSPROC3_PATHCONF(evpl, NULL, &res, req->encoding);
+        chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+        nfs_request_free(thread, req);
+        return;
+    }
 
-    res.resok.case_insensitive = 0;
-    res.resok.case_preserving  = 1;
-    res.resok.no_trunc         = 1;
-    res.resok.linkmax          = UINT32_MAX;
-    res.resok.name_max         = 255;
-    res.resok.chown_restricted = 1;   /* POSIX restricts chown to the superuser */
-
-    rc = shared->nfs_v3.send_reply_NFSPROC3_PATHCONF(evpl, NULL, &res, encoding);
-    chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
+    chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
+                        chimera_nfs3_pathconf_open_callback,
+                        req);
 } /* chimera_nfs3_pathconf */

--- a/src/server/nfs/nfs3_proc_remove.c
+++ b/src/server/nfs/nfs3_proc_remove.c
@@ -11,20 +11,6 @@
 #include "nfs3_dump.h"
 #include "nfs3_trace.h"
 
-/* True when a cross-protocol caching holder (NFSv4 delegation, SMB lease, or
- * SMB oplock) could exist on the shared store.  An NFSv3 REMOVE/RMDIR of an
- * object another protocol holds must recall that holder before the unlink
- * (RFC 7530 §10.4.5 / MS-SMB2 break-before-mutate, #1070); when no caching
- * protocol is enabled the extra LOOKUP needed to learn the victim FH is
- * skipped. */
-static inline int
-chimera_nfs3_recall_needed(struct chimera_server_nfs_thread *thread)
-{
-    return chimera_server_config_get_nfs4_delegations(thread->shared->config) ||
-           chimera_server_config_get_smb_leases(thread->shared->config) ||
-           chimera_server_config_get_smb_oplocks(thread->shared->config);
-} /* chimera_nfs3_recall_needed */
-
 static void
 chimera_nfs3_remove_complete(
     enum chimera_vfs_error    error_code,
@@ -55,13 +41,11 @@ chimera_nfs3_remove_complete(
     nfs_request_free(thread, req);
 } /* chimera_nfs3_remove_complete */
 
-/* Issue the unlink.  child_fh (when known) lets the VFS recall any
- * delegation/oplock/lease on the victim before it is removed. */
+/* Issue the unlink.  child_fh is left NULL: when a caching protocol is enabled
+ * the VFS resolves the victim's FH itself and recalls any delegation/oplock/
+ * lease on it before the unlink. */
 static void
-chimera_nfs3_remove_dispatch(
-    struct nfs_request *req,
-    const uint8_t      *child_fh,
-    int                 child_fh_len)
+chimera_nfs3_remove_dispatch(struct nfs_request *req)
 {
     struct chimera_server_nfs_thread *thread = req->thread;
     struct REMOVE3args               *args   = req->args_remove;
@@ -70,39 +54,15 @@ chimera_nfs3_remove_dispatch(
                           req->handle,
                           args->object.name.str,
                           args->object.name.len,
-                          child_fh,
-                          child_fh_len,
-                          CHIMERA_VFS_REMOVE_ISNOTDIR,
+                          NULL,
+                          0,
+                          CHIMERA_VFS_REMOVE_ISNOTDIR | CHIMERA_VFS_REMOVE_RECALL,
                           CHIMERA_NFS3_ATTR_WCC_MASK,
                           CHIMERA_NFS3_ATTR_MASK,
                           NULL,
                           chimera_nfs3_remove_complete,
                           req);
 } /* chimera_nfs3_remove_dispatch */
-
-static void
-chimera_nfs3_remove_lookup_callback(
-    enum chimera_vfs_error    error_code,
-    struct chimera_vfs_attrs *attr,
-    struct chimera_vfs_attrs *dir_attr,
-    void                     *private_data)
-{
-    struct nfs_request *req = private_data;
-
-    /* Hand the victim's FH to remove_at so the VFS recalls any delegation/
-     * oplock/lease held on it before the unlink (#1070).  A failed lookup is
-     * not fatal here -- let remove_at produce the authoritative error.  Stash
-     * the FH in req->fh (unused by NFSv3 procs) so it stays valid across the
-     * async remove. */
-    if (error_code == CHIMERA_VFS_OK &&
-        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
-        memcpy(req->fh, attr->va_fh, attr->va_fh_len);
-        req->fhlen = attr->va_fh_len;
-        chimera_nfs3_remove_dispatch(req, req->fh, req->fhlen);
-    } else {
-        chimera_nfs3_remove_dispatch(req, NULL, 0);
-    }
-} /* chimera_nfs3_remove_lookup_callback */
 
 static void
 chimera_nfs3_remove_open_callback(
@@ -114,28 +74,12 @@ chimera_nfs3_remove_open_callback(
     struct chimera_server_nfs_thread *thread = req->thread;
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct evpl                      *evpl   = thread->evpl;
-    struct REMOVE3args               *args   = req->args_remove;
     struct REMOVE3res                 res;
     int                               rc;
 
     if (error_code == CHIMERA_VFS_OK) {
         req->handle = handle;
-
-        /* Resolve the victim FH first so a cross-protocol caching holder is
-         * recalled before the unlink.  Skip the extra LOOKUP when no caching
-         * protocol is enabled (no holder can exist). */
-        if (chimera_nfs3_recall_needed(thread)) {
-            chimera_vfs_lookup_at(thread->vfs_thread, &req->cred,
-                                  handle,
-                                  args->object.name.str,
-                                  args->object.name.len,
-                                  CHIMERA_VFS_ATTR_FH,
-                                  0,
-                                  chimera_nfs3_remove_lookup_callback,
-                                  req);
-        } else {
-            chimera_nfs3_remove_dispatch(req, NULL, 0);
-        }
+        chimera_nfs3_remove_dispatch(req);
     } else {
         res.status = chimera_vfs_error_to_nfsstat3(error_code);
         chimera_nfs3_set_wcc_data(&res.resfail.dir_wcc, NULL, NULL);

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -10,18 +10,6 @@
 #include "nfs3_dump.h"
 #include "nfs3_trace.h"
 
-/* See chimera_nfs3_remove.c: when a caching protocol is enabled, an NFSv3
- * RENAME that overwrites an existing destination must recall any delegation/
- * lease held on the clobbered target before it is replaced (#1071). */
-static inline int
-chimera_nfs3_recall_needed(struct chimera_server_nfs_thread *thread)
-{
-    return chimera_server_config_get_nfs4_delegations(thread->shared->config) ||
-           chimera_server_config_get_smb_leases(thread->shared->config) ||
-           chimera_server_config_get_smb_oplocks(thread->shared->config);
-} /* chimera_nfs3_recall_needed */
-
-
 static void
 chimera_nfs3_rename_complete(
     enum chimera_vfs_error    error_code,
@@ -55,14 +43,11 @@ chimera_nfs3_rename_complete(
     nfs_request_free(thread, req);
 } /* chimera_nfs3_mkdir_complete */
 
-/* Issue the rename.  target_fh (when the destination name already exists) lets
- * the VFS recall any delegation/lease on the clobbered file before it is
- * replaced.  The VFS recalls the source itself. */
+/* Issue the rename.  target_fh is left NULL: when a caching protocol is enabled
+ * the VFS resolves the clobbered destination's FH itself and recalls any
+ * delegation/lease on it -- and on the renamed source -- before the rename. */
 static void
-chimera_nfs3_rename_dispatch(
-    struct nfs_request *req,
-    const uint8_t      *target_fh,
-    int                 target_fh_len)
+chimera_nfs3_rename_dispatch(struct nfs_request *req)
 {
     struct chimera_server_nfs_thread *thread = req->thread;
     struct RENAME3args               *args   = req->args_rename;
@@ -79,8 +64,9 @@ chimera_nfs3_rename_dispatch(
                           req->saved_fhlen,
                           args->to.name.str,
                           args->to.name.len,
-                          target_fh,
-                          target_fh_len,
+                          NULL,
+                          0,
+                          CHIMERA_VFS_REMOVE_RECALL,
                           CHIMERA_NFS3_ATTR_WCC_MASK | CHIMERA_VFS_ATTR_ATOMIC,
                           CHIMERA_NFS3_ATTR_MASK,
                           NULL,
@@ -88,31 +74,6 @@ chimera_nfs3_rename_dispatch(
                           chimera_nfs3_rename_complete,
                           req);
 } /* chimera_nfs3_rename_dispatch */
-
-static void
-chimera_nfs3_rename_target_lookup_callback(
-    enum chimera_vfs_error    error_code,
-    struct chimera_vfs_attrs *attr,
-    void                     *private_data)
-{
-    struct nfs_request *req = private_data;
-
-    /* Destination exists: hand its FH to rename_at so the VFS recalls any
-     * delegation/lease on the doomed target before it is replaced (#1071).
-     * No destination (e.g. ENOENT) is the common case -- proceed with no
-     * target recall.  Stash the FH in req->rename_target_fh (req->fh /
-     * req->saved_fh hold the source / dest directory handles) so it survives
-     * the async rename. */
-    if (error_code == CHIMERA_VFS_OK &&
-        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
-        memcpy(req->rename_target_fh, attr->va_fh, attr->va_fh_len);
-        req->rename_target_fhlen = attr->va_fh_len;
-        chimera_nfs3_rename_dispatch(req, req->rename_target_fh,
-                                     req->rename_target_fhlen);
-    } else {
-        chimera_nfs3_rename_dispatch(req, NULL, 0);
-    }
-} /* chimera_nfs3_rename_target_lookup_callback */
 
 void
 chimera_nfs3_rename(
@@ -162,21 +123,5 @@ chimera_nfs3_rename(
 
     req->args_rename = args;
 
-    /* Resolve the destination name first (in the decoded dest dir) so a
-     * delegation/lease on a clobbered target is recalled before the rename.
-     * Skip the lookup when no caching protocol is enabled (no holder can
-     * exist). */
-    if (chimera_nfs3_recall_needed(thread)) {
-        chimera_vfs_lookup(thread->vfs_thread, &req->cred,
-                           req->saved_fh,
-                           req->saved_fhlen,
-                           args->to.name.str,
-                           args->to.name.len,
-                           CHIMERA_VFS_ATTR_FH,
-                           0,
-                           chimera_nfs3_rename_target_lookup_callback,
-                           req);
-    } else {
-        chimera_nfs3_rename_dispatch(req, NULL, 0);
-    }
+    chimera_nfs3_rename_dispatch(req);
 } /* chimera_nfs3_rename */

--- a/src/server/nfs/nfs3_proc_rmdir.c
+++ b/src/server/nfs/nfs3_proc_rmdir.c
@@ -11,17 +11,6 @@
 #include "nfs3_trace.h"
 #include "vfs/vfs_procs.h"
 
-/* See chimera_nfs3_remove.c: a directory removed via NFSv3 may be held under an
- * SMB directory lease (or, rarely, a delegation); recall the holder before the
- * rmdir when a caching protocol is enabled (#1070). */
-static inline int
-chimera_nfs3_recall_needed(struct chimera_server_nfs_thread *thread)
-{
-    return chimera_server_config_get_nfs4_delegations(thread->shared->config) ||
-           chimera_server_config_get_smb_leases(thread->shared->config) ||
-           chimera_server_config_get_smb_oplocks(thread->shared->config);
-} /* chimera_nfs3_recall_needed */
-
 static void
 chimera_nfs3_rmdir_complete(
     enum chimera_vfs_error    error_code,
@@ -52,13 +41,11 @@ chimera_nfs3_rmdir_complete(
     nfs_request_free(thread, req);
 } /* chimera_nfs3_rmdir_complete */
 
-/* Issue the rmdir.  child_fh (when known) lets the VFS recall a directory
- * lease/delegation on the victim before it is removed. */
+/* Issue the rmdir.  child_fh is left NULL: when a caching protocol is enabled
+ * the VFS resolves the victim's FH itself and recalls a directory lease/
+ * delegation on it before the rmdir. */
 static void
-chimera_nfs3_rmdir_dispatch(
-    struct nfs_request *req,
-    const uint8_t      *child_fh,
-    int                 child_fh_len)
+chimera_nfs3_rmdir_dispatch(struct nfs_request *req)
 {
     struct chimera_server_nfs_thread *thread = req->thread;
     struct RMDIR3args                *args   = req->args_rmdir;
@@ -67,34 +54,15 @@ chimera_nfs3_rmdir_dispatch(
                           req->handle,
                           args->object.name.str,
                           args->object.name.len,
-                          child_fh,
-                          child_fh_len,
-                          CHIMERA_VFS_REMOVE_ISDIR,
+                          NULL,
+                          0,
+                          CHIMERA_VFS_REMOVE_ISDIR | CHIMERA_VFS_REMOVE_RECALL,
                           CHIMERA_NFS3_ATTR_WCC_MASK,
                           CHIMERA_NFS3_ATTR_MASK,
                           NULL,
                           chimera_nfs3_rmdir_complete,
                           req);
 } /* chimera_nfs3_rmdir_dispatch */
-
-static void
-chimera_nfs3_rmdir_lookup_callback(
-    enum chimera_vfs_error    error_code,
-    struct chimera_vfs_attrs *attr,
-    struct chimera_vfs_attrs *dir_attr,
-    void                     *private_data)
-{
-    struct nfs_request *req = private_data;
-
-    if (error_code == CHIMERA_VFS_OK &&
-        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
-        memcpy(req->fh, attr->va_fh, attr->va_fh_len);
-        req->fhlen = attr->va_fh_len;
-        chimera_nfs3_rmdir_dispatch(req, req->fh, req->fhlen);
-    } else {
-        chimera_nfs3_rmdir_dispatch(req, NULL, 0);
-    }
-} /* chimera_nfs3_rmdir_lookup_callback */
 
 static void
 chimera_nfs3_rmdir_open_callback(
@@ -106,25 +74,12 @@ chimera_nfs3_rmdir_open_callback(
     struct chimera_server_nfs_thread *thread = req->thread;
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct evpl                      *evpl   = thread->evpl;
-    struct RMDIR3args                *args   = req->args_rmdir;
     struct RMDIR3res                  res;
     int                               rc;
 
     if (error_code == CHIMERA_VFS_OK) {
         req->handle = handle;
-
-        if (chimera_nfs3_recall_needed(thread)) {
-            chimera_vfs_lookup_at(thread->vfs_thread, &req->cred,
-                                  handle,
-                                  args->object.name.str,
-                                  args->object.name.len,
-                                  CHIMERA_VFS_ATTR_FH,
-                                  0,
-                                  chimera_nfs3_rmdir_lookup_callback,
-                                  req);
-        } else {
-            chimera_nfs3_rmdir_dispatch(req, NULL, 0);
-        }
+        chimera_nfs3_rmdir_dispatch(req);
     } else {
         res.status = chimera_vfs_error_to_nfsstat3(error_code);
         chimera_nfs3_set_wcc_data(&res.resfail.dir_wcc, NULL, NULL);

--- a/src/server/nfs/nfs4_proc_rename.c
+++ b/src/server/nfs/nfs4_proc_rename.c
@@ -61,6 +61,7 @@ chimera_nfs4_rename_do(struct nfs_request *req)
         args->newname.len,
         NULL,
         0,
+        0,
         CHIMERA_VFS_ATTR_MTIME,
         CHIMERA_VFS_ATTR_MTIME,
         NULL,

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -96,12 +96,6 @@ struct nfs_request {
     int                               fhlen;
     uint8_t                           saved_fh[NFS4_FHSIZE];
     int                               saved_fhlen;
-    /* Scratch for an NFSv3 RENAME's clobbered-target FH, resolved before the
-     * rename so the VFS recalls a delegation/lease on it (#1071).  Held here
-     * (not on the stack) because rename_at stores target_fh as a bare pointer
-     * that must outlive the async call. */
-    uint8_t                           rename_target_fh[NFS4_FHSIZE];
-    int                               rename_target_fhlen;
     /* Export the current/saved file handle belongs to, recovered from the
      * wire handle on receive (and inherited by child handles minted in the
      * reply).  Drives per-request squash attribution and is re-stamped into

--- a/src/server/s3/s3_copy.c
+++ b/src/server/s3/s3_copy.c
@@ -352,6 +352,7 @@ chimera_s3_copy_finalize(struct chimera_s3_copy_ctx *ctx)
             0,
             0,
             0,
+            0,
             NULL,
             NULL,
             chimera_s3_copy_rename_callback,

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -2455,6 +2455,7 @@ chimera_s3_complete_finalize(struct chimera_s3_complete_ctx *ctx)
             0,
             0,
             0,
+            0,
             NULL,
             NULL,
             chimera_s3_complete_rename_callback,

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -146,6 +146,7 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
             0,
             0,
             0,
+            0,
             NULL,
             NULL,
             chimera_s3_put_rename_callback,

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2386,6 +2386,15 @@ chimera_server_init(
      * open outbound connections with the same transport. */
     chimera_vfs_set_tcp_flavor(server->vfs, config->tcp_flavor);
 
+    /* Tell the VFS whether any caching protocol is enabled, so its
+     * remove/rename paths know to resolve a by-name victim's FH and recall a
+     * cross-protocol holder before the namespace change (see
+     * chimera_vfs_remove_at).  When none are enabled the lookup is skipped. */
+    chimera_vfs_set_caching_enabled(server->vfs,
+                                    config->nfs4_delegations ||
+                                    config->smb_leases ||
+                                    config->smb_oplocks);
+
     /* Enable the pNFS feature whenever configured.  Orchestrated flex-files
      * needs a data-server table (below); a layout-sourcing backend (e.g. diskfs
      * block mode) produces its own layouts and needs no data servers, so the

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -160,6 +160,7 @@ chimera_smb_set_info_rename_emit(struct chimera_smb_request *request)
         0,
         0,
         0,
+        0,
         /* Self-exempt the directory lease named by the operating open's
          * ParentLeaseKey (dirlease.rename correct-parent-leaskey case). */
         open_file->parent_lease_key,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4936,11 +4936,24 @@ memfs_rename_at(
                 return;
             }
 
-            /* Remove the existing destination entry and decrement link count */
+            /* Remove the existing destination entry and drop its link.  If that
+             * was its last link and no open handle still references it, free the
+             * clobbered inode -- bumping its generation so a stale handle to it
+             * returns ENOENT, exactly as unlink does (memfs_remove_at).  Without
+             * this the clobbered inode leaked and its file handle kept resolving
+             * after the rename that replaced it. */
             rb_tree_remove(&new_parent_inode->dir.dirents, &existing_dirent->node);
-            existing_inode->nlink--;
             if (S_ISDIR(existing_inode->mode)) {
                 new_parent_inode->nlink--;
+                existing_inode->nlink = 0;
+            } else {
+                existing_inode->nlink--;
+            }
+            if (existing_inode->nlink == 0) {
+                --existing_inode->refcnt;
+                if (existing_inode->refcnt == 0) {
+                    memfs_inode_free(thread, existing_inode);
+                }
             }
             pthread_mutex_unlock(&existing_inode->lock);
             memfs_dirent_free(thread, existing_dirent);

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -660,6 +660,14 @@ chimera_vfs_set_tcp_flavor(
     vfs->tcp_flavor = flavor;
 } /* chimera_vfs_set_tcp_flavor */
 
+SYMBOL_EXPORT void
+chimera_vfs_set_caching_enabled(
+    struct chimera_vfs *vfs,
+    int                 enabled)
+{
+    vfs->caching_enabled = enabled;
+} /* chimera_vfs_set_caching_enabled */
+
 SYMBOL_EXPORT int
 chimera_vfs_fh_is_plausible(
     struct chimera_vfs_thread *thread,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -148,6 +148,12 @@ struct chimera_vfs_mount_options {
  * behavior). */
 #define CHIMERA_VFS_REMOVE_ISDIR        (1U << 0)  /* target must be a directory */
 #define CHIMERA_VFS_REMOVE_ISNOTDIR     (1U << 1)  /* target must not be a directory */
+/* The caller wants the VFS to recall any cross-protocol caching holder on the
+ * victim before the unlink.  When set (and caching is enabled and no child_fh
+ * was supplied), the remove path resolves the name to its FH and drives a
+ * synchronous recall.  Callers with their own recall scheme (e.g. NFSv4, which
+ * breaks the delegation and returns NFS4ERR_DELAY) leave it clear. */
+#define CHIMERA_VFS_REMOVE_RECALL       (1U << 2)
 
 /* Allocate flags */
 #define CHIMERA_VFS_ALLOCATE_DEALLOCATE 0x01
@@ -924,8 +930,11 @@ struct chimera_vfs_request {
             uint64_t                 new_name_hash;
             const char              *new_name;
             int                      new_namelen;
+            unsigned int             flags;  /* CHIMERA_VFS_REMOVE_* (RECALL) */
             const uint8_t           *target_fh; /* Optional: target FH if known (for silly rename) */
             int                      target_fh_len; /* 0 if target_fh not provided */
+            /* Backing store for a target FH the VFS resolved itself (RECALL). */
+            uint8_t                  resolved_target_fh[CHIMERA_VFS_FH_SIZE];
             uint8_t                  source_fh[CHIMERA_VFS_FH_SIZE]; /* resolved source FH, for delegation recall */
             int                      source_fh_len; /* 0 if source FH could not be resolved */
             /* SMB3 directory-lease self-exemption (see link_at): spare the dir
@@ -1561,6 +1570,12 @@ struct chimera_vfs {
     struct chimera_vfs_close_thread       close_thread;
     struct chimera_vfs_metrics            metrics;
     enum chimera_tcp_flavor               tcp_flavor;
+    /* True when any cross-protocol caching lease can exist (NFSv4
+     * delegations, SMB2 leases, or SMB oplocks are enabled).  Gates the
+     * name->FH resolution the remove/rename paths do so that an unlink of a
+     * name another protocol caches recalls that holder first.  When clear
+     * (single-protocol deployments) the extra lookup is skipped. */
+    int                                   caching_enabled;
     int                                   machine_name_len;
     char                                  machine_name[256];
 };
@@ -1629,6 +1644,15 @@ void
 chimera_vfs_set_tcp_flavor(
     struct chimera_vfs     *vfs,
     enum chimera_tcp_flavor flavor);
+
+/* Declare whether any cross-protocol caching lease can exist (NFSv4
+ * delegations / SMB2 leases / SMB oplocks enabled).  When set, the VFS
+ * remove/rename paths resolve a by-name victim to its FH so a caching holder
+ * is recalled before the namespace change; when clear the lookup is skipped. */
+void
+chimera_vfs_set_caching_enabled(
+    struct chimera_vfs *vfs,
+    int                 enabled);
 
 /* Get the root pseudo-filesystem's file handle */
 void

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -310,8 +310,63 @@ chimera_vfs_remove_at_common(
                                    callback, private_data);
 } /* chimera_vfs_remove_at_common */
 
+/*
+ * Recall pre-step for a by-name remove.  An NFSv3/NFSv4 REMOVE/RMDIR (and the
+ * SMB namespace deletes) arrive with a parent handle and a name but no handle
+ * for the victim, so the VFS cannot recall a delegation/oplock/lease held on
+ * it before the unlink -- io_recall keys on the FH.  When a caching protocol
+ * is enabled we resolve the name to its FH here, once, in the VFS, rather than
+ * making every by-name caller do it.  A failed lookup is not fatal: the by-name
+ * remove then produces the authoritative error.
+ */
+struct chimera_vfs_remove_recall_ctx {
+    struct chimera_vfs_thread       *thread;
+    const struct chimera_vfs_cred   *cred;
+    struct chimera_vfs_open_handle  *handle;
+    const char                      *name;
+    int                              namelen;
+    unsigned int                     flags;
+    uint64_t                         pre_attr_mask;
+    uint64_t                         post_attr_mask;
+    const uint8_t                   *parent_lease_skip;
+    chimera_vfs_remove_at_callback_t callback;
+    void                            *private_data;
+    uint8_t                          child_fh[CHIMERA_VFS_FH_SIZE];
+    int                              child_fh_len;
+};
+
+static void
+chimera_vfs_remove_recall_lookup_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    struct chimera_vfs_attrs *dir_attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_remove_recall_ctx *ctx          = private_data;
+    const uint8_t                        *child_fh     = NULL;
+    int                                   child_fh_len = 0;
+
+    if (error_code == CHIMERA_VFS_OK &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+        memcpy(ctx->child_fh, attr->va_fh, attr->va_fh_len);
+        ctx->child_fh_len = attr->va_fh_len;
+        child_fh          = ctx->child_fh;
+        child_fh_len      = ctx->child_fh_len;
+    }
+
+    chimera_vfs_remove_at_common(ctx->thread, ctx->cred, ctx->handle,
+                                 ctx->name, ctx->namelen, child_fh, child_fh_len,
+                                 0 /* match_child_fh */, ctx->flags,
+                                 ctx->pre_attr_mask, ctx->post_attr_mask,
+                                 ctx->parent_lease_skip, ctx->callback,
+                                 ctx->private_data);
+    free(ctx);
+} /* chimera_vfs_remove_recall_lookup_complete */
+
 /* Remove a name in a directory (unconditional by-name unlink).  child_fh, when
  * supplied, is used for delegation/oplock recall and change-notify, NOT to guard
+ * the unlink.  When it is NOT supplied and a caching protocol is enabled, the
+ * VFS resolves it first (above) so a cross-protocol holder is recalled before
  * the unlink. */
 SYMBOL_EXPORT void
 chimera_vfs_remove_at(
@@ -329,6 +384,36 @@ chimera_vfs_remove_at(
     chimera_vfs_remove_at_callback_t callback,
     void                            *private_data)
 {
+    /* Resolve the victim's FH first so a cross-protocol caching holder is
+     * recalled before the unlink.  Only when the caller opted in
+     * (CHIMERA_VFS_REMOVE_RECALL), a caching protocol is enabled, the caller
+     * has not already supplied the FH, and the name is a real component
+     * ("." / ".." are rejected by _common). */
+    if ((flags & CHIMERA_VFS_REMOVE_RECALL) && thread->vfs->caching_enabled &&
+        !child_fh && namelen >= 1 && namelen < CHIMERA_VFS_NAME_MAX &&
+        !(namelen == 1 && name[0] == '.') &&
+        !(namelen == 2 && name[0] == '.' && name[1] == '.')) {
+        struct chimera_vfs_remove_recall_ctx *ctx = malloc(sizeof(*ctx));
+
+        ctx->thread            = thread;
+        ctx->cred              = cred;
+        ctx->handle            = handle;
+        ctx->name              = name;
+        ctx->namelen           = namelen;
+        ctx->flags             = flags;
+        ctx->pre_attr_mask     = pre_attr_mask;
+        ctx->post_attr_mask    = post_attr_mask;
+        ctx->parent_lease_skip = parent_lease_skip;
+        ctx->callback          = callback;
+        ctx->private_data      = private_data;
+        ctx->child_fh_len      = 0;
+
+        chimera_vfs_lookup_at(thread, cred, handle, name, namelen,
+                              CHIMERA_VFS_ATTR_FH, 0,
+                              chimera_vfs_remove_recall_lookup_complete, ctx);
+        return;
+    }
+
     chimera_vfs_remove_at_common(thread, cred, handle, name, namelen,
                                  child_fh, child_fh_len, 0 /* match_child_fh */,
                                  flags, pre_attr_mask, post_attr_mask, parent_lease_skip,

--- a/src/vfs/vfs_proc_rename.c
+++ b/src/vfs/vfs_proc_rename.c
@@ -117,6 +117,7 @@ chimera_vfs_rename_target_lookup_complete(
         request->rename.target_fh_len,
         0,
         0,
+        0,
         NULL,
         NULL,
         chimera_vfs_rename_op_complete,
@@ -194,6 +195,7 @@ chimera_vfs_rename_fast_target_lookup_complete(
         request->rename.new_pathlen,
         request->rename.target_fh_len ? request->rename.target_fh : NULL,
         request->rename.target_fh_len,
+        0,
         0,
         0,
         NULL,
@@ -337,6 +339,7 @@ chimera_vfs_rename(
                 0,
                 0,
                 0,
+                0,
                 NULL,  /* parent_lease_skip: path-only mount has no parent lease */
                 NULL,  /* op_handle */
                 chimera_vfs_rename_op_complete,
@@ -405,6 +408,7 @@ chimera_vfs_rename(
                     request->rename.new_path + request->rename.new_name_offset,
                     request->rename.new_pathlen - request->rename.new_name_offset,
                     NULL,
+                    0,
                     0,
                     0,
                     0,

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -226,6 +226,49 @@ chimera_vfs_rename_at_source_lookup_complete(
     }
 } /* chimera_vfs_rename_at_source_lookup_complete */
 
+/* Recall the source file being moved, then (via the chain above) the target.
+ * The source FH is resolved only when the lease subsystem is active; otherwise
+ * we go straight to the destination recall (which fast-paths to dispatch when
+ * there is nothing to break).  Uses the source dir FH / cred / name stashed on
+ * the request so it can run after an optional target-FH resolution. */
+static void
+chimera_vfs_rename_at_recall_source(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_thread *thread = request->thread;
+
+    if (thread->vfs->vfs_state) {
+        chimera_vfs_lookup(thread, request->cred, request->fh, request->fh_len,
+                           request->rename_at.name, request->rename_at.namelen,
+                           CHIMERA_VFS_ATTR_FH, 0,
+                           chimera_vfs_rename_at_source_lookup_complete,
+                           request);
+    } else {
+        chimera_vfs_rename_at_recall_target(request);
+    }
+} /* chimera_vfs_rename_at_recall_source */
+
+/* Completion of the VFS-driven destination lookup (CHIMERA_VFS_REMOVE_RECALL):
+ * a resolved FH means the destination exists and will be clobbered, so stash it
+ * for the target recall; an error (e.g. ENOENT -- the common no-overwrite case)
+ * just proceeds with no target recall. */
+static void
+chimera_vfs_rename_at_target_lookup_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    if (error_code == CHIMERA_VFS_OK &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
+        memcpy(request->rename_at.resolved_target_fh, attr->va_fh, attr->va_fh_len);
+        request->rename_at.target_fh     = request->rename_at.resolved_target_fh;
+        request->rename_at.target_fh_len = attr->va_fh_len;
+    }
+
+    chimera_vfs_rename_at_recall_source(request);
+} /* chimera_vfs_rename_at_target_lookup_complete */
+
 static void
 chimera_vfs_rename_at_dispatch(
     struct chimera_vfs_thread       *thread,
@@ -240,6 +283,7 @@ chimera_vfs_rename_at_dispatch(
     int                              new_namelen,
     const uint8_t                   *target_fh,
     int                              target_fh_len,
+    unsigned int                     flags,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,
@@ -267,6 +311,7 @@ chimera_vfs_rename_at_dispatch(
     request->rename_at.new_name                        = new_name;
     request->rename_at.new_namelen                     = new_namelen;
     request->rename_at.new_name_hash                   = chimera_vfs_hash(new_name, new_namelen);
+    request->rename_at.flags                           = flags;
     request->rename_at.target_fh                       = target_fh;
     request->rename_at.target_fh_len                   = target_fh_len;
     request->rename_at.r_fromdir_pre_attr.va_req_mask  = pre_attr_mask;
@@ -295,17 +340,23 @@ chimera_vfs_rename_at_dispatch(
 
     /* Recall delegations before the directory change: first on the source file
      * being moved (its ctime/linkage changes invalidate cached state), then on
-     * any file overwritten at the destination.  Resolve the source FH only when
-     * the lease subsystem is active; otherwise go straight to the destination
-     * recall (which fast-paths to dispatch when there is nothing to break). */
-    if (thread->vfs->vfs_state) {
-        chimera_vfs_lookup(thread, cred, fh, fhlen, name, namelen,
+     * any file overwritten at the destination.
+     *
+     * When the caller opted into VFS recall (CHIMERA_VFS_REMOVE_RECALL) and did
+     * not supply the clobbered destination's FH, resolve it here so a
+     * delegation/lease on the doomed target is recalled before it is replaced
+     * -- rather than making every by-name caller (NFSv3 RENAME) do that lookup
+     * itself.  Only when a caching protocol is enabled. */
+    if ((flags & CHIMERA_VFS_REMOVE_RECALL) && thread->vfs->caching_enabled &&
+        !target_fh) {
+        chimera_vfs_lookup(thread, cred, new_fh, new_fhlen, new_name, new_namelen,
                            CHIMERA_VFS_ATTR_FH, 0,
-                           chimera_vfs_rename_at_source_lookup_complete,
+                           chimera_vfs_rename_at_target_lookup_complete,
                            request);
-    } else {
-        chimera_vfs_rename_at_recall_target(request);
+        return;
     }
+
+    chimera_vfs_rename_at_recall_source(request);
 } /* chimera_vfs_rename_at_dispatch */
 
 /*
@@ -336,6 +387,7 @@ struct chimera_vfs_rename_at_gate {
     int                              new_namelen;
     const uint8_t                   *target_fh;
     int                              target_fh_len;
+    unsigned int                     flags;
     uint8_t                          src_child_fh[CHIMERA_VFS_FH_SIZE];
     int                              src_child_fh_len;
     uint64_t                         pre_attr_mask;
@@ -364,6 +416,7 @@ chimera_vfs_rename_at_gate_dispatch(struct chimera_vfs_rename_at_gate *gate)
                                    gate->new_fh, gate->new_fhlen,
                                    gate->new_name, gate->new_namelen,
                                    gate->target_fh, gate->target_fh_len,
+                                   gate->flags,
                                    gate->pre_attr_mask, gate->post_attr_mask,
                                    gate->parent_lease_skip_valid ?
                                    gate->parent_lease_skip : NULL,
@@ -477,6 +530,7 @@ chimera_vfs_rename_at(
     int                              new_namelen,
     const uint8_t                   *target_fh,
     int                              target_fh_len,
+    unsigned int                     flags,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,
@@ -528,6 +582,7 @@ chimera_vfs_rename_at(
         gate->new_namelen    = new_namelen;
         gate->target_fh      = target_fh;
         gate->target_fh_len  = target_fh_len;
+        gate->flags          = flags;
         gate->pre_attr_mask  = pre_attr_mask;
         gate->post_attr_mask = post_attr_mask;
         if (parent_lease_skip) {
@@ -552,7 +607,7 @@ chimera_vfs_rename_at(
 
     chimera_vfs_rename_at_dispatch(thread, cred, fh, fhlen, name, namelen,
                                    new_fh, new_fhlen, new_name, new_namelen,
-                                   target_fh, target_fh_len, pre_attr_mask,
+                                   target_fh, target_fh_len, flags, pre_attr_mask,
                                    post_attr_mask, parent_lease_skip,
                                    op_handle, callback, private_data);
 } /* chimera_vfs_rename_at */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -733,6 +733,7 @@ chimera_vfs_rename_at(
     int                              new_namelen,
     const uint8_t                   *target_fh,
     int                              target_fh_len,
+    unsigned int                     flags,
     uint64_t                         pre_attr_mask,
     uint64_t                         post_attr_mask,
     const uint8_t                   *parent_lease_skip,


### PR DESCRIPTION
Bundles the recall-in-VFS refactor with four NFSv3/memfs correctness fixes uncovered while building a model-based test suite for the NFS3 server. Each is a separate commit.

## vfs: move namespace-change recall into the VFS
An NFSv3 REMOVE/RMDIR/RENAME that unlinks or clobbers a file must first recall any NFSv4 delegation / SMB2 lease / oplock held on the victim (NFSv3 has no recall of its own). The NFS3 server did this itself, resolving the victim's handle with an extra by-name LOOKUP and passing it down — putting cross-protocol caching policy in the wrong layer and duplicating the lookup across three procs. This moves it into the VFS: a `CHIMERA_VFS_REMOVE_RECALL` flag on `chimera_vfs_remove_at` / `chimera_vfs_rename_at` makes the VFS resolve the victim itself and recall it, gated by a new `chimera_vfs->caching_enabled` that the server sets when any caching protocol (nfs4_delegations / smb_leases / smb_oplocks) is configured. NFS3 remove/rmdir/rename opt in and drop their recall helpers; NFSv4 keeps its own break + NFS4ERR_DELAY scheme (flags = 0); S3/SMB callers pass 0. No behavior change when no caching protocol is enabled.

## nfs3: return dir_wcc on an idempotent EXCLUSIVE create retry
An EXCLUSIVE CREATE retransmitted with the same verifier succeeds idempotently but returned no `dir_wcc` — the verify-reopen requested pre/post attr masks of 0. RFC 1813 3.3.8 owes `dir_wcc` on the retry too (the directory is unchanged, so before == after). Now requests the WCC masks on the reopen so the retry matches every other create mode.

## memfs: free the clobbered target inode on rename
`memfs_rename_at` decremented the overwritten file's `nlink` but never freed the inode when it reached zero, unlike `memfs_remove_at`. The inode leaked, and — because its generation was never bumped — a stale file handle to the clobbered object kept resolving (GETATTR returned the old object instead of NFS3ERR_NOENT); a clobbered empty directory was also left at nlink 1. Now frees it when the last link goes, respecting `refcnt` so an open handle still keeps it alive for delete-on-last-close, exactly as the unlink path does.

## nfs3: validate the file handle in PATHCONF
PATHCONF returned its synthetic constants without ever decoding the request handle, so a bogus handle got a successful reply instead of NFS3ERR_BADHANDLE and a stale handle instead of NFS3ERR_NOENT. Now decodes and resolves the handle (a getattr whose attributes are discarded, as fsstat/fsinfo already do) before returning the same constants.

## nfs3: don't mask a real FSSTAT error as NFS3ERR_NOTSUPP
The FSSTAT completion applied its "missing statfs attributes → NOTSUPP" check unconditionally, overwriting the status already derived from the getattr error code. A failed getattr (e.g. NFS3ERR_NOENT from a stale handle, whose empty attr mask trips the check) was clobbered into a misleading NFS3ERR_NOTSUPP. Now gated on getattr success.