### PR TITLE
Adopt libevpl 7f3ebba and fix the resulting breakage

### DIFF
--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -132,6 +132,7 @@ chimera_metrics_thread_init(
     void        *private_data)
 {
     struct chimera_metrics *metrics = private_data;
+    int                     rc;
 
     metrics->metrics = prometheus_metrics_create(NULL, NULL, 0);
 
@@ -144,7 +145,9 @@ chimera_metrics_thread_init(
 
     metrics->server = evpl_http_attach(metrics->agent, metrics->listener, chimera_metrics_dispatch, metrics);
 
-    evpl_listen(metrics->listener, EVPL_STREAM_SOCKET_TCP, metrics->endpoint);
+    rc = evpl_listen(metrics->listener, EVPL_STREAM_SOCKET_TCP, metrics->endpoint);
+    chimera_metrics_abort_if(rc, "failed to listen for prometheus metrics on port %d",
+                             metrics->port);
 
     chimera_metrics_info("Serving prometheus metrics on http://0.0.0.0:%d/metrics", metrics->port);
 

--- a/src/nfs_common/CMakeLists.txt
+++ b/src/nfs_common/CMakeLists.txt
@@ -27,44 +27,56 @@ set(SM_INTER_XDR_X ${CMAKE_CURRENT_SOURCE_DIR}/sm_inter.x)
 set(SM_INTER_XDR_C ${CMAKE_CURRENT_BINARY_DIR}/sm_inter_xdr.c)
 set(SM_INTER_XDR_H ${CMAKE_CURRENT_BINARY_DIR}/sm_inter_xdr.h)
 
+# Flags for every .x here.
+#
+# -r emits the RPC2 client and server dispatch code.
+#
+# -e accepts an enum value the declaration does not name.  These files are
+# snapshots of IETF protocols that keep gaining values: layouttype4 here stops
+# at LAYOUT4_BLOCK_VOLUME, but flex-files is 0x4 from RFC 8435 and the pNFS
+# code uses it.  Rejecting such a value on decode fails a request the rest of
+# the stack handles perfectly well, so take it and let the protocol code
+# decide.
+set(XDRZCC_FLAGS -r -e)
+
 add_custom_command(
     OUTPUT ${NFS3_XDR_C} ${NFS3_XDR_H}
-    COMMAND ${XDRZCC} -r ${NFS3_XDR_X} ${NFS3_XDR_C} ${NFS3_XDR_H}
+    COMMAND ${XDRZCC} ${XDRZCC_FLAGS} ${NFS3_XDR_X} ${NFS3_XDR_C} ${NFS3_XDR_H}
     DEPENDS ${NFS3_XDR_X} ${XDRZCC}
     COMMENT "Compiling ${NFS3_XDR_X}"
 )
 
 add_custom_command(
     OUTPUT ${NFS4_XDR_C} ${NFS4_XDR_H}
-    COMMAND ${XDRZCC} -r ${NFS4_XDR_X} ${NFS4_XDR_C} ${NFS4_XDR_H}
+    COMMAND ${XDRZCC} ${XDRZCC_FLAGS} ${NFS4_XDR_X} ${NFS4_XDR_C} ${NFS4_XDR_H}
     DEPENDS ${NFS4_XDR_X} ${XDRZCC}
     COMMENT "Compiling ${NFS4_XDR_X}"
 )
 
 add_custom_command(
     OUTPUT ${NFS_MOUNT_XDR_C} ${NFS_MOUNT_XDR_H}
-    COMMAND ${XDRZCC} -r ${NFS_MOUNT_XDR_X} ${NFS_MOUNT_XDR_C} ${NFS_MOUNT_XDR_H}
+    COMMAND ${XDRZCC} ${XDRZCC_FLAGS} ${NFS_MOUNT_XDR_X} ${NFS_MOUNT_XDR_C} ${NFS_MOUNT_XDR_H}
     DEPENDS ${NFS_MOUNT_XDR_X} ${XDRZCC}
     COMMENT "Compiling ${NFS_MOUNT_XDR_X}"
 )
 
 add_custom_command(
     OUTPUT ${PORTMAP_XDR_C} ${PORTMAP_XDR_H}
-    COMMAND ${XDRZCC} -r ${PORTMAP_XDR_X} ${PORTMAP_XDR_C} ${PORTMAP_XDR_H}
+    COMMAND ${XDRZCC} ${XDRZCC_FLAGS} ${PORTMAP_XDR_X} ${PORTMAP_XDR_C} ${PORTMAP_XDR_H}
     DEPENDS ${PORTMAP_XDR_X} ${XDRZCC}
     COMMENT "Compiling ${PORTMAP_XDR_X}"
 )
 
 add_custom_command(
     OUTPUT ${NLM4_XDR_C} ${NLM4_XDR_H}
-    COMMAND ${XDRZCC} -r ${NLM4_XDR_X} ${NLM4_XDR_C} ${NLM4_XDR_H}
+    COMMAND ${XDRZCC} ${XDRZCC_FLAGS} ${NLM4_XDR_X} ${NLM4_XDR_C} ${NLM4_XDR_H}
     DEPENDS ${NLM4_XDR_X} ${XDRZCC}
     COMMENT "Compiling ${NLM4_XDR_X}"
 )
 
 add_custom_command(
     OUTPUT ${SM_INTER_XDR_C} ${SM_INTER_XDR_H}
-    COMMAND ${XDRZCC} -r ${SM_INTER_XDR_X} ${SM_INTER_XDR_C} ${SM_INTER_XDR_H}
+    COMMAND ${XDRZCC} ${XDRZCC_FLAGS} ${SM_INTER_XDR_X} ${SM_INTER_XDR_C} ${SM_INTER_XDR_H}
     DEPENDS ${SM_INTER_XDR_X} ${XDRZCC}
     COMMENT "Compiling ${SM_INTER_XDR_X}"
 )
@@ -75,7 +87,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Suppress warnings for the generated source files
 set_source_files_properties(
-    ${NFS3_XDR_C} ${NFS4_XDR_C} ${NFS_MOUNT_XDR_C} ${PORTMAP_XDR_C} ${NLM4_XDR_C} ${SM_INTER_XDR_C} PROPERTIES COMPILE_OPTIONS "-Wno-unused;-Wno-switch;-Wno-format-truncation"
+    ${NFS3_XDR_C} ${NFS4_XDR_C} ${NFS_MOUNT_XDR_C} ${PORTMAP_XDR_C} ${NLM4_XDR_C} ${SM_INTER_XDR_C} PROPERTIES COMPILE_OPTIONS "-Wno-unused;-Wno-format-truncation"
 )
 
 add_definitions(-fvisibility=default)

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -522,33 +522,45 @@ nfs_server_start(void *arg)
 {
     struct chimera_server_nfs_shared *shared = arg;
     enum evpl_protocol_id             rdma_protocol;
+    int                               rc;
 
-    evpl_rpc2_server_start(shared->nfs_server,
-                           chimera_server_config_get_tcp_stream_protocol(shared->config),
-                           shared->nfs_endpoint);
+    /* evpl_rpc2_server_start reports a listen it could not establish -- a port
+     * already in use, an address that cannot be bound.  A server that carried
+     * on regardless would come up advertising a service nothing is listening
+     * on, so every one of these is checked; there is no useful recovery at
+     * this point, so the failure is fatal and named. */
+    rc = evpl_rpc2_server_start(shared->nfs_server,
+                                chimera_server_config_get_tcp_stream_protocol(shared->config),
+                                shared->nfs_endpoint);
+    chimera_nfs_abort_if(rc, "failed to start the NFS server");
 
     if (shared->nfs_rdma_endpoint) {
         /* Use TCP-RDMA emulation when nfs_tcp_rdma_port > 0, otherwise use native RDMA */
         rdma_protocol = chimera_server_config_get_nfs_tcp_rdma_port(shared->config) > 0
                         ? EVPL_DATAGRAM_TCP_RDMA : EVPL_DATAGRAM_RDMACM_RC;
-        evpl_rpc2_server_start(shared->nfs_server, rdma_protocol, shared->nfs_rdma_endpoint);
+        rc = evpl_rpc2_server_start(shared->nfs_server, rdma_protocol, shared->nfs_rdma_endpoint);
+        chimera_nfs_abort_if(rc, "failed to start the NFS RDMA server");
     }
 
     if (shared->mount_server) {
-        evpl_rpc2_server_start(shared->mount_server, EVPL_STREAM_SOCKET_TCP, shared->mount_endpoint);
+        rc = evpl_rpc2_server_start(shared->mount_server, EVPL_STREAM_SOCKET_TCP, shared->mount_endpoint);
+        chimera_nfs_abort_if(rc, "failed to start the MOUNT server");
     }
     if (shared->nlm_server) {
-        evpl_rpc2_server_start(shared->nlm_server, EVPL_STREAM_SOCKET_TCP, shared->nlm_endpoint);
+        rc = evpl_rpc2_server_start(shared->nlm_server, EVPL_STREAM_SOCKET_TCP, shared->nlm_endpoint);
+        chimera_nfs_abort_if(rc, "failed to start the NLM server");
     }
     if (shared->nsm_server) {
-        evpl_rpc2_server_start(shared->nsm_server, EVPL_STREAM_SOCKET_TCP, shared->nsm_endpoint);
+        rc = evpl_rpc2_server_start(shared->nsm_server, EVPL_STREAM_SOCKET_TCP, shared->nsm_endpoint);
+        chimera_nfs_abort_if(rc, "failed to start the NSM server");
     }
 
     /* A data server registers no portmap services (it skips the auxiliary
      * protocols entirely). */
     if (!chimera_server_config_get_nfs_data_server(shared->config)) {
         if (shared->portmap_server) {
-            evpl_rpc2_server_start(shared->portmap_server, EVPL_STREAM_SOCKET_TCP, shared->portmap_endpoint);
+            rc = evpl_rpc2_server_start(shared->portmap_server, EVPL_STREAM_SOCKET_TCP, shared->portmap_endpoint);
+            chimera_nfs_abort_if(rc, "failed to start the PORTMAP server");
         } else {
             register_nfs_rpc_services(chimera_server_config_get_nfs_lockmgr_port(shared->config),
                                       chimera_server_config_get_nfs_nsm_port(shared->config));

--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -751,20 +751,26 @@ chimera_rest_init(
 SYMBOL_EXPORT void
 chimera_rest_start(struct chimera_rest_server *rest)
 {
+    int rc;
+
     if (!rest) {
         return;
     }
 
     if (rest->http_listener) {
-        evpl_listen(rest->http_listener, EVPL_STREAM_SOCKET_TCP,
-                    rest->http_endpoint);
+        rc = evpl_listen(rest->http_listener, EVPL_STREAM_SOCKET_TCP,
+                         rest->http_endpoint);
+        chimera_rest_abort_if(rc, "failed to listen for REST HTTP on port %d",
+                              rest->http_port);
         chimera_rest_info("REST API HTTP server started on port %d",
                           rest->http_port);
     }
 
     if (rest->https_listener) {
-        evpl_listen(rest->https_listener, EVPL_STREAM_SOCKET_TLS,
-                    rest->https_endpoint);
+        rc = evpl_listen(rest->https_listener, EVPL_STREAM_SOCKET_TLS,
+                         rest->https_endpoint);
+        chimera_rest_abort_if(rc, "failed to listen for REST HTTPS on port %d",
+                              rest->https_port);
         chimera_rest_info("REST API HTTPS server started on port %d",
                           rest->https_port);
     }

--- a/src/server/rest/rest_internal.h
+++ b/src/server/rest/rest_internal.h
@@ -18,6 +18,12 @@ struct evpl_http_request;
 #define chimera_rest_error(...) chimera_error("rest", __FILE__, __LINE__, __VA_ARGS__)
 #define chimera_rest_abort(...) chimera_abort("rest", __FILE__, __LINE__, __VA_ARGS__)
 
+#define chimera_rest_abort_if(cond, ...) \
+        chimera_abort_if(cond, "rest", \
+                         __FILE__, \
+                         __LINE__, \
+                         __VA_ARGS__)
+
 struct chimera_rest_server {
     int                    http_port;
     int                    https_port;

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -1212,8 +1212,10 @@ static void
 s3_server_start(void *data)
 {
     struct chimera_server_s3_shared *shared = data;
+    int                              rc;
 
-    evpl_listen(shared->listener, shared->tcp_protocol, shared->endpoint);
+    rc = evpl_listen(shared->listener, shared->tcp_protocol, shared->endpoint);
+    chimera_s3_abort_if(rc, "failed to listen for S3");
 } /* s3_server_start */
 
 static void *

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -387,11 +387,14 @@ static void
 chimera_smb_server_start(void *data)
 {
     struct chimera_server_smb_shared *shared = data;
+    int                               rc;
 
-    evpl_listen(shared->listener, shared->tcp_protocol, shared->endpoint);
+    rc = evpl_listen(shared->listener, shared->tcp_protocol, shared->endpoint);
+    chimera_smb_abort_if(rc, "failed to listen for SMB");
 
     if (shared->endpoint_rdma) {
-        evpl_listen(shared->listener, EVPL_DATAGRAM_RDMACM_RC, shared->endpoint_rdma);
+        rc = evpl_listen(shared->listener, EVPL_DATAGRAM_RDMACM_RC, shared->endpoint_rdma);
+        chimera_smb_abort_if(rc, "failed to listen for SMB over RDMA");
     }
 } /* smb_server_start */
 
@@ -2608,8 +2611,11 @@ chimera_smb_server_segment(
 
     len = evpl_peek(evpl, bind, &hdr, 4);
 
+    /* Not enough buffered yet to read the NBSS length prefix.  Zero means
+    * "no complete segment available", which leaves the connection alone
+    * until more arrives; a negative return would ask evpl to close it. */
     if (len < 4) {
-        return -1;
+        return 0;
     }
 
     hdr = __builtin_bswap32(hdr);

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -167,6 +167,12 @@ chimera_nfs_protocol_to_string(enum evpl_protocol_id protocol)
             return "RDMA-RC";
         case EVPL_STREAM_SOCKET_TLS:
             return "TLS";
+        case EVPL_STREAM_SOCKET_UNIX:
+            return "UNIX";
+        case EVPL_STREAM_INPROC:
+            return "INPROC";
+        case EVPL_DATAGRAM_INPROC:
+            return "INPROC-DGRAM";
         case EVPL_NUM_PROTO:
             return "UNKNOWN";
     } /* switch */

--- a/src/vfs/smb/smb.c
+++ b/src/vfs/smb/smb.c
@@ -832,8 +832,11 @@ chimera_smb_client_segment(
     (void) private_data;
 
     len = evpl_peek(evpl, bind, &hdr, 4);
+
+    /* Zero, not negative: the NBSS length prefix has not arrived in full yet,
+     * which is a wait-for-more condition rather than a request to close. */
     if (len < 4) {
-        return -1;
+        return 0;
     }
 
     hdr  = __builtin_bswap32(hdr);


### PR DESCRIPTION
Moves ext/libevpl from #118 to #128 and fixes what that breaks, plus one pre-existing error-swallowing bug of the same kind found while checking.

The bump brings the RPC2 correctness fixes, the RPC-over-RDMA chunk work and RDMA_ERROR, AF_UNIX and in-process transports, the model-based conformance suite, the xdrzcc enum strictness flag, and libevpl's own CI pipeline.

## Required by the bump

**`evpl_rpc2_server_start` returns `int` now.** It reports a listen that could not be established — a port already in use, an address that cannot be bound. All six call sites ignored it, so chimera would have come up advertising a service nothing was listening on. Each is now checked and names the server it failed to start; there is no useful recovery that late in startup, so the failure is fatal rather than logged and swallowed.

**Three new protocol ids** — `STREAM_SOCKET_UNIX`, `STREAM_INPROC`, `DATAGRAM_INPROC` — reach `chimera_nfs_protocol_to_string`, whose switch enumerates every value under `-Werror=switch`.

**The SMB segment callbacks returned `-1` for "not enough buffered yet".** libevpl's framing fix in #120 made that mean "close the connection"; `0` is "no complete segment available". Both the server and the VFS client callback are corrected. Without this SMB drops connections mid-negotiation.

Those three are one commit because none of them compiles without the others.

## Also fixed: the same bug in `evpl_listen`

Checking whether anything else changed signature turned up six `evpl_listen()` call sites — in metrics, S3, SMB and REST — swallowing an `int` return the same way. That signature has **not** changed across this bump, so this is pre-existing rather than fallout, but it is the identical failure: a listen that did not happen, reported as though it had. Each now aborts naming what failed to listen. The REST module gained the `chimera_rest_abort_if()` its siblings already had.

## Generated XDR build flags

Two changes, both enabled by the xdrzcc this libevpl carries.

**`-e` accepts an enum value the declaration does not name.** These `.x` files are snapshots of IETF protocols that keep gaining values: `layouttype4` here stops at `LAYOUT4_BLOCK_VOLUME`, but flex-files is `0x4` from RFC 8435 and `nfs4_pnfs.c` uses it through a local `#define`. xdrzcc's new enum domain check rejected every flex-files layout on decode, and all 27 `pynfs` flex tests failed — bisected to exactly that. Taking the value and letting the protocol code decide is the right trade for a spec that is still growing. The flag is chimera-nas/xdrzcc#15; the `.x` files are unchanged.

**`-Wno-switch` can go**, because xdrzcc now emits a default arm for a union that declares none. It had been suppressing the warning for every switch in those files, not only the generated unions.

## Final commit: libevpl 7f3ebba

Picks up libevpl #127 and #128 on top of the #126 the branch already adopted. **The submodule pointer is the entire diff** — nothing here changes an API chimera uses.

#128 gives libevpl its own CI pipeline, modelled on this project's: the same platforms and the same build, test and analyze steps, minus the merge queue, plus a macOS leg on a GitHub-hosted runner. Standing it up shook out portability bugs that only a non-Linux target could reach:

- `EVPL_AF_INPROC` was `0x4950`, chosen to clear `AF_MAX`. It does in Linux's 16-bit `sa_family_t`, but Darwin's is 8 bits, so it truncated
- a leading NUL in `sun_path` was read as an abstract name, which is a Linux extension — on the BSDs it only means the socket is unnamed, so **every unbound AF_UNIX peer rendered as `unix:@`**
- two null-deref findings the analyzer had against `inproc.c`
- `-Wno-format-truncation` and `SOCK_NONBLOCK`, both GCC/Linux-only

Two of those needed fixes in libevpl's own submodules, both merged upstream: chimera-nas/oteltracing-c#1 (linking a `libuuid` that does not exist on Darwin) and chimera-nas/xdrzcc#16 (the GCC-only warning flag).

#127 fixes a use-after-free in libevpl's own doorbell test.

## Verification

Builds clean with no new warnings; `make syntax-check` passes. At the updated submodule, Release builds clean and the 158 libevpl tests pass from chimera's build.

`pynfs`: **1367/1374**, including all 27 flex tests. The 7 failures are `delegations` and `courteous` cases that all pass on `ctest --rerun-failed`, i.e. flaky under load rather than regressions. That run predates the final submodule bump, which touches no API chimera uses.

I did not run the rest of the suite locally.
