### PR TITLE
smb2/replay: park conflicting opens on handle-lease breaks, add a Win…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,7 @@ the canonical place to set them.
 | `smb_named_streams` | bool | `false` | Enable SMB named streams (alternate data streams). |
 | `smb_encryption` | string/int | `"off"` | SMB3 transport encryption: `"off"`/`"disabled"` (0), `"enabled"`/`"on"` (1), or `"required"` (2). |
 | `smb_acl_inherited_canonicalize` | bool | `true` | Canonicalize inherited ACLs on SMB. |
+| `smb_replay_pending_windows` | bool | `false` | Answer a replayed durable-v2 CREATE that collides with a still-deferred CREATE the way Windows servers do (`STATUS_ACCESS_DENIED`, and no replay detection while the original waits on a share conflict). The default answers `STATUS_FILE_NOT_AVAILABLE`, which clients retry until the original create completes. MS-SMB2 does not specify this race; the two profiles are mutually exclusive. |
 | `metrics_port` | int | `9000` | Prometheus metrics port (`/metrics`). Make it distinct when running multiple daemons per host. |
 | `rest_http_port` | int | - | HTTP port for the REST admin API. Set to enable it (examples use `8080`). |
 | `rest_https_port` | int | `0` | HTTPS port for the REST API (`0` = disabled). |

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -579,6 +579,11 @@ main(
         chimera_server_config_set_smb_acl_inherited_canonicalize(server_config, json_is_true(json_value));
     }
 
