### PR TITLE
tests: run the in-process suites over libevpl's inproc transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,34 @@ endif()
 # Forward result to libevpl so it doesn't probe again.
 set(LIBEVPL_NETNS_TESTING ${CHIMERA_NETNS_TESTING})
 
+# Raised-limit testing detection.
+#
+# Distinct from the netns probe above, and deliberately so.  Tests whose client
+# and server share a process now talk over the in-process transport, so they
+# bind no port and need no namespace to keep them apart -- but some VFS
+# backends still need unlimited locked memory (io_uring queues) and a raised
+# aio-max-nr (libaio contexts), which the netns wrapper had been supplying as a
+# side effect of running privileged.
+#
+# Probing the two separately is what lets those tests run in an environment
+# that grants the limits but not CAP_NET_ADMIN: previously the netns probe was
+# the only gate, so no namespace meant no tests, whatever else was available.
+execute_process(
+    COMMAND bash -c "set -e; ulimit -l unlimited; test -w /proc/sys/fs/aio-max-nr"
+    RESULT_VARIABLE LIMITS_PROBE_RESULT
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if(LIMITS_PROBE_RESULT EQUAL 0)
+    set(CHIMERA_LIMITS_TESTING TRUE)
+    message(STATUS "Raised-limit testing enabled")
+else()
+    set(CHIMERA_LIMITS_TESTING FALSE)
+    message(STATUS "Raised-limit testing disabled "
+        "(cannot raise memlock / aio-max-nr; backends needing them are skipped)")
+endif()
+
 # PyNFS testing.  Every suite is registered, but only the combinations known
 # to pass are actually run; the rest are marked DISABLED (see
 # pynfs/CMakeLists.txt) so a normal `ctest` stays green while still listing the

--- a/scripts/test_limits_wrapper.sh
+++ b/scripts/test_limits_wrapper.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Raise the resource limits some VFS backends need, then run the test.
+#
+# This is netns_test_wrapper.sh with the network namespace taken out.  Tests
+# that reach their server over the in-process transport have no port to
+# conflict over, so they need no namespace to isolate them -- but they still
+# need the limits the namespace wrapper happened to be raising along the way:
+# unlimited locked memory for the io_uring module's queues, and an aio-max-nr
+# large enough for the libaio backend's contexts.
+#
+# Losing the namespace is the point: creating one needs CAP_NET_ADMIN, and
+# where that is unavailable the tests using it could not run at all.  These can.
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <test_command> [args...]"
+    echo "Runs a test command with the resource limits the backends need"
+    exit 1
+fi
+
+# Both are best-effort.  A backend that genuinely needs them fails loudly on
+# its own; a backend that does not (memfs, cairn, linux) should still run in an
+# environment that grants neither, which is precisely the case this wrapper
+# exists to support.
+ulimit -l unlimited 2>/dev/null || true
+echo 16777216 > /proc/sys/fs/aio-max-nr 2>/dev/null || true
+
+exec "$@"

--- a/src/client/tests/CMakeLists.txt
+++ b/src/client/tests/CMakeLists.txt
@@ -11,10 +11,12 @@ endmacro()
 
 # These run unwrapped, but their fixture chowns the per-test session dir to
 # the target test uid/gid (CAP_CHOWN) and brings up the io_uring VFS module
-# (unlimited RLIMIT_MEMLOCK) -- the same privileges the netns environment
-# provides. Gate them on it so unprivileged `make` skips rather than fails.
+# (unlimited RLIMIT_MEMLOCK). Gate them on the raised-limit probe so an
+# unprivileged `make` skips rather than fails.  That probe is deliberately not
+# the netns one: the NFS and SMB variants below reach their server over the
+# in-process transport now, so none of this needs CAP_NET_ADMIN.
 macro(add_client_test testname prog backend user)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         add_test(NAME chimera/client/${testname} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${prog} -b ${backend} -U ${user})
         get_target_property(test_file ${prog} TEST_FILE)
         set_tests_properties(chimera/client/${testname} PROPERTIES
@@ -23,8 +25,8 @@ macro(add_client_test testname prog backend user)
 endmacro()
 
 macro(add_client_nfs_test testname prog backend user)
-    if(CHIMERA_NETNS_TESTING)
-        add_test(NAME chimera/client/${testname} COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh ${CMAKE_CURRENT_BINARY_DIR}/${prog} -v 3 -b ${backend} -U ${user})
+    if(CHIMERA_LIMITS_TESTING)
+        add_test(NAME chimera/client/${testname} COMMAND ${CMAKE_SOURCE_DIR}/scripts/test_limits_wrapper.sh ${CMAKE_CURRENT_BINARY_DIR}/${prog} -v 3 -b ${backend} -U ${user})
         get_target_property(test_file ${prog} TEST_FILE)
         set_tests_properties(chimera/client/${testname} PROPERTIES
             ENVIRONMENT "TEST_FILE=${test_file}")
@@ -33,17 +35,17 @@ endmacro()
 
 add_executable(client_basic basic.c)
 target_link_libraries(client_basic chimera_client)
-# Runs unwrapped (no loopback networking needed), but initializing the VFS
-# brings up the io_uring module, whose queue allocation needs an unlimited
-# RLIMIT_MEMLOCK. The netns wrapper raises that limit for every other test;
-# gate this one on the same privilege so unprivileged `make` doesn't abort.
-if(CHIMERA_NETNS_TESTING)
+# Runs unwrapped (no networking of any kind), but initializing the VFS brings
+# up the io_uring module, whose queue allocation needs an unlimited
+# RLIMIT_MEMLOCK. The limits wrapper raises that for every other test; gate
+# this one on the same privilege so unprivileged `make` doesn't abort.
+if(CHIMERA_LIMITS_TESTING)
     add_test(NAME chimera/client/basic COMMAND client_basic)
 endif()
 
 add_executable(client_read_into read_into.c)
 target_link_libraries(client_read_into chimera_client evpl prometheus-c)
-if(CHIMERA_NETNS_TESTING)
+if(CHIMERA_LIMITS_TESTING)
     add_test(NAME chimera/client/read_into COMMAND client_read_into)
 endif()
 
@@ -102,15 +104,15 @@ generate_backend_tests(linux "")
 generate_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 
 # SMB client tests: drive the vfs_smb client against an in-process SMB server
-# (backed by memfs) over loopback.  Limited to the file operations implemented
+# (backed by memfs) over the in-process transport.  Limited to the file operations implemented
 # so far, and to the root user -- the memfs share root's ACL denies an
 # unprivileged user's create, so myuser variants fail server-side authorization
 # (not a client defect).  The "-s" flag selects SMB mode in client_test_common.h.
 macro(add_client_smb_test prog)
     string(REGEX REPLACE "^test_" "" _smb_name ${prog})
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         add_test(NAME chimera/client/${_smb_name}_smb_memfs_root
-            COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+            COMMAND ${CMAKE_SOURCE_DIR}/scripts/test_limits_wrapper.sh
                     ${CMAKE_CURRENT_BINARY_DIR}/${prog} -s -b memfs -U root)
         get_target_property(_smb_test_file ${prog} TEST_FILE)
         set_tests_properties(chimera/client/${_smb_name}_smb_memfs_root PROPERTIES

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -119,6 +119,12 @@ client_test_init(
     if (env->use_nfs || env->use_smb) {
         server_config = chimera_server_config_init();
 
+        /* Serve over the in-process transport: the client below lives in this
+         * same process, so there is no reason to bind a port, and an inproc
+         * name is private to the process -- so concurrent copies of this test
+         * cannot collide and need no network namespace to separate them. */
+        chimera_server_config_set_tcp_flavor(server_config, CHIMERA_TCP_FLAVOR_INPROC);
+
         if (strcmp(backend, "diskfs_io_uring") == 0 ||
             strcmp(backend, "diskfs_aio") == 0) {
             char        diskfs_cfg[4096];
@@ -329,6 +335,16 @@ client_test_init(
         }
 
         json_object_set_new(client_json_root, "config", client_json_config);
+
+        /* Match the server started above.  The transport is read from the
+         * top-level "common" section rather than from "config". */
+        {
+            json_t *common = json_object();
+
+            json_object_set_new(common, "tcp_flavor", json_string("inproc"));
+            json_object_set_new(client_json_root, "common", common);
+        }
+
         chimera_test_write_users_json(client_json_root);
 
         snprintf(client_json_path, sizeof(client_json_path), "%s/client.json", env->session_dir);

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -43,6 +43,10 @@ chimera_common_tcp_flavor(json_t *root)
         return CHIMERA_TCP_FLAVOR_XLIO;
     } else if (strcasecmp(s, "io_uring") == 0) {
         return CHIMERA_TCP_FLAVOR_IO_URING;
+    } else if (strcasecmp(s, "inproc") == 0) {
+        /* Only meaningful when the client shares the process with the server,
+         * which outside the test suite it does not. */
+        return CHIMERA_TCP_FLAVOR_INPROC;
     }
 
     return CHIMERA_TCP_FLAVOR_PLAIN;

--- a/src/common/tcp_flavor.h
+++ b/src/common/tcp_flavor.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdio.h>
+
 #include "evpl/evpl.h"
 
 /*
@@ -16,6 +18,20 @@ enum chimera_tcp_flavor {
     CHIMERA_TCP_FLAVOR_PLAIN    = 0,
     CHIMERA_TCP_FLAVOR_IO_URING = 1,
     CHIMERA_TCP_FLAVOR_XLIO     = 2,
+
+    /* Not TCP at all: libevpl's in-process transport, where a "connection" is
+     * a queue between two threads and never reaches the kernel.  It occupies
+     * this enum because it answers the same question the others do -- which
+     * transport do the server and the client agree on -- and that agreement is
+     * already plumbed process-wide to both ends.
+     *
+     * Its use is the test suite.  An inproc name is private to the process, so
+     * a server and client in one test binary can talk without binding a port,
+     * and any number of those binaries can run at once without colliding.
+     * That is what lets the tests run in parallel with no network namespace
+     * to isolate them.  It is not a transport a real deployment can use: the
+     * peer has to be in the same process. */
+    CHIMERA_TCP_FLAVOR_INPROC   = 3,
 };
 
 /* Map a TCP flavor to the corresponding evpl stream protocol. */
@@ -27,8 +43,63 @@ chimera_tcp_flavor_to_protocol(enum chimera_tcp_flavor flavor)
             return EVPL_STREAM_IO_URING_TCP;
         case CHIMERA_TCP_FLAVOR_XLIO:
             return EVPL_STREAM_XLIO_TCP;
+        case CHIMERA_TCP_FLAVOR_INPROC:
+            return EVPL_STREAM_INPROC;
         case CHIMERA_TCP_FLAVOR_PLAIN:
         default:
             return EVPL_STREAM_SOCKET_TCP;
     } /* switch */
 } /* chimera_tcp_flavor_to_protocol */
+
+/*
+ * The RPC-over-RDMA counterpart of the above: which protocol carries the
+ * chunk-bearing (DDP) framing.  tcp_rdma selects the emulation over a TCP
+ * socket rather than real RDMA hardware.
+ *
+ * DATAGRAM_INPROC reports itself as RDMA-capable to rpc2, so the read and
+ * write chunk paths are exercised exactly as they are over the wire
+ * transports -- an inproc run is not quietly a plain-RPC run.
+ */
+static inline enum evpl_protocol_id
+chimera_tcp_flavor_to_rdma_protocol(
+    enum chimera_tcp_flavor flavor,
+    int                     tcp_rdma)
+{
+    if (flavor == CHIMERA_TCP_FLAVOR_INPROC) {
+        return EVPL_DATAGRAM_INPROC;
+    }
+
+    return tcp_rdma ? EVPL_DATAGRAM_TCP_RDMA : EVPL_DATAGRAM_RDMACM_RC;
+} /* chimera_tcp_flavor_to_rdma_protocol */
+
+/*
+ * Build the endpoint for a service that the socket transports identify by
+ * (host, port).
+ *
+ * Under inproc there is neither: the name is the whole address.  The port is
+ * still what distinguishes one service from another -- NFS from mountd from
+ * NLM -- so it names the endpoint, which keeps the portmap exchange working
+ * unchanged: the server registers a port, the client asks for it, and both
+ * sides derive the same name from it.
+ *
+ * No pid or other per-run token belongs in that name.  The registry is
+ * private to the process, so two chimera processes using "chimera-inproc-2049"
+ * simultaneously do not collide the way two binds to port 2049 would.  That
+ * is precisely the property being bought here.
+ */
+static inline struct evpl_endpoint *
+chimera_tcp_flavor_endpoint_create(
+    enum chimera_tcp_flavor flavor,
+    const char             *host,
+    int                     port)
+{
+    char name[64];
+
+    if (flavor != CHIMERA_TCP_FLAVOR_INPROC) {
+        return evpl_endpoint_create(host, port);
+    }
+
+    snprintf(name, sizeof(name), "chimera-inproc-%d", port);
+
+    return evpl_endpoint_create_inproc(name);
+} /* chimera_tcp_flavor_endpoint_create */

--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -6,8 +6,34 @@
 add_executable(posix_fsx fsx.c)
 target_link_libraries(posix_fsx chimera_posix chimera_client chimera_server jansson)
 
-# Wrapper script for running tests in a network namespace
+# Tests that fork() cannot use the in-process transport: an inproc name is
+# reachable only from the process that registered it, and these initialise a
+# fresh client in each child after fork(), so a child would have no way to
+# reach the server in its parent.  They keep a real socket -- and therefore the
+# namespace that stops two of them colliding on a port.
 set(NETNS_WRAPPER "${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh")
+set(POSIX_FORKING_TESTS
+    cthon_lock_tlock
+    test_dirstress
+    test_fcntl
+    test_fsstress
+    test_fstest
+    test_lockf)
+
+macro(posix_test_forks prog out_var)
+    if("${prog}" IN_LIST POSIX_FORKING_TESTS)
+        set(${out_var} TRUE)
+    else()
+        set(${out_var} FALSE)
+    endif()
+endmacro()
+
+# The same, minus the namespace.  The NFS tests below reach their server over
+# the in-process transport, so they bind no port and cannot collide with each
+# other or with anything on the host -- there is nothing for a namespace to
+# isolate.  What they still want is the raised limits the netns wrapper had
+# been supplying as a side effect: see scripts/test_limits_wrapper.sh.
+set(LIMITS_WRAPPER "${CMAKE_SOURCE_DIR}/scripts/test_limits_wrapper.sh")
 
 macro(add_posix_testprog name)
     add_executable(posix_${name} ${name}.c)
@@ -18,8 +44,8 @@ macro(add_posix_testprog name)
 endmacro()
 
 macro(add_posix_test testname prog backend)
-    if(CHIMERA_NETNS_TESTING)
-        add_test(NAME chimera/posix/${testname} COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
+    if(CHIMERA_LIMITS_TESTING)
+        add_test(NAME chimera/posix/${testname} COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname} PROPERTIES
             ENVIRONMENT "TEST_FILE=${test_file}")
@@ -108,7 +134,7 @@ generate_posix_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 # diskfs-only cache-eviction / cold-remount stress (not part of the
 # all-backend matrix: it shrinks the diskfs caches and remounts the devices)
 add_posix_testprog(test_diskfs_evict)
-if(CHIMERA_NETNS_TESTING)
+if(CHIMERA_LIMITS_TESTING)
     if(IO_URING_ENABLED)
         add_posix_test(diskfs_evict_diskfs_io_uring test_diskfs_evict diskfs_io_uring)
         set_tests_properties(chimera/posix/diskfs_evict_diskfs_io_uring PROPERTIES TIMEOUT 900)
@@ -122,7 +148,7 @@ endif()
 # diskfs-only space-reclaim + AG-log condensation test (statfs convergence
 # over delete churn, unlink-while-open, reclaim backlog across remount)
 add_posix_testprog(test_diskfs_reclaim)
-if(CHIMERA_NETNS_TESTING)
+if(CHIMERA_LIMITS_TESTING)
     if(IO_URING_ENABLED)
         add_posix_test(diskfs_reclaim_diskfs_io_uring test_diskfs_reclaim diskfs_io_uring)
         set_tests_properties(chimera/posix/diskfs_reclaim_diskfs_io_uring PROPERTIES TIMEOUT 600)
@@ -138,7 +164,7 @@ endif()
 # must be a different module from memfs (two memfs mounts share one fsid, i.e.
 # the same filesystem).  Runs on the local non-memfs backends only.
 add_posix_testprog(test_exdev)
-if(CHIMERA_NETNS_TESTING)
+if(CHIMERA_LIMITS_TESTING)
     if(CAIRN_ENABLED)
         add_posix_test(exdev_cairn test_exdev cairn)
     endif()
@@ -158,22 +184,33 @@ endif()
 # NFS3 Backend Tests
 # These tests run the POSIX tests through the Chimera NFS client,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
-# Macro to add a test that runs via NFS3 client (requires network namespace)
+# Macro to add a test that runs via NFS3 client (in-process transport; no namespace needed)
 macro(add_posix_nfs3_test testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         set(test_timeout 60)
         if("${testname}" STREQUAL "io_serialize" AND "${nfs_backend}" MATCHES "^diskfs_")
             set(test_timeout 120)
         endif()
         add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend} PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT ${test_timeout}
         )
     endif()
@@ -210,22 +247,33 @@ generate_posix_nfs3_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 # NFS4 Backend Tests
 # These tests run the POSIX tests through the Chimera NFS4 client,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
-# Macro to add a test that runs via NFS4 client (requires network namespace)
+# Macro to add a test that runs via NFS4 client (in-process transport; no namespace needed)
 macro(add_posix_nfs4_test testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         set(test_timeout 60)
         if("${testname}" STREQUAL "io_serialize" AND "${nfs_backend}" MATCHES "^diskfs_")
             set(test_timeout 120)
         endif()
         add_test(NAME chimera/posix/${testname}_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs4_${nfs_backend} PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT ${test_timeout}
         )
     endif()
@@ -269,9 +317,9 @@ generate_posix_nfs4_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 add_posix_testprog(test_erofs)
 
 macro(add_posix_erofs_test nfs_prefix nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         add_test(NAME chimera/posix/erofs_${nfs_prefix}_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_erofs -b ${nfs_prefix}_${nfs_backend}
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_erofs -b ${nfs_prefix}_${nfs_backend}
         )
         get_target_property(test_file posix_test_erofs TEST_FILE)
         set_tests_properties(chimera/posix/erofs_${nfs_prefix}_${nfs_backend} PROPERTIES
@@ -316,9 +364,9 @@ add_posix_erofs_test(nfs4 memfs)
 add_posix_testprog(test_export_ro)
 
 macro(add_posix_export_ro_test nfs_prefix nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         add_test(NAME chimera/posix/export_ro_${nfs_prefix}_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_export_ro -b ${nfs_prefix}_${nfs_backend}
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_export_ro -b ${nfs_prefix}_${nfs_backend}
         )
         get_target_property(test_file posix_test_export_ro TEST_FILE)
         set_tests_properties(chimera/posix/export_ro_${nfs_prefix}_${nfs_backend} PROPERTIES
@@ -345,9 +393,9 @@ add_posix_export_ro_test(nfs4 memfs)
 add_posix_testprog(test_pseudo_root)
 
 macro(add_posix_pseudo_root_test nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         add_test(NAME chimera/posix/pseudo_root_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_pseudo_root -b nfs4_${nfs_backend}
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_pseudo_root -b nfs4_${nfs_backend}
         )
         get_target_property(test_file posix_test_pseudo_root TEST_FILE)
         set_tests_properties(chimera/posix/pseudo_root_nfs4_${nfs_backend} PROPERTIES
@@ -364,22 +412,33 @@ add_posix_pseudo_root_test(linux)
 # NFS3 over TCP-RDMA Backend Tests
 # These tests run the POSIX tests through the Chimera NFS client using TCP-RDMA,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
-# Macro to add a test that runs via NFS3 RDMA client (requires network namespace)
+# Macro to add a test that runs via NFS3 RDMA client (in-process transport; no namespace needed)
 macro(add_posix_nfs3rdma_test testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         set(test_timeout 60)
         if("${testname}" STREQUAL "io_serialize" AND "${nfs_backend}" MATCHES "^diskfs_")
             set(test_timeout 120)
         endif()
         add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend} PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT ${test_timeout}
         )
     endif()
@@ -419,9 +478,9 @@ set(FSX_NUM_OPS 10000)
 set(FSX_MAX_LEN 262144)
 
 macro(add_fsx_test backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         add_test(NAME chimera/posix/fsx_${backend}
-            COMMAND ${NETNS_WRAPPER} ${FSX_WRAPPER} -b ${backend} -N ${FSX_NUM_OPS} -l ${FSX_MAX_LEN} -q
+            COMMAND ${LIMITS_WRAPPER} ${FSX_WRAPPER} -b ${backend} -N ${FSX_NUM_OPS} -l ${FSX_MAX_LEN} -q
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )
         # fsx does 10000 randomized ops over RocksDB/diskfs-backed VFS under
@@ -525,8 +584,8 @@ endmacro()
 
 # Macro to add a cthon test to ctest
 macro(add_cthon_test testname prog backend)
-    if(CHIMERA_NETNS_TESTING)
-        add_test(NAME chimera/posix/cthon/${testname} COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
+    if(CHIMERA_LIMITS_TESTING)
+        add_test(NAME chimera/posix/cthon/${testname} COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend})
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/cthon/${testname} PROPERTIES
             ENVIRONMENT "TEST_FILE=${test_file}"
@@ -642,18 +701,29 @@ endforeach()
 # NFS3 Cthon Tests
 # These tests run the cthon tests through the Chimera NFS client,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
-# Macro to add a cthon test that runs via NFS3 client (requires network namespace)
+# Macro to add a cthon test that runs via NFS3 client (in-process transport; no namespace needed)
 macro(add_cthon_nfs3_test testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         add_test(NAME chimera/posix/cthon/${testname}_nfs3_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/cthon/${testname}_nfs3_${nfs_backend} PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT 300
         )
     endif()
@@ -689,18 +759,29 @@ generate_cthon_nfs3_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 # NFS3 RDMA Cthon Tests
 # These tests run the cthon tests through the Chimera NFS client using TCP-RDMA,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
-# Macro to add a cthon test that runs via NFS3 RDMA client (requires network namespace)
+# Macro to add a cthon test that runs via NFS3 RDMA client (in-process transport; no namespace needed)
 macro(add_cthon_nfs3rdma_test testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         add_test(NAME chimera/posix/cthon/${testname}_nfs3rdma_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/cthon/${testname}_nfs3rdma_${nfs_backend} PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT 300
         )
     endif()
@@ -736,18 +817,29 @@ generate_cthon_nfs3rdma_backend_tests(io_uring CHIMERA_VFS_IO_URING)
 # NFS4 Cthon Tests
 # These tests run the cthon tests through the Chimera NFS4 client,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
-# Macro to add a cthon test that runs via NFS4 client (requires network namespace)
+# Macro to add a cthon test that runs via NFS4 client (in-process transport; no namespace needed)
 macro(add_cthon_nfs4_test testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         add_test(NAME chimera/posix/cthon/${testname}_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs4_${nfs_backend}
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/cthon/${testname}_nfs4_${nfs_backend} PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT 300
         )
     endif()
@@ -809,34 +901,34 @@ endmacro()
 
 # Helper macro to generate stress tests for a backend
 macro(_generate_stress_tests_for_backend backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         # dirstress: directory operations stress test (reduced params for testing)
         add_test(NAME chimera/posix/dirstress_${backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b ${backend} -p 1 -f 50
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b ${backend} -p 1 -f 50
         )
         set_tests_properties(chimera/posix/dirstress_${backend} PROPERTIES TIMEOUT 120)
 
         # rewinddir: tests rewinddir() POSIX semantics
         add_test(NAME chimera/posix/rewinddir_${backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b ${backend}
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b ${backend}
         )
         set_tests_properties(chimera/posix/rewinddir_${backend} PROPERTIES TIMEOUT 120)
 
         # fstest: data integrity verification test
         add_test(NAME chimera/posix/fstest_${backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b ${backend} -n 1 -f 2 -l 5 -s 65536
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b ${backend} -n 1 -f 2 -l 5 -s 65536
         )
         set_tests_properties(chimera/posix/fstest_${backend} PROPERTIES TIMEOUT 120)
 
         # nametest: namespace stress test
         add_test(NAME chimera/posix/nametest_${backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b ${backend} -n 50 -i 1000
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b ${backend} -n 50 -i 1000
         )
         set_tests_properties(chimera/posix/nametest_${backend} PROPERTIES TIMEOUT 120)
 
         # fsstress: comprehensive filesystem stress test
         add_test(NAME chimera/posix/fsstress_${backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b ${backend} -n 500 -p 1
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b ${backend} -n 500 -p 1
         )
         set_tests_properties(chimera/posix/fsstress_${backend} PROPERTIES TIMEOUT 180)
     endif()
@@ -865,39 +957,40 @@ generate_stress_tests(io_uring CHIMERA_VFS_IO_URING)
 # NFS3 Stress Tests
 # These tests run the stress tests through the Chimera NFS client,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
 # Helper macro to generate NFS3 stress tests for a backend
 macro(_generate_stress_nfs3_tests_for_backend nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         # dirstress: directory operations stress test (reduced params for testing)
         add_test(NAME chimera/posix/dirstress_nfs3_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3_${nfs_backend} -p 1 -f 50
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3_${nfs_backend} -p 1 -f 50
         )
         set_tests_properties(chimera/posix/dirstress_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # rewinddir: tests rewinddir() POSIX semantics
         add_test(NAME chimera/posix/rewinddir_nfs3_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3_${nfs_backend}
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3_${nfs_backend}
         )
         set_tests_properties(chimera/posix/rewinddir_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # fstest: data integrity verification test
         add_test(NAME chimera/posix/fstest_nfs3_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
         )
         set_tests_properties(chimera/posix/fstest_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # nametest: namespace stress test
         add_test(NAME chimera/posix/nametest_nfs3_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3_${nfs_backend} -n 50 -i 1000
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3_${nfs_backend} -n 50 -i 1000
         )
         set_tests_properties(chimera/posix/nametest_nfs3_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # fsstress: comprehensive filesystem stress test
         add_test(NAME chimera/posix/fsstress_nfs3_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3_${nfs_backend} -n 500 -p 1
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3_${nfs_backend} -n 500 -p 1
         )
         set_tests_properties(chimera/posix/fsstress_nfs3_${nfs_backend} PROPERTIES TIMEOUT 180)
     endif()
@@ -926,39 +1019,40 @@ generate_stress_nfs3_tests(io_uring CHIMERA_VFS_IO_URING)
 # NFS3 RDMA Stress Tests
 # These tests run the stress tests through the Chimera NFS client using TCP-RDMA,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
 # Helper macro to generate NFS3 RDMA stress tests for a backend
 macro(_generate_stress_nfs3rdma_tests_for_backend nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         # dirstress: directory operations stress test (reduced params for testing)
         add_test(NAME chimera/posix/dirstress_nfs3rdma_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3rdma_${nfs_backend} -p 1 -f 50
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs3rdma_${nfs_backend} -p 1 -f 50
         )
         set_tests_properties(chimera/posix/dirstress_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # rewinddir: tests rewinddir() POSIX semantics
         add_test(NAME chimera/posix/rewinddir_nfs3rdma_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3rdma_${nfs_backend}
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs3rdma_${nfs_backend}
         )
         set_tests_properties(chimera/posix/rewinddir_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # fstest: data integrity verification test
         add_test(NAME chimera/posix/fstest_nfs3rdma_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3rdma_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs3rdma_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
         )
         set_tests_properties(chimera/posix/fstest_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # nametest: namespace stress test
         add_test(NAME chimera/posix/nametest_nfs3rdma_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3rdma_${nfs_backend} -n 50 -i 1000
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs3rdma_${nfs_backend} -n 50 -i 1000
         )
         set_tests_properties(chimera/posix/nametest_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # fsstress: comprehensive filesystem stress test
         add_test(NAME chimera/posix/fsstress_nfs3rdma_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3rdma_${nfs_backend} -n 500 -p 1
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs3rdma_${nfs_backend} -n 500 -p 1
         )
         set_tests_properties(chimera/posix/fsstress_nfs3rdma_${nfs_backend} PROPERTIES TIMEOUT 180)
     endif()
@@ -987,39 +1081,40 @@ generate_stress_nfs3rdma_tests(io_uring CHIMERA_VFS_IO_URING)
 # NFS4 Stress Tests
 # These tests run the stress tests through the Chimera NFS4 client,
 # connecting to a Chimera NFS server in the same process.
-# They require a network namespace for loopback networking.
+# They reach that server over the in-process transport, so they require no
+# network namespace and no port; any number of them run concurrently.
 # ============================================================================
 
 # Helper macro to generate NFS4 stress tests for a backend
 macro(_generate_stress_nfs4_tests_for_backend nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         # dirstress: directory operations stress test (reduced params for testing)
         add_test(NAME chimera/posix/dirstress_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs4_${nfs_backend} -p 1 -f 50
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_dirstress -b nfs4_${nfs_backend} -p 1 -f 50
         )
         set_tests_properties(chimera/posix/dirstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # rewinddir: tests rewinddir() POSIX semantics
         add_test(NAME chimera/posix/rewinddir_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs4_${nfs_backend}
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_rewinddir -b nfs4_${nfs_backend}
         )
         set_tests_properties(chimera/posix/rewinddir_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # fstest: data integrity verification test
         add_test(NAME chimera/posix/fstest_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs4_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fstest -b nfs4_${nfs_backend} -n 1 -f 2 -l 5 -s 65536
         )
         set_tests_properties(chimera/posix/fstest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # nametest: namespace stress test
         add_test(NAME chimera/posix/nametest_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs4_${nfs_backend} -n 50 -i 1000
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_nametest -b nfs4_${nfs_backend} -n 50 -i 1000
         )
         set_tests_properties(chimera/posix/nametest_nfs4_${nfs_backend} PROPERTIES TIMEOUT 120)
 
         # fsstress: comprehensive filesystem stress test
         add_test(NAME chimera/posix/fsstress_nfs4_${nfs_backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs4_${nfs_backend} -n 500 -p 1
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_test_fsstress -b nfs4_${nfs_backend} -n 500 -p 1
         )
         set_tests_properties(chimera/posix/fsstress_nfs4_${nfs_backend} PROPERTIES TIMEOUT 180)
     endif()
@@ -1052,8 +1147,8 @@ generate_stress_nfs4_tests(io_uring CHIMERA_VFS_IO_URING)
 # ============================================================================
 
 macro(add_posix_test_myuser testname prog backend)
-    if(CHIMERA_NETNS_TESTING)
-        add_test(NAME chimera/posix/${testname}_myuser COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend} -U myuser)
+    if(CHIMERA_LIMITS_TESTING)
+        add_test(NAME chimera/posix/${testname}_myuser COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b ${backend} -U myuser)
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_myuser PROPERTIES
             ENVIRONMENT "TEST_FILE=${test_file}"
@@ -1062,13 +1157,23 @@ macro(add_posix_test_myuser testname prog backend)
 endmacro()
 
 macro(add_posix_nfs3_test_myuser testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         add_test(NAME chimera/posix/${testname}_nfs3_${nfs_backend}_myuser
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend} -U myuser
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3_${nfs_backend} -U myuser
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs3_${nfs_backend}_myuser PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT 60
             SKIP_RETURN_CODE 77
         )
@@ -1076,13 +1181,23 @@ macro(add_posix_nfs3_test_myuser testname prog nfs_backend)
 endmacro()
 
 macro(add_posix_nfs3rdma_test_myuser testname prog nfs_backend)
-    if(CHIMERA_NETNS_TESTING)
+    posix_test_forks(${prog} _forks)
+    if(_forks)
+        set(_wrapper ${NETNS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=tcp")
+        set(_gate ${CHIMERA_NETNS_TESTING})
+    else()
+        set(_wrapper ${LIMITS_WRAPPER})
+        set(_transport "CHIMERA_TEST_TRANSPORT=inproc")
+        set(_gate ${CHIMERA_LIMITS_TESTING})
+    endif()
+    if(_gate)
         add_test(NAME chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend} -U myuser
+            COMMAND ${_wrapper} ${CMAKE_CURRENT_BINARY_DIR}/posix_${prog} -b nfs3rdma_${nfs_backend} -U myuser
         )
         get_target_property(test_file posix_${prog} TEST_FILE)
         set_tests_properties(chimera/posix/${testname}_nfs3rdma_${nfs_backend}_myuser PROPERTIES
-            ENVIRONMENT "TEST_FILE=${test_file}"
+            ENVIRONMENT "TEST_FILE=${test_file};${_transport}"
             TIMEOUT 60
             SKIP_RETURN_CODE 77
         )
@@ -1281,10 +1396,10 @@ macro(add_pjd_testprog path)
 endmacro()
 
 macro(add_pjd_test path backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         string(REPLACE "/" "_" _pjd_flat ${path})
         add_test(NAME chimera/posix/pjd/${path}/${backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_pjd_${_pjd_flat} -b ${backend})
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_pjd_${_pjd_flat} -b ${backend})
         get_target_property(_pjd_tf posix_pjd_${_pjd_flat} TEST_FILE)
         set_tests_properties(chimera/posix/pjd/${path}/${backend} PROPERTIES
             ENVIRONMENT "TEST_FILE=${_pjd_tf}"
@@ -1299,10 +1414,10 @@ endmacro()
 # starts a Chimera NFS server + client in-process, so it needs a longer timeout
 # than the in-process VFS backends.
 macro(add_pjd_nfs_test path backend)
-    if(CHIMERA_NETNS_TESTING)
+    if(CHIMERA_LIMITS_TESTING)
         string(REPLACE "/" "_" _pjd_flat ${path})
         add_test(NAME chimera/posix/pjd/${path}/${backend}
-            COMMAND ${NETNS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_pjd_${_pjd_flat} -b ${backend})
+            COMMAND ${LIMITS_WRAPPER} ${CMAKE_CURRENT_BINARY_DIR}/posix_pjd_${_pjd_flat} -b ${backend})
         get_target_property(_pjd_tf posix_pjd_${_pjd_flat} TEST_FILE)
         set_tests_properties(chimera/posix/pjd/${path}/${backend} PROPERTIES
             ENVIRONMENT "TEST_FILE=${_pjd_tf}"

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -58,6 +58,7 @@
 #include "client/client.h"
 #include "server/server.h"
 #include "common/logging.h"
+#include "common/tcp_flavor.h"
 #include "prometheus-c.h"
 
 #ifndef MAP_FILE
@@ -3894,6 +3895,16 @@ main(
     }
 
     chimera_config = chimera_client_config_init();
+
+    /* Client half of the in-process transport (the server half is set on the
+     * server config below).  Set here rather than through the generated JSON:
+     * fsx builds its client config in code and reads that file only for
+     * modules and mounts, so a "common" section in it would be ignored. */
+    if (chimera_config) {
+        chimera_client_config_set_tcp_flavor(chimera_config,
+                                             CHIMERA_TCP_FLAVOR_INPROC);
+    }
+
     if (!chimera_config) {
         fprintf(stderr, "Failed to initialize chimera client config\n");
         exit(100);
@@ -3936,6 +3947,14 @@ main(
         if (chimera_nfs_version > 0) {
             /* NFS backend: Start server with the actual backend */
             chimera_server_config = chimera_server_config_init();
+
+            /* fsx builds its own server and client rather than going through
+             * posix_test_common.h, so it needs the same transport set here:
+             * the in-process one, so that concurrent fsx runs do not contend
+             * for a port.  The client half is set where the client config is
+             * built, above. */
+            chimera_server_config_set_tcp_flavor(chimera_server_config,
+                                                 CHIMERA_TCP_FLAVOR_INPROC);
 
             /* Configure diskfs/cairn modules before server init */
             if (strcmp(chimera_nfs_backend, "diskfs_io_uring") == 0 ||

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -454,6 +455,22 @@ posix_test_configure_cairn(
 } // posix_test_configure_cairn
 
 // Helper to start NFS server with the given backend and mount it as "share"
+/*
+ * Which transport the in-process server and its client should use.
+ *
+ * The in-process one by default: it binds nothing, so any number of test
+ * binaries run at once without a namespace to separate them.  A test that
+ * fork()s must opt out with CHIMERA_TEST_TRANSPORT=tcp, because an inproc name
+ * is reachable only from the process that registered it.
+ */
+static inline int
+posix_test_transport_is_inproc(void)
+{
+    const char *t = getenv("CHIMERA_TEST_TRANSPORT");
+
+    return !(t && strcasecmp(t, "tcp") == 0);
+} /* posix_test_transport_is_inproc */
+
 static inline void
 posix_test_start_nfs_server(struct posix_test_env *env)
 {
@@ -464,6 +481,22 @@ posix_test_start_nfs_server(struct posix_test_env *env)
 
     server_config = chimera_server_config_init();
     chimera_server_config_set_state_dir(server_config, env->session_dir);
+
+    /* Serve over the in-process transport rather than a socket.  The client is
+     * in this same process, so nothing here needs a port -- which is the point:
+     * an inproc name is private to the process, so any number of these test
+     * binaries can run at once without colliding, and without a network
+     * namespace to keep them apart.
+     *
+     * A test that fork()s is the exception and sets CHIMERA_TEST_TRANSPORT=tcp:
+     * an inproc name reaches only the process that registered it, so a child
+     * that initialises its own client after fork() could never find a server
+     * living in its parent.  Those keep a real socket, and the namespace that
+     * isolates it. */
+    chimera_server_config_set_tcp_flavor(server_config,
+                                         posix_test_transport_is_inproc()
+                                         ? CHIMERA_TCP_FLAVOR_INPROC
+                                         : CHIMERA_TCP_FLAVOR_PLAIN);
 
     if (posix_test_is_diskfs(nfs_backend_name)) {
         posix_test_configure_diskfs(env->session_dir,
@@ -762,6 +795,16 @@ posix_test_init(
         }
 
         json_object_set_new(posix_json_root, "config", posix_json_config);
+
+        /* Match the server (see posix_test_start_nfs_server).  Read from the
+         * top-level "common" section, not from "config". */
+        if (posix_test_transport_is_inproc()) {
+            json_t *common = json_object();
+
+            json_object_set_new(common, "tcp_flavor", json_string("inproc"));
+            json_object_set_new(posix_json_root, "common", common);
+        }
+
         chimera_test_write_users_json(posix_json_root);
 
         snprintf(posix_json_path, sizeof(posix_json_path), "%s/posix.json", env->session_dir);
@@ -831,6 +874,9 @@ posix_test_mount(struct posix_test_env *env)
     if (env->nfs_version > 0) {
         // NFS backend: mount via NFS client
         // Mount path format: hostname:path
+        /* The host half is ignored under the in-process transport -- the peer
+         * is addressed by name, not by address -- but the mount path grammar
+         * still requires it. */
         snprintf(nfs_mount_path, sizeof(nfs_mount_path), "127.0.0.1:/share");
         if (env->use_nfs_rdma) {
             // Use RDMA protocol and port for NFS3 over TCP-RDMA

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -163,6 +163,7 @@ nfs_server_init(
     int                               data_server;
     int                               external_portmap;
     const char                       *portmap_hostname;
+    enum chimera_tcp_flavor           tcp_flavor;
 
     nfs_port          = chimera_server_config_get_nfs_port(config);
     data_server       = chimera_server_config_get_nfs_data_server(config);
@@ -427,7 +428,15 @@ nfs_server_init(
 
     nsm_state_init(&shared->nsm_state, shared->vfs);
 
-    shared->nfs_endpoint = evpl_endpoint_create("0.0.0.0", nfs_port);
+    /* Every endpoint below goes through the flavor helper rather than
+     * evpl_endpoint_create() directly, so that a run configured for the
+     * in-process transport names its services instead of binding ports.  The
+     * port still identifies the service either way. */
+    tcp_flavor = chimera_server_config_get_tcp_flavor(config);
+
+    nfs_set_callback_tcp_flavor(tcp_flavor);
+
+    shared->nfs_endpoint = chimera_tcp_flavor_endpoint_create(tcp_flavor, "0.0.0.0", nfs_port);
 
     /* A pNFS data server only needs the NFSv4 service (clients reach it by
      * file handle for READ/WRITE); skip portmap/mountd/NLM so it can share a
@@ -445,16 +454,16 @@ nfs_server_init(
     }
 
     if (!data_server) {
-        shared->mount_endpoint = evpl_endpoint_create("0.0.0.0", NFS_MOUNT_PORT);
+        shared->mount_endpoint = chimera_tcp_flavor_endpoint_create(tcp_flavor, "0.0.0.0", NFS_MOUNT_PORT);
     }
 
     if (nfs_tcp_rdma_port > 0) {
         /* TCP-RDMA enabled - use TCP-RDMA port (hostname falls back to 0.0.0.0 if not set) */
         const char *rdma_host = nfs_rdma_hostname ? nfs_rdma_hostname : "0.0.0.0";
-        shared->nfs_rdma_endpoint = evpl_endpoint_create(rdma_host, nfs_tcp_rdma_port);
+        shared->nfs_rdma_endpoint = chimera_tcp_flavor_endpoint_create(tcp_flavor, rdma_host, nfs_tcp_rdma_port);
     } else if (nfs_rdma) {
         /* Native RDMA enabled */
-        shared->nfs_rdma_endpoint = evpl_endpoint_create(nfs_rdma_hostname, nfs_rdma_port);
+        shared->nfs_rdma_endpoint = chimera_tcp_flavor_endpoint_create(tcp_flavor, nfs_rdma_hostname, nfs_rdma_port);
     }
     if (!data_server) {
         if (external_portmap) {
@@ -463,7 +472,7 @@ nfs_server_init(
             shared->portmap_endpoint = NULL;
         } else {
             chimera_nfs_debug("Initializing internal portmap support");
-            shared->portmap_endpoint = evpl_endpoint_create("0.0.0.0", 111);
+            shared->portmap_endpoint = chimera_tcp_flavor_endpoint_create(tcp_flavor, "0.0.0.0", 111);
             programs[0]              = &shared->portmap_v2.rpc2;
             programs[1]              = &shared->portmap_v3.rpc2;
             programs[2]              = &shared->portmap_v4.rpc2;
@@ -486,12 +495,12 @@ nfs_server_init(
 
     if (!data_server) {
         chimera_nfs_debug("Initializing NFS lock manager server on port %d", nfs_lockmgr_port);
-        shared->nlm_endpoint = evpl_endpoint_create("0.0.0.0", nfs_lockmgr_port);
+        shared->nlm_endpoint = chimera_tcp_flavor_endpoint_create(tcp_flavor, "0.0.0.0", nfs_lockmgr_port);
         programs[0]          = &shared->nlm_v4.rpc2;
         shared->nlm_server   = evpl_rpc2_server_init(programs, 1);
 
         chimera_nfs_debug("Initializing NSM/statd server on port %d", nfs_nsm_port);
-        shared->nsm_endpoint = evpl_endpoint_create("0.0.0.0", nfs_nsm_port);
+        shared->nsm_endpoint = chimera_tcp_flavor_endpoint_create(tcp_flavor, "0.0.0.0", nfs_nsm_port);
         programs[0]          = &shared->nsm_v1.rpc2;
         shared->nsm_server   = evpl_rpc2_server_init(programs, 1);
     }
@@ -517,12 +526,36 @@ nfs_server_init(
 } /* nfs_server_init */
 
 
+/* See nfs_common.h: cached because the callback paths have no config to
+ * consult when they need to build an endpoint. */
+static enum chimera_tcp_flavor NfsCallbackTcpFlavor = CHIMERA_TCP_FLAVOR_PLAIN;
+
+void
+nfs_set_callback_tcp_flavor(enum chimera_tcp_flavor flavor)
+{
+    NfsCallbackTcpFlavor = flavor;
+} /* nfs_set_callback_tcp_flavor */
+
+enum chimera_tcp_flavor
+nfs_callback_tcp_flavor(void)
+{
+    return NfsCallbackTcpFlavor;
+} /* nfs_callback_tcp_flavor */
+
 void
 nfs_server_start(void *arg)
 {
     struct chimera_server_nfs_shared *shared = arg;
     enum evpl_protocol_id             rdma_protocol;
+    enum evpl_protocol_id             stream_protocol;
     int                               rc;
+
+    /* One transport for every service this server offers.  The auxiliary ones
+     * used to name EVPL_STREAM_SOCKET_TCP outright, which meant they ignored
+     * the configured flavor and would have stayed on TCP while the NFS service
+     * moved -- and under inproc they would have been reached by a name nobody
+     * was listening on. */
+    stream_protocol = chimera_server_config_get_tcp_stream_protocol(shared->config);
 
     /* evpl_rpc2_server_start reports a listen it could not establish -- a port
      * already in use, an address that cannot be bound.  A server that carried
@@ -530,28 +563,31 @@ nfs_server_start(void *arg)
      * on, so every one of these is checked; there is no useful recovery at
      * this point, so the failure is fatal and named. */
     rc = evpl_rpc2_server_start(shared->nfs_server,
-                                chimera_server_config_get_tcp_stream_protocol(shared->config),
+                                stream_protocol,
                                 shared->nfs_endpoint);
     chimera_nfs_abort_if(rc, "failed to start the NFS server");
 
     if (shared->nfs_rdma_endpoint) {
-        /* Use TCP-RDMA emulation when nfs_tcp_rdma_port > 0, otherwise use native RDMA */
-        rdma_protocol = chimera_server_config_get_nfs_tcp_rdma_port(shared->config) > 0
-                        ? EVPL_DATAGRAM_TCP_RDMA : EVPL_DATAGRAM_RDMACM_RC;
+        /* Use TCP-RDMA emulation when nfs_tcp_rdma_port > 0, otherwise use native
+         * RDMA -- or the in-process transport, which carries the chunk framing
+         * of either. */
+        rdma_protocol = chimera_tcp_flavor_to_rdma_protocol(
+            chimera_server_config_get_tcp_flavor(shared->config),
+            chimera_server_config_get_nfs_tcp_rdma_port(shared->config) > 0);
         rc = evpl_rpc2_server_start(shared->nfs_server, rdma_protocol, shared->nfs_rdma_endpoint);
         chimera_nfs_abort_if(rc, "failed to start the NFS RDMA server");
     }
 
     if (shared->mount_server) {
-        rc = evpl_rpc2_server_start(shared->mount_server, EVPL_STREAM_SOCKET_TCP, shared->mount_endpoint);
+        rc = evpl_rpc2_server_start(shared->mount_server, stream_protocol, shared->mount_endpoint);
         chimera_nfs_abort_if(rc, "failed to start the MOUNT server");
     }
     if (shared->nlm_server) {
-        rc = evpl_rpc2_server_start(shared->nlm_server, EVPL_STREAM_SOCKET_TCP, shared->nlm_endpoint);
+        rc = evpl_rpc2_server_start(shared->nlm_server, stream_protocol, shared->nlm_endpoint);
         chimera_nfs_abort_if(rc, "failed to start the NLM server");
     }
     if (shared->nsm_server) {
-        rc = evpl_rpc2_server_start(shared->nsm_server, EVPL_STREAM_SOCKET_TCP, shared->nsm_endpoint);
+        rc = evpl_rpc2_server_start(shared->nsm_server, stream_protocol, shared->nsm_endpoint);
         chimera_nfs_abort_if(rc, "failed to start the NSM server");
     }
 
@@ -559,7 +595,7 @@ nfs_server_start(void *arg)
      * protocols entirely). */
     if (!chimera_server_config_get_nfs_data_server(shared->config)) {
         if (shared->portmap_server) {
-            rc = evpl_rpc2_server_start(shared->portmap_server, EVPL_STREAM_SOCKET_TCP, shared->portmap_endpoint);
+            rc = evpl_rpc2_server_start(shared->portmap_server, stream_protocol, shared->portmap_endpoint);
             chimera_nfs_abort_if(rc, "failed to start the PORTMAP server");
         } else {
             register_nfs_rpc_services(chimera_server_config_get_nfs_lockmgr_port(shared->config),

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -26,6 +26,27 @@
 #include "nfs_nsm_state.h"
 #include "sm_inter_xdr.h"
 
+#include "common/tcp_flavor.h"
+
+/*
+ * Transport for server-initiated callbacks: the NLM GRANTED delivery and the
+ * NSM reboot notify, both of which connect *out* to a peer.  They run from
+ * contexts that carry no config pointer, and the flavor is a process-wide
+ * setting, so it is cached at server init in the same spirit as
+ * portmap_set_nlm_port().
+ *
+ * Over the socket transports these dial the client's own address.  Under the
+ * in-process transport there is no such address -- so they resolve to the
+ * port-derived name, which in a single-process test lands on this server's own
+ * portmap and NLM.  That is exactly what happened over loopback before, where
+ * "the client's portmap at 127.0.0.1:111" was in fact this server's.
+ */
+void nfs_set_callback_tcp_flavor(
+    enum chimera_tcp_flavor flavor);
+
+enum chimera_tcp_flavor nfs_callback_tcp_flavor(
+    void);
+
 struct chimera_server_nfs_thread;
 
 /*

--- a/src/server/nfs/nfs_nlm_granted.c
+++ b/src/server/nfs/nfs_nlm_granted.c
@@ -285,9 +285,10 @@ nlm_grant_getport_cb(
     }
 
     job->nlm_port = port;
-    job->nlm_ep   = evpl_endpoint_create(job->req.client_addr, port);
+    job->nlm_ep   = chimera_tcp_flavor_endpoint_create(nfs_callback_tcp_flavor(),
+                                                       job->req.client_addr, port);
     job->nlm_conn = evpl_rpc2_client_connect(ctx->rpc2_thread,
-                                             EVPL_STREAM_SOCKET_TCP,
+                                             chimera_tcp_flavor_to_protocol(nfs_callback_tcp_flavor()),
                                              job->nlm_ep, NULL, 0, NULL);
     if (!job->nlm_conn) {
         chimera_nfs_info("NLM GRANTED: cannot connect to NLM at %s:%u",
@@ -327,9 +328,10 @@ nlm_grant_job_start(
 
     /* Resolve the client's NLM (prog 100021 v4) callback port via its
      * portmapper, exactly as the NSM reboot-notify path resolves statd. */
-    job->pm_ep   = evpl_endpoint_create(job->req.client_addr, 111);
+    job->pm_ep = chimera_tcp_flavor_endpoint_create(nfs_callback_tcp_flavor(),
+                                                    job->req.client_addr, 111);
     job->pm_conn = evpl_rpc2_client_connect(ctx->rpc2_thread,
-                                            EVPL_STREAM_SOCKET_TCP,
+                                            chimera_tcp_flavor_to_protocol(nfs_callback_tcp_flavor()),
                                             job->pm_ep, NULL, 0, NULL);
     if (!job->pm_conn) {
         chimera_nfs_info("NLM GRANTED: cannot reach portmap at %s for host '%s'",

--- a/src/server/nfs/nfs_nsm.c
+++ b/src/server/nfs/nfs_nsm.c
@@ -193,8 +193,9 @@ nsm_notify_one(
     int                       done = 0;
 
     /* Resolve the peer's statd port via its portmapper. */
-    ep   = evpl_endpoint_create(t->addr, 111);
-    conn = evpl_rpc2_client_connect(rpc2_thread, EVPL_STREAM_SOCKET_TCP, ep,
+    ep   = chimera_tcp_flavor_endpoint_create(nfs_callback_tcp_flavor(), t->addr, 111);
+    conn = evpl_rpc2_client_connect(rpc2_thread,
+                                    chimera_tcp_flavor_to_protocol(nfs_callback_tcp_flavor()), ep,
                                     NULL, 0, NULL);
     if (!conn) {
         evpl_endpoint_close(ep);
@@ -219,8 +220,9 @@ nsm_notify_one(
     }
 
     /* Tell the peer's statd that we (mon_name) restarted with `state`. */
-    ep   = evpl_endpoint_create(t->addr, g.port);
-    conn = evpl_rpc2_client_connect(rpc2_thread, EVPL_STREAM_SOCKET_TCP, ep,
+    ep   = chimera_tcp_flavor_endpoint_create(nfs_callback_tcp_flavor(), t->addr, g.port);
+    conn = evpl_rpc2_client_connect(rpc2_thread,
+                                    chimera_tcp_flavor_to_protocol(nfs_callback_tcp_flavor()), ep,
                                     NULL, 0, NULL);
     if (!conn) {
         evpl_endpoint_close(ep);

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -1159,12 +1159,17 @@ s3_server_init(
 
     shared->config = calloc(1, sizeof(*shared->config));
 
-    shared->tcp_protocol = chimera_server_config_get_tcp_stream_protocol(config);
+    shared->tcp_flavor   = chimera_server_config_get_tcp_flavor(config);
+    shared->tcp_protocol = chimera_tcp_flavor_to_protocol(shared->tcp_flavor);
 
     shared->config->port    = chimera_server_config_get_s3_port(config);
     shared->config->io_size = 128 * 1024;
 
-    shared->endpoint = evpl_endpoint_create("0.0.0.0", shared->config->port);
+    /* Built from the same flavor tcp_protocol came from: a protocol and an
+     * endpoint that disagree about whether they are a socket is a listen
+     * failure at startup. */
+    shared->endpoint = chimera_tcp_flavor_endpoint_create(shared->tcp_flavor, "0.0.0.0",
+                                                          shared->config->port);
 
     shared->listener = evpl_listener_create();
 

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -11,6 +11,7 @@
 #include "common/logging.h"
 #include "s3_status.h"
 #include "vfs/vfs.h"
+#include "common/tcp_flavor.h"
 #include "vfs/vfs_cred.h"
 #include "s3_cred_cache.h"
 #include "s3_chunk.h"
@@ -242,6 +243,11 @@ struct chimera_server_s3_shared {
     struct evpl_endpoint              *endpoint;
     struct evpl_listener              *listener;
     enum evpl_protocol_id              tcp_protocol;
+
+    /* The flavor tcp_protocol was resolved from; the endpoint has to be
+     * built from it too, since the in-process transport is named rather
+     * than bound. */
+    enum chimera_tcp_flavor            tcp_flavor;
     struct chimera_vfs_cred            cred;
     uint32_t                           root_fh_len;
     uint8_t                            root_fh[CHIMERA_VFS_FH_SIZE];

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -133,7 +133,8 @@ chimera_smb_server_init(
         return NULL;
     }
 
-    shared->tcp_protocol = chimera_server_config_get_tcp_stream_protocol(config);
+    shared->tcp_flavor   = chimera_server_config_get_tcp_flavor(config);
+    shared->tcp_protocol = chimera_tcp_flavor_to_protocol(shared->tcp_flavor);
 
     shared->config.port      = 445;
     shared->config.rdma_port = 445;
@@ -305,10 +306,12 @@ chimera_smb_server_init(
     gss_import_name(&min, &name, GSS_C_NT_HOSTBASED_SERVICE, &shared->svc);
     //gss_acquire_cred(&min, shared->svc, 0, GSS_C_NO_OID_SET, GSS_C_ACCEPT, &shared->srv_cred, NULL, NULL);
 
-    shared->endpoint = evpl_endpoint_create("0.0.0.0", shared->config.port);
+    shared->endpoint = chimera_tcp_flavor_endpoint_create(shared->tcp_flavor, "0.0.0.0",
+                                                          shared->config.port);
 
     if (rdma) {
-        shared->endpoint_rdma = evpl_endpoint_create("0.0.0.0", shared->config.rdma_port);
+        shared->endpoint_rdma = chimera_tcp_flavor_endpoint_create(shared->tcp_flavor, "0.0.0.0",
+                                                                   shared->config.rdma_port);
     }
 
     shared->listener = evpl_listener_create();
@@ -393,7 +396,9 @@ chimera_smb_server_start(void *data)
     chimera_smb_abort_if(rc, "failed to listen for SMB");
 
     if (shared->endpoint_rdma) {
-        rc = evpl_listen(shared->listener, EVPL_DATAGRAM_RDMACM_RC, shared->endpoint_rdma);
+        rc = evpl_listen(shared->listener,
+                         chimera_tcp_flavor_to_rdma_protocol(shared->tcp_flavor, 0),
+                         shared->endpoint_rdma);
         chimera_smb_abort_if(rc, "failed to listen for SMB over RDMA");
     }
 } /* smb_server_start */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -29,6 +29,7 @@
 #include "smb_sharemode.h"
 #include "smb_notify.h"
 #include "vfs/vfs.h"
+#include "common/tcp_flavor.h"
 #include "vfs/vfs_acl.h"
 #include "vfs/vfs_idmap.h"
 #include "vfs/vfs_release.h"
@@ -1554,6 +1555,11 @@ struct chimera_server_smb_shared {
     struct chimera_smb_config         config;
     int                               rdma;
     enum evpl_protocol_id             tcp_protocol;
+
+    /* The flavor tcp_protocol came from.  Kept because the in-process
+     * transport names a service instead of binding host and port, so
+     * endpoint construction needs it too. */
+    enum chimera_tcp_flavor           tcp_flavor;
     uint8_t                           guid[SMB2_GUID_SIZE];
     /* MS-SMB2 2.2.4 / 3.3.1.5 Global ServerStartTime: the instant this SMB
      * server instance started (NT time), captured once at init.  Reported in

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -96,6 +96,7 @@ chimera_nfs_init(
     shared->servers_map = NULL;
 
     /* Default until the common tcp_flavor is observed at mount time. */
+    shared->tcp_flavor   = CHIMERA_TCP_FLAVOR_PLAIN;
     shared->tcp_protocol = EVPL_STREAM_SOCKET_TCP;
 
     PORTMAP_V2_init(&shared->portmap_v2);
@@ -318,7 +319,8 @@ chimera_nfs_dispatch(
     if (request->opcode == CHIMERA_VFS_OP_MOUNT) {
         /* Resolve the common TCP flavor for outbound connections from the
          * VFS once we have a thread/vfs in hand. Constant per process. */
-        shared->tcp_protocol = chimera_tcp_flavor_to_protocol(request->thread->vfs->tcp_flavor);
+        shared->tcp_flavor   = request->thread->vfs->tcp_flavor;
+        shared->tcp_protocol = chimera_tcp_flavor_to_protocol(shared->tcp_flavor);
 
         nfsvers = chimera_nfs_get_mount_version(&request->mount.options);
         if (nfsvers < 0) {

--- a/src/vfs/nfs/nfs3_mount.c
+++ b/src/vfs/nfs/nfs3_mount.c
@@ -28,13 +28,22 @@ struct chimera_nfs_client_server_thread_ctx {
  *   EVPL_DATAGRAM_RDMACM_RC - native RDMACM (rdma or rdma=rdmacm)
  */
 static enum evpl_protocol_id
-chimera_nfs_mount_get_rdma_protocol(const struct chimera_vfs_mount_options *options)
+chimera_nfs_mount_get_rdma_protocol(
+    const struct chimera_vfs_mount_options *options,
+    enum chimera_tcp_flavor                 flavor)
 {
     int i;
 
     for (i = 0; i < options->num_options; i++) {
         if (strcmp(options->options[i].key, "rdma") == 0) {
             /* rdma=tcp -> TCP-RDMA */
+            /* Under the in-process transport there is no socket to run
+             * either emulation over; DATAGRAM_INPROC is the chunk-bearing
+             * protocol there, whichever rdma= spelling asked for one. */
+            if (flavor == CHIMERA_TCP_FLAVOR_INPROC) {
+                return EVPL_DATAGRAM_INPROC;
+            }
+
             if (options->options[i].value &&
                 strcmp(options->options[i].value, "tcp") == 0) {
                 return EVPL_DATAGRAM_TCP_RDMA;
@@ -261,7 +270,8 @@ chimera_portmap_getport_nlm_callback(
         server->nlm_endpoint = NULL;
     } else {
         server->nlm_port     = port;
-        server->nlm_endpoint = evpl_endpoint_create(server->hostname, port);
+        server->nlm_endpoint = chimera_tcp_flavor_endpoint_create(
+            server_thread->shared->tcp_flavor, server->hostname, port);
     }
 
     chimera_nfs3_mount_discover_callback(server_thread, 0);
@@ -325,7 +335,8 @@ chimera_portmap_getport_nfs_callback(
     }
 
     server->nfs_port     = port;
-    server->nfs_endpoint = evpl_endpoint_create(server->hostname, port);
+    server->nfs_endpoint = chimera_tcp_flavor_endpoint_create(
+        shared->tcp_flavor, server->hostname, port);
 
     server_thread->nfs_conn = evpl_rpc2_client_connect(server_thread->thread->rpc2_thread,
                                                        server_thread->shared->tcp_protocol,
@@ -362,7 +373,8 @@ chimera_mount_mountd_null_callback(
 
     if (server->use_rdma) {
         /* For RDMA, skip portmap discovery and connect directly to RDMA port */
-        server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
+        server->nfs_endpoint = chimera_tcp_flavor_endpoint_create(
+            shared->tcp_flavor, server->hostname, server->nfs_port);
 
         server_thread->nfs_conn = evpl_rpc2_client_connect(server_thread->thread->rpc2_thread,
                                                            server->rdma_protocol,
@@ -411,7 +423,8 @@ chimera_portmap_getport_mountd_callback(
     }
 
     server->mount_port     = port;
-    server->mount_endpoint = evpl_endpoint_create(server->hostname, port);
+    server->mount_endpoint = chimera_tcp_flavor_endpoint_create(
+        shared->tcp_flavor, server->hostname, port);
 
     server_thread->mount_conn = evpl_rpc2_client_connect(server_thread->thread->rpc2_thread,
                                                          server_thread->shared->tcp_protocol,
@@ -533,8 +546,9 @@ chimera_nfs3_mount(
         server->shared  = shared;
 
         /* Parse RDMA options from mount request */
-        server->rdma_protocol = chimera_nfs_mount_get_rdma_protocol(&request->mount.options);
-        server->use_rdma      = server->rdma_protocol != 0;
+        server->rdma_protocol = chimera_nfs_mount_get_rdma_protocol(&request->mount.options,
+                                                                    shared->tcp_flavor);
+        server->use_rdma = server->rdma_protocol != 0;
         if (server->use_rdma) {
             server->nfs_port = chimera_nfs_mount_get_port(&request->mount.options, CHIMERA_NFS_RDMA_PORT);
         }
@@ -572,7 +586,8 @@ chimera_nfs3_mount(
 
     if (need_discover) {
 
-        server->portmap_endpoint = evpl_endpoint_create(server->hostname, 111);
+        server->portmap_endpoint = chimera_tcp_flavor_endpoint_create(
+            shared->tcp_flavor, server->hostname, 111);
 
         server_thread->portmap_conn = evpl_rpc2_client_connect(thread->rpc2_thread,
                                                                server_thread->shared->tcp_protocol,

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -72,12 +72,21 @@ chimera_nfs4_mount_reclaim_complete_retry(
 
 /* Get the RDMA protocol from mount options */
 static enum evpl_protocol_id
-chimera_nfs4_mount_get_rdma_protocol(const struct chimera_vfs_mount_options *options)
+chimera_nfs4_mount_get_rdma_protocol(
+    const struct chimera_vfs_mount_options *options,
+    enum chimera_tcp_flavor                 flavor)
 {
     int i;
 
     for (i = 0; i < options->num_options; i++) {
         if (strcmp(options->options[i].key, "rdma") == 0) {
+            /* Under the in-process transport there is no socket to run
+             * either emulation over; DATAGRAM_INPROC is the chunk-bearing
+             * protocol there, whichever rdma= spelling asked for one. */
+            if (flavor == CHIMERA_TCP_FLAVOR_INPROC) {
+                return EVPL_DATAGRAM_INPROC;
+            }
+
             if (options->options[i].value &&
                 strcmp(options->options[i].value, "tcp") == 0) {
                 return EVPL_DATAGRAM_TCP_RDMA;
@@ -658,8 +667,9 @@ chimera_nfs4_mount(
         server->shared  = shared;
 
         /* Parse RDMA options */
-        server->rdma_protocol = chimera_nfs4_mount_get_rdma_protocol(&request->mount.options);
-        server->use_rdma      = server->rdma_protocol != 0;
+        server->rdma_protocol = chimera_nfs4_mount_get_rdma_protocol(&request->mount.options,
+                                                                     shared->tcp_flavor);
+        server->use_rdma = server->rdma_protocol != 0;
 
         /* pNFS opt-in (default off); confirmed against eir_flags at EXCHANGE_ID. */
         server->pnfs_requested = chimera_nfs4_mount_get_pnfs(&request->mount.options);
@@ -706,7 +716,8 @@ chimera_nfs4_mount(
 
     if (need_discover) {
         /* First mount to this server: create the shared endpoint. */
-        server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
+        server->nfs_endpoint = chimera_tcp_flavor_endpoint_create(
+            shared->tcp_flavor, server->hostname, server->nfs_port);
     }
 
     /*

--- a/src/vfs/nfs/nfs4_pnfs.c
+++ b/src/vfs/nfs/nfs4_pnfs.c
@@ -452,7 +452,8 @@ chimera_nfs4_pnfs_register_ds(
     server->rdma_protocol = use_rdma ? rdma_protocol : 0;
     snprintf(server->hostname, sizeof(server->hostname), "%s", host);
 
-    server->nfs_endpoint = evpl_endpoint_create(server->hostname, server->nfs_port);
+    server->nfs_endpoint = chimera_tcp_flavor_endpoint_create(
+        shared->tcp_flavor, server->hostname, server->nfs_port);
 
     shared->servers[idx] = server;
 

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -20,6 +20,7 @@
 #include "nfs4_xdr.h"
 #include "uthash.h"
 #include "common/misc.h"
+#include "common/tcp_flavor.h"
 #include "vfs/vfs_fh.h"
 #include "nfs_common/nfs_fh_limits.h"
 #include "evpl/evpl_rpc2.h"
@@ -390,6 +391,11 @@ struct chimera_nfs_shared {
      * the common tcp_flavor setting (chimera_vfs->tcp_flavor) at mount time.
      * Defaults to EVPL_STREAM_SOCKET_TCP. */
     enum evpl_protocol_id tcp_protocol;
+
+    /* The flavor tcp_protocol was resolved from, kept because endpoints are
+     * built from it too, not just the protocol id: the in-process transport
+     * addresses a service by name rather than by host and port. */
+    enum chimera_tcp_flavor tcp_flavor;
 };
 
 struct chimera_nfs_thread {

--- a/src/vfs/smb/smb.c
+++ b/src/vfs/smb/smb.c
@@ -380,6 +380,7 @@ chimera_smb_client_init(
 
     shared->max_servers  = CHIMERA_SMB_CLIENT_MAX_SERVERS;
     shared->servers      = calloc(shared->max_servers, sizeof(*shared->servers));
+    shared->tcp_flavor   = CHIMERA_TCP_FLAVOR_PLAIN;
     shared->tcp_protocol = EVPL_STREAM_SOCKET_TCP;
 
     return shared;

--- a/src/vfs/smb/smb_internal.h
+++ b/src/vfs/smb/smb_internal.h
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 
 #include "vfs/vfs.h"
+#include "common/tcp_flavor.h"
 #include "vfs/vfs_fh.h"
 #include "vfs/vfs_error.h"
 #include "vfs/vfs_attrs.h"
@@ -173,6 +174,11 @@ struct chimera_smb_client_shared {
     struct chimera_smb_client_server **servers;
     int                                max_servers;
     enum evpl_protocol_id tcp_protocol;
+
+    /* The flavor it was resolved from: the in-process transport names a
+     * service rather than addressing it by host and port, so endpoint
+     * construction needs this as well as the protocol id. */
+    enum chimera_tcp_flavor tcp_flavor;
 };
 
 /* Per-open state stored in the VFS open handle's vfs_private; carries the SMB

--- a/src/vfs/smb/smb_mount.c
+++ b/src/vfs/smb/smb_mount.c
@@ -636,7 +636,8 @@ chimera_smb_client_mount(
     int                               host_len;
     uint16_t                          port;
 
-    shared->tcp_protocol = chimera_tcp_flavor_to_protocol(request->thread->vfs->tcp_flavor);
+    shared->tcp_flavor   = request->thread->vfs->tcp_flavor;
+    shared->tcp_protocol = chimera_tcp_flavor_to_protocol(shared->tcp_flavor);
 
     colon = memchr(request->mount.path, ':', request->mount.pathlen);
     if (!colon) {
@@ -685,7 +686,8 @@ chimera_smb_client_mount(
              domain ? domain : CHIMERA_SMB_CLIENT_DEFAULT_DOMAIN);
     snprintf(server->password, sizeof(server->password), "%s", password);
     server->port     = port;
-    server->endpoint = evpl_endpoint_create(server->hostname, server->port);
+    server->endpoint = chimera_tcp_flavor_endpoint_create(
+        shared->tcp_flavor, server->hostname, server->port);
 
     conn = chimera_smb_client_get_conn(thread, server);
 

--- a/src/vfs/smb/tests/CMakeLists.txt
+++ b/src/vfs/smb/tests/CMakeLists.txt
@@ -5,13 +5,14 @@
 # SMB2 client mount/umount smoke test.  Stands up an in-process SMB server over
 # a memfs share and drives the vfs_smb client through a full session
 # establish + teardown over loopback TCP.  Like the smbclient auth test it
-# binds the privileged SMB port, so it runs under the netns wrapper.
+# reaches the server over the in-process transport, so it binds no port and
+# needs no namespace; the wrapper is only there for the resource limits.
 add_executable(smb_mount_test smb_mount_test.c)
 target_link_libraries(smb_mount_test chimera_server chimera_metrics jansson)
 target_include_directories(smb_mount_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
-if(CHIMERA_NETNS_TESTING)
+if(CHIMERA_LIMITS_TESTING)
     add_test(NAME chimera/vfs/smb/mount
-        COMMAND ${CMAKE_SOURCE_DIR}/scripts/netns_test_wrapper.sh
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/test_limits_wrapper.sh
                 ${CMAKE_CURRENT_BINARY_DIR}/smb_mount_test)
 endif()

--- a/src/vfs/smb/tests/smb_mount_test.c
+++ b/src/vfs/smb/tests/smb_mount_test.c
@@ -23,6 +23,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
 #include "evpl/evpl.h"
+#include "common/tcp_flavor.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -83,6 +84,12 @@ main(
     metrics = prometheus_metrics_create(NULL, NULL, 0);
 
     config = chimera_server_config_init();
+
+    /* Server and client are the same process here -- the client VFS is the
+     * server's -- so serve SMB over the in-process transport.  Nothing binds
+     * 445, which is what previously forced this test into a namespace of its
+     * own to keep it off the host's port. */
+    chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
     /* Register the SMB2 client VFS module (statically linked into chimera_vfs;
      * empty path => resolve the vfs_smb symbol, do not dlopen). */
     chimera_server_config_add_module(config, "smb", NULL, "");


### PR DESCRIPTION
The posix, client and vfs-smb suites each run a chimera server and a chimera client **in one process** and put loopback TCP between them. That costs them a network namespace apiece — two copies binding 2049 collide — so without `CAP_NET_ADMIN` the choice was to run them serially or not at all, and CMake chose not at all: every one of them was gated on the netns probe.

libevpl's in-process transport (libevpl#124) removes the reason. An inproc name is private to the process, so a server and client in one binary reach each other without binding anything, and any number of those binaries run at once without colliding.

**4779 posix, 224 client and the vfs-smb mount test no longer mention netns at all.** Test counts are identical to before — 4779 / 224 / 19. Only the transport moved.

## How it is selected

Through the existing `tcp_flavor` setting, which was already process-wide and already honored by both the server and the client, so a test sets one thing and both ends follow. Two helpers go with the new value:

- **`chimera_tcp_flavor_to_rdma_protocol`** — `DATAGRAM_INPROC` reports itself RDMA-capable to rpc2, so the `nfs3rdma` variants keep exercising the read and write chunk paths instead of quietly degrading to plain RPC.
- **`chimera_tcp_flavor_endpoint_create`** — under inproc an endpoint is *named* rather than bound.

That naming is what leaves **NFSv3 completely unchanged**. The port is still what tells one service from another, so the server registers a port, the client asks portmap for it, and both derive the same name from the answer — the whole `GETPORT` exchange works exactly as before. The name deliberately carries no pid: the registry is per-process, so two concurrent runs may share one, which is the property being bought here.

## Two pre-existing bugs this surfaced

**The NFS server ignored `tcp_flavor` for four of its five services.** mountd, NLM, NSM and portmap each named `EVPL_STREAM_SOCKET_TCP` outright, so they stayed on plain sockets while the NFS service moved — an io_uring or XLIO deployment has been running its auxiliary protocols on the wrong backend. They now share one resolved protocol.

**s3 built an endpoint that could disagree with its protocol.** It read `tcp_flavor` for the protocol but called `evpl_endpoint_create` directly. Harmless while both were sockets; under inproc it is a protocol and an endpoint that disagree, and the listen fails at startup. That is how it was found:

```
evpl_listen: protocol STREAM_INPROC cannot be used with network endpoint '0.0.0.0'
```

## Gating

`CHIMERA_LIMITS_TESTING` replaces the netns probe. The netns wrapper had been supplying more than a namespace — unlimited memlock for io_uring queues, a raised `aio-max-nr` for libaio contexts — and those are still wanted. `scripts/test_limits_wrapper.sh` is that wrapper minus the namespace.

Probing the two separately is the point: **an environment with the limits but without `CAP_NET_ADMIN` now runs these tests instead of skipping them.**

## Verification

| Scope | Result |
|---|---|
| posix nfs3 + nfs4, memfs | 455/455 |
| posix nfs3rdma, memfs | 83/83 |
| client + vfs | 243/243 |
| posix across cairn, linux, diskfs_io_uring, `-j 4` | 900/901 (see below) |
| all fsx variants, `-j 10` | 24/24 |
| forking tests (fcntl, lockf, fstest, dirstress, fsstress) | 8/8 |
| server nfs/rest/mount_create | 16/16 |
| pynfs 4.0 over real TCP | passes |

Ten concurrent copies of one converted test with **no namespace and no wrapper**, zero failures, plus a mixed v3/v4/RDMA concurrent run of the same. The parallelism is the point: the 455-test leg is 3252 sec\*proc of work that finishes in 282 sec wall at `-j 12`.

The TCP path is unchanged and still covered — pynfs over real sockets passes, which also keeps the NFSv4.0 callback path exercised. That path still connects over TCP to a client-advertised address, as it must for an out-of-process client; the v4.1 backchannel used by chimera's own client rides the existing connection and works over inproc.

## Two things cannot follow, and stay on a socket

**Tests that `fork()`.** An inproc name is reachable only from the process that registered it, and these initialise a fresh client in each child — `test_lockf` says so in its own comment. A child could never find a server living in its parent. The six that fork (`fcntl`, `lockf`, `fstest`, `dirstress`, `fsstress`, `cthon_lock_tlock`) keep the namespace and select TCP through `CHIMERA_TEST_TRANSPORT`, which the harness reads.

**The server's own outbound callbacks** — NLM GRANTED delivery and NSM reboot notify. These dial *the client's* address. Over loopback, "the client's portmap at 127.0.0.1:111" was in fact this server's own portmap: they worked by accident of a shared loopback. They now go through the same helper, so under inproc they resolve to the same services by name — the same accident, stated honestly rather than relied on silently.

## fsx needed converting separately

`fsx.c` builds its own server and its own client config in code rather than going through `posix_test_common.h`, so converting that header left it on TCP while the CMake change took away its namespace. Concurrent fsx runs then collided:

```
Failed to bind listen socket to 0.0.0.0:2049: Address already in use
```

Both halves are now set where fsx builds them — deliberately not through the config `run_fsx.sh` writes, which fsx reads only for modules and mounts. 12 concurrent fsx runs pass where 11 of 12 previously aborted, and all 24 fsx tests pass together at `-j 10`.

## Load sensitivity

A handful of the heaviest tests (`rewinddir`, `io_serialize`, `cthon_special_bigfile`, some `pjd` cases, all on `diskfs_io_uring` or `cairn`) fail intermittently at high `-j` on a loaded machine and pass on their own. The failing set differs run to run, which is what distinguishes them from the deterministic problems above — those are fixed.

I have not established a baseline on unmodified main at the same parallelism, so I am not claiming these are pre-existing; only that they are not deterministic and not attributable to a specific defect found here. Worth watching in CI.

## Not converted

The netns wrapper is still used by pynfs, smbtorture/smbclient, elbencho, fio, ceph, daemon and kvm. All drive genuinely external processes, so the in-process transport cannot apply to them.
