### PR TITLE
Serve protocols only when explicitly enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,11 @@ Chimera uses JSON configuration files. Example:
 
 ```json
 {
+    "server": {
+        "nfs_enabled": true,
+        "smb_enabled": true,
+        "s3_enabled": true
+    },
     "shares": {
         "share_name": {
             "module": "linux",
@@ -138,6 +143,11 @@ Chimera uses JSON configuration files. Example:
     "enable_rdma": false
 }
 ```
+
+Protocols are opt-in: each of NFS, SMB, and S3 serves only when its
+`*_enabled` flag is set (all default to false); the `nfs_port` / `smb_port` /
+`s3_port` settings keep the customary defaults and matter only once the
+protocol is enabled.
 
 ## Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A minimal example that exports a single in-memory filesystem over NFS at
 ```json
 {
     "server": {
+        "nfs_enabled": true,
         "threads": 32,
         "sync_delegation_threads": 32,
         "async_delegation": false,
@@ -141,6 +142,9 @@ Chimera uses JSON configuration files to define shares and runtime parameters:
 ```json
 {
     "server": {
+        "nfs_enabled": true,
+        "smb_enabled": true,
+        "s3_enabled": true,
         "threads": 16,
         "sync_delegation_threads": 64,
         "async_delegation": false,

--- a/chimera-docker.json
+++ b/chimera-docker.json
@@ -5,6 +5,9 @@
         "async_delegation_threads": 8
     },
     "server": {
+        "nfs_enabled": true,
+        "smb_enabled": true,
+        "s3_enabled": true,
         "threads": 4,
         "rest_http_port": 8080
     },

--- a/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh
+++ b/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh
@@ -76,6 +76,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         "kv_module": "cairn",

--- a/kvm/kvm_nfs40_drc_reboot_test_wrapper.sh
+++ b/kvm/kvm_nfs40_drc_reboot_test_wrapper.sh
@@ -76,6 +76,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         "kv_module": "cairn",

--- a/kvm/kvm_nfs_kerberos_test_wrapper.sh
+++ b/kvm/kvm_nfs_kerberos_test_wrapper.sh
@@ -179,6 +179,7 @@ generate_config() {
 {
     "common": { "rcu_reclaim_threads": 4 },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         ${vfs_section}

--- a/kvm/kvm_nfs_multinode_test_wrapper.sh
+++ b/kvm/kvm_nfs_multinode_test_wrapper.sh
@@ -79,6 +79,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         "kv_module": "cairn",

--- a/kvm/kvm_nfs_reboot_test_wrapper.sh
+++ b/kvm/kvm_nfs_reboot_test_wrapper.sh
@@ -77,6 +77,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         "kv_module": "cairn",

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -141,6 +141,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         $vfs_section

--- a/kvm/kvm_nfstest_2client_test_wrapper.sh
+++ b/kvm/kvm_nfstest_2client_test_wrapper.sh
@@ -123,6 +123,7 @@ generate_config() {
 {
     "common": { "rcu_reclaim_threads": 4 },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         "nfs4_delegations": ${KVM_NFS4_DELEGATIONS:-$deleg_default},

--- a/kvm/kvm_nfstest_test_wrapper.sh
+++ b/kvm/kvm_nfstest_test_wrapper.sh
@@ -151,6 +151,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         $vfs_section

--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -176,6 +176,7 @@ generate_mds_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "external_portmap": false,
         "vfs": {

--- a/kvm/kvm_pnfs_proxy_test_wrapper.sh
+++ b/kvm/kvm_pnfs_proxy_test_wrapper.sh
@@ -122,6 +122,7 @@ generate_ds_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 2,
         "nfs_port": ${DS_PORT},
         "data_server": true,
@@ -165,6 +166,7 @@ generate_mds_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "external_portmap": false,
         ${vfs_section}
@@ -194,6 +196,7 @@ generate_proxy_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "nfs_port": ${PROXY_PORT},
         "external_portmap": false,

--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -134,6 +134,7 @@ generate_mds_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "external_portmap": false,
         "vfs": {

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -161,6 +161,7 @@ generate_ds_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 2,
         "nfs_port": ${DS_PORT},
         "data_server": true,
@@ -209,6 +210,7 @@ generate_mds_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "external_portmap": false,
         ${vfs_section}
@@ -261,6 +263,7 @@ generate_combined_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "external_portmap": false,
         ${vfs_section}

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -148,6 +148,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "smb_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         $vfs_section

--- a/scripts/nfs_kerberos_test_wrapper.sh
+++ b/scripts/nfs_kerberos_test_wrapper.sh
@@ -230,6 +230,7 @@ generate_config() {
 {
     "common": { "rcu_reclaim_threads": 4 },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         "nfs4_lease_time": 5,

--- a/scripts/pike_smb_test_wrapper.sh
+++ b/scripts/pike_smb_test_wrapper.sh
@@ -139,6 +139,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "smb_enabled": true,
         ${persistent_line}
         ${encryption_line}
         ${multichannel_line}

--- a/scripts/pynfs_pnfs_test_wrapper.sh
+++ b/scripts/pynfs_pnfs_test_wrapper.sh
@@ -67,7 +67,7 @@ trap cleanup EXIT
 cat > "$DS_CONFIG" << EOF
 {
     "common": { "rcu_reclaim_threads": 4 },
-    "server": { "threads": 2, "nfs_port": ${DS_PORT}, "data_server": true,
+    "server": { "nfs_enabled": true, "threads": 2, "nfs_port": ${DS_PORT}, "data_server": true,
                 "nfs4_lease_time": ${PYNFS_NFS4_LEASE_TIME},
                 "nfs4_grace_time": ${PYNFS_NFS4_GRACE_TIME},
                 "external_portmap": true, "metrics_port": 9001 },
@@ -80,6 +80,7 @@ cat > "$MDS_CONFIG" << EOF
 {
     "common": { "rcu_reclaim_threads": 4 },
     "server": {
+        "nfs_enabled": true,
         "threads": 4, "external_portmap": false,
         "nfs4_lease_time": ${PYNFS_NFS4_LEASE_TIME},
         "nfs4_grace_time": ${PYNFS_NFS4_GRACE_TIME},

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -151,6 +151,7 @@ generate_config() {
         "rcu_reclaim_threads": 4
     },
     "server": {
+        "nfs_enabled": true,
         "threads": 4,
         "delegation_threads": 4,
         "nfs4_delegations": $DELEG_ENABLE,

--- a/scripts/wpts_smb_test_wrapper.sh
+++ b/scripts/wpts_smb_test_wrapper.sh
@@ -231,6 +231,7 @@ generate_config() {
     cat > "$CONFIG_FILE" << EOF
 {
     "server": {
+        "smb_enabled": true,
         ${persistent_line}
         ${compression_line}
         ${multichannel_line}

--- a/src/admin/tests/conftest.py
+++ b/src/admin/tests/conftest.py
@@ -75,6 +75,9 @@ def chimera_server():
     config = {
         "server": {
             "threads": 2,
+            "nfs_enabled": True,
+            "smb_enabled": True,
+            "s3_enabled": True,
             "sync_delegation_threads": 4,
             "rest_http_port": rest_port,
             "rest_auth_enabled": False,

--- a/src/client/tests/client_test_common.h
+++ b/src/client/tests/client_test_common.h
@@ -119,6 +119,14 @@ client_test_init(
     if (env->use_nfs || env->use_smb) {
         server_config = chimera_server_config_init();
 
+        /* Protocols are opt-in; serve only what this test will mount. */
+        if (env->use_nfs) {
+            chimera_server_config_set_nfs_enabled(server_config, 1);
+        }
+        if (env->use_smb) {
+            chimera_server_config_set_smb_enabled(server_config, 1);
+        }
+
         /* Serve over the in-process transport: the client below lives in this
          * same process, so there is no reason to bind a port, and an inproc
          * name is private to the process -- so concurrent copies of this test

--- a/src/daemon/chimera.json
+++ b/src/daemon/chimera.json
@@ -13,6 +13,8 @@
 	}
     },
     "server": {
+	"nfs_enabled": true,
+	"smb_enabled": true,
 	"threads": 16
     },
     "mounts": {

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -675,6 +675,31 @@ main(
         chimera_server_config_set_s3_port(server_config, int_value);
     }
 
+    json_value = json_object_get(server_params, "smb_port");
+    if (json_is_integer(json_value)) {
+        int_value = json_integer_value(json_value);
+        chimera_server_config_set_smb_port(server_config, int_value);
+    }
+
+    /* Protocols are opt-in: nothing serves until the config enables it, so an
+     * instance brought up for one purpose never surprise-binds the other
+     * protocols' well-known ports.  The *_port settings above keep their
+     * customary defaults and matter only once the protocol is enabled. */
+    json_value = json_object_get(server_params, "nfs_enabled");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_nfs_enabled(server_config, json_is_true(json_value));
+    }
+
+    json_value = json_object_get(server_params, "smb_enabled");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_smb_enabled(server_config, json_is_true(json_value));
+    }
+
+    json_value = json_object_get(server_params, "s3_enabled");
+    if (json_is_boolean(json_value)) {
+        chimera_server_config_set_s3_enabled(server_config, json_is_true(json_value));
+    }
+
     /* NFSv4.1 server identity (EXCHANGE_ID server scope).  Set a distinct value
      * on independent servers that do not share state -- e.g. a pNFS data server
      * co-deployed with its MDS -- so v4.1 clients do not coalesce them. */
@@ -1053,6 +1078,15 @@ main(
 
     shares = json_object_get(config, "shares");
 
+    /* A share/export/bucket section whose protocol is not enabled is a
+     * contradiction: nothing would ever serve it.  Fail hard like the
+     * malformed-export errors below rather than silently not serving. */
+    if (shares && json_object_size(shares) > 0 &&
+        !chimera_server_config_get_smb_enabled(server_config)) {
+        chimera_server_error("Config declares SMB shares but smb_enabled is false");
+        exit(1);
+    }
+
     if (shares) {
         json_object_foreach(shares, name, share)
         {
@@ -1104,6 +1138,12 @@ main(
     }
 
     exports = json_object_get(config, "exports");
+
+    if (exports && json_object_size(exports) > 0 &&
+        !chimera_server_config_get_nfs_enabled(server_config)) {
+        chimera_server_error("Config declares NFS exports but nfs_enabled is false");
+        exit(1);
+    }
 
     /* Two passes over the exports object: entries pinning an explicit
      * export_id are created first so auto-assignment for the remaining
@@ -1348,6 +1388,12 @@ main(
     }
 
     buckets = json_object_get(config, "buckets");
+
+    if (buckets && json_object_size(buckets) > 0 &&
+        !chimera_server_config_get_s3_enabled(server_config)) {
+        chimera_server_error("Config declares S3 buckets but s3_enabled is false");
+        exit(1);
+    }
 
     if (buckets) {
         json_object_foreach(buckets, name, bucket)

--- a/src/daemon/tests/daemon_config_test.sh
+++ b/src/daemon/tests/daemon_config_test.sh
@@ -69,6 +69,7 @@ write_config() {
 {
     "server": {
         "threads": 2,
+        "nfs_enabled": true,
         "rest_http_port": ${REST_PORT},
         "rest_auth_enabled": false,
         "state_dir": "${TMPDIR}/state"${extra_server}

--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -3948,6 +3948,8 @@ main(
             /* NFS backend: Start server with the actual backend */
             chimera_server_config = chimera_server_config_init();
 
+            chimera_server_config_set_nfs_enabled(chimera_server_config, 1);
+
             /* fsx builds its own server and client rather than going through
              * posix_test_common.h, so it needs the same transport set here:
              * the in-process one, so that concurrent fsx runs do not contend

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -498,6 +498,10 @@ posix_test_start_nfs_server(struct posix_test_env *env)
                                          ? CHIMERA_TCP_FLAVOR_INPROC
                                          : CHIMERA_TCP_FLAVOR_PLAIN);
 
+    /* The posix suite only talks NFS; the other protocols stay at their
+     * default of disabled. */
+    chimera_server_config_set_nfs_enabled(server_config, 1);
+
     if (posix_test_is_diskfs(nfs_backend_name)) {
         posix_test_configure_diskfs(env->session_dir,
                                     posix_test_diskfs_device_type(nfs_backend_name),

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -165,6 +165,11 @@ nfs_server_init(
     const char                       *portmap_hostname;
     enum chimera_tcp_flavor           tcp_flavor;
 
+    if (!chimera_server_config_get_nfs_enabled(config)) {
+        chimera_nfs_info("NFS server disabled (not enabled in config)");
+        return NULL;
+    }
+
     nfs_port          = chimera_server_config_get_nfs_port(config);
     data_server       = chimera_server_config_get_nfs_data_server(config);
     nfs_rdma          = chimera_server_config_get_nfs_rdma(config);

--- a/src/server/rest/tests/rest_exports_test.c
+++ b/src/server/rest/tests/rest_exports_test.c
@@ -288,6 +288,10 @@ main(
     }
 
     config = chimera_server_config_init();
+
+    /* The export table these endpoints manipulate is owned by the NFS
+     * protocol, so it must be enabled for exports to exist at all. */
+    chimera_server_config_set_nfs_enabled(config, 1);
     chimera_server_config_set_rest_http_port(config, REST_PORT);
     /* Disable auth so the export endpoints can be exercised directly,
      * mirroring the admin pytest setup. */

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -1155,6 +1155,11 @@ s3_server_init(
 {
     struct chimera_server_s3_shared *shared;
 
+    if (!chimera_server_config_get_s3_enabled(config)) {
+        chimera_s3_info("S3 server disabled (not enabled in config)");
+        return NULL;
+    }
+
     shared = calloc(1, sizeof(*shared));
 
     shared->config = calloc(1, sizeof(*shared->config));

--- a/src/server/s3/tests/ceph/run_ceph_s3tests.sh
+++ b/src/server/s3/tests/ceph/run_ceph_s3tests.sh
@@ -60,7 +60,7 @@ trap cleanup EXIT
 
 cat > "$WORK/chimera.conf" <<EOF
 {
-  "server": { "s3_port": $PORT },
+  "server": { "s3_enabled": true, "s3_port": $PORT },
   "s3_access_keys": [
     { "access_key": "mainaccesskey0001", "secret_key": "mainsecretkey0001" },
     { "access_key": "altaccesskey0002",  "secret_key": "altsecretkey0002" },

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -66,6 +66,7 @@ class ChimeraServer:
         """Create a JSON configuration for the test server."""
         config = {
             "server": {
+                "s3_enabled": True,
                 "s3_port": 5000,
             },
             "s3_access_keys": [

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -56,6 +56,10 @@ struct chimera_server_config {
     int                                   nfs_nsm_port;
     int                                   nfs_port;
     int                                   s3_port;
+    int                                   smb_port;
+    int                                   nfs_enabled;
+    int                                   smb_enabled;
+    int                                   s3_enabled;
     int                                   nfs_data_server;
     uint64_t                              nfs_server_scope;
     int                                   external_portmap;
@@ -259,10 +263,20 @@ chimera_server_config_init(void)
     config->pnfs_enabled = 0;
     config->pnfs_num_ds  = 0;
 
+    /* Every protocol is opt-in: a server serves nothing until its config
+     * explicitly enables a protocol, so an instance brought up for one
+     * purpose (a test fixture, a data server, an admin-only daemon) never
+     * surprise-binds the others' well-known ports.  The port fields keep the
+     * customary defaults and take effect only once the protocol is enabled. */
+    config->nfs_enabled = 0;
+    config->smb_enabled = 0;
+    config->s3_enabled  = 0;
+
     /* NFS service port (default 2049); data-server mode binds only the NFSv4
      * service so a pNFS data server can coexist with an MDS on one host. */
     config->nfs_port        = 2049;
     config->s3_port         = 5000;
+    config->smb_port        = 445;
     config->nfs_data_server = 0;
 
     /* NFSv4.1 server identity (EXCHANGE_ID eir_server_scope).  Clients treat two
@@ -844,6 +858,62 @@ chimera_server_config_get_s3_port(const struct chimera_server_config *config)
 } /* chimera_server_config_get_s3_port */
 
 SYMBOL_EXPORT void
+chimera_server_config_set_smb_port(
+    struct chimera_server_config *config,
+    int                           port)
+{
+    config->smb_port = port;
+} /* chimera_server_config_set_smb_port */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_port(const struct chimera_server_config *config)
+{
+    return config->smb_port;
+} /* chimera_server_config_get_smb_port */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_nfs_enabled(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->nfs_enabled = enabled;
+} /* chimera_server_config_set_nfs_enabled */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_nfs_enabled(const struct chimera_server_config *config)
+{
+    return config->nfs_enabled;
+} /* chimera_server_config_get_nfs_enabled */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_enabled(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->smb_enabled = enabled;
+} /* chimera_server_config_set_smb_enabled */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_enabled(const struct chimera_server_config *config)
+{
+    return config->smb_enabled;
+} /* chimera_server_config_get_smb_enabled */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_s3_enabled(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->s3_enabled = enabled;
+} /* chimera_server_config_set_s3_enabled */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_s3_enabled(const struct chimera_server_config *config)
+{
+    return config->s3_enabled;
+} /* chimera_server_config_get_s3_enabled */
+
+SYMBOL_EXPORT void
 chimera_server_config_set_nfs_data_server(
     struct chimera_server_config *config,
     int                           enable)
@@ -1343,6 +1413,11 @@ chimera_server_thread_init(
     chimera_tracing_thread_register();
 
     for (int i = 0; i < server->num_protocols; i++) {
+        /* A protocol whose init returned NULL is disabled. */
+        if (!server->protocol_private[i]) {
+            thread->protocol_private[i] = NULL;
+            continue;
+        }
         thread->protocol_private[i] = server->protocols[i]->thread_init(evpl,
                                                                         thread->vfs_thread,
                                                                         server->
@@ -2301,6 +2376,9 @@ chimera_server_thread_shutdown(
     chimera_vfs_thread_drain(thread->vfs_thread);
 
     for (i = 0; i < server->num_protocols; i++) {
+        if (!thread->protocol_private[i]) {
+            continue;
+        }
         server->protocols[i]->thread_destroy(thread->protocol_private[i]);
     }
 
@@ -2459,6 +2537,9 @@ chimera_server_start(struct chimera_server *server)
     pthread_mutex_unlock(&server->lock);
 
     for (i = 0; i < server->num_protocols; i++) {
+        if (!server->protocol_private[i]) {
+            continue;
+        }
         server->protocols[i]->start(server->protocol_private[i]);
     }
 
@@ -2473,6 +2554,9 @@ chimera_server_destroy(struct chimera_server *server)
     int i;
 
     for (i = 0; i < server->num_protocols; i++) {
+        if (!server->protocol_private[i]) {
+            continue;
+        }
         server->protocols[i]->stop(server->protocol_private[i]);
     }
 
@@ -2482,6 +2566,9 @@ chimera_server_destroy(struct chimera_server *server)
 
     /* Destroy protocols before VFS so they can release any open handles */
     for (i = 0; i < server->num_protocols; i++) {
+        if (!server->protocol_private[i]) {
+            continue;
+        }
         server->protocols[i]->destroy(server->protocol_private[i]);
     }
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -376,6 +376,45 @@ chimera_server_config_get_s3_port(
     const struct chimera_server_config *config);
 
 void
+chimera_server_config_set_smb_port(
+    struct chimera_server_config *config,
+    int                           port);
+
+int
+chimera_server_config_get_smb_port(
+    const struct chimera_server_config *config);
+
+/* Protocols are opt-in: each serves only when its config explicitly enables
+ * it (default off).  The corresponding port settings above keep the customary
+ * defaults and matter only once the protocol is enabled. */
+void
+chimera_server_config_set_nfs_enabled(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+int
+chimera_server_config_get_nfs_enabled(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_smb_enabled(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+int
+chimera_server_config_get_smb_enabled(
+    const struct chimera_server_config *config);
+
+void
+chimera_server_config_set_s3_enabled(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+int
+chimera_server_config_get_s3_enabled(
+    const struct chimera_server_config *config);
+
+void
 chimera_server_config_set_nfs_data_server(
     struct chimera_server_config *config,
     int                           enable);

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -133,10 +133,16 @@ chimera_smb_server_init(
         return NULL;
     }
 
+    if (!chimera_server_config_get_smb_enabled(config)) {
+        chimera_smb_info("SMB server disabled (not enabled in config)");
+        free(shared);
+        return NULL;
+    }
+
     shared->tcp_flavor   = chimera_server_config_get_tcp_flavor(config);
     shared->tcp_protocol = chimera_tcp_flavor_to_protocol(shared->tcp_flavor);
 
-    shared->config.port      = 445;
+    shared->config.port      = chimera_server_config_get_smb_port(config);
     shared->config.rdma_port = 445;
 
     shared->config.capabilities = SMB2_GLOBAL_CAP_LARGE_MTU | SMB2_GLOBAL_CAP_MULTI_CHANNEL |

--- a/src/server/smb/tests/rest_user_manip_test.c
+++ b/src/server/smb/tests/rest_user_manip_test.c
@@ -416,6 +416,7 @@ main(
 
     /* Initialize server configuration */
     config = chimera_server_config_init();
+    chimera_server_config_set_smb_enabled(config, 1);
     chimera_server_config_set_rest_http_port(config, REST_PORT);
 
     /* Initialize server */

--- a/src/server/smb/tests/smbclient_auth_test.c
+++ b/src/server/smb/tests/smbclient_auth_test.c
@@ -736,6 +736,7 @@ main(
 
     /* Initialize server configuration */
     config = chimera_server_config_init();
+    chimera_server_config_set_smb_enabled(config, 1);
 
     /* Configure authentication based on environment */
     const char *keytab = getenv("KRB5_KTNAME");

--- a/src/server/smb/tests/smbtorture_test.c
+++ b/src/server/smb/tests/smbtorture_test.c
@@ -394,6 +394,7 @@ main(
 
     /* Initialize server configuration */
     config = chimera_server_config_init();
+    chimera_server_config_set_smb_enabled(config, 1);
 
     /* Exercise the real SMB3 durable/persistent-handle path (as the WPTS
      * harness does via CHIMERA_SMB_PERSISTENT).  Without it the server refuses

--- a/src/server/tests/mount_create_test.sh
+++ b/src/server/tests/mount_create_test.sh
@@ -30,6 +30,7 @@ trap cleanup EXIT
 cat > "$CFG" <<'EOF'
 {
     "server": {
+        "nfs_enabled": true,
         "threads": 2,
         "nfs_port": 21049,
         "data_server": true,

--- a/src/vfs/smb/tests/smb_mount_test.c
+++ b/src/vfs/smb/tests/smb_mount_test.c
@@ -90,6 +90,7 @@ main(
      * 445, which is what previously forced this test into a namespace of its
      * own to keep it off the host's port. */
     chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
+    chimera_server_config_set_smb_enabled(config, 1);
     /* Register the SMB2 client VFS module (statically linked into chimera_vfs;
      * empty path => resolve the vfs_smb symbol, do not dlopen). */
     chimera_server_config_add_module(config, "smb", NULL, "");


### PR DESCRIPTION
NFS, SMB and S3 each gain an `enabled` flag defaulting to false: a server serves nothing until its configuration turns a protocol on, so an instance brought up for one purpose (a test fixture, a pNFS data server, an admin-only daemon) never surprise-binds the other protocols' well-known ports.  The existing `nfs_port`/`s3_port` settings keep their customary defaults and now matter only once the protocol is enabled; SMB gains the matching `smb_port` (default 445) it never had.

- A disabled protocol's init returns NULL and the per-thread protocol loops skip it.
- The daemon fails startup with an explicit error when a config declares `exports`, `shares` or `buckets` whose protocol is not enabled.  Previously exports died with an unexplained "Failed to create export" and shares/buckets silently served nothing -- the silent-fallback failure daemon_config_test exists to catch.
- Every in-process test fixture enables exactly the protocols it mounts, the daemon-config-writing test wrappers (pynfs, pike, WPTS, KVM suites, s3-tests, admin pytest) say what they serve, and the demo configs and doc examples are updated to match.

The macOS port PR (#1513) will be rebased on top of this; its `s3_port 0` workaround for the ControlCenter port-5000 collision disappears entirely, since S3 simply defaults to off.