### PR TITLE
tests: drive smbtorture ADS selection from a shared list

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2404,10 +2404,12 @@ chimera_smb_create_open_stream_chain(
 
     if (!(base_oh->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
         /* Gate 2: the feature is configured on, but this backend cannot do it.
-         * Distinct from the gate in chimera_smb_create_start(), which fires when
-         * the feature is off entirely -- both return OBJECT_NAME_INVALID, so the
-         * log line is the only way to tell them apart after the fact. */
-        chimera_smb_info(
+         * Distinct from the gate in chimera_smb_create(), which fires when the
+         * feature is off entirely -- both return OBJECT_NAME_INVALID, so the log
+         * line is the only way to tell them apart after the fact.  Debug level:
+         * the rejected name is client-controlled and clients probe stream paths
+         * on essentially every file, so this must not be on by default. */
+        chimera_smb_debug(
             "named streams: backend '%s' does not advertise CHIMERA_VFS_CAP_"
             "NAMED_STREAMS; rejecting stream CREATE '%.*s:%.*s'",
             base_oh->vfs_module->name,
@@ -4891,11 +4893,18 @@ chimera_smb_create(struct chimera_smb_request *request)
             /* Gate 1: the feature is off in config, so the name is refused
              * before any backend is consulted.  Indistinguishable on the wire
              * from gate 2 in chimera_smb_create_open_stream_chain() ("backend
-             * cannot do this") -- both are OBJECT_NAME_INVALID, which is
-             * correct but hid a cluster of misconfigured smbtorture subtests
-             *.  Log which one fired; tools/smbtorture/derive_ads.sh
-             * harvests this line to rediscover the tests that need the feature. */
-            chimera_smb_info(
+             * cannot do this") -- both are OBJECT_NAME_INVALID, which is correct
+             * but hid a cluster of misconfigured smbtorture subtests.  Log which
+             * one fired; tools/smbtorture/derive_ads.sh harvests this line to
+             * rediscover the tests that need the feature.
+             *
+             * Debug level, not info: named_streams is off by default, and macOS
+             * clients probe ':AFP_AfpInfo' / ':com.apple.ResourceFork' while
+             * Windows probes ':Zone.Identifier' on essentially every file, so at
+             * info a directory browse would emit a line per file -- unbounded,
+             * client-driven log volume carrying a client-controlled path.  The
+             * sweep raises the level itself via SMBTORTURE_LOG_LEVEL. */
+            chimera_smb_debug(
                 "named streams: disabled by config; rejecting stream CREATE '%.*s'",
                 request->create.name_len, request->create.name);
             chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2403,6 +2403,16 @@ chimera_smb_create_open_stream_chain(
     unsigned int               sflags     = 0;
 
     if (!(base_oh->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        /* Gate 2: the feature is configured on, but this backend cannot do it.
+         * Distinct from the gate in chimera_smb_create_start(), which fires when
+         * the feature is off entirely -- both return OBJECT_NAME_INVALID, so the
+         * log line is the only way to tell them apart after the fact. */
+        chimera_smb_info(
+            "named streams: backend '%s' does not advertise CHIMERA_VFS_CAP_"
+            "NAMED_STREAMS; rejecting stream CREATE '%.*s:%.*s'",
+            base_oh->vfs_module->name,
+            request->create.name_len, request->create.name,
+            request->create.stream_name_len, request->create.stream_name);
         chimera_vfs_release(vfs_thread, base_oh);
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
@@ -4878,6 +4888,16 @@ chimera_smb_create(struct chimera_smb_request *request)
         memchr(request->create.name, ':', request->create.name_len)) {
 
         if (!request->compound->thread->shared->config.named_streams) {
+            /* Gate 1: the feature is off in config, so the name is refused
+             * before any backend is consulted.  Indistinguishable on the wire
+             * from gate 2 in chimera_smb_create_open_stream_chain() ("backend
+             * cannot do this") -- both are OBJECT_NAME_INVALID, which is
+             * correct but hid a cluster of misconfigured smbtorture subtests
+             *.  Log which one fired; tools/smbtorture/derive_ads.sh
+             * harvests this line to rediscover the tests that need the feature. */
+            chimera_smb_info(
+                "named streams: disabled by config; rejecting stream CREATE '%.*s'",
+                request->create.name_len, request->create.name);
             chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
             return;
         }

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2403,6 +2403,18 @@ chimera_smb_create_open_stream_chain(
     unsigned int               sflags     = 0;
 
     if (!(base_oh->vfs_module->capabilities & CHIMERA_VFS_CAP_NAMED_STREAMS)) {
+        /* Gate 2: the feature is configured on, but this backend cannot do it.
+         * Distinct from the gate in chimera_smb_create(), which fires when the
+         * feature is off entirely -- both return OBJECT_NAME_INVALID, so the log
+         * line is the only way to tell them apart after the fact.  Debug level:
+         * the rejected name is client-controlled and clients probe stream paths
+         * on essentially every file, so this must not be on by default. */
+        chimera_smb_debug(
+            "named streams: backend '%s' does not advertise CHIMERA_VFS_CAP_"
+            "NAMED_STREAMS; rejecting stream CREATE '%.*s:%.*s'",
+            base_oh->vfs_module->name,
+            request->create.name_len, request->create.name,
+            request->create.stream_name_len, request->create.stream_name);
         chimera_vfs_release(vfs_thread, base_oh);
         chimera_smb_create_release_parent(request);
         chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
@@ -4878,6 +4890,26 @@ chimera_smb_create(struct chimera_smb_request *request)
         memchr(request->create.name, ':', request->create.name_len)) {
 
         if (!request->compound->thread->shared->config.named_streams) {
+            /* Gate 1: the feature is off in config, so the name is refused
+             * before any backend is consulted.  Indistinguishable on the wire
+             * from gate 2 in chimera_smb_create_open_stream_chain() ("backend
+             * cannot do this") -- both are OBJECT_NAME_INVALID, which is correct
+             * but hid a cluster of misconfigured smbtorture subtests.  Log
+             * which one fired: it is where investigating such a subtest starts.
+             * What decides whether that subtest belongs in
+             * smbtorture_ads_subtests.txt is the off/on outcome pair described
+             * there, not this line -- a subtest can trip this gate and pass
+             * BECAUSE it does.
+             *
+             * Debug level, not info: named_streams is off by default, and macOS
+             * clients probe ':AFP_AfpInfo' / ':com.apple.ResourceFork' while
+             * Windows probes ':Zone.Identifier' on essentially every file, so at
+             * info a directory browse would emit a line per file -- unbounded,
+             * client-driven log volume carrying a client-controlled path.  The
+             * sweep raises the level itself via SMBTORTURE_LOG_LEVEL. */
+            chimera_smb_debug(
+                "named streams: disabled by config; rejecting stream CREATE '%.*s'",
+                request->create.name_len, request->create.name);
             chimera_smb_complete_request(request, SMB2_STATUS_OBJECT_NAME_INVALID);
             return;
         }

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -505,13 +505,19 @@ target_include_directories(smbtorture_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 # both the driver (at run time, to set the config knob) and this file (at
 # configure time, to scope that knob under ctest -- see
 # add_smbtorture_backend_tests).  Editing the list re-runs cmake.
-set(SMBTORTURE_ADS_LIST ${CMAKE_CURRENT_SOURCE_DIR}/smbtorture_ads_subtests.txt)
+#
+# The driver opens this by absolute path at run time and treats a failure to
+# read it as EXIT_FAILURE (not the suites' SKIP_RETURN_CODE 77), so the copy it
+# points at must be the one guaranteed to exist wherever ctest runs: the build
+# tree, not the source tree.  configure_file COPYONLY also registers the source
+# as a configure dependency, so editing the list still re-runs cmake.
+set(SMBTORTURE_ADS_LIST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/smbtorture_ads_subtests.txt)
+set(SMBTORTURE_ADS_LIST ${CMAKE_CURRENT_BINARY_DIR}/smbtorture_ads_subtests.txt)
+configure_file(${SMBTORTURE_ADS_LIST_SRC} ${SMBTORTURE_ADS_LIST} COPYONLY)
 target_compile_definitions(smbtorture_test
     PRIVATE SMBTORTURE_ADS_LIST="${SMBTORTURE_ADS_LIST}")
-set_property(DIRECTORY APPEND
-    PROPERTY CMAKE_CONFIGURE_DEPENDS ${SMBTORTURE_ADS_LIST})
 
-file(STRINGS ${SMBTORTURE_ADS_LIST} _ads_lines)
+file(STRINGS ${SMBTORTURE_ADS_LIST_SRC} _ads_lines)
 set(SMBTORTURE_ADS_PATTERNS "")
 foreach(_line ${_ads_lines})
     string(REGEX REPLACE "#.*$" "" _line "${_line}")
@@ -5120,10 +5126,26 @@ macro(add_smbtorture_backend_tests backend)
                 _smbtorture_add_subtest(${backend} "${_sub}")
             endforeach()
         elseif(_plain AND _ads)
-            _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_plain})
-            foreach(_sub ${_ads})
-                _smbtorture_add_subtest(${backend} "${_sub}")
-            endforeach()
+            # _smbtorture_add_suite names the ctest entry from the mangled PARENT
+            # and _smbtorture_add_subtest from the mangled SUBTEST, which are the
+            # same string for a bare two-component test.  So if the suite's own
+            # bare name is the ADS member, registering both here would be a
+            # duplicate add_test NAME and cmake would hard-fail.  No parent in
+            # today's catalog has both a bare entry and dotted siblings, but the
+            # three bare ADS entries (smb2.ioctl-on-stream, smb2.sdread,
+            # smb2.stream-inherit-perms) are exactly that shape -- a Samba image
+            # upgrade that adds a subtest under one of them would trip it.  Split
+            # the whole suite in that case; every entry then gets a distinct name.
+            if("${_parent}" IN_LIST _ads)
+                foreach(_sub ${_plain} ${_ads})
+                    _smbtorture_add_subtest(${backend} "${_sub}")
+                endforeach()
+            else()
+                _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_plain})
+                foreach(_sub ${_ads})
+                    _smbtorture_add_subtest(${backend} "${_sub}")
+                endforeach()
+            endif()
         elseif(_plain)
             _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_plain})
         elseif(_ads)

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -501,6 +501,45 @@ add_executable(smbtorture_test smbtorture_test.c)
 target_link_libraries(smbtorture_test chimera_server chimera_metrics)
 target_include_directories(smbtorture_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
+# Subtests needing named-stream (ADS) support.  Single source of truth, read by
+# both the driver (at run time, to set the config knob) and this file (at
+# configure time, to scope that knob under ctest -- see
+# add_smbtorture_backend_tests).  Editing the list re-runs cmake.
+set(SMBTORTURE_ADS_LIST ${CMAKE_CURRENT_SOURCE_DIR}/smbtorture_ads_subtests.txt)
+target_compile_definitions(smbtorture_test
+    PRIVATE SMBTORTURE_ADS_LIST="${SMBTORTURE_ADS_LIST}")
+set_property(DIRECTORY APPEND
+    PROPERTY CMAKE_CONFIGURE_DEPENDS ${SMBTORTURE_ADS_LIST})
+
+file(STRINGS ${SMBTORTURE_ADS_LIST} _ads_lines)
+set(SMBTORTURE_ADS_PATTERNS "")
+foreach(_line ${_ads_lines})
+    string(REGEX REPLACE "#.*$" "" _line "${_line}")
+    string(STRIP "${_line}" _line)
+    if(NOT _line STREQUAL "")
+        list(APPEND SMBTORTURE_ADS_PATTERNS "${_line}")
+    endif()
+endforeach()
+
+# Mirrors ads_entry_matches() in smbtorture_test.c: exact, or parent-suite
+# prefix ("smb2.streams" matches "smb2.streams.io", not
+# "smb2.stream-inherit-perms").  Literal compares only -- entry text contains
+# '.' and '-', so a regex match would be wrong.
+function(_smbtorture_needs_ads subtest out)
+    foreach(_pat ${SMBTORTURE_ADS_PATTERNS})
+        if("${subtest}" STREQUAL "${_pat}")
+            set(${out} TRUE PARENT_SCOPE)
+            return()
+        endif()
+        string(FIND "${subtest}" "${_pat}." _idx)
+        if(_idx EQUAL 0)
+            set(${out} TRUE PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${out} FALSE PARENT_SCOPE)
+endfunction()
+
 set(SMBTORTURE_LSAN "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt")
 set(SMBTORTURE_CMD ${CMAKE_CURRENT_BINARY_DIR}/smbtorture_test)
 
@@ -1501,6 +1540,7 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
+    smb2.fileid.fileid
     smb2.fileid.unique
     smb2.fileid.unique-dir
     # smb2.getinfo
@@ -1581,7 +1621,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.ioctl.trim_simple
     # smb2.kernel-oplocks
     smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks2
     smb2.kernel-oplocks.kernel_oplocks3
+    smb2.kernel-oplocks.kernel_oplocks4
+    smb2.kernel-oplocks.kernel_oplocks6
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lease
     smb2.lease.break
@@ -1885,6 +1928,8 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.sharemode.access-sharemode
     smb2.sharemode.bug14375
     smb2.sharemode.sharemode-access
+    # smb2.stream-inherit-perms
+    smb2.stream-inherit-perms
     # smb2.streams
     smb2.streams.attributes1
     smb2.streams.attributes2
@@ -5041,26 +5086,48 @@ macro(add_smbtorture_explore_tests backend)
     endforeach()
 endmacro()
 
+# Named streams are a per-server-process config knob, but a consolidated suite
+# runs all of its subtests in ONE process -- so registering an ADS-needing
+# subtest alongside siblings that do not need it would turn the feature on for
+# the whole suite.  That silently couples ~43 currently-passing subtests across
+# five suites to a flag they never asked for, and makes ctest disagree with the
+# per-subtest matrix in tools/smbtorture/regen.sh (where the allowlist is exact).
+# So a suite with a MIX of ADS and non-ADS subtests is split: the plain subtests
+# keep their consolidated entry, and each ADS subtest gets its own.  A suite
+# whose enabled subtests ALL need ADS (smb2.streams) stays consolidated -- every
+# member wants the flag, so there is nothing to scope it away from.
 macro(add_smbtorture_backend_tests backend)
     foreach(_parent ${SMBTORTURE_PARENTS})
         set(_pid ${SMBTORTURE_PID_${_parent}})
-        set(_enabled "")
+        set(_plain "")
+        set(_ads "")
         foreach(_sub ${SMBTORTURE_SUBS_${_pid}})
             if("${_sub}" IN_LIST SMBTORTURE_DISABLED_SUBTESTS)
                 continue()
             endif()
-            if("${_sub}" IN_LIST SMBTORTURE_ENABLED_${backend})
-                list(APPEND _enabled "${_sub}")
+            if(NOT "${_sub}" IN_LIST SMBTORTURE_ENABLED_${backend})
+                continue()
+            endif()
+            _smbtorture_needs_ads("${_sub}" _needs_ads)
+            if(_needs_ads)
+                list(APPEND _ads "${_sub}")
+            else()
+                list(APPEND _plain "${_sub}")
             endif()
         endforeach()
-        if(_enabled)
-            if("${_parent}" IN_LIST SMBTORTURE_ISOLATE_SUITES)
-                foreach(_sub ${_enabled})
-                    _smbtorture_add_subtest(${backend} "${_sub}")
-                endforeach()
-            else()
-                _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_enabled})
-            endif()
+        if("${_parent}" IN_LIST SMBTORTURE_ISOLATE_SUITES)
+            foreach(_sub ${_plain} ${_ads})
+                _smbtorture_add_subtest(${backend} "${_sub}")
+            endforeach()
+        elseif(_plain AND _ads)
+            _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_plain})
+            foreach(_sub ${_ads})
+                _smbtorture_add_subtest(${backend} "${_sub}")
+            endforeach()
+        elseif(_plain)
+            _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_plain})
+        elseif(_ads)
+            _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_ads})
         endif()
     endforeach()
 endmacro()

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -501,6 +501,51 @@ add_executable(smbtorture_test smbtorture_test.c)
 target_link_libraries(smbtorture_test chimera_server chimera_metrics)
 target_include_directories(smbtorture_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
+# Subtests needing named-stream (ADS) support.  Single source of truth, read by
+# both the driver (at run time, to set the config knob) and this file (at
+# configure time, to scope that knob under ctest -- see
+# add_smbtorture_backend_tests).  Editing the list re-runs cmake.
+#
+# The driver opens this by absolute path at run time and treats a failure to
+# read it as EXIT_FAILURE (not the suites' SKIP_RETURN_CODE 77), so the copy it
+# points at must be the one guaranteed to exist wherever ctest runs: the build
+# tree, not the source tree.  configure_file COPYONLY also registers the source
+# as a configure dependency, so editing the list still re-runs cmake.
+set(SMBTORTURE_ADS_LIST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/smbtorture_ads_subtests.txt)
+set(SMBTORTURE_ADS_LIST ${CMAKE_CURRENT_BINARY_DIR}/smbtorture_ads_subtests.txt)
+configure_file(${SMBTORTURE_ADS_LIST_SRC} ${SMBTORTURE_ADS_LIST} COPYONLY)
+target_compile_definitions(smbtorture_test
+    PRIVATE SMBTORTURE_ADS_LIST="${SMBTORTURE_ADS_LIST}")
+
+file(STRINGS ${SMBTORTURE_ADS_LIST_SRC} _ads_lines)
+set(SMBTORTURE_ADS_PATTERNS "")
+foreach(_line ${_ads_lines})
+    string(REGEX REPLACE "#.*$" "" _line "${_line}")
+    string(STRIP "${_line}" _line)
+    if(NOT _line STREQUAL "")
+        list(APPEND SMBTORTURE_ADS_PATTERNS "${_line}")
+    endif()
+endforeach()
+
+# Mirrors ads_entry_matches() in smbtorture_test.c: exact, or parent-suite
+# prefix ("smb2.streams" matches "smb2.streams.io", not
+# "smb2.stream-inherit-perms").  Literal compares only -- entry text contains
+# '.' and '-', so a regex match would be wrong.
+function(_smbtorture_needs_ads subtest out)
+    foreach(_pat ${SMBTORTURE_ADS_PATTERNS})
+        if("${subtest}" STREQUAL "${_pat}")
+            set(${out} TRUE PARENT_SCOPE)
+            return()
+        endif()
+        string(FIND "${subtest}" "${_pat}." _idx)
+        if(_idx EQUAL 0)
+            set(${out} TRUE PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${out} FALSE PARENT_SCOPE)
+endfunction()
+
 set(SMBTORTURE_LSAN "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt")
 set(SMBTORTURE_CMD ${CMAKE_CURRENT_BINARY_DIR}/smbtorture_test)
 
@@ -1501,6 +1546,7 @@ set(SMBTORTURE_ENABLED_memfs
     # smb2.durable-v2-regressions
     smb2.durable-v2-regressions.durable_v2_reconnect_bug15624
     # smb2.fileid
+    smb2.fileid.fileid
     smb2.fileid.unique
     smb2.fileid.unique-dir
     # smb2.getinfo
@@ -1581,7 +1627,10 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.ioctl.trim_simple
     # smb2.kernel-oplocks
     smb2.kernel-oplocks.kernel_oplocks1
+    smb2.kernel-oplocks.kernel_oplocks2
     smb2.kernel-oplocks.kernel_oplocks3
+    smb2.kernel-oplocks.kernel_oplocks4
+    smb2.kernel-oplocks.kernel_oplocks6
     smb2.kernel-oplocks.kernel_oplocks8
     # smb2.lease
     smb2.lease.break
@@ -1885,6 +1934,8 @@ set(SMBTORTURE_ENABLED_memfs
     smb2.sharemode.access-sharemode
     smb2.sharemode.bug14375
     smb2.sharemode.sharemode-access
+    # smb2.stream-inherit-perms
+    smb2.stream-inherit-perms
     # smb2.streams
     smb2.streams.attributes1
     smb2.streams.attributes2
@@ -5041,26 +5092,64 @@ macro(add_smbtorture_explore_tests backend)
     endforeach()
 endmacro()
 
+# Named streams are a per-server-process config knob, but a consolidated suite
+# runs all of its subtests in ONE process -- so registering an ADS-needing
+# subtest alongside siblings that do not need it would turn the feature on for
+# the whole suite.  That silently couples ~43 currently-passing subtests across
+# five suites to a flag they never asked for, and makes ctest disagree with the
+# per-subtest matrix in tools/smbtorture/regen.sh (where the allowlist is exact).
+# So a suite with a MIX of ADS and non-ADS subtests is split: the plain subtests
+# keep their consolidated entry, and each ADS subtest gets its own.  A suite
+# whose enabled subtests ALL need ADS (smb2.streams) stays consolidated -- every
+# member wants the flag, so there is nothing to scope it away from.
 macro(add_smbtorture_backend_tests backend)
     foreach(_parent ${SMBTORTURE_PARENTS})
         set(_pid ${SMBTORTURE_PID_${_parent}})
-        set(_enabled "")
+        set(_plain "")
+        set(_ads "")
         foreach(_sub ${SMBTORTURE_SUBS_${_pid}})
             if("${_sub}" IN_LIST SMBTORTURE_DISABLED_SUBTESTS)
                 continue()
             endif()
-            if("${_sub}" IN_LIST SMBTORTURE_ENABLED_${backend})
-                list(APPEND _enabled "${_sub}")
+            if(NOT "${_sub}" IN_LIST SMBTORTURE_ENABLED_${backend})
+                continue()
+            endif()
+            _smbtorture_needs_ads("${_sub}" _needs_ads)
+            if(_needs_ads)
+                list(APPEND _ads "${_sub}")
+            else()
+                list(APPEND _plain "${_sub}")
             endif()
         endforeach()
-        if(_enabled)
-            if("${_parent}" IN_LIST SMBTORTURE_ISOLATE_SUITES)
-                foreach(_sub ${_enabled})
+        if("${_parent}" IN_LIST SMBTORTURE_ISOLATE_SUITES)
+            foreach(_sub ${_plain} ${_ads})
+                _smbtorture_add_subtest(${backend} "${_sub}")
+            endforeach()
+        elseif(_plain AND _ads)
+            # _smbtorture_add_suite names the ctest entry from the mangled PARENT
+            # and _smbtorture_add_subtest from the mangled SUBTEST, which are the
+            # same string for a bare two-component test.  So if the suite's own
+            # bare name is the ADS member, registering both here would be a
+            # duplicate add_test NAME and cmake would hard-fail.  No parent in
+            # today's catalog has both a bare entry and dotted siblings, but the
+            # three bare ADS entries (smb2.ioctl-on-stream, smb2.sdread,
+            # smb2.stream-inherit-perms) are exactly that shape -- a Samba image
+            # upgrade that adds a subtest under one of them would trip it.  Split
+            # the whole suite in that case; every entry then gets a distinct name.
+            if("${_parent}" IN_LIST _ads)
+                foreach(_sub ${_plain} ${_ads})
                     _smbtorture_add_subtest(${backend} "${_sub}")
                 endforeach()
             else()
-                _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_enabled})
+                _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_plain})
+                foreach(_sub ${_ads})
+                    _smbtorture_add_subtest(${backend} "${_sub}")
+                endforeach()
             endif()
