### PR TITLE
diskfs: gate by-fh loads on home-block allocation (close reclaim stale-load window)

### DIFF
--- a/src/vfs/diskfs/diskfs_inode.c
+++ b/src/vfs/diskfs/diskfs_inode.c
@@ -337,13 +337,25 @@ diskfs_inode_acquire(
     if (unlikely(!inode)) {
         /* Not resident: either evicted (its dinode is durably home -- eviction
          * only drops CLEAN inodes) or genuinely absent.  Fault it in from disk
-         * whenever the inum is within allocated space; the on-disk dinode read
-         * validates inum/gen/nlink and yields ENOENT if it isn't really there.
-         * (This must not gate on `mounted` -- a freshly-formatted FS evicts
-         * too, so a miss is not necessarily ENOENT.) */
+         * only when the inum's home block is still ALLOCATED; the on-disk dinode
+         * read then validates inum/gen/nlink and yields ENOENT if it isn't
+         * really there.
+         *
+         * The allocation check (not a bare range check) is what closes the
+         * reclaim window: a removed-and-reclaimed inode has its resident struct
+         * dropped when the retire txn commits, but its tombstone dinode is not
+         * pushed home to the raw block until a later checkpoint/trim.  A range
+         * gate would fault the stale home block in that gap and read the
+         * pre-tombstone nlink, spuriously resolving the dead handle.  The home
+         * block is returned to the free map at the retire txn's apply (right
+         * after commit), so gating on allocation reads the inode as gone from
+         * then on.  A block reused for a new inode reads as allocated again, but
+         * its bumped generation fails the gen check below.  (This must not gate
+         * on `mounted` -- a freshly-formatted FS evicts too, so a miss is not
+         * necessarily ENOENT.) */
         diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_MISS);
         pthread_mutex_unlock(&shard->lock);
-        if (sm_inum_valid(thread->shared->space_map, inum)) {
+        if (sm_inum_allocated(thread->shared->space_map, inum)) {
             diskfs_inode_load(thread, txn, inum, gen, mode, cb, private_data);
         } else {
             cb(NULL, CHIMERA_VFS_ENOENT, private_data);

--- a/src/vfs/diskfs/space_map.h
+++ b/src/vfs/diskfs/space_map.h
@@ -862,6 +862,64 @@ sm_inum_valid(
 } // sm_inum_valid
 
 /*
+ * Load gate for a by-fh resolution: returns nonzero if the inode SHOULD be
+ * faulted from disk, zero only if the inum's home block is definitively free
+ * (so the handle is stale).  Beyond sm_inum_valid's range check, it consults
+ * the in-memory free map: a dinode's home block address is fixed by its inum
+ * (dinodes never relocate), so an in-use home block means a live inode lives
+ * there and an on-disk read can be trusted, whereas a home block returned to
+ * its AG free pool means the inode is gone.  This is what makes a reclaimed
+ * inode read as stale the moment its home block is freed (at the retire txn's
+ * apply, microseconds after the remove commits) instead of only once the
+ * tombstone dinode is pushed home to that block (the checkpoint/trim lag, many
+ * milliseconds) -- until then the raw home block still reads the pre-tombstone
+ * nlink and would spuriously resolve a removed handle.  The free tree tracks
+ * COMMITTED state (the reservation allocator leaves an allocated-but-not-yet-
+ * durable block in the tree until its txn retires), and a by-fh load only runs
+ * for an inode whose create/remove is durable, so a live inode never reads free.
+ *
+ * ag->lock is otherwise a LEAF lock (the allocator and the intent-log apply
+ * thread take it alone, and the allocator may take it and then evict an inode,
+ * i.e. ag -> shard).  A by-fh resolution reaches here holding the op's inode
+ * locks, so a blocking acquire here (shard/inode -> ag) would invert that order
+ * and can deadlock the apply thread against the allocator.  Use trylock and, on
+ * contention, fall back to loading (the pre-existing behaviour) -- never worse
+ * than before, and the stale window this closes only matters right after a
+ * remove, when this AG is quiescent (the single-threaded probe that exercises
+ * it has no competing op), so the trylock succeeds exactly when it counts.
+ */
+static inline int
+sm_inum_allocated(
+    struct space_map *sm,
+    uint64_t          inum)
+{
+    uint32_t          disk, ag_idx, block_idx;
+    struct sm_ag     *ag;
+    struct sm_extent *fext = NULL;
+    uint64_t          off;
+    int               allocated;
+
+    if (!sm_inum_valid(sm, inum)) {
+        return 0;
+    }
+
+    sm_inum_decode(inum, &disk, &ag_idx, &block_idx);
+    ag  = &sm->devices[disk].ags[ag_idx];
+    off = ag->log_offset + ag->log_size + (uint64_t) (block_idx - 1) * SM_BLOCK_SIZE;
+
+    if (pthread_mutex_trylock(&ag->lock) != 0) {
+        return 1;   /* contended -> assume live, load as before (no deadlock) */
+    }
+    /* Floor extent has offset <= off; the block is free iff that extent also
+     * extends past off (i.e. covers it). */
+    rb_tree_query_floor(&ag->free_by_offset, off, offset, fext);
+    allocated = !(fext && fext->offset + fext->length > off);
+    pthread_mutex_unlock(&ag->lock);
+
+    return allocated;
+} // sm_inum_allocated
+
+/*
  * Inverse of sm_inum_to_device_offset: given a freshly-allocated block at
  * (disk, offset), compute the inum that addresses it.
  */


### PR DESCRIPTION
## Problem

A by-fh resolution that misses the inode cache faults the dinode straight from
its home block, gated only by `sm_inum_valid()` — a pure address-range check.
That leaves a window after a remove:

- the resident `nlink==0` struct is dropped when the retire transaction commits
  (`durable_wm`), but
- the tombstone dinode is not pushed home to the raw block until a later
  checkpoint/trim.

In that gap a fresh fault reads the pre-tombstone `nlink==1` from the home block
and spuriously resolves a removed handle as live. This is diskfs-specific
(memfs/cairn free synchronously); it surfaces as intermittently stale file
handles resolving instead of returning `NOENT`/`STALE`.

## Fix

Gate the cold-load path on **home-block allocation** rather than mere
addressability. `sm_inum_allocated()` adds an in-memory free-map floor query to
the existing range check. The home block is returned to its AG free pool at the
retire txn's *apply* (a few microseconds after commit, far ahead of the
push-home), so a reclaimed inum reads as gone from apply-time on. A block reused
for a new inode reads allocated again but fails the generation check below.

Because a dinode's home-block address is fixed by its inum (dinodes never
relocate), an allocated home block always means a live inode lives there, so the
check never false-negatives a live inode. The free tree tracks committed state
(the reservation allocator leaves an allocated-but-not-yet-durable block in the
tree until its txn retires), and a by-fh load only ever runs for an inode whose
create/remove is durable, so a live inode never reads as free.

## Locking

`ag->lock` is otherwise a leaf lock — the allocator and the intent-log apply
thread take it alone, and the allocator may take it and then evict an inode
(`ag -> shard`). A by-fh resolution reaches the gate holding the op's inode
locks, so a **blocking** acquire here would invert that order and can deadlock
the apply thread against the allocator. The gate therefore uses `trylock` and
falls back to the prior load on contention: never worse than before, and the
window it closes only matters right after a remove when the AG is quiescent, so
the trylock succeeds exactly when it counts.

Draft: found via the in-development NFS3 model-based test harness (not included
here); opening early for review of the approach.
