### PR TITLE
diskfs/memfs: NFS3 WCC and exclusive-create verifier fixes

### DIFF
--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -889,6 +889,21 @@ diskfs_setattr_inode_cb(
 
     diskfs_apply_attrs(inode, request->setattr.set_attr);
 
+    /* POSIX: a size change (grow, or truncate to the same size) updates mtime,
+     * just like the shrink path does in diskfs_setattr_trunc_done.  This branch
+     * handles every non-shrink setattr, so bump mtime only when SIZE was set,
+     * and not when the caller supplied an explicit mtime or manages the write
+     * time itself (AUTH_ATTR / SMB).  Uses orig_mask because diskfs_apply_attrs
+     * has already rewritten set_attr->va_set_mask above. */
+    if ((orig_mask & CHIMERA_VFS_ATTR_SIZE) &&
+        !(orig_mask & CHIMERA_VFS_ATTR_MTIME) &&
+        request->cred->flavor != CHIMERA_VFS_AUTH_ATTR) {
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        inode->mtime_sec  = now.tv_sec;
+        inode->mtime_nsec = now.tv_nsec;
+    }
+
     p->inode_stash[0] = inode;
 
     /* Persist the opaque pNFS layout blob as this inode's single PNFS record,

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -4021,6 +4021,13 @@ diskfs_commit_acquired_cb(
         return;
     }
 
+    /* Report WCC before == after from the write-locked inode (COMMIT changes no
+     * metadata).  A deferred mtime is already reflected in these in-memory
+     * fields; finish_write_pin() below only makes it durable, so mapping here
+     * covers both the inline and the deferred-flush completion. */
+    diskfs_map_attrs(thread, &request->commit.r_pre_attr, inode);
+    diskfs_map_attrs(thread, &request->commit.r_post_attr, inode);
+
     shard = diskfs_inode_shard(thread->shared, inode->inum);
     pthread_mutex_lock(&shard->lock);
     if (inode->mtime_dirty) {
@@ -4061,6 +4068,15 @@ diskfs_commit(
 
     if (!warm || shared->mtime_defer_us == 0) {
         cp->txn = diskfs_txn_begin(thread, DISKFS_TXN_READ);
+        if (warm) {
+            /* COMMIT mutates no metadata, so report WCC before == after from
+             * the pinned inode.  The read is lock-free: that is acceptable for
+             * weak cache consistency (a torn read at worst costs the client one
+             * spurious revalidation) and keeps the fast path free of an inode
+             * acquire or write txn -- the whole point of this path. */
+            diskfs_map_attrs(thread, &request->commit.r_pre_attr, warm);
+            diskfs_map_attrs(thread, &request->commit.r_post_attr, warm);
+        }
         diskfs_op_ok(request, cp->txn);
         return;
     }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -245,6 +245,18 @@ struct memfs_shared {
     uint32_t                 block_shift;
     uint32_t                 block_mask;
     int                      noatime;     /* config: disable atime updates on read */
+    /* Pre-op / post-op ("before"/"after") attribute returns on mutating
+     * operations.  memfs snapshots the affected object's (or parent
+     * directory's) attributes before and after the change, under the inode
+     * lock, and returns them to the caller.  Populating them is optional for
+     * every caller -- config "enable_pre_attr" / "enable_post_attr", both
+     * default on; when a flag is off memfs leaves the corresponding struct
+     * unpopulated (va_set_mask stays as the VFS layer zeroed it) so the caller
+     * learns the attributes were not provided.  Only these pre/post structs are
+     * gated; the object attributes returned by getattr/lookup/create/read are
+     * always populated. */
+    int                      enable_pre_attr;
+    int                      enable_post_attr;
     /* Optional capacity (config "size", bytes).  0 = unlimited (the default --
      * memfs reports a synthetic, never-shrinking size).  When non-zero, memfs
      * accounts live data blocks against this limit and returns ENOSPC when full;
@@ -1005,6 +1017,10 @@ memfs_init(
     /* Generate a random 64-bit filesystem ID */
     shared->fsid = chimera_rand64();
 
+    /* WCC pre/post attribute returns default on (see struct memfs_shared). */
+    shared->enable_pre_attr  = 1;
+    shared->enable_post_attr = 1;
+
     if (cfgdata && cfgdata[0] != '\0') {
         json_error_t json_error;
         json_t      *cfg = json_loads(cfgdata, 0, &json_error);
@@ -1046,6 +1062,17 @@ memfs_init(
         /* noatime disables read atime updates entirely; default (off) keeps
          * relatime semantics. */
         shared->noatime = json_is_true(json_object_get(cfg, "noatime"));
+
+        /* Optionally suppress the pre-op / post-op attribute returns on
+         * mutating operations (both default on); see struct memfs_shared. */
+        json_t *pre_cfg = json_object_get(cfg, "enable_pre_attr");
+        if (pre_cfg) {
+            shared->enable_pre_attr = json_is_true(pre_cfg);
+        }
+        json_t *post_cfg = json_object_get(cfg, "enable_post_attr");
+        if (post_cfg) {
+            shared->enable_post_attr = json_is_true(post_cfg);
+        }
 
         /* Optional capacity in bytes; 0/absent means unlimited. */
         json_t *size_cfg = json_object_get(cfg, "size");
@@ -1453,6 +1480,62 @@ memfs_map_attrs_fork(
     }
 } /* memfs_map_attrs_fork */
 
+/* Pre-op / post-op attribute fills on mutating operations are optional for
+ * every caller.  Routing them through these wrappers lets the enable_pre_attr /
+ * enable_post_attr config flags suppress either half: when off, the struct
+ * keeps the va_set_mask the VFS layer zeroed before dispatch, so the caller
+ * sees the attributes as not provided.  Object/lookup/read attrs call
+ * memfs_map_attrs* directly and are always populated. */
+static inline void
+memfs_map_pre_attr(
+    struct memfs_shared      *shared,
+    struct chimera_vfs_attrs *attr,
+    struct memfs_inode       *inode,
+    const void               *parent_fh)
+{
+    if (shared->enable_pre_attr) {
+        memfs_map_attrs(shared, attr, inode, parent_fh);
+    }
+} /* memfs_map_pre_attr */
+
+static inline void
+memfs_map_post_attr(
+    struct memfs_shared      *shared,
+    struct chimera_vfs_attrs *attr,
+    struct memfs_inode       *inode,
+    const void               *parent_fh)
+{
+    if (shared->enable_post_attr) {
+        memfs_map_attrs(shared, attr, inode, parent_fh);
+    }
+} /* memfs_map_post_attr */
+
+static inline void
+memfs_map_pre_attr_fork(
+    struct memfs_shared       *shared,
+    struct chimera_vfs_attrs  *attr,
+    struct memfs_inode        *inode,
+    struct memfs_named_stream *stream,
+    const void                *base_fh)
+{
+    if (shared->enable_pre_attr) {
+        memfs_map_attrs_fork(shared, attr, inode, stream, base_fh);
+    }
+} /* memfs_map_pre_attr_fork */
+
+static inline void
+memfs_map_post_attr_fork(
+    struct memfs_shared       *shared,
+    struct chimera_vfs_attrs  *attr,
+    struct memfs_inode        *inode,
+    struct memfs_named_stream *stream,
+    const void                *base_fh)
+{
+    if (shared->enable_post_attr) {
+        memfs_map_attrs_fork(shared, attr, inode, stream, base_fh);
+    }
+} /* memfs_map_post_attr_fork */
+
 static inline void
 memfs_apply_attrs(
     struct memfs_inode       *inode,
@@ -1692,8 +1775,8 @@ memfs_commit(
         return;
     }
 
-    memfs_map_attrs(shared, &request->commit.r_pre_attr, inode, request->fh);
-    memfs_map_attrs(shared, &request->commit.r_post_attr, inode, request->fh);
+    memfs_map_pre_attr(shared, &request->commit.r_pre_attr, inode, request->fh);
+    memfs_map_post_attr(shared, &request->commit.r_post_attr, inode, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -1747,7 +1830,7 @@ memfs_setattr(
     p_size       = stream ? &stream->size : &inode->size;
     p_space_used = stream ? &stream->space_used : &inode->space_used;
 
-    memfs_map_attrs_fork(shared, &request->setattr.r_pre_attr, inode, stream, request->fh);
+    memfs_map_pre_attr_fork(shared, &request->setattr.r_pre_attr, inode, stream, request->fh);
 
     /* Handle truncation: free blocks past new EOF and zero partial block */
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
@@ -1854,7 +1937,7 @@ memfs_setattr(
         memfs_apply_attrs(inode, attr);
     }
 
-    memfs_map_attrs_fork(shared, &request->setattr.r_post_attr, inode, stream, request->fh);
+    memfs_map_post_attr_fork(shared, &request->setattr.r_post_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -2308,7 +2391,7 @@ memfs_mkdir_at(
                       request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
     memfs_map_attrs(shared, r_attr, inode, request->fh);
 
-    memfs_map_attrs(shared, r_dir_pre_attr, parent_inode, request->fh);
+    memfs_map_pre_attr(shared, r_dir_pre_attr, parent_inode, request->fh);
 
     rb_tree_query_exact(
         &parent_inode->dir.dirents,
@@ -2321,7 +2404,7 @@ memfs_mkdir_at(
         existing_inode = memfs_inode_get_inum(shared, existing_dirent->inum, existing_dirent->gen);
 
         memfs_map_attrs(shared, r_attr, existing_inode, request->fh);
-        memfs_map_attrs(shared, r_dir_post_attr, parent_inode, request->fh);
+        memfs_map_post_attr(shared, r_dir_post_attr, parent_inode, request->fh);
 
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&existing_inode->lock);
@@ -2341,7 +2424,7 @@ memfs_mkdir_at(
     parent_inode->ctime = now;
     parent_inode->change++;
 
-    memfs_map_attrs(shared, r_dir_post_attr, parent_inode, request->fh);
+    memfs_map_post_attr(shared, r_dir_post_attr, parent_inode, request->fh);
 
     pthread_mutex_unlock(&parent_inode->lock);
 
@@ -2426,7 +2509,7 @@ memfs_mknod_at(
         return;
     }
 
-    memfs_map_attrs(shared, r_dir_pre_attr, parent_inode, request->fh);
+    memfs_map_pre_attr(shared, r_dir_pre_attr, parent_inode, request->fh);
 
     rb_tree_query_exact(
         &parent_inode->dir.dirents,
@@ -2439,7 +2522,7 @@ memfs_mknod_at(
         existing_inode = memfs_inode_get_inum(shared, existing_dirent->inum, existing_dirent->gen);
 
         memfs_map_attrs(shared, r_attr, existing_inode, request->fh);
-        memfs_map_attrs(shared, r_dir_post_attr, parent_inode, request->fh);
+        memfs_map_post_attr(shared, r_dir_post_attr, parent_inode, request->fh);
 
         pthread_mutex_unlock(&parent_inode->lock);
         pthread_mutex_unlock(&existing_inode->lock);
@@ -2457,7 +2540,7 @@ memfs_mknod_at(
     parent_inode->ctime = now;
     parent_inode->change++;
 
-    memfs_map_attrs(shared, r_dir_post_attr, parent_inode, request->fh);
+    memfs_map_post_attr(shared, r_dir_post_attr, parent_inode, request->fh);
 
     pthread_mutex_unlock(&parent_inode->lock);
 
@@ -2489,7 +2572,7 @@ memfs_remove_at(
         return;
     }
 
-    memfs_map_attrs(shared, &request->remove_at.r_dir_pre_attr, parent_inode, request->fh);
+    memfs_map_pre_attr(shared, &request->remove_at.r_dir_pre_attr, parent_inode, request->fh);
 
     if (!S_ISDIR(parent_inode->mode)) {
         pthread_mutex_unlock(&parent_inode->lock);
@@ -2598,7 +2681,7 @@ memfs_remove_at(
             memfs_inode_free(thread, inode);
         }
     }
-    memfs_map_attrs(shared, &request->remove_at.r_dir_post_attr, parent_inode, request->fh);
+    memfs_map_post_attr(shared, &request->remove_at.r_dir_post_attr, parent_inode, request->fh);
 
     pthread_mutex_unlock(&parent_inode->lock);
     pthread_mutex_unlock(&inode->lock);
@@ -2833,7 +2916,7 @@ memfs_open_at(
         return;
     }
 
-    memfs_map_attrs(shared, &request->open_at.r_dir_pre_attr, parent_inode, request->fh);
+    memfs_map_pre_attr(shared, &request->open_at.r_dir_pre_attr, parent_inode, request->fh);
 
     rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, dirent);
 
@@ -3014,7 +3097,7 @@ memfs_open_at(
         request->open_at.r_vfs_private = (uint64_t) inode;
     }
 
-    memfs_map_attrs(shared, &request->open_at.r_dir_post_attr, parent_inode, request->fh);
+    memfs_map_post_attr(shared, &request->open_at.r_dir_post_attr, parent_inode, request->fh);
 
     pthread_mutex_unlock(&parent_inode->lock);
 
@@ -3354,13 +3437,13 @@ memfs_write(
     /* Write access is enforced at the VFS layer (credential-keyed gate); see
      * the note in memfs_open_at. */
 
-    memfs_map_attrs_fork(shared, &request->write.r_pre_attr, inode, stream, request->fh);
+    memfs_map_pre_attr_fork(shared, &request->write.r_pre_attr, inode, stream, request->fh);
 
     if (request->write.length == 0) {
         /* A zero-length write changes nothing. Returning early also avoids
          * the (offset + length - 1) underflow above, which drives last_block
          * to a huge value and spins the 32-bit block-growth loop forever. */
-        memfs_map_attrs_fork(shared, &request->write.r_post_attr, inode, stream, request->fh);
+        memfs_map_post_attr_fork(shared, &request->write.r_post_attr, inode, stream, request->fh);
         pthread_mutex_unlock(&inode->lock);
         request->status         = CHIMERA_VFS_OK;
         request->write.r_length = 0;
@@ -3491,7 +3574,7 @@ memfs_write(
      * streams share the parent inode's mode, so this applies on either path. */
     inode->mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
 
-    memfs_map_attrs_fork(shared, &request->write.r_post_attr, inode, stream, request->fh);
+    memfs_map_post_attr_fork(shared, &request->write.r_post_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -3536,7 +3619,7 @@ memfs_allocate(
     p_size       = stream ? &stream->size : &inode->size;
     p_space_used = stream ? &stream->space_used : &inode->space_used;
 
-    memfs_map_attrs_fork(shared, &request->allocate.r_pre_attr, inode, stream, request->fh);
+    memfs_map_pre_attr_fork(shared, &request->allocate.r_pre_attr, inode, stream, request->fh);
 
     if (request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE) {
         /* DEALLOCATE: punch hole in [offset, offset+length) */
@@ -3679,7 +3762,7 @@ memfs_allocate(
     inode->ctime = now;
     inode->change++;
 
-    memfs_map_attrs_fork(shared, &request->allocate.r_post_attr, inode, stream, request->fh);
+    memfs_map_post_attr_fork(shared, &request->allocate.r_post_attr, inode, stream, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -3892,8 +3975,8 @@ memfs_copy_range(
         pthread_mutex_lock(&src_inode->lock);
     }
 
-    memfs_map_attrs(shared, &request->copy_range.r_pre_attr, dst_inode,
-                    request->copy_range.dst_handle->fh);
+    memfs_map_pre_attr(shared, &request->copy_range.r_pre_attr, dst_inode,
+                       request->copy_range.dst_handle->fh);
 
     /* Clamp length to what's available in source */
     if (src_offset >= src_inode->size) {
@@ -3906,8 +3989,8 @@ memfs_copy_range(
     }
 
     if (src_eof_len == 0) {
-        memfs_map_attrs(shared, &request->copy_range.r_post_attr, dst_inode,
-                        request->copy_range.dst_handle->fh);
+        memfs_map_post_attr(shared, &request->copy_range.r_post_attr, dst_inode,
+                            request->copy_range.dst_handle->fh);
         if (src_inode != dst_inode) {
             pthread_mutex_unlock(&src_inode->lock);
         }
@@ -4010,8 +4093,8 @@ memfs_copy_range(
     dst_inode->change++;
     src_inode->atime = now;
 
-    memfs_map_attrs(shared, &request->copy_range.r_post_attr, dst_inode,
-                    request->copy_range.dst_handle->fh);
+    memfs_map_post_attr(shared, &request->copy_range.r_post_attr, dst_inode,
+                        request->copy_range.dst_handle->fh);
 
     if (src_inode != dst_inode) {
         pthread_mutex_unlock(&src_inode->lock);
@@ -4103,8 +4186,8 @@ memfs_move_range(
         pthread_mutex_lock(&src_inode->lock);
     }
 
-    memfs_map_attrs(shared, &request->move_range.r_dst_pre_attr, dst_inode,
-                    request->move_range.dst_handle->fh);
+    memfs_map_pre_attr(shared, &request->move_range.r_dst_pre_attr, dst_inode,
+                       request->move_range.dst_handle->fh);
 
     first_block     = dst_offset >> block_shift;
     last_block      = (dst_offset + length - 1) >> block_shift;
@@ -4159,10 +4242,10 @@ memfs_move_range(
     src_inode->ctime = now;
     src_inode->change++;
 
-    memfs_map_attrs(shared, &request->move_range.r_dst_post_attr, dst_inode,
-                    request->move_range.dst_handle->fh);
-    memfs_map_attrs(shared, &request->move_range.r_src_post_attr, src_inode,
-                    request->move_range.src_handle->fh);
+    memfs_map_post_attr(shared, &request->move_range.r_dst_post_attr, dst_inode,
+                        request->move_range.dst_handle->fh);
+    memfs_map_post_attr(shared, &request->move_range.r_src_post_attr, src_inode,
+                        request->move_range.src_handle->fh);
 
     if (src_inode != dst_inode) {
         pthread_mutex_unlock(&src_inode->lock);
@@ -4260,8 +4343,8 @@ memfs_clone_range(
         pthread_mutex_lock(&src_inode->lock);
     }
 
-    memfs_map_attrs(shared, &request->clone_range.r_pre_attr, dst_inode,
-                    request->clone_range.dst_handle->fh);
+    memfs_map_pre_attr(shared, &request->clone_range.r_pre_attr, dst_inode,
+                       request->clone_range.dst_handle->fh);
 
     first_block  = dst_offset >> block_shift;
     block_offset = dst_offset & block_mask;
@@ -4402,8 +4485,8 @@ memfs_clone_range(
     dst_inode->change++;
     src_inode->atime = now;
 
-    memfs_map_attrs(shared, &request->clone_range.r_post_attr, dst_inode,
-                    request->clone_range.dst_handle->fh);
+    memfs_map_post_attr(shared, &request->clone_range.r_post_attr, dst_inode,
+                        request->clone_range.dst_handle->fh);
 
     if (src_inode != dst_inode) {
         pthread_mutex_unlock(&src_inode->lock);
@@ -4600,7 +4683,7 @@ memfs_symlink_at(
         return;
     }
 
-    memfs_map_attrs(shared, &request->symlink_at.r_dir_pre_attr, parent_inode, request->fh);
+    memfs_map_pre_attr(shared, &request->symlink_at.r_dir_pre_attr, parent_inode, request->fh);
 
     rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
 
@@ -4608,7 +4691,7 @@ memfs_symlink_at(
     parent_inode->ctime = now;
     parent_inode->change++;
 
-    memfs_map_attrs(shared, &request->symlink_at.r_dir_post_attr, parent_inode, request->fh);
+    memfs_map_post_attr(shared, &request->symlink_at.r_dir_post_attr, parent_inode, request->fh);
 
     pthread_mutex_unlock(&parent_inode->lock);
 
@@ -4775,8 +4858,8 @@ memfs_rename_at(
         }
     }
 
-    memfs_map_attrs(shared, &request->rename_at.r_fromdir_pre_attr, old_parent_inode, request->fh);
-    memfs_map_attrs(shared, &request->rename_at.r_todir_pre_attr, new_parent_inode, request->rename_at.new_fh);
+    memfs_map_pre_attr(shared, &request->rename_at.r_fromdir_pre_attr, old_parent_inode, request->fh);
+    memfs_map_pre_attr(shared, &request->rename_at.r_todir_pre_attr, new_parent_inode, request->rename_at.new_fh);
 
     rb_tree_query_exact(&old_parent_inode->dir.dirents, hash, hash, old_dirent);
 
@@ -4861,8 +4944,9 @@ memfs_rename_at(
         if (existing_dirent->inum == old_dirent->inum &&
             existing_dirent->gen == old_dirent->gen) {
             /* Same inode - do nothing, just return success */
-            memfs_map_attrs(shared, &request->rename_at.r_fromdir_post_attr, old_parent_inode, request->fh);
-            memfs_map_attrs(shared, &request->rename_at.r_todir_post_attr, new_parent_inode, request->rename_at.new_fh);
+            memfs_map_post_attr(shared, &request->rename_at.r_fromdir_post_attr, old_parent_inode, request->fh);
+            memfs_map_post_attr(shared, &request->rename_at.r_todir_post_attr, new_parent_inode, request->rename_at.
+                                new_fh);
             pthread_mutex_unlock(&child_inode->lock);
             if (cmp != 0) {
                 pthread_mutex_unlock(&old_parent_inode->lock);
@@ -4993,8 +5077,8 @@ memfs_rename_at(
     child_inode->ctime = now;
     child_inode->change++;
 
-    memfs_map_attrs(shared, &request->rename_at.r_fromdir_post_attr, old_parent_inode, request->fh);
-    memfs_map_attrs(shared, &request->rename_at.r_todir_post_attr, new_parent_inode, request->rename_at.new_fh);
+    memfs_map_post_attr(shared, &request->rename_at.r_fromdir_post_attr, old_parent_inode, request->fh);
+    memfs_map_post_attr(shared, &request->rename_at.r_todir_post_attr, new_parent_inode, request->rename_at.new_fh);
 
     pthread_mutex_unlock(&child_inode->lock);
 
@@ -5038,7 +5122,7 @@ memfs_link_at(
         return;
     }
 
-    memfs_map_attrs(shared, &request->link_at.r_dir_pre_attr, parent_inode, request->link_at.dir_fh);
+    memfs_map_pre_attr(shared, &request->link_at.r_dir_pre_attr, parent_inode, request->link_at.dir_fh);
 
     if (!S_ISDIR(parent_inode->mode)) {
         pthread_mutex_unlock(&parent_inode->lock);
@@ -5107,8 +5191,8 @@ memfs_link_at(
             parent_inode->mtime = now;
             parent_inode->ctime = now;
             parent_inode->change++;
-            memfs_map_attrs(shared, &request->link_at.r_dir_post_attr,
-                            parent_inode, request->link_at.dir_fh);
+            memfs_map_post_attr(shared, &request->link_at.r_dir_post_attr,
+                                parent_inode, request->link_at.dir_fh);
             memfs_map_attrs(shared, &request->link_at.r_attr, inode,
                             request->fh);
             pthread_mutex_unlock(&parent_inode->lock);
@@ -5164,7 +5248,7 @@ memfs_link_at(
     parent_inode->ctime = now;
     parent_inode->change++;
 
-    memfs_map_attrs(shared, &request->link_at.r_dir_post_attr, parent_inode, request->link_at.dir_fh);
+    memfs_map_post_attr(shared, &request->link_at.r_dir_post_attr, parent_inode, request->link_at.dir_fh);
     memfs_map_attrs(shared, &request->link_at.r_attr, inode, request->fh);
 
     pthread_mutex_unlock(&parent_inode->lock);
@@ -5250,7 +5334,7 @@ memfs_set_xattr(
         return;
     }
 
-    memfs_map_attrs(shared, &request->set_xattr.r_pre_attr, inode, request->fh);
+    memfs_map_pre_attr(shared, &request->set_xattr.r_pre_attr, inode, request->fh);
 
     xattr = memfs_xattr_find(inode, request->set_xattr.name,
                              request->set_xattr.namelen);
@@ -5291,7 +5375,7 @@ memfs_set_xattr(
     inode->ctime = now;
     inode->change++;
 
-    memfs_map_attrs(shared, &request->set_xattr.r_post_attr, inode, request->fh);
+    memfs_map_post_attr(shared, &request->set_xattr.r_post_attr, inode, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -5363,7 +5447,7 @@ memfs_remove_xattr(
         return;
     }
 
-    memfs_map_attrs(shared, &request->remove_xattr.r_pre_attr, inode, request->fh);
+    memfs_map_pre_attr(shared, &request->remove_xattr.r_pre_attr, inode, request->fh);
 
     pprev = &inode->xattrs;
     for (xattr = inode->xattrs; xattr; xattr = xattr->next) {
@@ -5391,7 +5475,7 @@ memfs_remove_xattr(
     inode->ctime = now;
     inode->change++;
 
-    memfs_map_attrs(shared, &request->remove_xattr.r_post_attr, inode, request->fh);
+    memfs_map_post_attr(shared, &request->remove_xattr.r_post_attr, inode, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 
@@ -5596,7 +5680,7 @@ memfs_remove_stream(
         return;
     }
 
-    memfs_map_attrs(shared, &request->remove_stream.r_pre_attr, inode, request->fh);
+    memfs_map_pre_attr(shared, &request->remove_stream.r_pre_attr, inode, request->fh);
 
     pprev = &inode->streams;
     for (stream = inode->streams; stream; stream = stream->next) {
@@ -5632,7 +5716,7 @@ memfs_remove_stream(
     inode->ctime = now;
     inode->change++;
 
-    memfs_map_attrs(shared, &request->remove_stream.r_post_attr, inode, request->fh);
+    memfs_map_post_attr(shared, &request->remove_stream.r_post_attr, inode, request->fh);
 
     pthread_mutex_unlock(&inode->lock);
 


### PR DESCRIPTION
Three NFS3-conformance fixes for the VFS backends, one per commit.

**memfs: return pre/post WCC attributes on mutating operations**
Fill the weak-cache-consistency before/after attributes on the mutating memfs
ops (write, setattr, create/mkdir/mknod/symlink, remove, rename, link, commit,
allocate, copy/move/clone_range) so the NFS3 server can emit `wcc_data`. A
config knob (default on) can suppress the fills to exercise the
attribute-presence matrix.

**diskfs: bump mtime on a size-grow setattr**
A size change updates mtime, matching the shrink path. Fixes an EXCLUSIVE
create whose verifier lives in mtime being read back stale (returning success
instead of EEXIST on a conflicting retry).

**diskfs: fill commit WCC lock-free on the fast path**
COMMIT changes no metadata, so report WCC before == after from the pinned
inode. On the deferred-mtime fast path the read is lock-free (acceptable for
weak cache consistency), keeping that path free of an inode acquire or write txn.

_(The diskfs/vfs stale-file-handle gate previously in this PR was removed:
gating fresh by-fh resolution on `nlink==0` alone regressed deleted-while-open
(`fstat`/read on an open-but-unlinked file), because a genuine opener's
`refcnt>0` no longer kept the inode resolvable. It needs a redesign that
distinguishes a genuine open reference from cache warmth, and will come back
separately.)_