+        elseif(_plain)
+            _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_plain})
+        elseif(_ads)
+            _smbtorture_add_suite(${backend} "${_parent}" "${_pid}" ${_ads})
         endif()
     endforeach()
 endmacro()

--- a/src/server/smb/tests/smbtorture_ads_subtests.txt
+++ b/src/server/smb/tests/smbtorture_ads_subtests.txt
@@ -37,7 +37,16 @@
 # MATCHING: an entry matches a test name exactly, or as a parent-suite prefix --
 # "smb2.streams" matches both "smb2.streams" and "smb2.streams.io".  It does not
 # match "smb2.stream-inherit-perms" (the '.' is required), which is why that
-# subtest is listed separately below.
+# subtest is listed separately below.  The required '.' is load-bearing in the
+# other direction too: an entry "smb2.create" would NOT match
+# "smb2.create_no_streams.no_stream", so it cannot break the negative test.
+#
+# The match is one-directional -- the ENTRY may be a prefix of the test name,
+# never the reverse.  So a whole-suite invocation whose name is shorter than the
+# entry does not enable the feature: "smbtorture_test -b memfs smb2.fileid" runs
+# smb2.fileid.fileid with ADS off and it fails at the gate, even though the
+# subtest is listed.  ctest never does this (it passes subtest names), but
+# reproducing by hand needs the subtest name, not the suite name.
 #
 # REGENERATING: do not grow this list one entry at a time by hand -- that is how
 # eleven subtests came to be missing from it.  Run