+    json_value = json_object_get(server_params, "smb_replay_pending_windows");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_replay_pending_windows(server_config, json_is_true(json_value));
+    }
+
     json_value = json_object_get(server_params, "smb2_max_async_credits");
     if (json_is_integer(json_value)) {
         chimera_server_config_set_smb2_max_async_credits(server_config, json_integer_value(json_value));

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -101,6 +101,7 @@ struct chimera_server_config {
     int                                   smb_oplocks;
     int                                   smb_notify_disabled;
     int                                   smb_acl_inherited_canonicalize;
+    int                                   smb_replay_pending_windows;
     int                                   smb2_max_async_credits;
     uint32_t                              smb_fs_physical_bytes_per_sector;
     uint32_t                              smb_fs_sector_size_flags;
@@ -234,6 +235,32 @@ chimera_server_config_init(void)
      * verbatim (Samba's "= no" mode that the smb2.acls_non_canonical suite
      * exercises). */
     config->smb_acl_inherited_canonicalize = 1;
+
+    /* How a replayed durable-v2 CREATE is answered when its create_guid matches
+     * an open whose own CREATE has not completed yet (it is deferred on a
+     * conflicting holder's oplock/lease break).  MS-SMB2 3.3.5.9 / 3.3.5.9.10
+     * do not cover this race -- the spec's replay lookup assumes a fully
+     * initialised Open -- so the two real implementations diverge:
+     *
+     *   0 (default): STATUS_FILE_NOT_AVAILABLE, as Samba answers.  A client
+     *      RETRIES on this status (three times, then every 5s until the
+     *      resiliency timeout), so the replay succeeds once the original create
+     *      completes -- which is the point of replaying it after a channel
+     *      failure.  smb2.replay.dhv2-pending*-sane assert this.
+     *   1: STATUS_ACCESS_DENIED, as Windows servers answer (it falls out of
+     *      the "Open.DurableOwner is NULL" rule in 3.3.5.9, DurableOwner not
+     *      being set until the open completes).  A client reports this to the
+     *      application rather than retrying.  Also suppresses replay detection
+     *      entirely while the original create is deferred on a SHARE conflict,
+     *      which is the other half of the Windows profile.
+     *      smb2.replay.dhv2-pending*-windows assert this.
+     *
+     * The two profiles are mutually exclusive on identical wire traffic (the
+     * -sane and -windows smbtorture variants send byte-identical sequences and
+     * differ only in the status they require), so one daemon satisfies one of
+     * them: the smbtorture driver runs each half against a daemon in the matching
+     * profile.  See https://bugzilla.samba.org/show_bug.cgi?id=14449. */
+    config->smb_replay_pending_windows = 0;
 
     /* Per-connection ceiling on outstanding async (STATUS_PENDING) operations.
      * 512 matches the value smb2.credits.*_ipc_max_async_credits asserts. */
@@ -583,6 +610,20 @@ chimera_server_config_get_smb_acl_inherited_canonicalize(const struct chimera_se
 {
     return config->smb_acl_inherited_canonicalize;
 } /* chimera_server_config_get_smb_acl_inherited_canonicalize */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_replay_pending_windows(
+    struct chimera_server_config *config,
+    int                           enable)
+{
+    config->smb_replay_pending_windows = enable;
+} /* chimera_server_config_set_smb_replay_pending_windows */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_replay_pending_windows(const struct chimera_server_config *config)
+{
+    return config->smb_replay_pending_windows;
+} /* chimera_server_config_get_smb_replay_pending_windows */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_smb2_max_async_credits(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -164,6 +164,20 @@ int
 chimera_server_config_get_smb_acl_inherited_canonicalize(
     const struct chimera_server_config *config);
 
+/* Answer a replayed durable-v2 CREATE that collides with a still-deferred
+ * CREATE the way Windows servers do (STATUS_ACCESS_DENIED, and no replay
+ * detection while the original is deferred on a share conflict) instead of the
+ * default Samba behaviour (STATUS_FILE_NOT_AVAILABLE, which clients retry).
+ * The two are mutually exclusive; see the default in chimera_server_config_init. */
+void
+chimera_server_config_set_smb_replay_pending_windows(
+    struct chimera_server_config *config,
+    int                           enable);
+
+int
+chimera_server_config_get_smb_replay_pending_windows(
+    const struct chimera_server_config *config);
+
 void
 chimera_server_config_set_smb2_max_async_credits(
     struct chimera_server_config *config,

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -243,6 +243,7 @@ chimera_smb_server_init(
     shared->config.smb2_max_async_credits       = chimera_server_config_get_smb2_max_async_credits(config);
     shared->config.fs_physical_bytes_per_sector = chimera_server_config_get_smb_fs_physical_bytes_per_sector(config);
     shared->config.fs_sector_size_flags         = chimera_server_config_get_smb_fs_sector_size_flags(config);
+    shared->config.replay_pending_windows       = chimera_server_config_get_smb_replay_pending_windows(config);
 
     if (shared->config.persistent_handles) {
         chimera_smb_info("SMB3 durable/persistent handles enabled (in-memory state)");
@@ -1065,6 +1066,16 @@ chimera_smb_complete_request(
      * SMB2_FLAGS_ASYNC_COMMAND and the matching AsyncId. */
     if (unlikely(request->async.armed)) {
         chimera_smb_async_interim_cancel(request);
+    }
+
+    /* A CREATE that was registered as deferred-and-not-yet-hashed
+     * (tree->pending_creates) is finished now however it got here, so drop the
+     * registration: the entry lives in this request and must never outlive it.
+     * Idempotent -- the create paths that resolve normally unregister at the
+     * point the open becomes visible in open_files[] instead. */
+    if (unlikely(request->smb2_hdr.command == SMB2_CREATE &&
+                 request->create.pending_linked)) {
+        chimera_smb_create_pending_unregister(request);
     }
 
     request->status = status;

--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -26,6 +26,7 @@
 
 #include "smb_internal.h"
 #include "smb_async_interim.h"
+#include "smb_procs.h"
 #include "smb_signing.h"
 #include "smb2.h"
 
@@ -172,6 +173,17 @@ chimera_smb_async_interim_drain(struct chimera_smb_conn *conn)
         request->async.park_next = NULL;
         request->async.armed     = 0;
         evpl_remove_timer(thread->evpl, &request->async.timer);
+
+        /* A CREATE parked on a share-acquire ticket (rather than on a break ack)
+         * is resumed by the VFS pump, which would dereference this request after
+         * the connection is gone.  Cancel the ticket and release the half-built
+         * open the way the DENIED resume would; there is nobody left to reply
+         * to. */
+        if (request->smb2_hdr.command == SMB2_CREATE &&
+            request->create.gen_parked) {
+            chimera_smb_create_abandon_share_park(request);
+            continue;
+        }
 
         /* A parked CREATE holds an open_file reference (taken when it deferred
         * on the lease/oplock break it triggered) that only its resume path

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -239,6 +239,12 @@ struct chimera_smb_config {
      * SET_SECURITY; see chimera_server_config_set_smb_acl_inherited_canonicalize
      * for semantics.  Default 1 (canonical). */
     int                            acl_inherited_canonicalize;
+    /* Answer a replayed durable-v2 CREATE that matches a still-deferred CREATE
+     * the Windows way (ACCESS_DENIED, and no replay detection while the original
+     * is deferred on a share conflict) rather than the default Samba way
+     * (FILE_NOT_AVAILABLE, which clients retry).  The two are mutually exclusive;
+     * see chimera_server_config_set_smb_replay_pending_windows.  Default 0. */
+    int                            replay_pending_windows;
     /* Per-connection ceiling on simultaneously outstanding async (STATUS_PENDING)
      * operations.  A blocking named-pipe READ that cannot be served now is made
      * async until the connection holds (smb2_max_async_credits - 1) of them;
@@ -629,10 +635,21 @@ struct chimera_smb_request {
             uint8_t                            gen_share_retry;
             /* GRANTED/DENIED result stashed by chimera_smb_create_share_park_cb
              * when the share-park ticket resolves on another thread, so the
-             * owning thread's resume doorbell can finish the open with it.  The
-             * queue link reuses async.park_next (a gen_parked CREATE is not on
-             * conn->parked_requests). */
+             * owning thread's resume doorbell can finish the open with it.
+             * gen_resume_next is that queue's own link: it must NOT share
+             * async.park_next, because a share-parked CREATE also emits an
+             * async interim and is therefore linked on conn->parked_requests by
+             * that field at the same time. */
             enum chimera_vfs_lease_result      gen_resume_result;
+            struct chimera_smb_request        *gen_resume_next;
+            /* Registration of this deferred DH2Q create on tree->pending_creates
+            * (see the comment there): pending_link chains the list, and
+            * pending_linked says whether this request is currently on it.  The
+            * client GUID is snapshotted so the replay lookup can match
+            * Open.ClientGuid without touching the (possibly gone) connection. */
+            struct chimera_smb_request        *pending_link;
+            uint8_t                            pending_linked;
+            uint8_t                            pending_client_guid[16];
             uint8_t                            r_is_directory;
             uint32_t                           r_granted_access;
             uint32_t                           r_maximal_access;
@@ -2610,6 +2627,7 @@ chimera_smb_tree_alloc(struct chimera_server_smb_shared *shared)
         for (int i = 0; i < CHIMERA_SMB_OPEN_FILE_BUCKETS; i++) {
             pthread_mutex_init(&tree->open_files_lock[i], NULL);
         }
+        pthread_mutex_init(&tree->pending_creates_lock, NULL);
     }
 
     tree->fh_expiration.tv_sec  = 0;

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -2650,6 +2650,7 @@ chimera_smb_tree_free(
     struct chimera_smb_notify_state *nstate;
     struct chimera_smb_request      *lock_aborts = NULL;
     struct chimera_smb_request      *labort;
+    struct chimera_smb_request      *pcreate;
     bool                             closed_breaking = false;
     int                              i;
 
@@ -2810,6 +2811,25 @@ chimera_smb_tree_free(
         evpl_ring_doorbell(&thread->lease_resume_doorbell);
         chimera_smb_create_resume_parked_broadcast(thread);
     }
+
+    /* Detach any DH2Q creates still registered as deferred-and-not-yet-hashed on
+     * this tree (tree->pending_creates).  A deferred CREATE holds no tree
+     * reference -- refcnt is touched only by TREE_DISCONNECT -- so the tree can
+     * reach here while a create is parked on a handle-lease break or retrying a
+     * disconnecting durable holder, and the free list below does NOT zero the
+     * tree.  A surviving head would be inherited by the next tree to take this
+     * slot, where chimera_smb_create_pending_match would walk a request from a
+     * different tree connect and could answer an unrelated replay
+     * FILE_NOT_AVAILABLE (a client's two tree connects share one client_guid).
+     * Clear each entry's link as well, so the unregister those requests still run
+     * when they resolve is a no-op instead of a walk against a recycled list. */
+    pthread_mutex_lock(&tree->pending_creates_lock);
+    while ((pcreate = tree->pending_creates)) {
+        tree->pending_creates          = pcreate->create.pending_link;
+        pcreate->create.pending_link   = NULL;
+        pcreate->create.pending_linked = 0;
+    }
+    pthread_mutex_unlock(&tree->pending_creates_lock);
 
     pthread_mutex_lock(&shared->trees_lock);
 

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -113,6 +113,87 @@ chimera_smb_create_finish_with_eas(
 #define CHIMERA_SMB_CREATE_SHARE_RETRY_MAX         150    /* ~3 s total */
 #define CHIMERA_SMB_CREATE_SHARE_SPEC_RETRY_MAX    25     /* ~0.5 s total */
 
+/* ---------------------------------------------------------------------------
+ * In-flight (deferred, not-yet-hashed) DH2Q creates -- tree->pending_creates.
+ *
+ * A create is hashed into tree->open_files[] only once its share reservation is
+ * granted (chimera_smb_create_after_share), so a create that is deferred BEFORE
+ * that -- parked on a conflicting holder's handle-caching break, or retrying a
+ * disconnecting durable holder -- carries a create_guid no lookup can see.  A
+ * replay of such a create would fall through to a fresh open and hit the very
+ * conflict the original is waiting out, answering SHARING_VIOLATION where the
+ * pending-open rule requires FILE_NOT_AVAILABLE (smb2.replay.dhv2-pending1n-vs-
+ * violation-lease-{ack,close}-sane).  These three helpers make that window
+ * visible to chimera_smb_create_guid_replay.  Entries are stored in the deferred
+ * requests themselves, so an entry cannot outlive its request.
+ * --------------------------------------------------------------------------- */
+
+static void
+chimera_smb_create_pending_register(struct chimera_smb_request *request)
+{
+    struct chimera_smb_tree *tree = request->tree;
+
+    if (request->create.pending_linked || !tree ||
+        !(request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_DH2Q)) {
+        return;
+    }
+
+    memcpy(request->create.pending_client_guid,
+           request->compound->conn->client_guid, 16);
+
+    pthread_mutex_lock(&tree->pending_creates_lock);
+    request->create.pending_link   = tree->pending_creates;
+    tree->pending_creates          = request;
+    request->create.pending_linked = 1;
+    pthread_mutex_unlock(&tree->pending_creates_lock);
+} /* chimera_smb_create_pending_register */
+
+void
+chimera_smb_create_pending_unregister(struct chimera_smb_request *request)
+{
+    struct chimera_smb_tree     *tree = request->tree;
+    struct chimera_smb_request **pp;
+
+    if (!request->create.pending_linked || !tree) {
+        return;
+    }
+
+    pthread_mutex_lock(&tree->pending_creates_lock);
+    for (pp = &tree->pending_creates; *pp; pp = &(*pp)->create.pending_link) {
+        if (*pp == request) {
+            *pp = request->create.pending_link;
+            break;
+        }
+    }
+    request->create.pending_link   = NULL;
+    request->create.pending_linked = 0;
+    pthread_mutex_unlock(&tree->pending_creates_lock);
+} /* chimera_smb_create_pending_unregister */
+
+/* Non-zero if a create carrying `create_guid` from `client_guid` is deferred on
+ * this tree right now (MS-SMB2 3.3.5.9.10 matches Open.CreateGuid together with
+ * Open.ClientGuid).  Scoped to one tree connect, like the hashed open scan. */
+static int
+chimera_smb_create_pending_match(
+    struct chimera_smb_tree *tree,
+    const uint8_t           *create_guid,
+    const uint8_t           *client_guid)
+{
+    struct chimera_smb_request *req;
+    int                         found = 0;
+
+    pthread_mutex_lock(&tree->pending_creates_lock);
+    for (req = tree->pending_creates; req; req = req->create.pending_link) {
+        if (memcmp(req->create.dh2q.create_guid, create_guid, 16) == 0 &&
+            memcmp(req->create.pending_client_guid, client_guid, 16) == 0) {
+            found = 1;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&tree->pending_creates_lock);
+    return found;
+} /* chimera_smb_create_pending_match */
+
 /* Map a VFS error from an open-or-create path to the SMB2 status that
  * Windows clients expect.  EISDIR/ENOTDIR are critical here: cmd.exe and
  * other tools probe with FILE_NON_DIRECTORY_FILE first and retry with
@@ -1058,8 +1139,19 @@ chimera_smb_create_gen_open_file(
                    request->create.rqls.key, 8);
             memcpy(&open_file->share_lease.break_skip_hi,
                    request->create.rqls.key + 8, 8);
+            /* Same key, recorded for the opposite direction: a LATER conflicting
+             * open needs to find THIS open's handle-caching lease to park on its
+             * H break instead of denying outright (chimera_vfs_share_batch_escape's
+             * RqLs arm).  An RqLs lease is keyed by LeaseKey, so the reservation
+             * carries the key that links it to its own lease. */
+            open_file->share_lease.has_own_lease_key = 1;
+            memcpy(&open_file->share_lease.own_lease_lo,
+                   request->create.rqls.key, 8);
+            memcpy(&open_file->share_lease.own_lease_hi,
+                   request->create.rqls.key + 8, 8);
         } else {
             open_file->share_lease.has_break_skip_key = 0;
+            open_file->share_lease.has_own_lease_key  = 0;
         }
 
         /* AppInstanceId failover (MS-SMB2 3.3.5.9.7 / 3.3.5.9.16) was already
@@ -1137,6 +1229,23 @@ chimera_smb_create_gen_open_file(
             request->create.gen_parked_fs    = file_state;
             request->create.gen_held_granted = held_granted;
             request->create.gen_parked       = 1;
+            /* Publish this create's create_guid before the park: while it waits,
+             * it is not in tree->open_files[], so only tree->pending_creates lets
+             * a replay of it be recognised as a pending create. */
+            chimera_smb_create_pending_register(request);
+            /* Emit the interim STATUS_PENDING now, exactly as the break-park path
+             * does (MS-SMB2 3.3.5.9 pending open): the client must learn the
+             * create is in flight so it can cancel it and does not time out across
+             * the break wait, which lasts until the holder acks/closes (or the
+             * break deadline revokes it).  Without this a conflicting open looks
+             * simply unanswered -- smbtorture's WAIT_FOR_ASYNC_RESPONSE spins to
+             * its own request timeout and the test's later break ack arrives after
+             * the deadline has already revoked the lease
+             * (smb2.replay.dhv2-pending1n-vs-violation-lease-*).  The request lands
+             * on conn->parked_requests for CANCEL/teardown, but it resumes through
+             * its vfs ticket, NOT the parked-CREATE break sweep -- see the
+             * gen_parked guard in chimera_smb_create_resume_parked_conn. */
+            chimera_smb_async_interim_begin(request);
             chimera_vfs_lease_acquire(vfs_state, file_state,
                                       &open_file->share_lease,
                                       &request->create.gen_ticket, true,
@@ -1818,8 +1927,8 @@ chimera_smb_create_share_park_cb(
     request->create.gen_resume_result = result;
 
     pthread_mutex_lock(&thread->lease_break_lock);
-    request->async.park_next  = thread->share_resume_head;
-    thread->share_resume_head = request;
+    request->create.gen_resume_next = thread->share_resume_head;
+    thread->share_resume_head       = request;
     pthread_mutex_unlock(&thread->lease_break_lock);
 
     evpl_ring_doorbell(&thread->lease_resume_doorbell);
@@ -1852,9 +1961,15 @@ chimera_smb_create_share_park_finish(
         chimera_smb_create_finish_share_grant(open_file, file_state,
                                               request->create.gen_held_granted);
         chimera_smb_create_after_share(request, open_file);
+        /* after_share hashed the open, so drop the in-flight registration only
+         * now: a replay is covered by open_files[] from here on, with no window
+         * in which neither lookup can see this create. */
+        chimera_smb_create_pending_unregister(request);
         request->create.gen_finish_cb(request, open_file);
         return;
     }
+
+    chimera_smb_create_pending_unregister(request);
 
     /* DENIED: the holder acked its oplock / dir-lease break but kept the handle
      * open, so the share conflict stands. */
@@ -1867,6 +1982,42 @@ chimera_smb_create_share_park_finish(
     chimera_smb_create_release_parent(request);
     chimera_smb_complete_request(request, SMB2_STATUS_SHARING_VIOLATION);
 } /* chimera_smb_create_share_park_finish */
+
+/* Abandon a CREATE that is parked on a share-acquire ticket because its
+ * connection is being torn down (chimera_smb_async_interim_drain): cancel the
+ * ticket so the VFS pump can never resume into a dead request, then release the
+ * half-built open exactly as the DENIED resume does.  No reply is sent -- the
+ * connection is gone.  Runs on the conn's own thread. */
+void
+chimera_smb_create_abandon_share_park(struct chimera_smb_request *request)
+{
+    struct chimera_server_smb_thread *thread     = request->compound->thread;
+    struct chimera_vfs_thread        *vfs_thread = thread->vfs_thread;
+    struct chimera_vfs_state         *vfs_state  = vfs_thread->vfs->vfs_state;
+    struct chimera_smb_open_file     *open_file  = request->create.gen_parked_open;
+    struct chimera_vfs_file_state    *file_state = request->create.gen_parked_fs;
+
+    request->create.gen_parked = 0;
+
+    /* If the ticket had already fired (its resume is queued on a thread's resume
+     * doorbell) the cancel returns false and that resume still owns the open:
+     * leave the teardown to it. */
+    if (!chimera_vfs_lease_acquire_cancel(vfs_state, &request->create.gen_ticket)) {
+        return;
+    }
+
+    chimera_smb_create_pending_unregister(request);
+    chimera_vfs_state_put(vfs_state, file_state);
+    if (open_file) {
+        if (open_file->handle) {
+            chimera_vfs_release(vfs_thread, open_file->handle);
+            open_file->handle = NULL;
+        }
+        chimera_smb_open_file_free(thread, open_file);
+        request->create.gen_parked_open = NULL;
+    }
+    chimera_smb_create_release_parent(request);
+} /* chimera_smb_create_abandon_share_park */
 
 static inline uint32_t
 chimera_smb_create_granted_access(
@@ -2706,6 +2857,9 @@ chimera_smb_create_open_at_callback(
             request->create.share_conflict_retries < share_budget) {
             request->create.share_conflict_retries++;
             request->create.share_conflict_oh = oh;
+            /* Deferred without a hashed open, as for the share park above: keep
+             * the create_guid visible to a replay for the length of the retry. */
+            chimera_smb_create_pending_register(request);
             evpl_add_oneshot_timer(request->compound->thread->evpl,
                                    &request->async.timer,
                                    chimera_smb_create_share_retry_cb,
@@ -2713,11 +2867,16 @@ chimera_smb_create_open_at_callback(
             return;
         }
 
+        chimera_smb_create_pending_unregister(request);
         chimera_smb_create_release_handle(vfs_thread, oh);
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, request->create.force_close_status);
         return;
     }
+
+    /* The open is hashed now (chimera_smb_create_after_share), so any replay of
+     * it is served by the CREATE_PENDING / live-open scan from here on. */
+    chimera_smb_create_pending_unregister(request);
 
     chimera_smb_create_open_finish(request, open_file);
 } /* chimera_smb_create_open_at_callback */
@@ -3201,7 +3360,13 @@ chimera_smb_create_resume_parked_conn(
          * moment its break leaves the pending-notify state -- i.e. the
          * notification has been sent -- whereas an ordinary ack-required park
          * resumes only once the file's caching leases actually settle. */
+        /* A share-parked CREATE (gen_parked) is on this list only so CANCEL and
+         * teardown can find it: it waits on a vfs share-acquire ticket, has no
+         * park_fh, and completes through chimera_smb_create_share_park_finish.
+         * Sweeping it here would complete a create that never got its share
+         * reservation -- with SUCCESS, since park_fh_len 0 reads as "settled". */
         if (req->smb2_hdr.command == SMB2_CREATE &&
+            !req->create.gen_parked &&
             (req->create.park_on_notify
              ? !chimera_vfs_state_caching_break_pending_notify(
                  vfs_state, req->create.park_fh, req->create.park_fh_len,
@@ -3307,7 +3472,7 @@ chimera_smb_create_resume_doorbell_callback(
         pthread_mutex_lock(&thread->lease_break_lock);
         req = thread->share_resume_head;
         if (req) {
-            thread->share_resume_head = req->async.park_next;
+            thread->share_resume_head = req->create.gen_resume_next;
         }
         pthread_mutex_unlock(&thread->lease_break_lock);
 
@@ -3315,7 +3480,7 @@ chimera_smb_create_resume_doorbell_callback(
             break;
         }
 
-        req->async.park_next = NULL;
+        req->create.gen_resume_next = NULL;
         chimera_smb_create_share_park_finish(req, req->create.gen_resume_result);
     }
 
@@ -4510,17 +4675,39 @@ chimera_smb_create_guid_replay(struct chimera_smb_request *request)
         pthread_mutex_unlock(&tree->open_files_lock[b]);
     }
 
+    /* The create this replay matches may be deferred BEFORE it was hashed (parked
+     * on a conflicting holder's handle-cache break, or retrying a disconnecting
+     * durable holder), in which case the scan above cannot see it: consult the
+     * in-flight registry and answer the replay the same way a hashed pending open
+     * is answered.  Under the Windows profile the replay is not recognised here at
+     * all -- Windows lets it run the ordinary create path, where the unresolved
+     * conflict answers it SHARING_VIOLATION, which is what
+     * smb2.replay.dhv2-pending1n-vs-violation-lease-{ack,close}-windows assert;
+     * the -sane variants require the pending answer below. */
+    if (!pending_of && !match && request->is_replay &&
+        !thread->shared->config.replay_pending_windows &&
+        chimera_smb_create_pending_match(tree,
+                                         request->create.dh2q.create_guid,
+                                         request->compound->conn->client_guid)) {
+        chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+        return 1;
+    }
+
     if (pending_of) {
         /* A replay matched a still-pending create carrying this create_guid.
          * Normally the original create is genuinely in flight, so the replay is
-         * answered FILE_NOT_AVAILABLE (MS-SMB2 3.3.5.9.10).  But if that create was
+         * answered FILE_NOT_AVAILABLE -- the profile default; the Windows profile
+         * answers ACCESS_DENIED instead (see
+         * chimera_server_config_set_smb_replay_pending_windows: MS-SMB2 3.3.5.9 /
+         * 3.3.5.9.10 do not specify this race and the two real implementations
+         * diverge).  But if that create was
          * orphaned when its connection disconnected (CREATE_PENDING never resumed)
          * AND the break it parked on has since settled -- the conflicting holder
          * closed or acked -- the original create can never complete: evict the
          * resolved zombie (unhash + full teardown) and fall through to a fresh open.
          * A still-active break, or a non-orphaned pending create (which resumes
-         * normally), still yields FILE_NOT_AVAILABLE.
-         * smb2.replay.dhv2-pending2*-vs-{lease,oplock}-sane. */
+         * normally), still yields the pending answer.
+         * smb2.replay.dhv2-pending{1,2,3}*-vs-{lease,oplock}-{sane,windows}. */
         struct chimera_vfs_state *vfs_state = thread->vfs_thread->vfs->vfs_state;
         bool                      evict, won = false;
 
@@ -4534,7 +4721,10 @@ chimera_smb_create_guid_replay(struct chimera_smb_request *request)
 
         if (!evict) {
             chimera_smb_open_file_release(request, pending_of);
-            chimera_smb_complete_request(request, SMB2_STATUS_FILE_NOT_AVAILABLE);
+            chimera_smb_complete_request(request,
+                                         thread->shared->config.replay_pending_windows
+                                         ? SMB2_STATUS_ACCESS_DENIED
+                                         : SMB2_STATUS_FILE_NOT_AVAILABLE);
             return 1;
         }
 
@@ -4665,6 +4855,8 @@ chimera_smb_create(struct chimera_smb_request *request)
     request->create.access_retry_oh        = NULL;
     request->create.share_conflict_retries = 0;
     request->create.share_conflict_oh      = NULL;
+    request->create.pending_link           = NULL;
+    request->create.pending_linked         = 0;
     request->create.r_symlink_error        = 0;
     request->create.r_symlink_handle       = NULL;
 

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -9,6 +9,18 @@ chimera_smb_complete_request(
     struct chimera_smb_request *request,
     unsigned int                status);
 
+/* Drop a deferred CREATE's registration on tree->pending_creates (see
+ * smb_proc_create.c).  Idempotent; safe on a request that was never registered. */
+void
+chimera_smb_create_pending_unregister(
+    struct chimera_smb_request *request);
+
+/* Tear down a CREATE parked on a share-acquire ticket whose connection is going
+ * away (called from the async-interim drain). */
+void
+chimera_smb_create_abandon_share_park(
+    struct chimera_smb_request *request);
+
 int chimera_smb_parse_negotiate(
     struct evpl_iovec_cursor   *request_cursor,
     struct chimera_smb_request *request);

--- a/src/server/smb/smb_session.h
+++ b/src/server/smb/smb_session.h
@@ -64,9 +64,14 @@ struct chimera_smb_file_id {
  * holder to acknowledge a lease/oplock break (MS-SMB2 3.3.5.9 pending open).
  * The handle is already in the tree (so its durable create_guid is visible) but
  * the open has not completed.  A replayed durable create whose create_guid
- * matches a still-pending open must be answered STATUS_FILE_NOT_AVAILABLE
- * rather than parking a second time and timing out (MS-SMB2 3.3.5.9.10):
- * smb2.replay.dhv2-pending*. Cleared on resume / break-deadline. */
+ * matches a still-pending open is answered from the pending open rather than
+ * parking a second time and timing out: STATUS_FILE_NOT_AVAILABLE by default,
+ * STATUS_ACCESS_DENIED under the Windows profile (smb_replay_pending_windows --
+ * MS-SMB2 3.3.5.9 / 3.3.5.9.10 do not cover a create that has not completed, so
+ * the two implementations diverge).  Covers both halves of
+ * smb2.replay.dhv2-pending{1,2,3}{l,n,o}-vs-{lease,oplock}-{sane,windows}.
+ * Cleared on resume / break-deadline.  A create deferred BEFORE it is hashed
+ * (share conflict) is not covered here -- see tree->pending_creates. */
 #define CHIMERA_SMB_OPEN_FILE_CREATE_PENDING       0x00000200
 /* The file's data was modified through this open (a write occurred).  A write
  * does NOT immediately break the parent directory lease -- the file's size/mtime
@@ -78,10 +83,10 @@ struct chimera_smb_file_id {
  * still parked on a break ack: chimera_smb_async_interim_drain dropped the parked
  * request without a resume, so the open's CREATE can never complete.  It is left
  * hashed + CREATE_PENDING so a replayed durable create with this create_guid still
- * answers FILE_NOT_AVAILABLE -- until the break it waited on settles (the holder
+ * gets the pending answer -- until the break it waited on settles (the holder
  * closed/acked), at which point chimera_smb_create_guid_replay lazy-evicts the
  * resolved zombie and a replay falls through to a fresh open
- * (smb2.replay.dhv2-pending2*-vs-{lease,oplock}-sane). */
+ * (smb2.replay.dhv2-pending2*-vs-{lease,oplock}-{sane,windows}). */
 #define CHIMERA_SMB_OPEN_FILE_PENDING_ORPHANED     0x00000800
 
 /* Bits identifying which CREATE contexts a client supplied on the open. Mirrored
@@ -311,6 +316,21 @@ struct chimera_smb_tree {
 
     struct chimera_smb_open_file *open_files[CHIMERA_SMB_OPEN_FILE_BUCKETS];
     pthread_mutex_t               open_files_lock[CHIMERA_SMB_OPEN_FILE_BUCKETS];
+
+    /* DH2Q creates that are deferred BEFORE their open_file is hashed into
+     * open_files[]: a hard share conflict against a holder whose handle-caching
+     * oplock/lease is mid-break, which parks on that break (or retries a
+     * disconnecting durable holder on a timer).  Such a create is invisible to
+     * the CREATE_PENDING scan in chimera_smb_create_guid_replay -- the open is
+     * hashed only once its share reservation is granted -- so a replay of it
+     * would fall through to a fresh open and collide with the very conflict the
+     * original is waiting out (smb2.replay.dhv2-pending1n-vs-violation-lease-*).
+     * The entries live in the deferred requests themselves (no allocation) and
+     * are unlinked when the create resolves, so an entry never outlives its
+     * request.  Guarded by pending_creates_lock; the list is short (one entry per
+     * deferred create on this tree). */
+    struct chimera_smb_request   *pending_creates;
+    pthread_mutex_t               pending_creates_lock;
 
     struct chimera_smb_tree      *prev;
     struct chimera_smb_tree      *next;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -1741,23 +1741,45 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.replay
     smb2.replay.channel-sequence
     smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-lease-windows
     smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-windows
     smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-lease-windows
     smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows
     smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-lease-windows
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-windows
     smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-lease-windows
     smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-windows
     smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-lease-windows
     smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-windows
     smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-lease-windows
     smb2.replay.dhv2-pending2o-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-windows
     smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-lease-windows
     smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-windows
     smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-lease-windows
     smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-windows
     smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-lease-windows
     smb2.replay.dhv2-pending3o-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-windows
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -2323,23 +2345,45 @@ set(SMBTORTURE_ENABLED_linux
     # smb2.replay
     smb2.replay.channel-sequence
     smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-lease-windows
     smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-windows
     smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-lease-windows
     smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows
     smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-lease-windows
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-windows
     smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-lease-windows
     smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-windows
     smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-lease-windows
     smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-windows
     smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-lease-windows
     smb2.replay.dhv2-pending2o-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-windows
     smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-lease-windows
     smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-windows
     smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-lease-windows
     smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-windows
     smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-lease-windows
     smb2.replay.dhv2-pending3o-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-windows
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -2846,23 +2890,45 @@ set(SMBTORTURE_ENABLED_io_uring
     # smb2.replay
     smb2.replay.channel-sequence
     smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-lease-windows
     smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-windows
     smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-lease-windows
     smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows
     smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-lease-windows
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-windows
     smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-lease-windows
     smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-windows
     smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-lease-windows
     smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-windows
     smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-lease-windows
     smb2.replay.dhv2-pending2o-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-windows
     smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-lease-windows
     smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-windows
     smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-lease-windows
     smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-windows
     smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-lease-windows
     smb2.replay.dhv2-pending3o-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-windows
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -3397,23 +3463,45 @@ set(SMBTORTURE_ENABLED_cairn
     # smb2.replay
     smb2.replay.channel-sequence
     smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-lease-windows
     smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-windows
     smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-lease-windows
     smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows
     smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-lease-windows
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-windows
     smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-lease-windows
     smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-windows
     smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-lease-windows
     smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-windows
     smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-lease-windows
     smb2.replay.dhv2-pending2o-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-windows
     smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-lease-windows
     smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-windows
     smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-lease-windows
     smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-windows
     smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-lease-windows
     smb2.replay.dhv2-pending3o-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-windows
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -3976,23 +4064,45 @@ set(SMBTORTURE_ENABLED_diskfs_io_uring
     # smb2.replay
     smb2.replay.channel-sequence
     smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-lease-windows
     smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-windows
     smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-lease-windows
     smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows
     smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-lease-windows
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-windows
     smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-lease-windows
     smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-windows
     smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-lease-windows
     smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-windows
     smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-lease-windows
     smb2.replay.dhv2-pending2o-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-windows
     smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-lease-windows
     smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-windows
     smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-lease-windows
     smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-windows
     smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-lease-windows
     smb2.replay.dhv2-pending3o-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-windows
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -4552,23 +4662,45 @@ set(SMBTORTURE_ENABLED_diskfs_aio
     # smb2.replay
     smb2.replay.channel-sequence
     smb2.replay.dhv2-pending1l-vs-lease-sane
+    smb2.replay.dhv2-pending1l-vs-lease-windows
     smb2.replay.dhv2-pending1l-vs-oplock-sane
+    smb2.replay.dhv2-pending1l-vs-oplock-windows
     smb2.replay.dhv2-pending1n-vs-lease-sane
+    smb2.replay.dhv2-pending1n-vs-lease-windows
     smb2.replay.dhv2-pending1n-vs-oplock-sane
+    smb2.replay.dhv2-pending1n-vs-oplock-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-ack-windows
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-sane
+    smb2.replay.dhv2-pending1n-vs-violation-lease-close-windows
     smb2.replay.dhv2-pending1o-vs-lease-sane
+    smb2.replay.dhv2-pending1o-vs-lease-windows
     smb2.replay.dhv2-pending1o-vs-oplock-sane
+    smb2.replay.dhv2-pending1o-vs-oplock-windows
     smb2.replay.dhv2-pending2l-vs-lease-sane
+    smb2.replay.dhv2-pending2l-vs-lease-windows
     smb2.replay.dhv2-pending2l-vs-oplock-sane
+    smb2.replay.dhv2-pending2l-vs-oplock-windows
     smb2.replay.dhv2-pending2n-vs-lease-sane
+    smb2.replay.dhv2-pending2n-vs-lease-windows
     smb2.replay.dhv2-pending2n-vs-oplock-sane
+    smb2.replay.dhv2-pending2n-vs-oplock-windows
     smb2.replay.dhv2-pending2o-vs-lease-sane
+    smb2.replay.dhv2-pending2o-vs-lease-windows
     smb2.replay.dhv2-pending2o-vs-oplock-sane
+    smb2.replay.dhv2-pending2o-vs-oplock-windows
     smb2.replay.dhv2-pending3l-vs-lease-sane
+    smb2.replay.dhv2-pending3l-vs-lease-windows
     smb2.replay.dhv2-pending3l-vs-oplock-sane
+    smb2.replay.dhv2-pending3l-vs-oplock-windows
     smb2.replay.dhv2-pending3n-vs-lease-sane
+    smb2.replay.dhv2-pending3n-vs-lease-windows
     smb2.replay.dhv2-pending3n-vs-oplock-sane
+    smb2.replay.dhv2-pending3n-vs-oplock-windows
     smb2.replay.dhv2-pending3o-vs-lease-sane
+    smb2.replay.dhv2-pending3o-vs-lease-windows
     smb2.replay.dhv2-pending3o-vs-oplock-sane
+    smb2.replay.dhv2-pending3o-vs-oplock-windows
     smb2.replay.durable-reconnect-replay1
     smb2.replay.durable-reconnect-replay2
     smb2.replay.durable-reconnect-replay3
@@ -4747,6 +4879,12 @@ set(SMBTORTURE_ISOLATE_SUITES
     smb2.durable-v2-open
     smb2.lease
     smb2.oplock
+    # smb2.replay must ALSO stay per-subtest for a second, non-timing reason: the
+    # driver selects the replay-vs-pending-create profile per subtest name
+    # (smb_replay_pending_windows for dhv2-pending*-windows, default for
+    # *-sane), and those two profiles cannot coexist in one daemon.  A
+    # consolidated run would put every subtest in whichever profile the batch
+    # happened to select and fail the other half.
     smb2.replay
     # smb2.session needs per-subtest isolation: the anon-encryption* cases make
     # the test driver enable SMB3 transport encryption for the whole daemon, and

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -477,6 +477,51 @@ main(
         }
     }
 
+    /* The smb2.replay.dhv2-pending*-{sane,windows} pairs send byte-identical
+     * traffic and differ only in the status each requires for a replayed durable
+     * create that collides with a still-deferred create: FILE_NOT_AVAILABLE
+     * (Samba, the chimera default) vs ACCESS_DENIED (Windows).  No server can
+     * satisfy both, so the -windows variants run against a daemon put in the
+     * Windows profile; the -sane variants keep the default.  Both halves are
+     * gated, which is what keeps the non-default profile from rotting.  This
+     * works only because smb2.replay is in SMBTORTURE_ISOLATE_SUITES (one daemon
+     * per subtest) so the knob cannot bleed into a -sane case; the refusal below
+     * enforces that rather than trusting the note in that list. */
+    {
+        int want_windows = 0, want_sane = 0;
+
+        for (i = 0; i < num_tests; i++) {
+            if (strstr(tests[i], "dhv2-pending") == NULL) {
+                continue;
+            }
+            if (strstr(tests[i], "-windows") != NULL) {
+                want_windows = 1;
+            } else if (strstr(tests[i], "-sane") != NULL) {
+                want_sane = 1;
+            }
+        }
+
+        /* Both halves in one invocation means one daemon would have to answer a
+         * replayed create two different ways: whichever profile we picked, the
+         * other half would fail and read as a protocol regression rather than a
+         * harness mistake.  Refuse instead -- the only way to get here is to
+         * consolidate smb2.replay, so say what to do about it. */
+        if (want_windows && want_sane) {
+            fprintf(stderr,
+                    "smbtorture_test: refusing to run dhv2-pending -sane and "
+                    "-windows subtests in one daemon: they require mutually "
+                    "exclusive replay-vs-pending-create profiles.  Keep "
+                    "smb2.replay in SMBTORTURE_ISOLATE_SUITES so each subtest "
+                    "gets its own daemon.\n");
+            test_cleanup(&env, 0);
+            return EXIT_FAILURE;
+        }
+
+        if (want_windows) {
+            chimera_server_config_set_smb_replay_pending_windows(config, 1);
+        }
+    }
+
     /* Configure backend-specific modules */
     if (strcmp(backend, "diskfs_io_uring") == 0 ||
         strcmp(backend, "diskfs_aio") == 0) {

--- a/src/vfs/tests/vfs_state_test.c
+++ b/src/vfs/tests/vfs_state_test.c
@@ -1040,6 +1040,116 @@ test_nonbreakable_share_denies(void)
     chimera_vfs_state_destroy(state);
 } /* test_nonbreakable_share_denies */
 
+/* Test 19: the share-conflict escape onto a handle-caching RqLs lease must
+* never land on the ACQUIRER's own lease.  A second open under one LeaseKey
+* presents that key on both opens, so the escape's RqLs arm -- which matches a
+* holder's lease via the own_lease_key stamped on its share reservation -- would
+* otherwise match the probe's own lease and break a handle cache the client is
+* still using, parking the conflicting open behind its own ack.  A DIFFERENT
+* key must still escape, or a conflicting open could never wait for a
+* handle-lease holder to close. ---------------------------------------- */
+static void
+test_share_escape_skips_own_lease(void)
+{
+    struct chimera_vfs_state         *state;
+    struct chimera_vfs_file_state    *file;
+    struct chimera_vfs_caching_grant *grant = NULL;
+    struct chimera_vfs_lease_owner    lease_owner;
+    struct chimera_vfs_lease_mode     want;
+    struct chimera_vfs_lease          holder, probe;
+    enum chimera_vfs_lease_result     r;
+    struct chimera_vfs_lease         *conflict    = NULL;
+    struct break_recorder             rec         = { 0 };
+    int                               holder_open = 0; /* stands in for open_file */
+
+    fprintf(stderr, "\ntest_share_escape_skips_own_lease\n");
+
+    state = chimera_vfs_state_init();
+    file  = get_file(state, 1);
+
+    /* The holder's RqLs lease under LeaseKey 0x1111/0x2222: RWH, breakable,
+     * keyed by lease key (is_lease), with a grant that is neither an oplock nor
+     * a directory lease -- the shape the escape's RqLs arm matches. */
+    init_owner(&lease_owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 0x1111);
+    lease_owner.owner_hi   = 0x2222;
+    lease_owner.is_lease   = 1;
+    lease_owner.break_cb   = recording_break_cb;
+    lease_owner.cb_private = &rec;
+
+    want.granted = CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W |
+        CHIMERA_VFS_LEASE_MODE_H;
+    want.denied = 0;
+
+    r = chimera_vfs_caching_grant_acquire(state, file, &lease_owner, want, 0,
+                                          &grant, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED && grant, "holder RWH lease granted");
+
+    /* The holder's open: ShareAccess=0 (denies R and W), NOT breakable (an
+     * ordinary client open), carrying the lease key that links it to the lease
+     * above. */
+    memset(&holder, 0, sizeof(holder));
+    holder.kind         = CHIMERA_VFS_LEASE_SHARE;
+    holder.mode.granted = CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W;
+    holder.mode.denied  = CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W;
+    init_owner(&holder.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 1);
+    holder.owner.owner_hi    = 1;
+    holder.owner.cb_private  = &holder_open;
+    holder.has_own_lease_key = 1;
+    holder.own_lease_lo      = 0x1111;
+    holder.own_lease_hi      = 0x2222;
+
+    r = chimera_vfs_state_try_insert(state, file, &holder, &conflict);
+    CHECK(r == CHIMERA_VFS_LEASE_GRANTED, "holder deny-all open granted");
+
+    /* Same client, SAME LeaseKey, a second open that share-conflicts.  The
+     * conflict is real and stands, but it must be answered without breaking the
+     * client's own lease. */
+    rec.fired = 0;
+    memset(&probe, 0, sizeof(probe));
+    probe.kind         = CHIMERA_VFS_LEASE_SHARE;
+    probe.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    init_owner(&probe.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 2);
+    probe.owner.owner_hi     = 2;
+    probe.has_break_skip_key = 1;
+    probe.break_skip_lo      = 0x1111;
+    probe.break_skip_hi      = 0x2222;
+
+    r = chimera_vfs_state_try_insert(state, file, &probe, &conflict);
+    chimera_vfs_state_conflict_unref(state, conflict);
+    conflict = NULL;
+    CHECK(r == CHIMERA_VFS_LEASE_DENIED,
+          "same-lease-key second open denied, not parked");
+    CHECK(rec.fired == 0, "own handle lease not broken by its own opener");
+
+    /* A different LeaseKey is a genuine peer: the escape applies, so the open
+     * parks on the holder's HANDLE break instead of being denied outright. */
+    memset(&probe, 0, sizeof(probe));
+    probe.kind         = CHIMERA_VFS_LEASE_SHARE;
+    probe.mode.granted = CHIMERA_VFS_LEASE_MODE_R;
+    init_owner(&probe.owner, CHIMERA_VFS_LEASE_PROTO_SMB2, 0xA, 3);
+    probe.owner.owner_hi     = 3;
+    probe.has_break_skip_key = 1;
+    probe.break_skip_lo      = 0x3333;
+    probe.break_skip_hi      = 0x4444;
+
+    r = chimera_vfs_state_try_insert(state, file, &probe, &conflict);
+    chimera_vfs_state_conflict_unref(state, conflict);
+    conflict = NULL;
+    CHECK(r == CHIMERA_VFS_LEASE_BREAKING,
+          "different-lease-key open still escapes onto the H break");
+    CHECK(rec.fired == 1, "holder lease broken for a peer opener");
+    CHECK((rec.last_needed_mode & CHIMERA_VFS_LEASE_MODE_H) == 0 &&
+          (rec.last_needed_mode &
+           (CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W)) ==
+          (CHIMERA_VFS_LEASE_MODE_R | CHIMERA_VFS_LEASE_MODE_W),
+          "break drops H only, leaving read/write caching (RWH -> RW)");
+
+    chimera_vfs_state_remove(state, file, &holder);
+    chimera_vfs_caching_grant_release(state, grant, false);
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_share_escape_skips_own_lease */
+
 /* Main ---------------------------------------------------------------- */
 int
 main(
@@ -1070,6 +1180,7 @@ main(
     test_lease_test();
     test_breakable_share_recall();
     test_nonbreakable_share_denies();
+    test_share_escape_skips_own_lease();
 
     fprintf(stderr, "\n========================================\n");
     fprintf(stderr, "Results: %d passed, %d failed\n", passed, failed);

--- a/src/vfs/vfs_lease_types.h
+++ b/src/vfs/vfs_lease_types.h
@@ -166,6 +166,18 @@ struct chimera_vfs_lease {
     uint64_t                          break_skip_lo;
     uint64_t                          break_skip_hi;
 
+    /* For a SHARE reservation only: the LeaseKey of the SMB2 RqLs caching lease
+     * that the SAME open holds, when it holds one.  A hard share conflict against
+     * this open may still be resolvable -- if that lease caches the handle, the
+     * holder can be told to relinquish it and may close, freeing the conflict --
+     * but an RqLs lease is keyed by LeaseKey while the share reservation is keyed
+     * by open, so nothing else links the two (chimera_vfs_share_batch_escape).
+     * Set by the SMB server when a lease-bearing open takes its share
+     * reservation; left zero by every other caller. */
+    uint8_t                           has_own_lease_key;
+    uint64_t                          own_lease_lo;
+    uint64_t                          own_lease_hi;
+
     /* Set by the SMB server when this caching lease's owning open is PARKED as a
      * disconnected durable handle (MS-SMB2 "courtesy-held" open).  A parked
      * holder with no write cache is treated as non-conflicting for the

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -758,11 +758,15 @@ chimera_vfs_eval_breakable(
  * common owning open (cb_private, set identically on an SMB open's share
  * reservation and caching lease) -- so a SHARE acquire can park on its break
  * instead of denying outright.  Returns NULL when the holder has no
- * still-breakable handle-caching lease, i.e. a genuine hard conflict. */
+ * still-breakable handle-caching lease, i.e. a genuine hard conflict.
+ *
+ * `probe` is the acquiring lease, needed only so the RqLs arm can skip the
+ * acquirer's OWN caching lease (see the same-key skip below). */
 static inline struct chimera_vfs_lease *
 chimera_vfs_share_batch_escape(
     const struct chimera_vfs_file_state *file,
-    const struct chimera_vfs_lease      *share_holder)
+    const struct chimera_vfs_lease      *share_holder,
+    const struct chimera_vfs_lease      *probe)
 {
     struct chimera_vfs_lease *cur;
 
@@ -810,11 +814,30 @@ chimera_vfs_share_batch_escape(
          * and keeps the handle -> SHARING_VIOLATION).  Note this does NOT make an
          * RqLs lease sole-handle across clients: only a genuine share-mode
          * conflict reaches here, and a compatible open still coexists with the
-         * holder's H via the caching matrix. */
+         * holder's H via the caching matrix.
+         *
+         * The escape must never land on the ACQUIRER's own caching lease.  A
+         * second open under one LeaseKey presents that key on both opens, so
+         * without the skip the arm matches the probe's own lease: same
+         * client_key, and the holder's own_lease_* IS the probe's key.  The
+         * client would then be told to relinquish a handle cache it is still
+         * using, and its conflicting open would park behind its own break ack
+         * before the share conflict was answered at all -- where MS-SMB2 has a
+         * create never break the lease it presents.  This mirrors the
+         * SHARE-acquire skip in chimera_vfs_state_would_conflict's caching loop
+         * and chimera_vfs_lease_smb2_same_key; the escape needs `probe` passed in
+         * to apply it.  Deliberately scoped to this arm: a legacy oplock's
+         * caching lease is keyed by open rather than by LeaseKey, and the
+         * dir-lease arm matches by client alone (pre-existing, untouched here). */
+        bool probe_owns_lease =
+            probe->has_break_skip_key &&
+            cur->owner.owner_lo == probe->break_skip_lo &&
+            cur->owner.owner_hi == probe->break_skip_hi;
+
         bool rqls_lease_match =
             cur->grant && !cur->grant->is_oplock && !cur->grant->is_dir &&
             share_holder->has_own_lease_key &&
-            cur->owner.is_lease &&
+            cur->owner.is_lease && !probe_owns_lease &&
             cur->owner.client_key == share_holder->owner.client_key &&
             cur->owner.owner_lo == share_holder->own_lease_lo &&
             cur->owner.owner_hi == share_holder->own_lease_hi;
@@ -1004,7 +1027,7 @@ chimera_vfs_state_would_conflict(
                 if (chimera_vfs_eval_breakable(cur, &has_breakable_conflict,
                                                &idle_break, &expired_break)) {
                     struct chimera_vfs_lease *batch =
-                        chimera_vfs_share_batch_escape(file, cur);
+                        chimera_vfs_share_batch_escape(file, cur, probe);
 
                     if (!batch) {
                         if (conflict_out) {

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -799,9 +799,28 @@ chimera_vfs_share_batch_escape(
         bool dir_lease_match =
             cur->grant && cur->grant->is_dir &&
             cur->owner.client_key == share_holder->owner.client_key;
+        /* An RqLs FILE lease is keyed by LeaseKey, so neither cb_private (the
+         * grant) nor owner_lo/hi (the key) matches the share holder's open;
+         * the holder's own lease key, stamped on its share reservation when the
+         * open took it, is the link.  A conflicting open must be able to park on
+         * such a lease's HANDLE break exactly as it parks on a batch oplock's:
+         * the holder may close its handle-cached open and free the conflict
+         * (MS-FSA break-before-share; smb2.replay.dhv2-pending1n-vs-violation-
+         * lease-*, where the holder either closes -> the open is granted, or acks
+         * and keeps the handle -> SHARING_VIOLATION).  Note this does NOT make an
+         * RqLs lease sole-handle across clients: only a genuine share-mode
+         * conflict reaches here, and a compatible open still coexists with the
+         * holder's H via the caching matrix. */
+        bool rqls_lease_match =
+            cur->grant && !cur->grant->is_oplock && !cur->grant->is_dir &&
+            share_holder->has_own_lease_key &&
+            cur->owner.is_lease &&
+            cur->owner.client_key == share_holder->owner.client_key &&
+            cur->owner.owner_lo == share_holder->own_lease_lo &&
+            cur->owner.owner_hi == share_holder->own_lease_hi;
 
         if (cur->owner.cb_private != share_holder->owner.cb_private &&
-            !legacy_oplock_match && !dir_lease_match) {
+            !legacy_oplock_match && !dir_lease_match && !rqls_lease_match) {
             continue;
         }
 
@@ -1524,9 +1543,21 @@ chimera_vfs_state_try_insert(
                  * holder may close and free the share conflict (else it stands ->
                  * SHARING_VIOLATION).  A SHARE acquirer carries no H bit, so the
                  * generic retain floor would leave H intact; force it off for a
-                 * directory-lease conflict (dirlease.v2_request / rename_dst_parent). */
+                 * directory-lease conflict (dirlease.v2_request / rename_dst_parent).
+                 *
+                 * The same applies to a FILE lease whose handle cache is what a
+                 * hard share conflict must dislodge (the RqLs arm of
+                 * chimera_vfs_share_batch_escape): break H and ONLY H, leaving the
+                 * holder's read/write caching alone -- the conflicting open never
+                 * gains access unless the holder closes, so its cached data stays
+                 * valid (smb2.replay.dhv2-pending1n-vs-violation-lease-* assert
+                 * exactly one break, RWH -> RW). */
                 if (conflict->kind == CHIMERA_VFS_LEASE_CACHING &&
-                    conflict->grant && conflict->grant->is_dir) {
+                    conflict->grant &&
+                    (conflict->grant->is_dir ||
+                     (lease->kind == CHIMERA_VFS_LEASE_SHARE &&
+                      !conflict->grant->is_oplock &&
+                      (conflict->mode.granted & CHIMERA_VFS_LEASE_MODE_H)))) {
                     floor = conflict->mode.granted & ~CHIMERA_VFS_LEASE_MODE_H;
                 }
 
@@ -2725,6 +2756,7 @@ chimera_vfs_lease_ack(
 SYMBOL_EXPORT void
 chimera_vfs_lease_revoke(struct chimera_vfs_lease *lease)
 {
+
     struct chimera_vfs_file_state *file = lease->file;
     chimera_vfs_lease_revoked_cb_t revoked_cb;
     void                          *cb_private;


### PR DESCRIPTION
This PR introduces three categories of behavior change along with a change to test methodology so that we can satisfy tests that depend on a mutually exclusive behavior around error reporting.

1. Fix replay open behavior with durable handles
2. Fix open conflict behavior in the presence of RqLs lease
3. Create behavior knob for error status in the case of pending (partially created) open and modify test behavior to select the knob appropriately for replay tests that depend on a particular behavior. We are creating an equivalent to the "-sane" and "-windows" setting in Samba.

These changes resolve all the smb2.replay.dhv2-pending* tests on all six VFS backends.

Additional AI generated detail:

## 1. Conflicting opens now park on a handle-caching *lease* break

`chimera_vfs_share_batch_escape` recognised only legacy batch oplocks and
directory leases, so a hard share conflict against a holder whose handle
caching came from an **RqLs lease** never took the park path. It fell through
to the disconnecting-durable retry timer, which lapsed after ~0.5 s into
`SHARING_VIOLATION`.

That is wrong in both directions: the holder is told to relinquish its handle
cache (we already fired that break) but we never wait to see whether it does,
so an open that should succeed once the holder closes is refused, and an open
that should be refused is refused for the wrong reason (a timeout, not the
holder's decision).

**Before:** conflicting open → immediate `SHARING_VIOLATION` after ~0.5 s.
**After:** interim `STATUS_PENDING`, then either `SUCCESS` when the holder
closes, or `SHARING_VIOLATION` when the holder acks and keeps its handle — with
the 30 s break deadline as the backstop. This matches what MS-FSA specifies
(break before the share check) and what both Windows and Samba do.

Applications that relied on failing fast against an exclusively-held file will
now block for the break window instead. That is the intended semantics, but it
is the change most worth a second opinion.

Mechanics:
- A share reservation carries its own lease key (`has_own_lease_key`) so the VFS
  can link a share holder to its RqLs lease — an RqLs lease is keyed by LeaseKey
  while the reservation is keyed by open, so nothing else connects them.
- The break floor for this case drops **HANDLE only**, leaving the holder's
  read/write caching intact: the conflicting open gains no access unless the
  holder closes, so its cached data stays valid. (`RWH → RW`, which is what the
  tests assert.)
- Unchanged for compatible opens: an RqLs lease is still not sole-handle across
  clients. Only a genuine share-mode conflict reaches this path.

## 2. Deferred creates are visible to the DH2Q replay lookup

An open is hashed into `tree->open_files[]` only once its share reservation is
granted, so a create deferred *before* that carried a `create_guid` no lookup
could see. A replay of it fell through to a fresh open and collided with the
very conflict the original was waiting out.

`tree->pending_creates` publishes those in-flight `create_guid`s. Entries live
in the deferred requests themselves (no allocation, and an entry cannot outlive
its request), and are dropped at the moment the open becomes visible in
`open_files[]`, so there is no window where neither lookup can see the create.


## 3. The replay-vs-pending-create answer is now a profile

MS-SMB2 3.3.5.9 / 3.3.5.9.10 describe the replay lookup against a fully
initialised `Open` and say nothing about one whose create has not completed, so
the two real implementations diverge and neither is non-conformant:

| | answer | client consequence |
|---|---|---|
| Samba (**our default**) | `FILE_NOT_AVAILABLE` | transient: retried 3×, then every 5 s to the resiliency timeout, so the replay succeeds once the original create completes |
| Windows | `ACCESS_DENIED` | terminal: reported to the application |

`smb_replay_pending_windows` (bool, default `false`, JSON-settable, documented
in `docs/configuration.md`) selects the Windows profile. It covers both halves
of that profile: the status, and Windows' non-detection of a replay while the
original create is deferred on a share conflict. Rationale for the default is
the retry semantics above (see [Samba bug
14449](https://bugzilla.samba.org/show_bug.cgi?id=14449)); the previous code
comments citing 3.3.5.9.10 as *mandating* `FILE_NOT_AVAILABLE` overstated the
spec and have been corrected.

This follows the existing `smb_acl_inherited_canonicalize` pattern: a documented
policy knob with a default, which the smbtorture driver flips for the one suite
asserting the other behaviour.

## 5. Test matrix

The 40 subtests are **20 matched pairs** — one wire scenario each, with two
permitted answers. Any single server configuration satisfies exactly one member
of every pair, so **20/40 is the ceiling for one config**; the driver runs each
half against a daemon in the matching profile, which is how all 40 go green.

Read the cell count accordingly: the 108 newly-green cells (18 × 6 backends) are
one code path in each direction, not 108 units of new capability. What is
genuinely new is the Windows profile itself plus the three defects in §1–§3.

- All 40 enabled in `SMBTORTURE_ENABLED_<backend>` for all six backends (240
  cells). Regen-stable: `regen.sh` measures through the same driver.
- Nothing added to `SMBTORTURE_DISABLED_SUBTESTS`; that list is unchanged from
  `main`, `smb2.oplock.levelii500` included (no knob exists for that one).
- `smb2.replay` **must** stay in `SMBTORTURE_ISOLATE_SUITES` — the profile is
  selected per subtest, so a consolidated run would put both halves in one
  daemon. The driver now *refuses* such a batch with a message naming the fix,
  rather than trusting a comment.

## Verification

- 40 `dhv2-pending` subtests × 6 backends: all pass.
- `ctest -R smbtorture_smb2_replay` (354 cells, 6 backends): **two consecutive
  runs, 354/354** — this cluster was deterministic before and stays so.
- lease / oplock / durable / dirlease gated families: 268/268 (memfs + linux).
- 226-subtest manual sweep of the affected families on memfs: 13 failures, all
  pre-existing at the identical assert line as the pre-change baseline, none
  gated.
- Debug/ASAN: violation family and the disconnect-race durable tests clean.
- `make syntax-check` clean; `scan-build` (release) reports no bugs; unit tests
  including `chimera/vfs/state_test` pass.

## Notes for reviewers

- §1 is the change with real blast radius; §4 is the smallest piece despite
  being the most visible one in the test names.
- `smb_replay_pending_windows` has no consumer outside the test harness today.
  It is a real interop profile and CI exercises both values on six backends, but
  the test is currently its only oracle — same trade as
  `smb_acl_inherited_canonicalize`.
- One boolean gates two mechanisms (status + replay detection) because they are
  two halves of one observed profile; splitting them would permit combinations
  no real server exhibits.
- `tree->pending_creates` holds one entry per *concurrently deferred* create on
  that tree, not one per open.