@@ -144,7 +153,8 @@ smb2.ioctl.copy-chunk streams
 #                                    NT_STATUS_NOT_IMPLEMENTED (getinfo.c:115).
 #   smb2.getinfo.normalized       -- the normalized-name query does not preserve
 #                                    case ("torture_dir1n" for "torture_dIr1N").
-#   smb2.compound.compound-padding-- response body_size is 19, should be 24
+#   smb2.compound.compound-padding
+#                                 -- response body_size is 19, should be 24
 #                                    (compound.c:1356).
 #   smb2.kernel-oplocks.kernel_oplocks5
 #                                 -- granted oplock level is not NONE

--- a/src/server/smb/tests/smbtorture_ads_subtests.txt
+++ b/src/server/smb/tests/smbtorture_ads_subtests.txt
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# smbtorture subtests that require named-stream (ADS) support on the server.
+#
+# THIS IS THE SINGLE SOURCE OF TRUTH.  Two consumers read it:
+#
+#   smbtorture_test.c  -- enables chimera's smb_named_streams config knob when
+#                         any test named on its command line appears here.
+#   CMakeLists.txt     -- scopes that knob correctly under ctest.  A suite's
+#                         subtests share one server process, so a subtest listed
+#                         here is registered as its own ctest entry when its
+#                         siblings are not (otherwise enabling ADS for one
+#                         subtest silently enables it for the whole suite).
+#
+# Do NOT blanket-enable ADS instead of maintaining this list.
+# smb2.create_no_streams.no_stream is a negative test: it asserts that a server
+# without stream support rejects a stream path, and it passes on all six
+# backends today precisely because the feature is off.  Per-test selection is
+# load-bearing.
+#
+# That test also pins down how COARSE the rejection has to be, which is worth
+# recording because the gate looks over-broad.  It opens four names with
+# disposition OPEN -- "test_no_stream::$DATA", "test_no_stream::foooooooooooo",
+# "test_no_stream:stream", "test_no_stream:stream:$DATA" -- and requires
+# OBJECT_NAME_INVALID for every one, including the "::$DATA" default-fork
+# spelling that names nothing but the base file.  So gate 1 in smb_proc_create.c
+# is right to reject any ':' in the name BEFORE parsing it: narrowing it to
+# reject only genuine named streams would resolve "test_no_stream::$DATA" to a
+# base file the test never creates, answer OBJECT_NAME_NOT_FOUND, and break this
+# subtest on all six backends.  With named_streams ON the default-fork forms
+# parse to has_stream = 0 and open the base object without needing
+# CHIMERA_VFS_CAP_NAMED_STREAMS, so both behaviours are already reachable by
+# config and there is nothing here to fix.
+#
+# MATCHING: an entry matches a test name exactly, or as a parent-suite prefix --
+# "smb2.streams" matches both "smb2.streams" and "smb2.streams.io".  It does not
+# match "smb2.stream-inherit-perms" (the '.' is required), which is why that
+# subtest is listed separately below.
+#
+# REGENERATING: do not grow this list one entry at a time by hand -- that is how
+# eleven subtests came to be missing from it.  Run
+# tools/smbtorture/derive_ads.sh, which sweeps the catalog with ADS forced off
+# and harvests every subtest the server logs as hitting the named-streams gate.
+# Re-run it after upgrading the Samba devcontainer image, which changes the
+# subtest catalog.
+
+# The named-streams suites themselves.
+smb2.streams
+smb2.ioctl-on-stream
+smb2.sdread
+
+# smb2.stream-inherit-perms is a top-level test, NOT a member of smb2.streams --
+# note the missing 's'.  It needs its own entry; the suite prefix cannot cover
+# it.
+smb2.stream-inherit-perms
+
+# Oplock/lease subtests that need the ADS namespace to exist.  Read from
+# source4/torture/smb2/{oplock,lease}.c rather than inferred -- there are two
+# shapes, and both use REAL named streams ("file:foo"), never the default-fork
+# spelling, so a narrower gate would not rescue any of them:
+#
+#   Grant taken on a stream handle.  smb2.oplock.stream1 opens streams directly.
+#   smb2.oplock.batch26 takes a BATCH oplock on the base file, then opens
+#   "test_oplock.txt:Stream One:$DATA" and asserts the stream gets its own BATCH
+#   grant while the base file drops to LEVEL_II.  smb2.lease.request leases
+#   "lease_request.dat:stream" -- "And grants leases on streams (with separate
+#   leasekey)".
+#
+#   Grant taken on the BASE file, with a stream open as the SECOND opener.  The
+#   kernel_oplocks subtests are this shape: kernel_oplocks2 takes an EXCLUSIVE
+#   oplock on "test_kernel_oplock2.dat", opens "test_kernel_oplock2.dat:foo",
+#   then asserts the stream open did not break it ("Stream open caused oplock
+#   break").
+#   No grant is ever taken on a stream here, but the stream CREATE still has to
+#   succeed for the subtest to reach its assertion.
+#
+# A real Windows server always exposes the ADS namespace, so these were written
+# without a guard.
+smb2.oplock.stream1
+smb2.oplock.batch26
+smb2.lease.request
+smb2.kernel-oplocks.kernel_oplocks2
+smb2.kernel-oplocks.kernel_oplocks4
+smb2.kernel-oplocks.kernel_oplocks5
+smb2.kernel-oplocks.kernel_oplocks6
+
+# Subtests of other suites that open a stream incidentally, as scaffolding for
+# whatever they actually assert -- a second handle on a file, an elaborate file
+# or directory to query.  None is a streams test by name, which is why they went
+# unnoticed.  The paths, read from the Samba sources:
+#
+#   smb2.getinfo.complex   torture_setup_complex_file on FNAME ":streamtwo" AND
+#                          on DNAME ":streamtwo" -- a stream on a directory as
+#                          well as on a file.
+#   smb2.getinfo.normalized
+#                          builds "%s:sTrEaM3", "%s::$dAtA" and "%s:StReAm4"
+#                          with talloc_asprintf at run time.  This is the
+#                          concrete reason the set cannot be derived
+#                          statically: those
+#                          paths exist nowhere as literals, in the binary or out
+#                          of it.
+#   smb2.fileid.fileid     DNAME "\foo:bar".
+#   smb2.fileid.fileid-dir DNAME "\foo:bar" as well -- despite the name it is
+#                          an ordinary named stream, not a directory index
+#                          stream.
+#   smb2.compound.compound-padding
+#                          "compound_read.dat:foo".
+#   smb2.create.quota-fake-file
+#                          "$Extend\$Quota:$Q:$INDEX_ALLOCATION" -- stream "$Q"
+#                          of type $INDEX_ALLOCATION.  chimera's parser takes
+#                          $INDEX_ALLOCATION only in the bare "::$INDEX_
+#                          ALLOCATION" form, so with ADS on this one is refused
+#                          by the parse rather than by either gate.
+smb2.getinfo.complex
+smb2.getinfo.normalized
+smb2.fileid.fileid
+smb2.fileid.fileid-dir
+smb2.compound.compound-padding
+smb2.create.quota-fake-file
+
+# The space in the next entry is part of the subtest name as smbtorture reports
+# it, not a separator -- both readers keep the line intact (the driver reads
+# whole lines; cmake's file(STRINGS) splits on ';' only, never on blanks).  It
+# copies between named streams of one file, so its stream opens are scaffolding
+# for the copy-chunk assertions rather than the thing under test.
+smb2.ioctl.copy-chunk streams
+
+# Listed above but NOT yet in SMBTORTURE_ENABLED_memfs: these reach their real
+# assertions once the gate is open and then fail for genuine reasons, tracked
+# separately.  They stay out of the ctest allowlists until fixed.
+#
+#   smb2.fileid.fileid-dir        -- the subtest passes, but the server then
+#                                    aborts at teardown with a leaked evpl
+#                                    buffer reference (deterministic).  This
+#                                    note used to blame the
+#                                    "::$INDEX_ALLOCATION" open path; the
+#                                    subtest opens DNAME "\foo:bar" and no
+#                                    index-stream path at all, so that
+#                                    attribution was wrong.  Re-confirm the
+#                                    leak site from a fresh log when fixing.
+#   smb2.getinfo.complex          -- RAW_FILEINFO_ALT_NAME_INFORMATION returns
+#                                    NT_STATUS_NOT_IMPLEMENTED (getinfo.c:115).
+#   smb2.getinfo.normalized       -- the normalized-name query does not preserve
+#                                    case ("torture_dir1n" for "torture_dIr1N").
+#   smb2.compound.compound-padding-- response body_size is 19, should be 24
+#                                    (compound.c:1356).
+#   smb2.kernel-oplocks.kernel_oplocks5
+#                                 -- granted oplock level is not NONE
+#                                    (oplock.c:4848).
+#   smb2.create.quota-fake-file   -- not a gate failure at all: it opens
+#                                    "$Extend\$Quota:$Q:$INDEX_ALLOCATION", a
+#                                    Samba fake file backing quota queries.
+#                                    chimera has no quota namespace, so this
+#                                    still fails with ADS on.  Listed here only
+#                                    so the sweep in derive_ads.sh stays
+#                                    idempotent -- it does reach the gate first.
+#
+# smb2.ioctl.copy-chunk streams is out of SMBTORTURE_ENABLED_memfs for a
+# different reason from the block above: nobody has run it with the gate open,
+# so there is no "it then fails for reason X" to record.  What is known is only
+# that it reaches gate 1 today -- the server logs "named streams: disabled by
+# config; rejecting stream CREATE 'src:foo'" and never "SMB named streams (ADS)
+# enabled", and it fails (rc=1) at source4/torture/smb2/ioctl.c:2041
+# "copy_one_stream failed" after ioctl.c:325 warns
+# "status was NT_STATUS_OBJECT_NAME_INVALID, expected NT_STATUS_OK: file
+# create".  Listing it here only opens the gate for a run that names it; it does
+# not claim an outcome.  Run it and record what happens before adding it to any
+# backend allowlist.

--- a/src/server/smb/tests/smbtorture_ads_subtests.txt
+++ b/src/server/smb/tests/smbtorture_ads_subtests.txt
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# smbtorture subtests that require named-stream (ADS) support on the server.
+#
+# THIS IS THE SINGLE SOURCE OF TRUTH.  Two consumers read it:
+#
+#   smbtorture_test.c  -- enables chimera's smb_named_streams config knob when
+#                         any test named on its command line appears here.
+#   CMakeLists.txt     -- scopes that knob correctly under ctest.  A suite's
+#                         subtests share one server process, so a subtest listed
+#                         here is registered as its own ctest entry when its
+#                         siblings are not (otherwise enabling ADS for one
+#                         subtest silently enables it for the whole suite).
+#
+# Do NOT blanket-enable ADS instead of maintaining this list.
+# smb2.create_no_streams.no_stream is a negative test: it asserts that a server
+# without stream support rejects a stream path, and it passes on all six
+# backends today precisely because the feature is off.  Per-test selection is
+# load-bearing.
+#
+# That test also pins down how COARSE the rejection has to be, which is worth
+# recording because the gate looks over-broad.  It opens four names with
+# disposition OPEN -- "test_no_stream::$DATA", "test_no_stream::foooooooooooo",
+# "test_no_stream:stream", "test_no_stream:stream:$DATA" -- and requires
+# OBJECT_NAME_INVALID for every one, including the "::$DATA" default-fork
+# spelling that names nothing but the base file.  So gate 1 in smb_proc_create.c
+# is right to reject any ':' in the name BEFORE parsing it: narrowing it to
+# reject only genuine named streams would resolve "test_no_stream::$DATA" to a
+# base file the test never creates, answer OBJECT_NAME_NOT_FOUND, and break this
+# subtest on all six backends.  With named_streams ON the default-fork forms
+# parse to has_stream = 0 and open the base object without needing
+# CHIMERA_VFS_CAP_NAMED_STREAMS, so both behaviours are already reachable by
+# config and there is nothing here to fix.
+#
+# MATCHING: an entry matches a test name exactly, or as a parent-suite prefix --
+# "smb2.streams" matches both "smb2.streams" and "smb2.streams.io".  It does not
+# match "smb2.stream-inherit-perms" (the '.' is required), which is why that
+# subtest is listed separately below.  The required '.' is load-bearing in the
+# other direction too: an entry "smb2.create" would NOT match
+# "smb2.create_no_streams.no_stream", so it cannot break the negative test.
+#
+# The match is one-directional -- the ENTRY may be a prefix of the test name,
+# never the reverse.  So a whole-suite invocation whose name is shorter than the
+# entry does not enable the feature: "smbtorture_test -b memfs smb2.fileid" runs
+# smb2.fileid.fileid with ADS off and it fails at the gate, even though the
+# subtest is listed.  ctest never does this (it passes subtest names), but
+# reproducing by hand needs the subtest name, not the suite name.
+#
+# MAINTAINING: whether an entry belongs here turns on whether named-stream
+# support CHANGES THE SUBTEST'S OUTCOME -- not on whether the subtest trips the
+# gate.  Run it with the feature forced off, run it again forced on, and read
+# the pair:
+#
+#   off    on     meaning                              belongs in the list?
+#   ----   ----   ----------------------------------   --------------------
+#   fail   pass   needs the feature                    yes
+#   fail   fail   needs it to reach its real failure   yes, still failing
+#   pass   fail   negative test; requires it OFF       NEVER
+#   pass   pass   indifferent                          no; stale if listed
+#
+# SMBTORTURE_ADS=off|on forces the feature for one run independently of this
+# list, which is what makes that pair cheap to measure.  $BUILD is build/Release
+# in a worktree and /build/Release in the main tree:
+#
+#   for phase in off on; do \
+#       SMBTORTURE_LOG_LEVEL=debug SMBTORTURE_ADS=$phase \
+#       scripts/netns_test_wrapper.sh \
+#       $BUILD/src/server/smb/tests/smbtorture_test -b memfs SUBTEST \
+#       >/dev/null 2>&1; echo "$phase: $?"; done
+#
+# Measure the pair; do not infer it from gate 1's "named streams: disabled by
+# config" log line.  That line says a stream name was refused, which cannot tell
+# row 1 from row 3 -- smb2.create_no_streams.no_stream trips the gate four times
+# and passes BECAUSE it does, so harvesting gate hits reports it as a missing
+# entry, and adding it breaks it on all six backends exactly as the warning
+# above describes.  The log line is still where to START, since it names which
+# gate refused which stream when a subtest dies in setup for what looks like a
+# server bug.  It just does not decide.
+#
+# Rows 3 and 4 are invisible to per-failure investigation: nobody investigates a
+# passing subtest, so a stale or over-broad entry never surfaces on its own.
+# Audit the list against the catalog after upgrading the Samba devcontainer
+# image, which is what changes the subtest set.
+#
+# Do not grow this list one entry at a time as failures are noticed -- that is
+# how eleven subtests came to be missing from it.  They open a stream as
+# incidental setup (a second handle, an elaborate file or directory to query)
+# and died there with NT_STATUS_OBJECT_NAME_INVALID, looking exactly like a
+# server bug, and nobody was looking.  A sweep of the whole catalog found them;
+# it lived in tools/smbtorture/derive_ads.sh and was removed once it had done
+# that job, because it needed 60-90 minutes, root and memfs, so it never ran in
+# CI -- and a gate nothing runs rots silently.  It is archived at the tag
+# ads-sweep-archive (a tag, not a branch, so it survives a squash-merge);
+# `git show ads-sweep-archive` prints what it did and how to restore it.  Worth
+# reviving if a Samba upgrade ever warrants a full re-derivation, or if it can
+# be hung off the same nightly trigger as regen.sh.
+
+# The named-streams suites themselves.
+smb2.streams
+smb2.ioctl-on-stream
+smb2.sdread
+
+# smb2.stream-inherit-perms is a top-level test, NOT a member of smb2.streams --
+# note the missing 's'.  It needs its own entry; the suite prefix cannot cover
+# it.
+smb2.stream-inherit-perms
+
+# Oplock/lease subtests that need the ADS namespace to exist.  Read from
+# source4/torture/smb2/{oplock,lease}.c rather than inferred -- there are two
+# shapes, and both use REAL named streams ("file:foo"), never the default-fork
+# spelling, so a narrower gate would not rescue any of them:
+#
+#   Grant taken on a stream handle.  smb2.oplock.stream1 opens streams directly.
+#   smb2.oplock.batch26 takes a BATCH oplock on the base file, then opens
+#   "test_oplock.txt:Stream One:$DATA" and asserts the stream gets its own BATCH
+#   grant while the base file drops to LEVEL_II.  smb2.lease.request leases
+#   "lease_request.dat:stream" -- "And grants leases on streams (with separate
+#   leasekey)".
+#
+#   Grant taken on the BASE file, with a stream open as the SECOND opener.  The
+#   kernel_oplocks subtests are this shape: kernel_oplocks2 takes an EXCLUSIVE
+#   oplock on "test_kernel_oplock2.dat", opens "test_kernel_oplock2.dat:foo",
+#   then asserts the stream open did not break it ("Stream open caused oplock
+#   break").
+#   No grant is ever taken on a stream here, but the stream CREATE still has to
+#   succeed for the subtest to reach its assertion.
+#
+# A real Windows server always exposes the ADS namespace, so these were written
+# without a guard.
+smb2.oplock.stream1
+smb2.oplock.batch26
+smb2.lease.request
+smb2.kernel-oplocks.kernel_oplocks2
+smb2.kernel-oplocks.kernel_oplocks4
+smb2.kernel-oplocks.kernel_oplocks5
+smb2.kernel-oplocks.kernel_oplocks6
+
+# Subtests of other suites that open a stream incidentally, as scaffolding for
+# whatever they actually assert -- a second handle on a file, an elaborate file
+# or directory to query.  None is a streams test by name, which is why they went
+# unnoticed.  The paths, read from the Samba sources:
+#
+#   smb2.getinfo.complex   torture_setup_complex_file on FNAME ":streamtwo" AND
+#                          on DNAME ":streamtwo" -- a stream on a directory as
+#                          well as on a file.
+#   smb2.getinfo.normalized
+#                          builds "%s:sTrEaM3", "%s::$dAtA" and "%s:StReAm4"
+#                          with talloc_asprintf at run time.  This is the
+#                          concrete reason the set cannot be derived
+#                          statically: those
+#                          paths exist nowhere as literals, in the binary or out
+#                          of it.
+#   smb2.fileid.fileid     DNAME "\foo:bar".
+#   smb2.fileid.fileid-dir DNAME "\foo:bar" as well -- despite the name it is
+#                          an ordinary named stream, not a directory index
+#                          stream.
+#   smb2.compound.compound-padding
+#                          "compound_read.dat:foo".
+#   smb2.create.quota-fake-file
+#                          "$Extend\$Quota:$Q:$INDEX_ALLOCATION" -- stream "$Q"
+#                          of type $INDEX_ALLOCATION.  chimera's parser takes
+#                          $INDEX_ALLOCATION only in the bare "::$INDEX_
+#                          ALLOCATION" form, so with ADS on this one is refused
+#                          by the parse rather than by either gate.
+smb2.getinfo.complex
+smb2.getinfo.normalized
+smb2.fileid.fileid
+smb2.fileid.fileid-dir
+smb2.compound.compound-padding
+smb2.create.quota-fake-file
+
+# The space in the next entry is part of the subtest name as smbtorture reports
+# it, not a separator -- both readers keep the line intact (the driver reads
+# whole lines; cmake's file(STRINGS) splits on ';' only, never on blanks).  It
+# copies between named streams of one file, so its stream opens are scaffolding
+# for the copy-chunk assertions rather than the thing under test.
+smb2.ioctl.copy-chunk streams
+
+# Listed above but NOT yet in SMBTORTURE_ENABLED_memfs: these reach their real
+# assertions once the gate is open and then fail for genuine reasons, tracked
+# separately.  They stay out of the ctest allowlists until fixed.
+#
+#   smb2.fileid.fileid-dir        -- the subtest passes, but the server then
+#                                    aborts at teardown with a leaked evpl
+#                                    buffer reference (deterministic).  This
+#                                    note used to blame the
+#                                    "::$INDEX_ALLOCATION" open path; the
+#                                    subtest opens DNAME "\foo:bar" and no
+#                                    index-stream path at all, so that
+#                                    attribution was wrong.  Re-confirm the
+#                                    leak site from a fresh log when fixing.
+#   smb2.getinfo.complex          -- RAW_FILEINFO_ALT_NAME_INFORMATION returns
+#                                    NT_STATUS_NOT_IMPLEMENTED (getinfo.c:115).
+#   smb2.getinfo.normalized       -- the normalized-name query does not preserve
+#                                    case ("torture_dir1n" for "torture_dIr1N").
+#   smb2.compound.compound-padding
+#                                 -- response body_size is 19, should be 24
+#                                    (compound.c:1356).
+#   smb2.kernel-oplocks.kernel_oplocks5
+#                                 -- granted oplock level is not NONE
+#                                    (oplock.c:4848).
+#   smb2.create.quota-fake-file   -- not a gate failure at all: it opens
+#                                    "$Extend\$Quota:$Q:$INDEX_ALLOCATION", a
+#                                    Samba fake file backing quota queries.
+#                                    chimera has no quota namespace, so this
+#                                    still fails with ADS on.  It belongs here
+#                                    all the same: it fails both ways, which is
+#                                    the "needs the feature to reach its real
+#                                    failure" case, same as the entries above.
+#
+# smb2.ioctl.copy-chunk streams is out of SMBTORTURE_ENABLED_memfs for a
+# different reason from the block above: nobody has run it with the gate open,
+# so there is no "it then fails for reason X" to record.  What is known is only
+# that it reaches gate 1 today -- the server logs "named streams: disabled by
+# config; rejecting stream CREATE 'src:foo'" and never "SMB named streams (ADS)
+# enabled", and it fails (rc=1) at source4/torture/smb2/ioctl.c:2041
+# "copy_one_stream failed" after ioctl.c:325 warns
+# "status was NT_STATUS_OBJECT_NAME_INVALID, expected NT_STATUS_OK: file
+# create".  Listing it here only opens the gate for a run that names it; it does
+# not claim an outcome.  Run it and record what happens before adding it to any
+# backend allowlist.

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -64,6 +64,148 @@ test_cleanup(
     }
 } /* test_cleanup */
 
+/* Log level for this run.  Defaults to info, as every other test harness here
+ * does; SMBTORTURE_LOG_LEVEL=error|info|debug overrides it.  An unrecognized
+ * value is a hard error rather than a silent fallback: a sweep that asked for
+ * debug and quietly got info would harvest nothing and report success. */
+static int
+smbtorture_log_level(void)
+{
+    const char *env = getenv("SMBTORTURE_LOG_LEVEL");
+
+    if (!env || *env == '\0') {
+        return CHIMERA_LOG_INFO;
+    }
+
+    if (strcmp(env, "debug") == 0) {
+        return CHIMERA_LOG_DEBUG;
+    }
+
+    if (strcmp(env, "info") == 0) {
+        return CHIMERA_LOG_INFO;
+    }
+
+    if (strcmp(env, "error") == 0) {
+        return CHIMERA_LOG_ERROR;
+    }
+
+    fprintf(stderr, "SMBTORTURE_LOG_LEVEL='%s' is not one of error|info|debug\n",
+            env);
+    exit(EXIT_FAILURE);
+} /* smbtorture_log_level */
+
+/* Does `name` match `entry` from the ADS list?  Exact, or as a parent-suite
+ * prefix: "smb2.streams" matches "smb2.streams" and "smb2.streams.io", but not
+ * "smb2.stream-inherit-perms" (the '.' is required).  The old hand-written
+ * chain used strncmp(name, "smb2.streams.", 13), which silently failed to match
+ * smb2.stream-inherit-perms -- there is no 's' before the hyphen. */
+static int
+ads_entry_matches(
+    const char *entry,
+    const char *name)
+{
+    size_t len = strlen(entry);
+
+    if (strcmp(entry, name) == 0) {
+        return 1;
+    }
+
+    return strncmp(entry, name, len) == 0 && name[len] == '.';
+} /* ads_entry_matches */
+
+/* True if any test named on the command line requires named-stream (ADS)
+ * support.  The list is data, not code: see smbtorture_ads_subtests.txt, which
+ * CMakeLists.txt reads as well so ctest can scope the flag to exactly these
+ * subtests.  Returns -1 if the list cannot be read -- failing loudly rather
+ * than silently running with the feature off, which is the failure mode this
+ * whole mechanism exists to prevent. */
+static int
+tests_need_named_streams(
+    int          num_tests,
+    const char **tests)
+{
+    const char *env = getenv("SMBTORTURE_ADS");
+    FILE       *fp;
+    char        line[256];
+    int         need = 0;
+
+    /* Escape hatch for classifying a subtest by hand: run it twice, once forced
+     * off and once forced on, and read whether the outcome changed.  That pair,
+     * not a hit on the gate's log line, is what decides membership -- see the
+     * MAINTAINING section of smbtorture_ads_subtests.txt.  Tri-state rather
+     * than the presence test this replaced: SMBTORTURE_ADS_OFF=0 forced the
+     * feature OFF, which is the opposite of what anyone typing it means, and an
+     * unrecognized value is a hard error for the same reason
+     * SMBTORTURE_LOG_LEVEL makes one -- a run that asked to force the feature
+     * and quietly got the list instead would classify the subtest wrongly. */
+    if (env && *env != '\0') {
+        if (strcmp(env, "off") == 0) {
+            fprintf(stderr, "SMBTORTURE_ADS=off: named streams forced off\n");
+            return 0;
+        }
+
+        if (strcmp(env, "on") == 0) {
+            fprintf(stderr, "SMBTORTURE_ADS=on: named streams forced on\n");
+            return 1;
+        }
+
+        if (strcmp(env, "list") != 0) {
+            fprintf(stderr, "SMBTORTURE_ADS='%s' is not one of off|on|list\n",
+                    env);
+            return -1;
+        }
+    }
+
+    fp = fopen(SMBTORTURE_ADS_LIST, "r");
+
+    if (!fp) {
+        fprintf(stderr, "Failed to open ADS subtest list %s: %s\n",
+                SMBTORTURE_ADS_LIST, strerror(errno));
+        return -1;
+    }
+
+    while (!need && fgets(line, sizeof(line), fp)) {
+        char *entry = line, *end;
+
+        while (*entry == ' ' || *entry == '\t') {
+            entry++;
+        }
+
+        end = entry + strcspn(entry, "#\r\n");
+
+        while (end > entry && (end[-1] == ' ' || end[-1] == '\t')) {
+            end--;
+        }
+        *end = '\0';
+
+        if (*entry == '\0') {
+            continue;
+        }
+
+        for (int i = 0; i < num_tests; i++) {
+            if (ads_entry_matches(entry, tests[i])) {
+                need = 1;
+                break;
+            }
+        }
+    }
+
+    /* A read error stops fgets() exactly like end-of-file does, so without this
+     * a truncated or unreadable list yields need = 0 and the feature silently
+     * stays off -- the failure this function exists to prevent, arrived at by a
+     * different route than the fopen() above already guards. */
+    if (ferror(fp)) {
+        fprintf(stderr, "Failed to read ADS subtest list %s: %s\n",
+                SMBTORTURE_ADS_LIST, strerror(errno));
+        fclose(fp);
+        return -1;
+    }
+
+    fclose(fp);
+
+    return need;
+} /* tests_need_named_streams */
+
 static int
 run_smbtorture(
     int         num_tests,
@@ -365,8 +507,11 @@ main(
         return 77;
     }
 
-    /* Initialize logging */
-    ChimeraLogLevel = CHIMERA_LOG_INFO;
+    /* Initialize logging.  SMBTORTURE_LOG_LEVEL raises (or lowers) the level for
+     * a single run; set it to debug to see the named-streams gate, which logs
+     * at debug because that log is on a client-driven per-request path and so
+     * cannot default to info. */
+    ChimeraLogLevel = smbtorture_log_level();
     evpl_set_log_fn(chimera_vlog, chimera_log_flush);
 
     env.metrics = prometheus_metrics_create(NULL, NULL, 0);
@@ -439,29 +584,21 @@ main(
         chimera_server_config_set_smb_nic_info(config, 2, nics);
     }
 
-    /* CTest invokes this binary once per suite.  Enable named-stream (ADS)
-     * support only for the stream suites, so the negative smb2.create_no_streams
-     * suite still runs with the feature off on the same backend.  Also match
-     * individual smb2.streams.* subtests so the per-subtest harvest variant
-     * (run one stream subtest in its own server process) gets the same
-     * capability the combined smb2.streams suite needs.
-     *
-     * A handful of oplock/lease subtests open named streams (a real Windows
-     * server always exposes the ADS namespace), so they need the same
-     * capability: smb2.oplock.stream1 / smb2.oplock.batch26 take oplocks on a
-     * stream, and smb2.lease.request leases a stream.  Without it the stream
-     * create is refused OBJECT_NAME_INVALID by the named-streams-off gate. */
-    for (i = 0; i < num_tests; i++) {
-        if (strcmp(tests[i], "smb2.streams") == 0 ||
-            strncmp(tests[i], "smb2.streams.", 13) == 0 ||
-            strcmp(tests[i], "smb2.ioctl-on-stream") == 0 ||
-            strcmp(tests[i], "smb2.sdread") == 0 ||
-            strcmp(tests[i], "smb2.oplock.stream1") == 0 ||
-            strcmp(tests[i], "smb2.oplock.batch26") == 0 ||
-            strcmp(tests[i], "smb2.lease.request") == 0) {
-            chimera_server_config_set_smb_named_streams(config, 1);
-            break;
-        }
+    /* Enable named-stream (ADS) support only for the subtests that need it, so
+     * the negative smb2.create_no_streams suite still runs with the feature off
+     * on the same backend.  The list is data shared with CMakeLists.txt --
+     * see smbtorture_ads_subtests.txt.  Without the feature a stream create is
+     * refused OBJECT_NAME_INVALID by the named-streams-off gate, and the
+     * subtest dies in its own setup before asserting anything. */
+    rc = tests_need_named_streams(num_tests, tests);
+
+    if (rc < 0) {
+        test_cleanup(&env, 1);
+        return EXIT_FAILURE;
+    }
+
+    if (rc) {
+        chimera_server_config_set_smb_named_streams(config, 1);
     }
 
     /* The smb2.acls_non_canonical suite asserts Samba's

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -64,6 +64,36 @@ test_cleanup(
     }
 } /* test_cleanup */
 
+/* Log level for this run.  Defaults to info, as every other test harness here
+ * does; SMBTORTURE_LOG_LEVEL=error|info|debug overrides it.  An unrecognized
+ * value is a hard error rather than a silent fallback: a sweep that asked for
+ * debug and quietly got info would harvest nothing and report success. */
+static int
+smbtorture_log_level(void)
+{
+    const char *env = getenv("SMBTORTURE_LOG_LEVEL");
+
+    if (!env || *env == '\0') {
+        return CHIMERA_LOG_INFO;
+    }
+
+    if (strcmp(env, "debug") == 0) {
+        return CHIMERA_LOG_DEBUG;
+    }
+
+    if (strcmp(env, "info") == 0) {
+        return CHIMERA_LOG_INFO;
+    }
+
+    if (strcmp(env, "error") == 0) {
+        return CHIMERA_LOG_ERROR;
+    }
+
+    fprintf(stderr, "SMBTORTURE_LOG_LEVEL='%s' is not one of error|info|debug\n",
+            env);
+    exit(EXIT_FAILURE);
+} /* smbtorture_log_level */
+
 /* Does `name` match `entry` from the ADS list?  Exact, or as a parent-suite
  * prefix: "smb2.streams" matches "smb2.streams" and "smb2.streams.io", but not
  * "smb2.stream-inherit-perms" (the '.' is required).  The old hand-written
@@ -445,8 +475,11 @@ main(
         return 77;
     }
 
-    /* Initialize logging */
-    ChimeraLogLevel = CHIMERA_LOG_INFO;
+    /* Initialize logging.  SMBTORTURE_LOG_LEVEL raises (or lowers) the level for
+     * a single run; tools/smbtorture/derive_ads.sh sets it to debug because the
+     * named-streams gate it harvests logs at debug -- that log is on a
+     * client-driven per-request path, so it cannot default to info. */
+    ChimeraLogLevel = smbtorture_log_level();
     evpl_set_log_fn(chimera_vlog, chimera_log_flush);
 
     env.metrics = prometheus_metrics_create(NULL, NULL, 0);

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -64,6 +64,86 @@ test_cleanup(
     }
 } /* test_cleanup */
 
+/* Does `name` match `entry` from the ADS list?  Exact, or as a parent-suite
+ * prefix: "smb2.streams" matches "smb2.streams" and "smb2.streams.io", but not
+ * "smb2.stream-inherit-perms" (the '.' is required).  The old hand-written
+ * chain used strncmp(name, "smb2.streams.", 13), which silently failed to match
+ * smb2.stream-inherit-perms -- there is no 's' before the hyphen. */
+static int
+ads_entry_matches(
+    const char *entry,
+    const char *name)
+{
+    size_t len = strlen(entry);
+
+    if (strcmp(entry, name) == 0) {
+        return 1;
+    }
+
+    return strncmp(entry, name, len) == 0 && name[len] == '.';
+} /* ads_entry_matches */
+
+/* True if any test named on the command line requires named-stream (ADS)
+ * support.  The list is data, not code: see smbtorture_ads_subtests.txt, which
+ * CMakeLists.txt reads as well so ctest can scope the flag to exactly these
+ * subtests.  Returns -1 if the list cannot be read -- failing loudly rather
+ * than silently running with the feature off, which is the failure mode this
+ * whole mechanism exists to prevent. */
+static int
+tests_need_named_streams(
+    int          num_tests,
+    const char **tests)
+{
+    FILE *fp;
+    char  line[256];
+    int   need = 0;
+
+    /* Escape hatch for tools/smbtorture/derive_ads.sh, which sweeps the catalog
+     * with the feature forced off to rediscover which subtests need it. */
+    if (getenv("SMBTORTURE_ADS_OFF")) {
+        fprintf(stderr, "SMBTORTURE_ADS_OFF set: named streams forced off\n");
+        return 0;
+    }
+
+    fp = fopen(SMBTORTURE_ADS_LIST, "r");
+
+    if (!fp) {
+        fprintf(stderr, "Failed to open ADS subtest list %s: %s\n",
+                SMBTORTURE_ADS_LIST, strerror(errno));
+        return -1;
+    }
+
+    while (!need && fgets(line, sizeof(line), fp)) {
+        char *entry = line, *end;
+
+        while (*entry == ' ' || *entry == '\t') {
+            entry++;
+        }
+
+        end = entry + strcspn(entry, "#\r\n");
+
+        while (end > entry && (end[-1] == ' ' || end[-1] == '\t')) {
+            end--;
+        }
+        *end = '\0';
+
+        if (*entry == '\0') {
+            continue;
+        }
+
+        for (int i = 0; i < num_tests; i++) {
+            if (ads_entry_matches(entry, tests[i])) {
+                need = 1;
+                break;
+            }
+        }
+    }
+
+    fclose(fp);
+
+    return need;
+} /* tests_need_named_streams */
+
 static int
 run_smbtorture(
     int         num_tests,
@@ -439,29 +519,21 @@ main(
         chimera_server_config_set_smb_nic_info(config, 2, nics);
     }
 
-    /* CTest invokes this binary once per suite.  Enable named-stream (ADS)
-     * support only for the stream suites, so the negative smb2.create_no_streams
-     * suite still runs with the feature off on the same backend.  Also match
-     * individual smb2.streams.* subtests so the per-subtest harvest variant
-     * (run one stream subtest in its own server process) gets the same
-     * capability the combined smb2.streams suite needs.
-     *
-     * A handful of oplock/lease subtests open named streams (a real Windows
-     * server always exposes the ADS namespace), so they need the same
-     * capability: smb2.oplock.stream1 / smb2.oplock.batch26 take oplocks on a
-     * stream, and smb2.lease.request leases a stream.  Without it the stream
-     * create is refused OBJECT_NAME_INVALID by the named-streams-off gate. */
-    for (i = 0; i < num_tests; i++) {
-        if (strcmp(tests[i], "smb2.streams") == 0 ||
-            strncmp(tests[i], "smb2.streams.", 13) == 0 ||
-            strcmp(tests[i], "smb2.ioctl-on-stream") == 0 ||
-            strcmp(tests[i], "smb2.sdread") == 0 ||
-            strcmp(tests[i], "smb2.oplock.stream1") == 0 ||
-            strcmp(tests[i], "smb2.oplock.batch26") == 0 ||
-            strcmp(tests[i], "smb2.lease.request") == 0) {
-            chimera_server_config_set_smb_named_streams(config, 1);
-            break;
-        }
+    /* Enable named-stream (ADS) support only for the subtests that need it, so
+     * the negative smb2.create_no_streams suite still runs with the feature off
+     * on the same backend.  The list is data shared with CMakeLists.txt --
+     * see smbtorture_ads_subtests.txt.  Without the feature a stream create is
+     * refused OBJECT_NAME_INVALID by the named-streams-off gate, and the
+     * subtest dies in its own setup before asserting anything. */
+    rc = tests_need_named_streams(num_tests, tests);
+
+    if (rc < 0) {
+        test_cleanup(&env, 1);
+        return EXIT_FAILURE;
+    }
+
+    if (rc) {
+        chimera_server_config_set_smb_named_streams(config, 1);
     }
 
     /* The smb2.acls_non_canonical suite asserts Samba's

--- a/tools/smbtorture/derive_ads.sh
+++ b/tools/smbtorture/derive_ads.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2024-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+#
+# Rediscover which smbtorture subtests need named-stream (ADS) support, and
+# report any that are missing from src/server/smb/tests/smbtorture_ads_subtests.txt.
+#
+# Why this exists: that list used to be a hand-maintained strcmp chain in
+# smbtorture_test.c, grown one entry at a time whenever somebody noticed a
+# failure.  Eleven subtests were never noticed -- they open a stream as
+# incidental setup (a second handle, an elaborate file to query, a directory
+# reached via "::$INDEX_ALLOCATION") and died in that setup with
+# NT_STATUS_OBJECT_NAME_INVALID, looking exactly like a server bug.
+#
+# The set cannot be derived statically: there is no Samba source in this tree,
+# and smbtorture builds its paths at run time from format strings, so scanning
+# the binary yields noise.  So derive it empirically -- sweep the catalog with
+# the feature forced OFF (SMBTORTURE_ADS_OFF=1) and collect every subtest whose
+# server log reports hitting the named-streams-off gate.
+#
+# Runs against memfs only: it is the sole backend advertising
+# CHIMERA_VFS_CAP_NAMED_STREAMS, so it is the only one where the gate that fires
+# is unambiguously gate 1 ("feature off") rather than gate 2 ("backend cannot").
+#
+# Pre-requisites: same as regen.sh -- smbtorture in PATH, chimera built in
+# build/Release, run as root (the netns wrapper needs CAP_NET_ADMIN).
+#
+# Output: prints the derived list, and diffs it against the checked-in file.
+# Exits non-zero if the checked-in list is missing an entry, so CI can gate on
+# it.  Does not rewrite the file: the list carries hand-written commentary
+# (which subtests still fail for real reasons, and why), and clobbering that is
+# worse than the drift it would fix.  Add new entries by hand.
+
+set -euo pipefail
+
+REPO=$(cd "$(dirname "$0")/../.." && pwd)
+LIST=$REPO/src/server/smb/tests/smbtorture_ads_subtests.txt
+WORK=${SMBTORTURE_ADS_WORK:-/tmp/smbtorture-ads}
+PARALLEL=${SMBTORTURE_PARALLEL:-12}
+DRIVER=build/Release/src/server/smb/tests/smbtorture_test
+
+# The log line emitted by gate 1 in chimera_smb_create_start().
+GATE1='named streams: disabled by config'
+
+cd "$REPO"
+
+if [ ! -x "$DRIVER" ]; then
+    echo "error: $DRIVER not built; run 'make release' first" >&2
+    exit 1
+fi
+if ! command -v smbtorture >/dev/null; then
+    echo "error: smbtorture client not in PATH (install samba-testsuite)" >&2
+    exit 1
+fi
+
+rm -rf "$WORK"
+mkdir -p "$WORK/logs"
+
+# 1) Catalog, same derivation as regen.sh.
+smbtorture --list 2>&1 | grep -E '^smb2\.' \
+    | python3 -c '
+import sys
+seen = set()
+for line in sys.stdin:
+    a = line.strip().rsplit(".",1)[0]   # drop the trailing display-name dup
+    if a:
+        seen.add(a)
+for a in sorted(seen):
+    print(a)
+' > "$WORK/subtests.txt"
+echo "catalog: $(wc -l < "$WORK/subtests.txt") subtests"
+
+# 2) Sweep with the feature forced off, one subtest per server process so a hit
+#    is attributable to exactly one subtest.  Keep every log, pass or fail: a
+#    subtest can hit the gate on a path it does not assert on and still pass,
+#    and that still means it needs the feature.
+RUNNER=$(mktemp "$WORK/runner.XXXXXX.sh")
+cat > "$RUNNER" <<'RUNNER_EOF'
+#!/bin/bash
+set -u
+SUITE="$1"
+cd %REPO%
+SMBTORTURE_ADS_OFF=1 timeout --signal=KILL 300 \
+    scripts/netns_test_wrapper.sh %DRIVER% -b memfs "$SUITE" \
+    > "%WORK%/logs/${SUITE//[^A-Za-z0-9]/_}.log" 2>&1
+exit 0
+RUNNER_EOF
+sed -i "s|%REPO%|$REPO|g; s|%WORK%|$WORK|g; s|%DRIVER%|$DRIVER|g" "$RUNNER"
+chmod +x "$RUNNER"
+
+echo "sweeping with SMBTORTURE_ADS_OFF=1 at parallel=$PARALLEL"
+# One subtest per line, and -d '\n' so xargs honours that.  Eight catalog names
+# contain spaces -- "smb2.ioctl.copy-chunk streams" and the smb2.charset /
+# delete-on-close-perms display names -- and xargs' default blank-and-newline
+# splitting would dispatch each of them as two nonexistent subtests, so the real
+# name would never be swept and could never show up as missing -- leaving the
+# sweep blind to exactly the kind of name it exists to find.  -d also turns off
+# xargs' quote and backslash processing, which those same names would otherwise
+# be subject to.
+xargs -d '\n' -P "$PARALLEL" -n 1 -a "$WORK/subtests.txt" "$RUNNER"
+
+# 3) Harvest. Map log file back to its subtest via the same name mangling.
+python3 - "$WORK" "$LIST" <<'PY'
+import os, re, sys
+
+work, listfile = sys.argv[1], sys.argv[2]
+GATE1 = "named streams: disabled by config"
+
+subs = [l.strip() for l in open(f"{work}/subtests.txt") if l.strip()]
+by_mangled = {re.sub(r"[^A-Za-z0-9]", "_", s): s for s in subs}
+
+hits = set()
+for fn in os.listdir(f"{work}/logs"):
+    with open(f"{work}/logs/{fn}", errors="replace") as fp:
+        if GATE1 in fp.read():
+            name = by_mangled.get(fn[:-4])
+            if name:
+                hits.add(name)
+
+# Checked-in list, with the same match semantics as ads_entry_matches() in
+# smbtorture_test.c and _smbtorture_needs_ads() in CMakeLists.txt.
+patterns = []
+for line in open(listfile):
+    line = line.split("#", 1)[0].strip()
+    if line:
+        patterns.append(line)
+
+def covered(name):
+    return any(name == p or name.startswith(p + ".") for p in patterns)
+
+missing = sorted(h for h in hits if not covered(h))
+
+print(f"\nsubtests hitting the named-streams-off gate: {len(hits)}")
+for h in sorted(hits):
+    print(f"  {'   ' if covered(h) else '+++'} {h}")
+
+if missing:
+    print(f"\n{len(missing)} subtest(s) MISSING from {listfile}:")
+    for m in missing:
+        print(f"    {m}")
+    print("\nAdd them by hand (the file carries commentary worth keeping).")
+    sys.exit(1)
+
+print(f"\n{listfile} covers every subtest that hit the gate.")
+PY

--- a/tools/smbtorture/derive_ads.sh
+++ b/tools/smbtorture/derive_ads.sh
@@ -17,7 +17,8 @@
 # and smbtorture builds its paths at run time from format strings, so scanning
 # the binary yields noise.  So derive it empirically -- sweep the catalog with
 # the feature forced OFF (SMBTORTURE_ADS_OFF=1) and collect every subtest whose
-# server log reports hitting the named-streams-off gate.
+# server log reports hitting the named-streams-off gate.  The gate logs at debug,
+# so the sweep raises the driver's level with SMBTORTURE_LOG_LEVEL=debug.
 #
 # Runs against memfs only: it is the sole backend advertising
 # CHIMERA_VFS_CAP_NAMED_STREAMS, so it is the only one where the gate that fires
@@ -27,10 +28,18 @@
 # build/Release, run as root (the netns wrapper needs CAP_NET_ADMIN).
 #
 # Output: prints the derived list, and diffs it against the checked-in file.
-# Exits non-zero if the checked-in list is missing an entry, so CI can gate on
-# it.  Does not rewrite the file: the list carries hand-written commentary
-# (which subtests still fail for real reasons, and why), and clobbering that is
-# worse than the drift it would fix.  Add new entries by hand.
+# Does not rewrite the file: the list carries hand-written commentary (which
+# subtests still fail for real reasons, and why), and clobbering that is worse
+# than the drift it would fix.  Add new entries by hand.
+#
+# Exit status, so CI can gate on it:
+#   0  the checked-in list covers every subtest that hit the gate
+#   1  the list is missing an entry (drift; the sweep itself was sound)
+#   2  the sweep is untrustworthy and NO drift verdict was reached -- it observed
+#      the gate zero times, or missed the subtests that unambiguously open a
+#      stream, or some subtest timed out / was killed / produced no log.  A
+#      verdict is only meaningful if the sweep actually ran, so this case must
+#      never be reported as success.
 
 set -euo pipefail
 
@@ -40,8 +49,26 @@ WORK=${SMBTORTURE_ADS_WORK:-/tmp/smbtorture-ads}
 PARALLEL=${SMBTORTURE_PARALLEL:-12}
 DRIVER=build/Release/src/server/smb/tests/smbtorture_test
 
-# The log line emitted by gate 1 in chimera_smb_create_start().
+# The log line emitted by gate 1 in chimera_smb_create().  Threaded into both the
+# sweep and the harvest below rather than duplicated -- a stale copy would make
+# the sweep find nothing, which used to look exactly like success.
 GATE1='named streams: disabled by config'
+
+# Subtests that unambiguously open a named stream, used as a sanity floor: if the
+# sweep does not see the gate fire for these, it is broken and its "nothing is
+# missing" verdict is worthless.  Any of them may vanish from the catalog on a
+# Samba upgrade, so the floor requires at least one, not all.
+FLOOR='smb2.streams.'
+
+# WORK is recursively deleted below, so refuse an obviously wrong override
+# instead of eating someone's home directory.
+case $WORK in
+    /tmp/*) ;;
+    *)
+        echo "error: SMBTORTURE_ADS_WORK must be under /tmp (got '$WORK')" >&2
+        exit 1
+        ;;
+esac
 
 cd "$REPO"
 
@@ -69,27 +96,45 @@ for line in sys.stdin:
 for a in sorted(seen):
     print(a)
 ' > "$WORK/subtests.txt"
-echo "catalog: $(wc -l < "$WORK/subtests.txt") subtests"
+CATALOG=$(wc -l < "$WORK/subtests.txt")
+echo "catalog: $CATALOG subtests"
+if [ "$CATALOG" -eq 0 ]; then
+    echo "error: 'smbtorture --list' yielded no smb2.* subtests; nothing to sweep" >&2
+    exit 1
+fi
 
 # 2) Sweep with the feature forced off, one subtest per server process so a hit
-#    is attributable to exactly one subtest.  Keep every log, pass or fail: a
-#    subtest can hit the gate on a path it does not assert on and still pass,
+#    is attributable to exactly one subtest.  Sweep every subtest, pass or fail:
+#    a subtest can hit the gate on a path it does not assert on and still pass,
 #    and that still means it needs the feature.
+mkdir -p "$WORK/full"
 RUNNER=$(mktemp "$WORK/runner.XXXXXX.sh")
 cat > "$RUNNER" <<'RUNNER_EOF'
 #!/bin/bash
 set -u
 SUITE="$1"
+SAFE="${SUITE//[^A-Za-z0-9]/_}"
+FULL="%WORK%/full/$SAFE.out"
 cd %REPO%
-SMBTORTURE_ADS_OFF=1 timeout --signal=KILL 300 \
+SMBTORTURE_LOG_LEVEL=debug SMBTORTURE_ADS_OFF=1 timeout --signal=KILL 300 \
     scripts/netns_test_wrapper.sh %DRIVER% -b memfs "$SUITE" \
-    > "%WORK%/logs/${SUITE//[^A-Za-z0-9]/_}.log" 2>&1
+    > "$FULL" 2>&1
+rc=$?
+# Distil rather than keep: the exit status, so a killed or crashed run is not
+# silently read as "this subtest does not need ADS", plus the gate lines only.
+# Debug-level logs for the whole catalog would otherwise run to many GB.
+{
+    echo "runner-exit=$rc"
+    grep -F "%GATE1%" "$FULL" || true
+} > "%WORK%/logs/$SAFE.log"
+rm -f "$FULL"
 exit 0
 RUNNER_EOF
-sed -i "s|%REPO%|$REPO|g; s|%WORK%|$WORK|g; s|%DRIVER%|$DRIVER|g" "$RUNNER"
+sed -i "s|%REPO%|$REPO|g; s|%WORK%|$WORK|g; s|%DRIVER%|$DRIVER|g; s|%GATE1%|$GATE1|g" \
+    "$RUNNER"
 chmod +x "$RUNNER"
 
-echo "sweeping with SMBTORTURE_ADS_OFF=1 at parallel=$PARALLEL"
+echo "sweeping with SMBTORTURE_ADS_OFF=1 SMBTORTURE_LOG_LEVEL=debug at parallel=$PARALLEL"
 # One subtest per line, and -d '\n' so xargs honours that.  Eight catalog names
 # contain spaces -- "smb2.ioctl.copy-chunk streams" and the smb2.charset /
 # delete-on-close-perms display names -- and xargs' default blank-and-newline
@@ -99,24 +144,36 @@ echo "sweeping with SMBTORTURE_ADS_OFF=1 at parallel=$PARALLEL"
 # xargs' quote and backslash processing, which those same names would otherwise
 # be subject to.
 xargs -d '\n' -P "$PARALLEL" -n 1 -a "$WORK/subtests.txt" "$RUNNER"
+rmdir "$WORK/full" 2>/dev/null || true
 
 # 3) Harvest. Map log file back to its subtest via the same name mangling.
-python3 - "$WORK" "$LIST" <<'PY'
+python3 - "$WORK" "$LIST" "$GATE1" "$FLOOR" "$DRIVER" <<'PY'
 import os, re, sys
 
-work, listfile = sys.argv[1], sys.argv[2]
-GATE1 = "named streams: disabled by config"
+work, listfile, gate1, floor, DRIVER = sys.argv[1:6]
 
 subs = [l.strip() for l in open(f"{work}/subtests.txt") if l.strip()]
 by_mangled = {re.sub(r"[^A-Za-z0-9]", "_", s): s for s in subs}
 
-hits = set()
-for fn in os.listdir(f"{work}/logs"):
-    with open(f"{work}/logs/{fn}", errors="replace") as fp:
-        if GATE1 in fp.read():
-            name = by_mangled.get(fn[:-4])
-            if name:
-                hits.add(name)
+# A run that timed out, was killed, or skipped never got far enough for the
+# absence of a gate line to mean anything.  Counting it as "does not need ADS"
+# is how a broken sweep produces a clean bill of health.
+INCONCLUSIVE_RC = {77, 124, 137}
+
+hits, inconclusive, nolog = set(), [], []
+for mangled, name in by_mangled.items():
+    path = f"{work}/logs/{mangled}.log"
+    if not os.path.exists(path):
+        nolog.append(name)
+        continue
+    with open(path, errors="replace") as fp:
+        body = fp.read()
+    m = re.search(r"^runner-exit=(-?\d+)$", body, re.M)
+    if m is None or int(m.group(1)) in INCONCLUSIVE_RC:
+        inconclusive.append(name)
+        continue
+    if gate1 in body:
+        hits.add(name)
 
 # Checked-in list, with the same match semantics as ads_entry_matches() in
 # smbtorture_test.c and _smbtorture_needs_ads() in CMakeLists.txt.
@@ -129,12 +186,40 @@ for line in open(listfile):
 def covered(name):
     return any(name == p or name.startswith(p + ".") for p in patterns)
 
-missing = sorted(h for h in hits if not covered(h))
-
 print(f"\nsubtests hitting the named-streams-off gate: {len(hits)}")
 for h in sorted(hits):
     print(f"  {'   ' if covered(h) else '+++'} {h}")
 
+# Sanity floor.  Everything below this point only means something if the sweep
+# actually observed the gate; without these checks an empty harvest -- wrong log
+# level, driver aborting at startup, netns wrapper broken, drifted log string --
+# reports "covers every subtest" and exits 0.
+fatal = []
+if nolog:
+    fatal.append(f"{len(nolog)} subtest(s) produced no log at all, e.g. "
+                 + ", ".join(sorted(nolog)[:5]))
+if inconclusive:
+    fatal.append(f"{len(inconclusive)} subtest(s) timed out, were killed, or "
+                 "skipped, so their result is unknown, e.g. "
+                 + ", ".join(sorted(inconclusive)[:5]))
+if not hits:
+    fatal.append("the sweep observed the gate ZERO times; it tested nothing")
+elif not any(h.startswith(floor) for h in hits):
+    fatal.append(f"no '{floor}*' subtest hit the gate; those unambiguously open "
+                 "a stream, so the sweep is not observing the gate correctly")
+
+if fatal:
+    print("\nSWEEP IS NOT TRUSTWORTHY -- not reporting drift:")
+    for f in fatal:
+        print(f"  ! {f}")
+    print("\nFix the cause and re-run the sweep.  A single subtest can be checked\n"
+          "by hand without a full sweep:\n"
+          "  SMBTORTURE_LOG_LEVEL=debug SMBTORTURE_ADS_OFF=1 \\\n"
+          "    scripts/netns_test_wrapper.sh " + DRIVER + " -b memfs SUBTEST \\\n"
+          "    2>&1 | grep -F '" + gate1 + "'")
+    sys.exit(2)
+
+missing = sorted(h for h in hits if not covered(h))
 if missing:
     print(f"\n{len(missing)} subtest(s) MISSING from {listfile}:")
     for m in missing:


### PR DESCRIPTION
## Problem

Eleven memfs smbtorture subtests failed with NT_STATUS_OBJECT_NAME_INVALID where NT_STATUS_OK was expected, and every one of them looked like a server bug. None was: each opens a path containing ':' as incidental setup — a second handle on a file, an elaborate file or directory to query — and the harness enabled named-stream (ADS) support only for a hardcoded strcmp chain in `smbtorture_test.c` that did not cover them, so the stream CREATE was refused at the named-streams-off gate before the subtest asserted anything.

The two gates that refuse such a CREATE — the feature being off in config, and the backend lacking `CHIMERA_VFS_CAP_NAMED_STREAMS` — both answer OBJECT_NAME_INVALID and were indistinguishable after the fact, which is part of how the cluster stayed hidden.

## Changes

**The subtest list becomes data.** `src/server/smb/tests/smbtorture_ads_subtests.txt` is now the single source of truth, read by the driver at run time to set the config knob and by `CMakeLists.txt` at configure time to scope it under ctest. An entry matches a test name exactly or as a parent-suite prefix, so `smb2.streams` covers `smb2.streams.io` — which the old `strncmp(name, "smb2.streams.", 13)` could never do for `smb2.stream-inherit-perms`, since there is no 's' before the hyphen. Selection stays per-test rather than global: `smb2.create_no_streams.no_stream` asserts that a server without stream support rejects a stream path, and it passes on all six backends today precisely because the feature is off.

**Suites that mix ADS and non-ADS subtests are split under ctest.** A consolidated suite runs all of its subtests in one server process, so registering an ADS subtest alongside siblings that do not need it turns the feature on for every sibling. Measured against the allowlists as they stand that is five currently-passing subtests across two suites, all on memfs — two in `smb2.fileid` and three in `smb2.kernel-oplocks` — and zero on the other five backends. That count is small only because six of the eleven subtests stay out of the allowlists pending individual fixes; as those land they pull `smb2.compound`, `smb2.create` and `smb2.getinfo` into the mixed set, and enabling `smb2.ioctl.copy-chunk streams` would add `smb2.ioctl`'s 67. The stronger reason is agreement between harnesses: `tools/smbtorture/regen.sh` dispatches one subtest per server process, so its ADS decision is per-subtest by construction, and a suite-level knob under ctest would run the same subtest name under a different server config in the two places — pass/fail could then differ between ctest and the matrix with no code change involved, and the matrix is what gets triaged. So a suite with a mix is split, and a suite whose enabled subtests all need ADS stays consolidated. That mixed branch is also the first path to register a consolidated suite entry and per-subtest entries under the same parent, which makes a duplicate `add_test NAME` reachable: the three bare ADS entries (`smb2.ioctl-on-stream`, `smb2.sdread`, `smb2.stream-inherit-perms`) are exactly that shape once a Samba image upgrade adds a subtest under one of them, so a suite is also split when its own bare name is the ADS member.

**The list is read from the build tree**, copied there with `configure_file(... COPYONLY)`. The driver opens it by absolute path at run time and treats a failed open as EXIT_FAILURE rather than the suites' `SKIP_RETURN_CODE` 77, so a source path baked in at configure time would make every smbtorture entry a hard failure — indistinguishable from a real regression — in any environment where the source tree is no longer at that path.

**Each named-streams gate now logs which one fired.** At debug rather than info, and that is load-bearing: `named_streams` is off by default and gate 1 sits on a per-CREATE path, so with macOS clients probing `:AFP_AfpInfo` and `:com.apple.ResourceFork` and Windows probing `:Zone.Identifier` on essentially every file, a Finder or Explorer browse of a share would emit an info line per file, each carrying a client-controlled path. `SMBTORTURE_LOG_LEVEL=error|info|debug` gives a single run that level, and `SMBTORTURE_ADS=off|on` forces the feature either way independently of the list, which is what makes it cheap to confirm a subtest's membership by running it both ways and comparing. Both hard-error on an unrecognized value rather than falling back silently.

## Result

Five subtests now pass and join `SMBTORTURE_ENABLED_memfs`: `smb2.fileid.fileid`, `smb2.kernel-oplocks.kernel_oplocks2/4/6`, and `smb2.stream-inherit-perms`.

Six more now reach their real assertions and fail for genuine reasons. Each is recorded alongside its entry in the list file and stays out of the ctest allowlists pending an individual fix:

| Subtest | Failure |
| --- | --- |
| `smb2.getinfo.complex` | `RAW_FILEINFO_ALT_NAME_INFORMATION` returns NOT_IMPLEMENTED |
| `smb2.getinfo.normalized` | normalized-name query does not preserve case |
| `smb2.compound.compound-padding` | response `body_size` is 19, expected 24 |
| `smb2.kernel-oplocks.kernel_oplocks5` | granted oplock level is not NONE |
| `smb2.fileid.fileid-dir` | subtest passes, then the server aborts at teardown on a leaked evpl buffer reference |
| `smb2.create.quota-fake-file` | opens Samba's `$Extend\$Quota` fake file; chimera has no quota namespace, so it fails with ADS on as well |

`smb2.ioctl.copy-chunk streams` is listed so the gate opens for a run that names it, but nobody has run it that way yet, so it claims no outcome and stays out of every backend allowlist.
