### PR TITLE
POSIX conformance fixes across the client, VFS, memfs, diskfs and cairn

### DIFF
--- a/src/client/client_fsetattr.h
+++ b/src/client/client_fsetattr.h
@@ -32,7 +32,9 @@ chimera_dispatch_fsetattr(
     struct chimera_client_thread  *thread,
     struct chimera_client_request *request)
 {
-    chimera_vfs_setattr(
+    /* Descriptor-originated: WRITE_DATA-only mutations (ftruncate,
+     * futimens-to-now) ride the descriptor's open-time grant. */
+    chimera_vfs_fsetattr(
         thread->vfs_thread,
         chimera_client_req_cred(request),
         request->fsetattr.handle,

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -226,6 +226,10 @@ struct chimera_client_request {
             struct chimera_vfs_open_handle *dest_parent_handle;
             chimera_link_callback_t         callback;
             void                           *private_data;
+            /* CHIMERA_VFS_LOOKUP_FOLLOW to resolve a final-component
+             * symlink in source_path and link its target
+             * (linkat AT_SYMLINK_FOLLOW); 0 links the symlink itself. */
+            unsigned int                    source_lookup_flags;
             int                             source_path_len;
             int                             source_parent_len;
             int                             source_name_offset;

--- a/src/client/client_link.h
+++ b/src/client/client_link.h
@@ -41,6 +41,7 @@ chimera_dispatch_link(
         thread->client->root_fh_len,
         request->link.source_path,
         request->link.source_path_len,
+        request->link.source_lookup_flags,
         request->link.dest_path,
         request->link.dest_path_len,
         0,

--- a/src/posix/posix.c
+++ b/src/posix/posix.c
@@ -317,6 +317,21 @@ chimera_posix_shutdown(void)
         return;
     }
 
+    /* Close any descriptors the application leaked: their open handles
+     * otherwise keep the VFS close-thread handshake in chimera_vfs_destroy
+     * from ever completing, hanging shutdown forever.  Must run while the
+     * workers are still alive to process the closes. */
+    if (posix->fds) {
+        for (int i = 0; i < posix->max_fds; i++) {
+            struct chimera_posix_fd_entry *entry = &posix->fds[i];
+
+            if (entry->handle &&
+                !(entry->flags & CHIMERA_POSIX_FD_CLOSED)) {
+                (void) chimera_posix_close(i);
+            }
+        }
+    }
+
     chimera_posix_global = NULL;
 
     if (posix->pool) {

--- a/src/posix/posix.c
+++ b/src/posix/posix.c
@@ -170,7 +170,7 @@ chimera_posix_init(
         pthread_mutex_init(&posix->fds[i].lock, NULL);
         pthread_cond_init(&posix->fds[i].cond, NULL);
         posix->fds[i].handle        = NULL;
-        posix->fds[i].offset        = 0;
+        posix->fds[i].ofd           = NULL;
         posix->fds[i].flags         = CHIMERA_POSIX_FD_CLOSED;
         posix->fds[i].refcnt        = 0;
         posix->fds[i].io_waiters    = 0;
@@ -264,7 +264,7 @@ chimera_posix_init_json(
         pthread_mutex_init(&posix->fds[i].lock, NULL);
         pthread_cond_init(&posix->fds[i].cond, NULL);
         posix->fds[i].handle        = NULL;
-        posix->fds[i].offset        = 0;
+        posix->fds[i].ofd           = NULL;
         posix->fds[i].flags         = CHIMERA_POSIX_FD_CLOSED;
         posix->fds[i].refcnt        = 0;
         posix->fds[i].io_waiters    = 0;

--- a/src/posix/posix_chown.c
+++ b/src/posix/posix_chown.c
@@ -44,6 +44,17 @@ chimera_posix_chown(
         return -1;
     }
 
+    if (owner == (uid_t) -1 && group == (gid_t) -1) {
+        /* No id named: nothing travels in the setattr mask, so apply the
+         * POSIX ownership rule here (see chown_restate_check). */
+        struct stat st;
+
+        if (chimera_posix_stat(path, &st) < 0) {
+            return -1;
+        }
+        return chimera_posix_chown_restate_check(&st);
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode               = CHIMERA_CLIENT_OP_SETATTR;

--- a/src/posix/posix_clone_file_range.c
+++ b/src/posix/posix_clone_file_range.c
@@ -52,6 +52,16 @@ chimera_posix_clone_file_range(
         return -1;
     }
 
+    /* FICLONERANGE: the source must be open for reading and the
+     * destination for writing (EBADF otherwise). */
+    if (!chimera_posix_fd_may_read(src_entry) ||
+        !chimera_posix_fd_may_write(dst_entry)) {
+        chimera_posix_fd_release(dst_entry, 0);
+        chimera_posix_fd_release(src_entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode                   = CHIMERA_CLIENT_OP_CLONE_RANGE;

--- a/src/posix/posix_copy_file_range.c
+++ b/src/posix/posix_copy_file_range.c
@@ -74,15 +74,15 @@ chimera_posix_copy_file_range(
      * writing, and fd_out must not have O_APPEND set -- all EBADF. */
     if (!chimera_posix_fd_may_read(in_entry) ||
         !chimera_posix_fd_may_write(out_entry) ||
-        (out_entry->oflags & O_APPEND)) {
+        (out_entry->ofd->oflags & O_APPEND)) {
         chimera_posix_fd_release(out_entry, 0);
         chimera_posix_fd_release(in_entry, 0);
         errno = EBADF;
         return -1;
     }
 
-    src_off = off_in ? *off_in : (off_t) in_entry->offset;
-    dst_off = off_out ? *off_out : (off_t) out_entry->offset;
+    src_off = off_in ? *off_in : (off_t) in_entry->ofd->offset;
+    dst_off = off_out ? *off_out : (off_t) out_entry->ofd->offset;
 
     chimera_posix_completion_init(&st.comp, &req);
     st.bytes_copied = 0;
@@ -105,12 +105,12 @@ chimera_posix_copy_file_range(
         if (off_in) {
             *off_in = src_off + (off_t) st.bytes_copied;
         } else {
-            in_entry->offset = (uint64_t) (src_off + (off_t) st.bytes_copied);
+            in_entry->ofd->offset = (uint64_t) (src_off + (off_t) st.bytes_copied);
         }
         if (off_out) {
             *off_out = dst_off + (off_t) st.bytes_copied;
         } else {
-            out_entry->offset = (uint64_t) (dst_off + (off_t) st.bytes_copied);
+            out_entry->ofd->offset = (uint64_t) (dst_off + (off_t) st.bytes_copied);
         }
     }
 

--- a/src/posix/posix_copy_file_range.c
+++ b/src/posix/posix_copy_file_range.c
@@ -70,6 +70,17 @@ chimera_posix_copy_file_range(
         return -1;
     }
 
+    /* copy_file_range(2): fd_in must be open for reading and fd_out for
+     * writing, and fd_out must not have O_APPEND set -- all EBADF. */
+    if (!chimera_posix_fd_may_read(in_entry) ||
+        !chimera_posix_fd_may_write(out_entry) ||
+        (out_entry->oflags & O_APPEND)) {
+        chimera_posix_fd_release(out_entry, 0);
+        chimera_posix_fd_release(in_entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     src_off = off_in ? *off_in : (off_t) in_entry->offset;
     dst_off = off_out ? *off_out : (off_t) out_entry->offset;
 

--- a/src/posix/posix_dup.c
+++ b/src/posix/posix_dup.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_dup.c
+++ b/src/posix/posix_dup.c
@@ -39,6 +39,13 @@ chimera_posix_dup(int oldfd)
         return -1;
     }
 
+    /* POSIX: the duplicate shares the open file description -- same file
+     * offset and status flags.  The description is not yet a shared object
+     * here, so propagate both at duplication time; a later lseek on one
+     * descriptor still does not move the other (known gap). */
+    posix->fds[newfd].offset = entry->offset;
+    posix->fds[newfd].oflags = entry->oflags;
+
     chimera_posix_fd_release(entry, 0);
 
     return newfd;

--- a/src/posix/posix_dup.c
+++ b/src/posix/posix_dup.c
@@ -39,12 +39,10 @@ chimera_posix_dup(int oldfd)
         return -1;
     }
 
-    /* POSIX: the duplicate shares the open file description -- same file
-     * offset and status flags.  The description is not yet a shared object
-     * here, so propagate both at duplication time; a later lseek on one
-     * descriptor still does not move the other (known gap). */
-    posix->fds[newfd].offset = entry->offset;
-    posix->fds[newfd].oflags = entry->oflags;
+    /* POSIX: the duplicate SHARES the open file description -- one file
+     * offset, one set of status flags -- so an lseek or F_SETFL through
+     * either descriptor is visible through the other. */
+    chimera_posix_ofd_adopt(posix, &posix->fds[newfd], entry);
 
     chimera_posix_fd_release(entry, 0);
 

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -90,19 +90,21 @@ chimera_posix_dup2(
     /* Increment the opencnt on the source handle */
     chimera_dup_handle(worker->client_thread, handle);
 
-    /* Set up the new fd entry.  POSIX: the duplicate shares the open file
-     * description, so it takes the source's file offset and status flags
-     * (previously the offset was reset to 0 and oflags left stale). */
+    /* Set up the new fd entry. */
     pthread_mutex_lock(&new_entry->lock);
     new_entry->handle      = handle;
-    new_entry->offset      = old_entry->offset;
-    new_entry->oflags      = old_entry->oflags;
     new_entry->flags       = 0;
     new_entry->refcnt      = 0;
     new_entry->eof_flag    = 0;
     new_entry->error_flag  = 0;
     new_entry->ungetc_char = -1;
     pthread_mutex_unlock(&new_entry->lock);
+
+    /* POSIX: the duplicate SHARES the source's open file description --
+     * one file offset, one set of status flags -- releasing whatever
+     * description the target slot held (a reclaimed free-list slot holds
+     * none; an implicitly-closed target's description is dropped here). */
+    chimera_posix_ofd_adopt(posix, new_entry, old_entry);
 
     chimera_posix_fd_release(old_entry, 0);
 

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -90,10 +90,13 @@ chimera_posix_dup2(
     /* Increment the opencnt on the source handle */
     chimera_dup_handle(worker->client_thread, handle);
 
-    /* Set up the new fd entry */
+    /* Set up the new fd entry.  POSIX: the duplicate shares the open file
+     * description, so it takes the source's file offset and status flags
+     * (previously the offset was reset to 0 and oflags left stale). */
     pthread_mutex_lock(&new_entry->lock);
     new_entry->handle      = handle;
-    new_entry->offset      = 0;
+    new_entry->offset      = old_entry->offset;
+    new_entry->oflags      = old_entry->oflags;
     new_entry->flags       = 0;
     new_entry->refcnt      = 0;
     new_entry->eof_flag    = 0;

--- a/src/posix/posix_faccessat.c
+++ b/src/posix/posix_faccessat.c
@@ -156,7 +156,11 @@ chimera_posix_faccessat(
     req.opcode            = CHIMERA_CLIENT_OP_STAT;
     req.stat.callback     = chimera_posix_faccessat_callback;
     req.stat.private_data = &state;
-    req.stat.path_len     = path_len;
+    /* access()/faccessat() check the file a symlink resolves to, so the
+     * underlying stat must follow (a dangling link is ENOENT, a loop
+     * ELOOP).  This was previously left uninitialized. */
+    req.stat.flags    = CHIMERA_VFS_LOOKUP_FOLLOW;
+    req.stat.path_len = path_len;
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_faccessat_exec);
 

--- a/src/posix/posix_faccessat.c
+++ b/src/posix/posix_faccessat.c
@@ -33,9 +33,8 @@ chimera_posix_faccessat_callback(
     void                         *private_data)
 {
     struct chimera_posix_faccessat_state *state = private_data;
-    int                                   r, w, x;
-    uid_t                                 proc_uid;
-    gid_t                                 proc_gid;
+    const struct chimera_vfs_cred        *cred;
+    int                                   r, w, x, in_group;
     mode_t                                mode;
 
     if (status != CHIMERA_VFS_OK) {
@@ -48,20 +47,41 @@ chimera_posix_faccessat_callback(
         return;
     }
 
-    proc_uid = getuid();
-    proc_gid = getgid();
-    mode     = st->st_mode;
+    /* Evaluate the XBD 4.5 file access permission algorithm against the
+     * chimera credential the operation runs as -- the caller's effective
+     * credential captured into the request by completion_init (this
+     * callback runs on a worker thread, so the thread-local override must
+     * not be consulted here), else the client-global credential.  NOT the
+     * host process's uid/gid, which have nothing to do with the identity
+     * chimera authorizes.  The chimera credential carries a single
+     * identity, so the real-vs-effective distinction (AT_EACCESS) is
+     * vacuous here.  Class selection is exclusive: the owner class
+     * applies whenever the uid matches, even if its bits deny what
+     * another class would grant. */
+    if (state->comp.request->has_cred) {
+        cred = &state->comp.request->req_cred;
+    } else {
+        cred = &chimera_posix_get_global()->client->cred;
+    }
 
-    if (proc_uid == 0) {
-        /* Root can read/write anything; execute requires at least one x bit */
+    mode = st->st_mode;
+
+    in_group = (cred->gid == st->st_gid);
+    for (uint32_t i = 0; !in_group && i < cred->ngids; i++) {
+        in_group = (cred->gids[i] == st->st_gid);
+    }
+
+    if (cred->uid == 0) {
+        /* Privilege grants read/write outright; execute needs the file to
+         * be a directory or carry at least one execute bit. */
         r = 1;
         w = 1;
-        x = !!(mode & (S_IXUSR | S_IXGRP | S_IXOTH));
-    } else if ((uint64_t) proc_uid == st->st_uid) {
+        x = S_ISDIR(mode) || !!(mode & (S_IXUSR | S_IXGRP | S_IXOTH));
+    } else if (cred->uid == st->st_uid) {
         r = !!(mode & S_IRUSR);
         w = !!(mode & S_IWUSR);
         x = !!(mode & S_IXUSR);
-    } else if ((uint64_t) proc_gid == st->st_gid) {
+    } else if (in_group) {
         r = !!(mode & S_IRGRP);
         w = !!(mode & S_IWGRP);
         x = !!(mode & S_IXGRP);

--- a/src/posix/posix_fallocate.c
+++ b/src/posix/posix_fallocate.c
@@ -55,7 +55,7 @@ chimera_posix_do_fallocate(
     }
 
     /* (de)allocate requires the descriptor be open for writing. */
-    if ((entry->oflags & O_ACCMODE) == O_RDONLY) {
+    if ((entry->ofd->oflags & O_ACCMODE) == O_RDONLY) {
         chimera_posix_fd_release(entry, 0);
         errno = EBADF;
         return -1;

--- a/src/posix/posix_fchown.c
+++ b/src/posix/posix_fchown.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_fchown.c
+++ b/src/posix/posix_fchown.c
@@ -46,6 +46,18 @@ chimera_posix_fchown(
         return -1;
     }
 
+    if (owner == (uid_t) -1 && group == (gid_t) -1) {
+        /* No id named: nothing travels in the setattr mask, so apply the
+         * POSIX ownership rule here (see chown_restate_check). */
+        struct stat st;
+
+        chimera_posix_fd_release(entry, 0);
+        if (chimera_posix_fstat(fd, &st) < 0) {
+            return -1;
+        }
+        return chimera_posix_chown_restate_check(&st);
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode                = CHIMERA_CLIENT_OP_FSETATTR;

--- a/src/posix/posix_fchownat.c
+++ b/src/posix/posix_fchownat.c
@@ -137,6 +137,18 @@ chimera_posix_fchownat(
     // AT_SYMLINK_NOFOLLOW and AT_EMPTY_PATH are not implemented
     (void) flags;
 
+    if (owner == (uid_t) -1 && group == (gid_t) -1 && dirfd == AT_FDCWD) {
+        /* No id named: nothing travels in the setattr mask, so apply the
+         * POSIX ownership rule here (see chown_restate_check).  Real
+         * dirfds keep the normal path below. */
+        struct stat st;
+
+        if (chimera_posix_stat(pathname, &st) < 0) {
+            return -1;
+        }
+        return chimera_posix_chown_restate_check(&st);
+    }
+
     chimera_posix_completion_init(&ctx.comp, &req);
 
     // Handle AT_FDCWD case - use simple path-based setattr

--- a/src/posix/posix_fcntl.c
+++ b/src/posix/posix_fcntl.c
@@ -51,10 +51,8 @@ chimera_posix_fcntl_dupfd(
         return -1;
     }
 
-    /* Like dup(): the duplicate takes the description's offset and
-     * status flags. */
-    posix->fds[newfd].offset = entry->offset;
-    posix->fds[newfd].oflags = entry->oflags;
+    /* Like dup(): the duplicate SHARES the open file description. */
+    chimera_posix_ofd_adopt(posix, &posix->fds[newfd], entry);
 
     chimera_posix_fd_release(entry, 0);
 
@@ -76,7 +74,7 @@ chimera_posix_fcntl_getfl(
         return -1;
     }
 
-    flags = (int) (entry->oflags &
+    flags = (int) (entry->ofd->oflags &
                    (O_ACCMODE | CHIMERA_POSIX_SETFL_MASK));
 
     chimera_posix_fd_release(entry, 0);
@@ -99,7 +97,7 @@ chimera_posix_fcntl_setfl(
         return -1;
     }
 
-    entry->oflags = (entry->oflags & ~(unsigned int) CHIMERA_POSIX_SETFL_MASK)
+    entry->ofd->oflags = (entry->ofd->oflags & ~(unsigned int) CHIMERA_POSIX_SETFL_MASK)
         | ((unsigned int) arg & CHIMERA_POSIX_SETFL_MASK);
 
     chimera_posix_fd_release(entry, 0);
@@ -219,7 +217,7 @@ chimera_posix_fcntl(
             break;
         }
         case SEEK_CUR: {
-            int64_t abs_offset = (int64_t) entry->offset + (int64_t) fl->l_start;
+            int64_t abs_offset = (int64_t) entry->ofd->offset + (int64_t) fl->l_start;
 
             if (abs_offset < 0) {
                 chimera_posix_fd_release(entry, 0);

--- a/src/posix/posix_fcntl.c
+++ b/src/posix/posix_fcntl.c
@@ -9,6 +9,103 @@
 
 #include "posix_internal.h"
 #include "../client/client_lock.h"
+#include "../client/client_dup.h"
+
+/* Status flags F_SETFL may change; everything else in the argument is
+ * ignored per POSIX (the access mode and creation flags are immutable). */
+#define CHIMERA_POSIX_SETFL_MASK (O_APPEND | O_NONBLOCK)
+
+static int
+chimera_posix_fcntl_dupfd(
+    struct chimera_posix_client *posix,
+    struct chimera_posix_worker *worker,
+    int                          fd,
+    int                          minfd)
+{
+    struct chimera_posix_fd_entry  *entry;
+    struct chimera_vfs_open_handle *handle;
+    int                             newfd;
+
+    if (minfd < 0 || minfd >= posix->max_fds) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    handle = entry->handle;
+
+    chimera_dup_handle(worker->client_thread, handle);
+
+    newfd = chimera_posix_fd_alloc_at_least(posix, handle, minfd);
+
+    if (newfd < 0) {
+        chimera_close(worker->client_thread, handle);
+        chimera_posix_fd_release(entry, 0);
+        errno = EMFILE;
+        return -1;
+    }
+
+    /* Like dup(): the duplicate takes the description's offset and
+     * status flags. */
+    posix->fds[newfd].offset = entry->offset;
+    posix->fds[newfd].oflags = entry->oflags;
+
+    chimera_posix_fd_release(entry, 0);
+
+    return newfd;
+} /* chimera_posix_fcntl_dupfd */
+
+static int
+chimera_posix_fcntl_getfl(
+    struct chimera_posix_client *posix,
+    int                          fd)
+{
+    struct chimera_posix_fd_entry *entry;
+    int                            flags;
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    flags = (int) (entry->oflags &
+                   (O_ACCMODE | CHIMERA_POSIX_SETFL_MASK));
+
+    chimera_posix_fd_release(entry, 0);
+
+    return flags;
+} /* chimera_posix_fcntl_getfl */
+
+static int
+chimera_posix_fcntl_setfl(
+    struct chimera_posix_client *posix,
+    int                          fd,
+    int                          arg)
+{
+    struct chimera_posix_fd_entry *entry;
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    entry->oflags = (entry->oflags & ~(unsigned int) CHIMERA_POSIX_SETFL_MASK)
+        | ((unsigned int) arg & CHIMERA_POSIX_SETFL_MASK);
+
+    chimera_posix_fd_release(entry, 0);
+
+    return 0;
+} /* chimera_posix_fcntl_setfl */
 
 static void
 chimera_posix_fcntl_lock_callback(
@@ -53,6 +150,24 @@ chimera_posix_fcntl(
     va_list                         args;
 
     switch (cmd) {
+        case F_DUPFD: {
+            int minfd;
+
+            va_start(args, cmd);
+            minfd = va_arg(args, int);
+            va_end(args);
+            return chimera_posix_fcntl_dupfd(posix, worker, fd, minfd);
+        }
+        case F_GETFL:
+            return chimera_posix_fcntl_getfl(posix, fd);
+        case F_SETFL: {
+            int arg;
+
+            va_start(args, cmd);
+            arg = va_arg(args, int);
+            va_end(args);
+            return chimera_posix_fcntl_setfl(posix, fd, arg);
+        }
         case F_GETLK:
             flags |= CHIMERA_VFS_LOCK_TEST;
         /* fall through */

--- a/src/posix/posix_fstatat.c
+++ b/src/posix/posix_fstatat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_fstatat.c
+++ b/src/posix/posix_fstatat.c
@@ -54,9 +54,6 @@ chimera_posix_fstatat(
     struct chimera_posix_completion comp;
     int                             path_len;
 
-    // Note: AT_SYMLINK_NOFOLLOW is not yet implemented (would need lstat)
-    (void) flags;
-
     // For now, only support AT_FDCWD
     if (dirfd != AT_FDCWD) {
         errno = ENOSYS;
@@ -79,7 +76,11 @@ chimera_posix_fstatat(
     req.opcode            = CHIMERA_CLIENT_OP_STAT;
     req.stat.callback     = chimera_posix_fstatat_callback;
     req.stat.private_data = &comp;
-    req.stat.path_len     = path_len;
+    /* AT_SYMLINK_NOFOLLOW selects lstat semantics; the flag was previously
+     * ignored and req.stat.flags left uninitialized. */
+    req.stat.flags = (flags & AT_SYMLINK_NOFOLLOW) ?
+        0 : CHIMERA_VFS_LOOKUP_FOLLOW;
+    req.stat.path_len = path_len;
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_fstatat_exec);
 

--- a/src/posix/posix_ftruncate.c
+++ b/src/posix/posix_ftruncate.c
@@ -51,7 +51,7 @@ chimera_posix_ftruncate(
     }
 
     /* POSIX: ftruncate on a descriptor not open for writing fails with EINVAL. */
-    if ((entry->oflags & O_ACCMODE) == O_RDONLY) {
+    if ((entry->ofd->oflags & O_ACCMODE) == O_RDONLY) {
         chimera_posix_fd_release(entry, 0);
         errno = EINVAL;
         return -1;

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -618,6 +618,28 @@ chimera_posix_fd_lseek(
     return new_offset;
 } // chimera_posix_fd_lseek
 
+/* chown()-family calls with both ids -1 change nothing, but POSIX still
+ * applies the ownership rule: "the effective user ID does not match the
+ * owner of the file and the process does not have appropriate privileges"
+ * is EPERM regardless (the VFS setattr gate never sees such a call because
+ * no UID/GID travels in the set mask, so the check lives client-side).
+ * Runs on the calling thread, so the thread-local credential override is
+ * the right identity source.  Returns 0 or -1 with errno = EPERM. */
+static FORCE_INLINE int
+chimera_posix_chown_restate_check(const struct stat *st)
+{
+    const struct chimera_vfs_cred *cred = chimera_posix_effective_cred();
+    uint32_t                       uid;
+
+    uid = cred ? cred->uid : chimera_posix_get_global()->client->cred.uid;
+
+    if (uid != 0 && uid != st->st_uid) {
+        errno = EPERM;
+        return -1;
+    }
+    return 0;
+} /* chimera_posix_chown_restate_check */
+
 /* Resolve the current EOF of the file behind an fd entry, for O_APPEND
  * write placement.  Returns 0 and fills *eof, or an errno value.
  * Defined in posix_write.c. */

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -46,12 +46,30 @@ struct chimera_posix_completion {
 #define CHIMERA_POSIX_FD_CLOSING   0x02
 #define CHIMERA_POSIX_FD_CLOSED    0x04
 
+/* One open file description (POSIX XBD): the file offset and status flags
+ * shared by every descriptor duplicated from one open() -- dup/dup2/
+ * F_DUPFD return descriptors referencing the SAME description, so an
+ * lseek or F_SETFL through one duplicate is visible through the others.
+ * Independent open() calls create independent descriptions.
+ *
+ * refcnt counts fd entries referencing the description and is managed
+ * under the client's fd_lock.  offset/oflags carry the same (loose)
+ * concurrency discipline the per-entry fields had: the per-descriptor
+ * IO_ACTIVE gate serializes offset-consuming I/O on one descriptor;
+ * concurrent I/O through two duplicates of one description is not
+ * additionally serialized here. */
+struct chimera_posix_ofd {
+    uint64_t     offset;
+    unsigned int oflags;     // Raw open(2) flags (for O_ACCMODE checks)
+    int          refcnt;
+};
+
 struct chimera_posix_fd_entry {
     pthread_mutex_t                 lock;
     pthread_cond_t                  cond;
     struct chimera_vfs_open_handle *handle;
     struct chimera_posix_fd_entry  *next;
-    uint64_t                        offset;
+    struct chimera_posix_ofd       *ofd;
     unsigned int                    flags;
     int                             refcnt;
     int                             io_waiters;
@@ -60,7 +78,6 @@ struct chimera_posix_fd_entry {
     int                             eof_flag;    // For FILE* feof() support
     int                             error_flag;  // For FILE* ferror() support
     int                             ungetc_char; // For FILE* ungetc() support (-1 = none)
-    unsigned int                    oflags;      // Raw open(2) flags (for O_ACCMODE checks)
 } __attribute__((aligned(64)));
 
 // CHIMERA_FILE is a pointer to an fd_entry for FILE* operations
@@ -124,6 +141,33 @@ chimera_posix_get_global(void)
 {
     return chimera_posix_global;
 } // chimera_posix_get_global
+
+/* Drop an fd entry's reference on its open file description, freeing the
+ * description when the last duplicate goes.  Caller holds fd_lock. */
+static FORCE_INLINE void
+chimera_posix_ofd_release_locked(struct chimera_posix_fd_entry *entry)
+{
+    if (entry->ofd && --entry->ofd->refcnt == 0) {
+        free(entry->ofd);
+    }
+    entry->ofd = NULL;
+} // chimera_posix_ofd_release_locked
+
+/* Point `entry` at `src`'s open file description (dup/dup2/F_DUPFD: the
+ * duplicate SHARES the description), releasing whatever description the
+ * entry held. */
+static FORCE_INLINE void
+chimera_posix_ofd_adopt(
+    struct chimera_posix_client   *posix,
+    struct chimera_posix_fd_entry *entry,
+    struct chimera_posix_fd_entry *src)
+{
+    pthread_mutex_lock(&posix->fd_lock);
+    chimera_posix_ofd_release_locked(entry);
+    entry->ofd = src->ofd;
+    entry->ofd->refcnt++;
+    pthread_mutex_unlock(&posix->fd_lock);
+} // chimera_posix_ofd_adopt
 
 static FORCE_INLINE int
 chimera_posix_errno_from_status(enum chimera_vfs_error status)
@@ -374,8 +418,21 @@ chimera_posix_fd_alloc_at_least(
 
     fd = (int) (entry - posix->fds);
 
+    /* A fresh open gets a fresh open file description (not shared with
+     * anyone yet, so no lock needed for the refcount). */
+    entry->ofd = calloc(1, sizeof(*entry->ofd));
+
+    if (!entry->ofd) {
+        pthread_mutex_lock(&posix->fd_lock);
+        entry->next      = posix->free_list;
+        posix->free_list = entry;
+        pthread_mutex_unlock(&posix->fd_lock);
+        return -1;
+    }
+
+    entry->ofd->refcnt = 1;
+
     entry->handle        = handle;
-    entry->offset        = 0;
     entry->flags         = 0;
     entry->refcnt        = 0;
     entry->io_waiters    = 0;
@@ -384,7 +441,6 @@ chimera_posix_fd_alloc_at_least(
     entry->eof_flag      = 0;
     entry->error_flag    = 0;
     entry->ungetc_char   = -1;
-    entry->oflags        = 0;
 
     return fd;
 } // chimera_posix_fd_alloc_at_least
@@ -411,12 +467,12 @@ chimera_posix_fd_free(
     entry = &posix->fds[fd];
 
     entry->handle      = NULL;
-    entry->offset      = 0;
     entry->eof_flag    = 0;
     entry->error_flag  = 0;
     entry->ungetc_char = -1;
 
     pthread_mutex_lock(&posix->fd_lock);
+    chimera_posix_ofd_release_locked(entry);
     entry->next      = posix->free_list;
     posix->free_list = entry;
     pthread_mutex_unlock(&posix->fd_lock);
@@ -531,20 +587,21 @@ chimera_posix_fd_release(
 } // chimera_posix_fd_release
 
 /* POSIX ties I/O rights to the descriptor's access mode, checked at open
- * and carried in oflags (propagated by dup/dup2): read-family calls need a
+ * and carried in the shared description's oflags: read-family calls need a
  * descriptor open for reading and write-family calls one open for writing,
  * otherwise EBADF (read()/write() ERRORS). */
 static FORCE_INLINE int
 chimera_posix_fd_may_read(const struct chimera_posix_fd_entry *entry)
 {
-    return (entry->oflags & O_ACCMODE) != O_WRONLY;
+    return (entry->ofd->oflags & O_ACCMODE) != O_WRONLY;
 } /* chimera_posix_fd_may_read */
 
 static FORCE_INLINE int
 chimera_posix_fd_may_write(const struct chimera_posix_fd_entry *entry)
 {
-    return (entry->oflags & O_ACCMODE) != O_RDONLY;
+    return (entry->ofd->oflags & O_ACCMODE) != O_RDONLY;
 } /* chimera_posix_fd_may_write */
+
 
 static FORCE_INLINE off_t
 chimera_posix_fd_lseek(
@@ -593,7 +650,7 @@ chimera_posix_fd_lseek(
             new_offset = offset;
             break;
         case SEEK_CUR:
-            new_offset = (off_t) entry->offset + offset;
+            new_offset = (off_t) entry->ofd->offset + offset;
             break;
         case SEEK_END:
             new_offset = file_size + offset;
@@ -611,7 +668,7 @@ chimera_posix_fd_lseek(
         return -1;
     }
 
-    entry->offset = (uint64_t) new_offset;
+    entry->ofd->offset = (uint64_t) new_offset;
 
     pthread_mutex_unlock(&entry->lock);
 

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -507,6 +507,22 @@ chimera_posix_fd_release(
     pthread_mutex_unlock(&entry->lock);
 } // chimera_posix_fd_release
 
+/* POSIX ties I/O rights to the descriptor's access mode, checked at open
+ * and carried in oflags (propagated by dup/dup2): read-family calls need a
+ * descriptor open for reading and write-family calls one open for writing,
+ * otherwise EBADF (read()/write() ERRORS). */
+static FORCE_INLINE int
+chimera_posix_fd_may_read(const struct chimera_posix_fd_entry *entry)
+{
+    return (entry->oflags & O_ACCMODE) != O_WRONLY;
+} /* chimera_posix_fd_may_read */
+
+static FORCE_INLINE int
+chimera_posix_fd_may_write(const struct chimera_posix_fd_entry *entry)
+{
+    return (entry->oflags & O_ACCMODE) != O_RDONLY;
+} /* chimera_posix_fd_may_write */
+
 static FORCE_INLINE off_t
 chimera_posix_fd_lseek(
     struct chimera_posix_client *posix,
@@ -578,6 +594,14 @@ chimera_posix_fd_lseek(
 
     return new_offset;
 } // chimera_posix_fd_lseek
+
+/* Resolve the current EOF of the file behind an fd entry, for O_APPEND
+ * write placement.  Returns 0 and fills *eof, or an errno value.
+ * Defined in posix_write.c. */
+int chimera_posix_fd_eof(
+    struct chimera_posix_worker   *worker,
+    struct chimera_posix_fd_entry *entry,
+    uint64_t                      *eof);
 
 void * chimera_posix_worker_init(
     struct evpl *evpl,

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -335,25 +335,40 @@ chimera_posix_check_path(const char *path)
     return (int) len;
 } /* chimera_posix_check_path */
 
+/* Allocate the lowest free descriptor slot with index >= minfd (POSIX
+ * open()/dup() require the lowest available descriptor; F_DUPFD the lowest
+ * >= its argument).  The free list is unordered, so scan it for the best
+ * index; it holds at most max_fds entries and allocation is not a hot
+ * path in this compatibility layer. */
 static FORCE_INLINE int
-chimera_posix_fd_alloc(
+chimera_posix_fd_alloc_at_least(
     struct chimera_posix_client    *posix,
-    struct chimera_vfs_open_handle *handle)
+    struct chimera_vfs_open_handle *handle,
+    int                             minfd)
 {
-    struct chimera_posix_fd_entry *entry;
-    int                            fd;
+    struct chimera_posix_fd_entry  *entry;
+    struct chimera_posix_fd_entry **pp, **best_pp = NULL;
+    int                             fd, best = posix->max_fds;
 
     pthread_mutex_lock(&posix->fd_lock);
 
-    entry = posix->free_list;
+    for (pp = &posix->free_list; *pp; pp = &(*pp)->next) {
+        int idx = (int) (*pp - posix->fds);
 
-    if (!entry) {
+        if (idx >= minfd && idx < best) {
+            best    = idx;
+            best_pp = pp;
+        }
+    }
+
+    if (!best_pp) {
         pthread_mutex_unlock(&posix->fd_lock);
         return -1;
     }
 
-    posix->free_list = entry->next;
-    entry->next      = NULL;
+    entry       = *best_pp;
+    *best_pp    = entry->next;
+    entry->next = NULL;
 
     pthread_mutex_unlock(&posix->fd_lock);
 
@@ -372,6 +387,14 @@ chimera_posix_fd_alloc(
     entry->oflags        = 0;
 
     return fd;
+} // chimera_posix_fd_alloc_at_least
+
+static FORCE_INLINE int
+chimera_posix_fd_alloc(
+    struct chimera_posix_client    *posix,
+    struct chimera_vfs_open_handle *handle)
+{
+    return chimera_posix_fd_alloc_at_least(posix, handle, 0);
 } // chimera_posix_fd_alloc
 
 static FORCE_INLINE void

--- a/src/posix/posix_lchown.c
+++ b/src/posix/posix_lchown.c
@@ -44,6 +44,17 @@ chimera_posix_lchown(
         return -1;
     }
 
+    if (owner == (uid_t) -1 && group == (gid_t) -1) {
+        /* No id named: nothing travels in the setattr mask, so apply the
+         * POSIX ownership rule here (see chown_restate_check). */
+        struct stat st;
+
+        if (chimera_posix_lstat(path, &st) < 0) {
+            return -1;
+        }
+        return chimera_posix_chown_restate_check(&st);
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode               = CHIMERA_CLIENT_OP_SETATTR;

--- a/src/posix/posix_link.c
+++ b/src/posix/posix_link.c
@@ -52,13 +52,16 @@ chimera_posix_link(
     source_slash = rindex(oldpath, '/');
     dest_slash   = rindex(newpath, '/');
 
-    req.opcode                 = CHIMERA_CLIENT_OP_LINK;
-    req.link.callback          = chimera_posix_link_callback;
-    req.link.private_data      = &comp;
-    req.link.source_path_len   = source_path_len;
-    req.link.source_parent_len = source_slash ? source_slash - oldpath : source_path_len;
-    req.link.dest_path_len     = dest_path_len;
-    req.link.dest_parent_len   = dest_slash ? dest_slash - newpath : dest_path_len;
+    req.opcode            = CHIMERA_CLIENT_OP_LINK;
+    req.link.callback     = chimera_posix_link_callback;
+    req.link.private_data = &comp;
+    /* link() links the symlink itself (Linux semantics; linkat with
+     * AT_SYMLINK_FOLLOW is the follow variant). */
+    req.link.source_lookup_flags = 0;
+    req.link.source_path_len     = source_path_len;
+    req.link.source_parent_len   = source_slash ? source_slash - oldpath : source_path_len;
+    req.link.dest_path_len       = dest_path_len;
+    req.link.dest_parent_len     = dest_slash ? dest_slash - newpath : dest_path_len;
 
     while (dest_slash && *dest_slash == '/') {
         dest_slash++;

--- a/src/posix/posix_linkat.c
+++ b/src/posix/posix_linkat.c
@@ -9,8 +9,12 @@
 #include "../client/client_link.h"
 
 #ifndef AT_FDCWD
-#define AT_FDCWD -100
+#define AT_FDCWD          -100
 #endif /* ifndef AT_FDCWD */
+
+#ifndef AT_SYMLINK_FOLLOW
+#define AT_SYMLINK_FOLLOW 0x400
+#endif /* ifndef AT_SYMLINK_FOLLOW */
 
 static void
 chimera_posix_linkat_callback(
@@ -46,9 +50,6 @@ chimera_posix_linkat(
     int                             old_path_len, new_path_len;
     const char                     *new_slash;
 
-    // Note: flags like AT_SYMLINK_FOLLOW are not yet implemented
-    (void) flags;
-
     // For now, only support AT_FDCWD for both paths
     if (olddirfd != AT_FDCWD || newdirfd != AT_FDCWD) {
         errno = ENOSYS;
@@ -70,6 +71,10 @@ chimera_posix_linkat(
 
     req.link.source_path_len   = old_path_len;
     req.link.source_parent_len = old_path_len;
+    /* AT_SYMLINK_FOLLOW resolves a final-component symlink in oldpath and
+     * links its target; without it the symlink itself is linked. */
+    req.link.source_lookup_flags = (flags & AT_SYMLINK_FOLLOW) ?
+        CHIMERA_VFS_LOOKUP_FOLLOW : 0;
 
     // Build dest path
     if (newpath[0] == '/') {

--- a/src/posix/posix_lseek.c
+++ b/src/posix/posix_lseek.c
@@ -90,7 +90,7 @@ chimera_posix_lseek_hole_data(
 
     if (!err) {
         pthread_mutex_lock(&entry->lock);
-        entry->offset = ctx.r_offset;
+        entry->ofd->offset = ctx.r_offset;
         pthread_mutex_unlock(&entry->lock);
     }
 

--- a/src/posix/posix_lseek.c
+++ b/src/posix/posix_lseek.c
@@ -59,7 +59,10 @@ chimera_posix_lseek_hole_data(
     struct chimera_posix_seek_ctx  ctx;
 
     if (offset < 0) {
-        errno = EINVAL;
+        /* No data or hole can exist at a negative offset; this is the same
+         * out-of-range condition as an offset at/past EOF, which POSIX and
+         * Linux report as ENXIO (not EINVAL) for SEEK_DATA/SEEK_HOLE. */
+        errno = ENXIO;
         return -1;
     }
 

--- a/src/posix/posix_lstat.c
+++ b/src/posix/posix_lstat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_lstat.c
+++ b/src/posix/posix_lstat.c
@@ -44,9 +44,17 @@ chimera_posix_lstat(
     struct chimera_posix_completion comp;
     int                             path_len;
 
-    chimera_posix_completion_init(&comp, &req);
-
     path_len = strlen(path);
+
+    /* XBD 4.16: a trailing slash forces a final symlink to be followed
+     * (the slash names the directory the link resolves to) and requires
+     * the result to be a directory -- so lstat("lnk/") behaves as
+     * stat("lnk/"), including its ENOTDIR check. */
+    if (path_len > 1 && path[path_len - 1] == '/') {
+        return chimera_posix_stat(path, st);
+    }
+
+    chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_STAT;
     req.stat.callback     = chimera_posix_lstat_callback;

--- a/src/posix/posix_mkdir.c
+++ b/src/posix/posix_mkdir.c
@@ -71,6 +71,23 @@ chimera_posix_mkdir(
     chimera_posix_completion_destroy(&comp);
 
     if (err) {
+        if ((err == EEXIST || err == EACCES) &&
+            path_len > 1 && path[path_len - 1] == '/') {
+            /* The backend judged the slash-stripped name.  XBD 4.16: a
+             * trailing slash makes the pathname resolve through the final
+             * component -- a non-directory there is ENOTDIR and a symlink
+             * loop is ELOOP, and resolution errors precede the operation's
+             * own existence/permission errors.  stat() with the slash
+             * preserved applies exactly those rules; any other stat
+             * outcome (a directory, a dangling link) keeps the backend's
+             * errno. */
+            struct stat st;
+
+            if (chimera_posix_stat(path, &st) < 0 &&
+                (errno == ENOTDIR || errno == ELOOP)) {
+                return -1;
+            }
+        }
         errno = err;
         return -1;
     }

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -108,12 +108,13 @@ chimera_posix_open(
     /* O_TRUNC: truncate an existing writable file to zero length on open.
      * The VFS open path does not yet honor CHIMERA_VFS_OPEN_TRUNCATE, so apply
      * it here for regular files opened for writing.  Truncation failures on
-     * non-regular targets are ignored (O_TRUNC is unspecified for them). */
+     * non-regular targets are ignored (O_TRUNC is unspecified for them).
+     * This runs even when the file is already empty: O_TRUNC marks
+     * mtime/ctime and clears set-user/group-ID regardless of the size. */
     if ((flags & O_TRUNC) && (flags & O_ACCMODE) != O_RDONLY) {
         struct stat st;
 
-        if (chimera_posix_fstat(fd, &st) == 0 && S_ISREG(st.st_mode) &&
-            st.st_size != 0) {
+        if (chimera_posix_fstat(fd, &st) == 0 && S_ISREG(st.st_mode)) {
             (void) chimera_posix_ftruncate(fd, 0);
         }
     }

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -94,7 +94,7 @@ chimera_posix_open(
             chimera_close(worker->client_thread, req.sync_open_handle);
             err = EMFILE;
         } else {
-            posix->fds[fd].oflags = (unsigned int) flags;
+            posix->fds[fd].ofd->oflags = (unsigned int) flags;
         }
     }
 

--- a/src/posix/posix_openat.c
+++ b/src/posix/posix_openat.c
@@ -146,7 +146,7 @@ chimera_posix_openat(
         return -1;
     }
 
-    posix->fds[fd].oflags = (unsigned int) flags;
+    posix->fds[fd].ofd->oflags = (unsigned int) flags;
 
     return fd;
 } /* chimera_posix_openat */

--- a/src/posix/posix_pread.c
+++ b/src/posix/posix_pread.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_pread.c
+++ b/src/posix/posix_pread.c
@@ -69,6 +69,12 @@ chimera_posix_pread(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_pwrite.c
+++ b/src/posix/posix_pwrite.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_pwrite.c
+++ b/src/posix/posix_pwrite.c
@@ -52,6 +52,12 @@ chimera_posix_pwrite(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_write(entry)) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode             = CHIMERA_CLIENT_OP_WRITE;

--- a/src/posix/posix_read.c
+++ b/src/posix/posix_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_read.c
+++ b/src/posix/posix_read.c
@@ -86,7 +86,7 @@ chimera_posix_read(
     req.read.callback     = chimera_posix_read_callback;
     req.read.private_data = &comp;
     req.read.handle       = entry->handle;
-    req.read.offset       = entry->offset;
+    req.read.offset       = entry->ofd->offset;
     req.read.length       = count;
     req.read.buf          = buf;
 
@@ -95,7 +95,7 @@ chimera_posix_read(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->ofd->offset += (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_read.c
+++ b/src/posix/posix_read.c
@@ -74,6 +74,12 @@ chimera_posix_read(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_read_into.c
+++ b/src/posix/posix_read_into.c
@@ -72,7 +72,7 @@ chimera_posix_read_into_common(
     req.read_into.callback     = chimera_posix_read_into_callback;
     req.read_into.private_data = &comp;
     req.read_into.handle       = entry->handle;
-    req.read_into.offset       = use_fd_offset ? entry->offset : (uint64_t) offset;
+    req.read_into.offset       = use_fd_offset ? entry->ofd->offset : (uint64_t) offset;
     req.read_into.length       = count;
     req.read_into.dest_niov    = niov;
 
@@ -85,7 +85,7 @@ chimera_posix_read_into_common(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && use_fd_offset && req.sync_result >= 0) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->ofd->offset += (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_read_into.c
+++ b/src/posix/posix_read_into.c
@@ -60,6 +60,12 @@ chimera_posix_read_into_common(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode                 = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_readv.c
+++ b/src/posix/posix_readv.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_readv.c
+++ b/src/posix/posix_readv.c
@@ -123,7 +123,7 @@ chimera_posix_readv_internal(
     req.read.callback     = chimera_posix_readv_callback;
     req.read.private_data = &comp;
     req.read.handle       = entry->handle;
-    req.read.offset       = use_fd_offset ? entry->offset : (uint64_t) offset;
+    req.read.offset       = use_fd_offset ? entry->ofd->offset : (uint64_t) offset;
     req.read.length       = total_len;
     req.read.buf          = (void *) iov;  // Store user iovec pointer
     req.read.niov         = iovcnt;        // Store user iovec count
@@ -133,7 +133,7 @@ chimera_posix_readv_internal(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0 && use_fd_offset) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->ofd->offset += (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_readv.c
+++ b/src/posix/posix_readv.c
@@ -111,6 +111,12 @@ chimera_posix_readv_internal(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, flags);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_stat.c
+++ b/src/posix/posix_stat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_stat.c
+++ b/src/posix/posix_stat.c
@@ -63,6 +63,13 @@ chimera_posix_stat(
 
     if (!err) {
         chimera_posix_fill_stat(st, &req.sync_stat);
+
+        /* XBD 4.16: a pathname with a trailing slash must resolve to a
+         * directory; anything else is ENOTDIR. */
+        if (path_len > 1 && path[path_len - 1] == '/' &&
+            !S_ISDIR(st->st_mode)) {
+            err = ENOTDIR;
+        }
     }
 
     chimera_posix_completion_destroy(&comp);

--- a/src/posix/posix_utimensat.c
+++ b/src/posix/posix_utimensat.c
@@ -31,9 +31,10 @@ chimera_posix_fill_utimes(
     const struct timespec     times[2])
 {
     sa->va_req_mask = 0;
-    sa->va_set_mask = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
+    sa->va_set_mask = 0;
 
     if (times == NULL) {
+        sa->va_set_mask      = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
         sa->va_atime.tv_sec  = 0;
         sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_NOW;
         sa->va_mtime.tv_sec  = 0;
@@ -41,26 +42,40 @@ chimera_posix_fill_utimes(
         return;
     }
 
+    /* An omitted field must not appear in the set mask at all: a stray
+     * OMIT sentinel under CHIMERA_VFS_ATTR_ATIME/MTIME made the setattr
+     * permission gate treat it as an EXPLICIT timestamp, demanding
+     * ownership (EPERM) for calls POSIX tiers by write access -- e.g. a
+     * to-now update paired with one omitted field, or a both-omitted
+     * no-op. */
     if (times[0].tv_nsec == UTIME_NOW) {
+        sa->va_set_mask     |= CHIMERA_VFS_ATTR_ATIME;
         sa->va_atime.tv_sec  = 0;
         sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_NOW;
-    } else if (times[0].tv_nsec == UTIME_OMIT) {
-        sa->va_atime.tv_sec  = 0;
-        sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
-    } else {
-        sa->va_atime = times[0];
+    } else if (times[0].tv_nsec != UTIME_OMIT) {
+        sa->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
+        sa->va_atime     = times[0];
     }
 
     if (times[1].tv_nsec == UTIME_NOW) {
+        sa->va_set_mask     |= CHIMERA_VFS_ATTR_MTIME;
         sa->va_mtime.tv_sec  = 0;
         sa->va_mtime.tv_nsec = CHIMERA_VFS_TIME_NOW;
-    } else if (times[1].tv_nsec == UTIME_OMIT) {
-        sa->va_mtime.tv_sec  = 0;
-        sa->va_mtime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
-    } else {
-        sa->va_mtime = times[1];
+    } else if (times[1].tv_nsec != UTIME_OMIT) {
+        sa->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
+        sa->va_mtime     = times[1];
     }
 } /* chimera_posix_fill_utimes */
+
+/* Both fields omitted: POSIX requires no ownership or permission check and
+ * no timestamp change -- only resolution/descriptor errors may surface. */
+static inline int
+chimera_posix_utimes_noop(const struct timespec times[2])
+{
+    return times != NULL &&
+           times[0].tv_nsec == UTIME_OMIT &&
+           times[1].tv_nsec == UTIME_OMIT;
+} /* chimera_posix_utimes_noop */
 
 /* ---- futimens(fd, times) : fsetattr on the open handle ---- */
 
@@ -99,6 +114,13 @@ chimera_posix_futimens(
     if (!entry) {
         errno = EBADF;
         return -1;
+    }
+
+    if (chimera_posix_utimes_noop(times)) {
+        /* The descriptor is valid and a both-omitted call changes
+         * nothing; POSIX forbids any further permission check. */
+        chimera_posix_fd_release(entry, 0);
+        return 0;
     }
 
     chimera_posix_completion_init(&comp, &req);
@@ -146,6 +168,9 @@ struct chimera_posix_utimensat_ctx {
     struct chimera_vfs_open_handle *file_handle;
     struct chimera_vfs_attrs        set_attr;
     uint32_t                        lookup_flags;   /* CHIMERA_VFS_LOOKUP_FOLLOW or 0 */
+    /* Both timestamps omitted: validate the path resolution, change
+     * nothing (see chimera_posix_utimes_noop). */
+    int                             validate_only;
     int                             start_fh_len;
     uint8_t                         start_fh[CHIMERA_VFS_FH_SIZE + 16];
     char                            path[CHIMERA_VFS_PATH_MAX];
@@ -207,6 +232,12 @@ chimera_posix_utimensat_lookup_complete(
         return;
     }
 
+    if (ctx->validate_only) {
+        /* Resolution succeeded; a both-omitted call changes nothing. */
+        chimera_posix_complete(&ctx->comp, CHIMERA_VFS_OK);
+        return;
+    }
+
     chimera_vfs_open_fh(
         request->thread->vfs_thread,
         chimera_client_req_cred(request),
@@ -253,7 +284,8 @@ chimera_posix_utimensat(
 
     chimera_posix_completion_init(&ctx.comp, &req);
 
-    ctx.file_handle = NULL;
+    ctx.file_handle   = NULL;
+    ctx.validate_only = chimera_posix_utimes_noop(times);
 
     /* By default follow a final symlink and set times on its target; with
      * AT_SYMLINK_NOFOLLOW operate on the symlink itself. */

--- a/src/posix/posix_write.c
+++ b/src/posix/posix_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_write.c
+++ b/src/posix/posix_write.c
@@ -7,6 +7,7 @@
 
 #include "posix_internal.h"
 #include "../client/client_write.h"
+#include "../client/client_fstat.h"
 
 static void
 chimera_posix_write_callback(
@@ -32,6 +33,61 @@ chimera_posix_write_exec(
     chimera_dispatch_write(thread, request);
 } /* chimera_posix_write_exec */
 
+static void
+chimera_posix_fd_eof_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    const struct chimera_stat    *st,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp    = private_data;
+    struct chimera_client_request   *request = comp->request;
+
+    if (status == CHIMERA_VFS_OK && st) {
+        request->sync_stat = *st;
+    }
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_fd_eof_callback */
+
+static void
+chimera_posix_fd_eof_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_fstat(thread, request);
+} /* chimera_posix_fd_eof_exec */
+
+int
+chimera_posix_fd_eof(
+    struct chimera_posix_worker   *worker,
+    struct chimera_posix_fd_entry *entry,
+    uint64_t                      *eof)
+{
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+    int                             err;
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode             = CHIMERA_CLIENT_OP_FSTAT;
+    req.fstat.handle       = entry->handle;
+    req.fstat.callback     = chimera_posix_fd_eof_callback;
+    req.fstat.private_data = &comp;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_fd_eof_exec);
+
+    err = chimera_posix_wait(&comp);
+
+    if (!err) {
+        *eof = (uint64_t) req.sync_stat.st_size;
+    }
+
+    chimera_posix_completion_destroy(&comp);
+
+    return err;
+} /* chimera_posix_fd_eof */
+
 SYMBOL_EXPORT ssize_t
 chimera_posix_write(
     int         fd,
@@ -50,13 +106,35 @@ chimera_posix_write(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_write(entry)) {
+        chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+        errno = EBADF;
+        return -1;
+    }
+
+    uint64_t write_offset = entry->offset;
+
+    /* POSIX write(): under O_APPEND the file offset is set to the end of
+     * the file prior to each write.  The IO_ACTIVE gate serializes appends
+     * through this descriptor; cross-descriptor append atomicity would
+     * need append support in the VFS write path. */
+    if (entry->oflags & O_APPEND) {
+        int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
+
+        if (aerr) {
+            chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+            errno = aerr;
+            return -1;
+        }
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode             = CHIMERA_CLIENT_OP_WRITE;
     req.write.callback     = chimera_posix_write_callback;
     req.write.private_data = &comp;
     req.write.handle       = entry->handle;
-    req.write.offset       = entry->offset;
+    req.write.offset       = write_offset;
     req.write.length       = count;
     req.write.buf          = buf;
 
@@ -65,7 +143,7 @@ chimera_posix_write(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_write.c
+++ b/src/posix/posix_write.c
@@ -112,13 +112,13 @@ chimera_posix_write(
         return -1;
     }
 
-    uint64_t write_offset = entry->offset;
+    uint64_t write_offset = entry->ofd->offset;
 
     /* POSIX write(): under O_APPEND the file offset is set to the end of
      * the file prior to each write.  The IO_ACTIVE gate serializes appends
      * through this descriptor; cross-descriptor append atomicity would
      * need append support in the VFS write path. */
-    if (entry->oflags & O_APPEND) {
+    if (entry->ofd->oflags & O_APPEND) {
         int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
 
         if (aerr) {
@@ -143,7 +143,7 @@ chimera_posix_write(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0) {
-        entry->offset = write_offset + (uint64_t) req.sync_result;
+        entry->ofd->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_writev.c
+++ b/src/posix/posix_writev.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_writev.c
+++ b/src/posix/posix_writev.c
@@ -78,11 +78,11 @@ chimera_posix_writev_internal(
         return -1;
     }
 
-    uint64_t write_offset = use_fd_offset ? entry->offset : (uint64_t) offset;
+    uint64_t write_offset = use_fd_offset ? entry->ofd->offset : (uint64_t) offset;
 
     /* writev() honors O_APPEND like write(): offset moves to EOF prior to
      * each write (pwritev keeps its explicit offset per POSIX). */
-    if (use_fd_offset && (entry->oflags & O_APPEND)) {
+    if (use_fd_offset && (entry->ofd->oflags & O_APPEND)) {
         int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
 
         if (aerr) {
@@ -108,7 +108,7 @@ chimera_posix_writev_internal(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0 && use_fd_offset) {
-        entry->offset = write_offset + (uint64_t) req.sync_result;
+        entry->ofd->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_writev.c
+++ b/src/posix/posix_writev.c
@@ -72,13 +72,33 @@ chimera_posix_writev_internal(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_write(entry)) {
+        chimera_posix_fd_release(entry, flags);
+        errno = EBADF;
+        return -1;
+    }
+
+    uint64_t write_offset = use_fd_offset ? entry->offset : (uint64_t) offset;
+
+    /* writev() honors O_APPEND like write(): offset moves to EOF prior to
+     * each write (pwritev keeps its explicit offset per POSIX). */
+    if (use_fd_offset && (entry->oflags & O_APPEND)) {
+        int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
+
+        if (aerr) {
+            chimera_posix_fd_release(entry, flags);
+            errno = aerr;
+            return -1;
+        }
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode              = CHIMERA_CLIENT_OP_WRITE;
     req.writev.callback     = chimera_posix_writev_callback;
     req.writev.private_data = &comp;
     req.writev.handle       = entry->handle;
-    req.writev.offset       = use_fd_offset ? entry->offset : (uint64_t) offset;
+    req.writev.offset       = write_offset;
     req.writev.length       = total_len;
     req.writev.src_iov      = iov;
     req.writev.src_iovcnt   = iovcnt;
@@ -88,7 +108,7 @@ chimera_posix_writev_internal(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0 && use_fd_offset) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/server/rest/rest_debug.c
+++ b/src/server/rest/rest_debug.c
@@ -251,7 +251,7 @@ chimera_rest_handle_debug_fsop(
         }
         snprintf(ctx->path2, sizeof(ctx->path2), "%s", path2);
         chimera_vfs_link(ctx->vfs_thread, cred, root_fh, root_fh_len,
-                         ctx->path, strlen(ctx->path),
+                         ctx->path, strlen(ctx->path), 0,
                          ctx->path2, strlen(ctx->path2),
                          0, 0, rest_fsop_link_cb, ctx);
     } else if (strcmp(op, "chmod") == 0) {

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1850,6 +1850,20 @@ cairn_apply_attrs(
         inode->gid         = attr->va_gid;
     }
 
+    /* POSIX chown(): changing (or restating) a regular file's owner or group
+    * clears set-user-ID, and set-group-ID when group-executable (a S_ISGID
+    * bit without group-exec marks mandatory locking and is preserved).  This
+    * applies to privileged callers too, matching Linux.  An explicit mode in
+    * the same setattr wins outright, so the clear only fires without one. */
+    if ((set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) &&
+        !(set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISREG(inode->mode)) {
+        inode->mode &= ~(uint32_t) S_ISUID;
+        if (inode->mode & S_IXGRP) {
+            inode->mode &= ~(uint32_t) S_ISGID;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1994,6 +1994,13 @@ cairn_setattr(
         cairn_punch_hole(thread, shared, inode, new_size, old_size - new_size);
     }
 
+    /* POSIX kill-priv: truncation by an unprivileged caller clears
+     * set-user-ID (and set-group-ID when group-executable), exactly like
+     * the write path does. */
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        inode->mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
+    }
+
     /* cairn_apply_attrs() rewrites set_attr->va_set_mask down to the scalar
      * bits it consumes (it drops the ACL bit), so capture the caller's original
      * mask first -- the ACL-coherence block below keys off it. */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2365,16 +2365,16 @@ cairn_mkdir_at(
     inode.space_used  = 4096;
     inode.uid         = request->cred->uid;
     /* POSIX: a set-group-ID parent directory forces the new node's group. */
-    inode.gid         = (parent_inode->mode & S_ISGID) ?
+    inode.gid = (parent_inode->mode & S_ISGID) ?
         parent_inode->gid : request->cred->gid;
-    inode.nlink       = 2;
-    inode.refcnt      = 1;   /* open reference; without it rmdir underflows the
+    inode.nlink  = 2;
+    inode.refcnt = 1;        /* open reference; without it rmdir underflows the
                               * count and never frees the inode (stale handle) */
-    inode.rdev        = 0;
-    inode.mode        = S_IFDIR | 0755;
-    inode.atime       = now;
-    inode.mtime       = now;
-    inode.ctime       = now;
+    inode.rdev   = 0;
+    inode.mode   = S_IFDIR | 0755;
+    inode.atime  = now;
+    inode.mtime  = now;
+    inode.ctime  = now;
     inode.change++;
     inode.btime          = now;
     inode.dos_attributes = 0;
@@ -2483,15 +2483,15 @@ cairn_mknod_at(
     inode.space_used  = 0;
     inode.uid         = request->cred->uid;
     /* POSIX: a set-group-ID parent directory forces the new node's group. */
-    inode.gid         = (parent_inode->mode & S_ISGID) ?
+    inode.gid = (parent_inode->mode & S_ISGID) ?
         parent_inode->gid : request->cred->gid;
-    inode.nlink       = 1;
-    inode.refcnt      = 1;   /* open reference (see cairn_open_at); without it
+    inode.nlink  = 1;
+    inode.refcnt = 1;        /* open reference (see cairn_open_at); without it
                               * unlink underflows the count and leaks the inode */
-    inode.rdev        = 0;
-    inode.atime       = now;
-    inode.mtime       = now;
-    inode.ctime       = now;
+    inode.rdev   = 0;
+    inode.atime  = now;
+    inode.mtime  = now;
+    inode.ctime  = now;
     inode.change++;
     inode.btime          = now;
     inode.dos_attributes = 0;
@@ -3941,16 +3941,16 @@ cairn_symlink_at(
     new_inode.space_used = request->symlink_at.targetlen;
     new_inode.uid        = request->cred->uid;
     /* POSIX: a set-group-ID parent directory forces the new node's group. */
-    new_inode.gid        = (parent_inode->mode & S_ISGID) ?
+    new_inode.gid = (parent_inode->mode & S_ISGID) ?
         parent_inode->gid : request->cred->gid;
-    new_inode.nlink      = 1;
-    new_inode.refcnt     = 1;   /* open reference (see cairn_open_at); without it
+    new_inode.nlink  = 1;
+    new_inode.refcnt = 1;       /* open reference (see cairn_open_at); without it
                                  * unlink underflows the count and leaks the inode */
-    new_inode.rdev       = 0;
-    new_inode.mode       = S_IFLNK | 0755;
-    new_inode.atime      = now;
-    new_inode.mtime      = now;
-    new_inode.ctime      = now;
+    new_inode.rdev   = 0;
+    new_inode.mode   = S_IFLNK | 0755;
+    new_inode.atime  = now;
+    new_inode.mtime  = now;
+    new_inode.ctime  = now;
     new_inode.change++;
     new_inode.btime          = now;
     new_inode.dos_attributes = 0;

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2364,7 +2364,9 @@ cairn_mkdir_at(
     inode.size        = 4096;
     inode.space_used  = 4096;
     inode.uid         = request->cred->uid;
-    inode.gid         = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode.gid         = (parent_inode->mode & S_ISGID) ?
+        parent_inode->gid : request->cred->gid;
     inode.nlink       = 2;
     inode.refcnt      = 1;   /* open reference; without it rmdir underflows the
                               * count and never frees the inode (stale handle) */
@@ -2480,7 +2482,9 @@ cairn_mknod_at(
     inode.size        = 0;
     inode.space_used  = 0;
     inode.uid         = request->cred->uid;
-    inode.gid         = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode.gid         = (parent_inode->mode & S_ISGID) ?
+        parent_inode->gid : request->cred->gid;
     inode.nlink       = 1;
     inode.refcnt      = 1;   /* open reference (see cairn_open_at); without it
                               * unlink underflows the count and leaks the inode */
@@ -3018,13 +3022,16 @@ cairn_open_at(
         new_inode.size       = 0;
         new_inode.space_used = 0;
         new_inode.uid        = request->cred->uid;
-        new_inode.gid        = request->cred->gid;
-        new_inode.nlink      = 1;
-        new_inode.rdev       = 0;
-        new_inode.mode       = S_IFREG |  0644;
-        new_inode.atime      = now;
-        new_inode.mtime      = now;
-        new_inode.ctime      = now;
+        /* POSIX: a set-group-ID parent directory forces the new file's
+         * group. */
+        new_inode.gid = (parent_inode->mode & S_ISGID) ?
+            parent_inode->gid : request->cred->gid;
+        new_inode.nlink = 1;
+        new_inode.rdev  = 0;
+        new_inode.mode  = S_IFREG |  0644;
+        new_inode.atime = now;
+        new_inode.mtime = now;
+        new_inode.ctime = now;
         new_inode.change++;
         new_inode.btime          = now;
         new_inode.dos_attributes = 0;
@@ -3933,7 +3940,9 @@ cairn_symlink_at(
     new_inode.size       = request->symlink_at.targetlen;
     new_inode.space_used = request->symlink_at.targetlen;
     new_inode.uid        = request->cred->uid;
-    new_inode.gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    new_inode.gid        = (parent_inode->mode & S_ISGID) ?
+        parent_inode->gid : request->cred->gid;
     new_inode.nlink      = 1;
     new_inode.refcnt     = 1;   /* open reference (see cairn_open_at); without it
                                  * unlink underflows the count and leaks the inode */

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -860,6 +860,14 @@ diskfs_setattr_inode_cb(
 
     diskfs_map_attrs(thread, &request->setattr.r_pre_attr, inode);
 
+    /* POSIX kill-priv: truncation by an unprivileged caller clears
+     * set-user-ID (and set-group-ID when group-executable), exactly like
+     * the write path; both the truncate chain and the direct apply path
+     * below see the cleared mode, and the setattr txn journals it. */
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        inode->mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
+    }
+
     if (orig_mask & CHIMERA_VFS_ATTR_SIZE) {
         chimera_diskfs_info("setattr SIZE inum=%lu cur=%lu new=%lu mask=0x%lx (%s)",
                             (unsigned long) inode->inum,

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -4992,6 +4992,20 @@ diskfs_apply_attrs(
         inode->gid         = attr->va_gid;
     }
 
+    /* POSIX chown(): changing (or restating) a regular file's owner or group
+    * clears set-user-ID, and set-group-ID when group-executable (a S_ISGID
+    * bit without group-exec marks mandatory locking and is preserved).  This
+    * applies to privileged callers too, matching Linux.  An explicit mode in
+    * the same setattr wins outright, so the clear only fires without one. */
+    if ((set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) &&
+        !(set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISREG(inode->mode)) {
+        inode->mode &= ~(uint32_t) S_ISUID;
+        if (inode->mode & S_IXGRP) {
+            inode->mode &= ~(uint32_t) S_ISGID;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -1337,8 +1337,11 @@ diskfs_read_inode_cb(
         return;
     }
 
+    /* read() of a directory is EISDIR; other non-regular types are EINVAL. */
     if (unlikely(!S_ISREG(inode->mode))) {
-        diskfs_op_fail(request, diskfs_private->txn, CHIMERA_VFS_EINVAL);
+        diskfs_op_fail(request, diskfs_private->txn,
+                       S_ISDIR(inode->mode) ?
+                       CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL);
         return;
     }
 

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -791,7 +791,9 @@ diskfs_mkdir_at_alloc_cb(
     inode->space_used = 4096;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 2;
     inode->mode       = S_IFDIR | 0755;
     inode->atime_sec  = now.tv_sec;
@@ -979,7 +981,9 @@ diskfs_mknod_at_alloc_cb(
     inode->space_used = 0;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 1;
     inode->rdev       = 0;
     inode->atime_sec  = now.tv_sec;
@@ -1884,7 +1888,9 @@ diskfs_open_at_alloc_cb(
     inode->space_used = 0;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 1;
     inode->mode       = S_IFREG | 0644;
     inode->atime_sec  = now.tv_sec;
@@ -2269,7 +2275,9 @@ diskfs_symlink_at_alloc_cb(
     inode->space_used = request->symlink_at.targetlen;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 1;
     inode->mode       = S_IFLNK | 0755;
     inode->atime_sec  = now.tv_sec;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2403,6 +2403,11 @@ memfs_mkdir_at(
     inode->dir.parent_inum = parent_inode->inum;
     inode->dir.parent_gen  = parent_inode->gen;
 
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    if (parent_inode->mode & S_ISGID) {
+        inode->gid = parent_inode->gid;
+    }
+
     /* Inherit the parent's inheritable ACEs (or seed a Windows default DACL for
      * SMB creates); refresh the child's attrs since the mode may have changed. */
     memfs_inherit_acl(inode, parent_inode,
@@ -2525,6 +2530,12 @@ memfs_mknod_at(
         memfs_inode_free(thread, inode);
         memfs_dirent_free(thread, dirent);
         return;
+    }
+
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    if (parent_inode->mode & S_ISGID) {
+        inode->gid = parent_inode->gid;
+        memfs_map_attrs(shared, r_attr, inode, request->fh);
     }
 
     memfs_map_pre_attr(shared, r_dir_pre_attr, parent_inode, request->fh);
@@ -2990,12 +3001,15 @@ memfs_open_at(
         inode->size       = 0;
         inode->space_used = 0;
         inode->uid        = request->cred->uid;
-        inode->gid        = request->cred->gid;
-        inode->nlink      = 1;
-        inode->mode       = S_IFREG |  0644;
-        inode->atime      = now;
-        inode->mtime      = now;
-        inode->ctime      = now;
+        /* POSIX: a set-group-ID parent directory forces the new file's
+         * group; the parent lock is held throughout the create. */
+        inode->gid = (parent_inode->mode & S_ISGID) ?
+            parent_inode->gid : request->cred->gid;
+        inode->nlink = 1;
+        inode->mode  = S_IFREG |  0644;
+        inode->atime = now;
+        inode->mtime = now;
+        inode->ctime = now;
         inode->change++;
         inode->file.blocks     = NULL;
         inode->file.max_blocks = 0;
@@ -4746,6 +4760,12 @@ memfs_symlink_at(
         memfs_inode_free(thread, inode);
         memfs_dirent_free(thread, dirent);
         return;
+    }
+
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    if (parent_inode->mode & S_ISGID) {
+        inode->gid = parent_inode->gid;
+        memfs_map_attrs(shared, &request->symlink_at.r_attr, inode, request->fh);
     }
 
     rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1930,6 +1930,10 @@ memfs_setattr(
             request->cred->flavor != CHIMERA_VFS_AUTH_ATTR) {
             chimera_vfs_realtime(&inode->mtime);
         }
+        /* POSIX kill-priv: truncation by an unprivileged writer clears
+         * set-user-ID (and set-group-ID when group-executable), exactly
+         * like the write path does. */
+        inode->mode        = chimera_vfs_killpriv_mode(request->cred, inode->mode);
         attr->va_set_mask &= ~CHIMERA_VFS_ATTR_SIZE;
         memfs_apply_attrs(inode, attr);
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
@@ -3271,6 +3275,15 @@ memfs_read(
         return;
     }
 
+    /* read() of a directory is EISDIR (the previous behavior fabricated
+     * zero-filled bytes from the empty data fork). */
+    if (unlikely(!stream && S_ISDIR(inode->mode))) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_EISDIR;
+        request->complete(request);
+        return;
+    }
+
     fork      = stream ? &stream->fork : &inode->file;
     fork_size = stream ? stream->size : inode->size;
 
@@ -4342,6 +4355,19 @@ memfs_clone_range(
     } else {
         pthread_mutex_lock(&dst_inode->lock);
         pthread_mutex_lock(&src_inode->lock);
+    }
+
+    /* The source range must lie within the source file (FICLONERANGE
+     * contract: EINVAL otherwise).  Checked under the inode lock so the
+     * size cannot move underneath the decision. */
+    if (src_offset + length > src_inode->size) {
+        if (src_inode != dst_inode) {
+            pthread_mutex_unlock(&src_inode->lock);
+        }
+        pthread_mutex_unlock(&dst_inode->lock);
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
     }
 
     memfs_map_pre_attr(shared, &request->clone_range.r_pre_attr, dst_inode,

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4042,6 +4042,41 @@ memfs_copy_range(
         }
 
         old_block = dst_inode->file.blocks[bi];
+
+        /* Full-destination-block copies preserve source holes: when every
+         * source block covering this destination block is absent, drop the
+         * destination block instead of materializing zeroes, so SEEK_HOLE
+         * still sees the hole after the copy.  (Partial edges keep the
+         * copy-through-zeroes behavior; byte overlap between source and
+         * destination was rejected above, so freeing here cannot free a
+         * block the source side still needs.) */
+        if (block_offset == 0 && block_len == block_size) {
+            uint64_t s_off  = src_offset + copied;
+            uint64_t s_bi   = s_off >> block_shift;
+            uint64_t s_last = (s_off + block_len - 1) >> block_shift;
+            int      hole   = 1;
+
+            for (uint64_t sb = s_bi; sb <= s_last; sb++) {
+                if (sb < src_inode->file.num_blocks &&
+                    src_inode->file.blocks &&
+                    src_inode->file.blocks[sb]) {
+                    hole = 0;
+                    break;
+                }
+            }
+
+            if (hole) {
+                if (old_block) {
+                    memfs_block_free(thread, old_block);
+                    dst_inode->file.blocks[bi] = NULL;
+                }
+                copied      += block_len;
+                left        -= block_len;
+                block_offset = 0;
+                continue;
+            }
+        }
+
         new_block = memfs_block_alloc(thread);
 
         if (!new_block) {

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1563,6 +1563,20 @@ memfs_apply_attrs(
         inode->gid         = attr->va_gid;
     }
 
+    /* POSIX chown(): changing (or restating) a regular file's owner or group
+    * clears set-user-ID, and set-group-ID when group-executable (a S_ISGID
+    * bit without group-exec marks mandatory locking and is preserved).  This
+    * applies to privileged callers too, matching Linux.  An explicit mode in
+    * the same setattr wins outright, so the clear only fires without one. */
+    if ((set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) &&
+        !(set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISREG(inode->mode)) {
+        inode->mode &= ~(uint32_t) S_ISUID;
+        if (inode->mode & S_IXGRP) {
+            inode->mode &= ~(uint32_t) S_ISGID;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -570,6 +570,12 @@ struct chimera_vfs_request {
             void                           *private_data;
             uint8_t                         parent_fh[CHIMERA_VFS_FH_SIZE];
             int                             parent_fh_len;
+            /* Open-time effective-access grant computed by the lookup gate,
+             * stamped onto the handle at completion (POSIX rights bind at
+             * open).  granted_valid is 0 unless the gated non-create path
+             * ran the access check. */
+            uint32_t                        granted_access;
+            uint8_t                         granted_valid;
             /* Zeroed stand-in handed to open_at when the caller passes no
              * set_attr (a non-create open) -- open_at requires a non-NULL
              * set_attr that the backend only consults when creating. */

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -14,11 +14,56 @@
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_fh.h"
+#include "vfs/vfs_acl.h"
 #include "vfs/vfs_mount_table.h"
 #include "common/logging.h"
 #include "common/misc.h"
 #include "metrics/metrics.h"
 #include "vfs/vfs_dump.h"
+
+/* Canonical access bits an open with the given flags requires against
+ * the target file. */
+static inline uint32_t
+chimera_vfs_open_required_access(unsigned int flags)
+{
+    uint32_t required = 0;
+
+    /* Access intent is signalled positively: O_RDONLY -> READ_ONLY,
+     * O_WRONLY -> WRITE_ONLY, O_RDWR -> both.  A raw open with neither bit
+     * (e.g. an O_PATH-style handle open) requests no data access and is not
+     * gated. */
+    if (flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+        required |= CHIMERA_ACE_READ_DATA;
+    }
+    if (flags & CHIMERA_VFS_OPEN_WRITE_ONLY) {
+        required |= CHIMERA_ACE_WRITE_DATA;
+    }
+    if (flags & CHIMERA_VFS_OPEN_TRUNCATE) {
+        required |= CHIMERA_ACE_WRITE_DATA;
+    }
+    return required;
+} /* chimera_vfs_open_required_access */
+
+/* Record an open-time effective-access grant on a handle.  POSIX (and the
+ * NFSv4/SMB stateful-open models) bind I/O rights when the file is opened;
+ * the I/O paths consult granted_access instead of re-deriving from the
+ * file's current mode, so later chmods do not revoke existing descriptors.
+ * The open cache shards handles by (fh, access_mode, cred_hash), so grants
+ * from same-credential opens of one file share a handle: union them --
+ * a successful open never narrows what an earlier open of the same handle
+ * legitimately obtained. */
+static inline void
+chimera_vfs_handle_stamp_access(
+    struct chimera_vfs_open_handle *handle,
+    uint32_t                        granted)
+{
+    if (handle->granted_valid) {
+        handle->granted_access |= granted;
+    } else {
+        handle->granted_access = granted;
+        handle->granted_valid  = 1;
+    }
+} /* chimera_vfs_handle_stamp_access */
 
 /* Size of the per-request scratch buffer used by VFS modules.
  * Must be large enough for the largest operation (symlink: name + target + 2 NULs). */

--- a/src/vfs/vfs_proc_copy_range.c
+++ b/src/vfs/vfs_proc_copy_range.c
@@ -301,6 +301,19 @@ chimera_vfs_copy_range(
 {
     struct chimera_vfs_request *request;
 
+    /* POSIX copy_file_range(): overlapping source and destination ranges
+     * within one file are EINVAL.  Enforced here so the streaming fallback
+     * and every backend agree with the native implementations (memfs applies
+     * the same check internally). */
+    if (length > 0 &&
+        src_handle->fh_len == dst_handle->fh_len &&
+        memcmp(src_handle->fh, dst_handle->fh, src_handle->fh_len) == 0 &&
+        src_offset < dst_offset + length &&
+        dst_offset < src_offset + length) {
+        callback(CHIMERA_VFS_EINVAL, 0, NULL, NULL, private_data);
+        return;
+    }
+
     /* A storage module without native server-side copy still gets working copy
      * semantics via a generic read/write streaming fallback.
      *

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -49,6 +49,15 @@ chimera_vfs_gate_fh_getattr(
 
     if (error_code != CHIMERA_VFS_OK) {
         status = error_code;
+    } else if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+               !S_ISDIR(attr->va_mode)) {
+        /* Every gate_fh caller gates a directory (the parent of a create/
+         * remove, a rename/link destination, a lookup dir); reaching a
+         * non-directory means the caller resolved through a non-directory
+         * descriptor or handle.  Report POSIX's ENOTDIR ahead of the
+         * access evaluation, so the type error is not masked as EACCES
+         * for callers the backend's own type check never reaches. */
+        status = CHIMERA_VFS_ENOTDIR;
     } else {
         status = chimera_vfs_gate(attr, ctx->cred, ctx->required);
     }

--- a/src/vfs/vfs_proc_link.c
+++ b/src/vfs/vfs_proc_link.c
@@ -150,6 +150,7 @@ chimera_vfs_link(
     int                            fhlen,
     const char                    *old_path,
     int                            old_pathlen,
+    unsigned int                   source_lookup_flags,
     const char                    *new_path,
     int                            new_pathlen,
     unsigned int                   replace,
@@ -231,7 +232,9 @@ chimera_vfs_link(
         memcpy(request->link.dest_parent_fh, fh, fhlen);
         request->link.dest_parent_fh_len = fhlen;
 
-        /* Still need to resolve source path to get source FH */
+        /* Still need to resolve source path to get source FH; the caller's
+         * lookup flags decide whether a final-component symlink is
+         * followed (linkat AT_SYMLINK_FOLLOW) or linked itself. */
         chimera_vfs_lookup(
             thread,
             cred,
@@ -240,7 +243,7 @@ chimera_vfs_link(
             request->link.path,
             request->link.pathlen,
             CHIMERA_VFS_ATTR_FH,
-            0,
+            source_lookup_flags & CHIMERA_VFS_LOOKUP_FOLLOW,
             chimera_vfs_link_source_lookup_fast_complete,
             request);
     } else {
@@ -257,7 +260,8 @@ chimera_vfs_link(
             request->link.new_name_offset = 0;
         }
 
-        /* Resolve source (full path) to get source FH */
+        /* Resolve source (full path) to get source FH; follow semantics
+         * as above. */
         chimera_vfs_lookup(
             thread,
             cred,
@@ -266,7 +270,7 @@ chimera_vfs_link(
             request->link.path,
             request->link.pathlen,
             CHIMERA_VFS_ATTR_FH,
-            0,
+            source_lookup_flags & CHIMERA_VFS_LOOKUP_FOLLOW,
             chimera_vfs_link_source_lookup_complete,
             request);
     }

--- a/src/vfs/vfs_proc_lookup.c
+++ b/src/vfs/vfs_proc_lookup.c
@@ -188,7 +188,13 @@ chimera_vfs_lookup_readlink_complete(
         start_fh_len = lp_request->lookup.parent_fh_len;
     }
 
-    /* Construct new path in plugin_data buffer */
+    /* Construct new path in the plugin_data buffer.  After the first
+     * followed link the current path (and the readlink target stored just
+     * past it) already live in plugin_data, so assemble the spliced path in
+     * a scratch buffer before copying it back to avoid overlapping the
+     * sources with the destination. */
+    char scratch[CHIMERA_VFS_PATH_MAX];
+
     new_path = lp_request->plugin_data;
 
     if (remaining_len > 0) {
@@ -201,16 +207,17 @@ chimera_vfs_lookup_readlink_complete(
             chimera_vfs_request_free(thread, lp_request);
             return;
         }
-        memcpy(new_path, target, target_length);
-        new_path[target_length] = '/';
-        memcpy(new_path + target_length + 1, lp_request->lookup.pathc, remaining_len);
-        new_path[new_pathlen] = '\0';
+        memcpy(scratch, target, target_length);
+        scratch[target_length] = '/';
+        memcpy(scratch + target_length + 1, lp_request->lookup.pathc, remaining_len);
     } else {
         /* Just the target */
         new_pathlen = target_length;
-        memcpy(new_path, target, target_length);
-        new_path[new_pathlen] = '\0';
+        memcpy(scratch, target, target_length);
     }
+
+    memcpy(new_path, scratch, new_pathlen);
+    new_path[new_pathlen] = '\0';
 
     /* Reset path pointer */
     lp_request->lookup.path    = new_path;

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -240,6 +240,18 @@ chimera_vfs_open_lookup_complete(
             return;
         }
 
+        /* FIFOs/sockets/devices have no blocking-open or device semantics
+         * behind a NAS client; opening one with data access is ENXIO.
+         * Accessless (O_PATH-style / INFERRED) opens still work so path
+         * metadata operations on such nodes are unaffected. */
+        if (!S_ISREG(attr->va_mode) && !S_ISDIR(attr->va_mode) &&
+            !S_ISLNK(attr->va_mode) &&
+            (f & (CHIMERA_VFS_OPEN_READ_ONLY | CHIMERA_VFS_OPEN_WRITE_ONLY))) {
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_ENXIO, NULL, NULL, priv);
+            return;
+        }
+
         /* Authorize the requested read/write access against the file. */
         if (chimera_vfs_gate_needed(request->module->capabilities, request->cred)) {
             if (chimera_vfs_gate(attr, request->cred,

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -17,27 +17,8 @@
 #define CHIMERA_VFS_OPEN_GATE_MASK (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL)
 
 /* Map an open's access mode + O_TRUNC to the ACE rights the caller must hold on
- * the target file. */
-static inline uint32_t
-chimera_vfs_open_required_access(unsigned int flags)
-{
-    uint32_t required = 0;
-
-    /* Access intent is signalled positively: O_RDONLY -> READ_ONLY,
-     * O_WRONLY -> WRITE_ONLY, O_RDWR -> both.  A raw open with neither bit
-     * (e.g. an O_PATH-style handle open) requests no data access and is not
-     * gated here. */
-    if (flags & CHIMERA_VFS_OPEN_READ_ONLY) {
-        required |= CHIMERA_ACE_READ_DATA;
-    }
-    if (flags & CHIMERA_VFS_OPEN_WRITE_ONLY) {
-        required |= CHIMERA_ACE_WRITE_DATA;
-    }
-    if (flags & CHIMERA_VFS_OPEN_TRUNCATE) {
-        required |= CHIMERA_ACE_WRITE_DATA;
-    }
-    return required;
-} /* chimera_vfs_open_required_access */
+ * the target file (moved to vfs_internal.h as
+ * chimera_vfs_open_required_access, shared with the open_at wrapper). */
 
 /*
  * Path-only deep-path rebasing.
@@ -113,6 +94,12 @@ chimera_vfs_open_root_complete(
     struct chimera_vfs_thread  *thread   = request->thread;
     chimera_vfs_open_callback_t callback = request->open.callback;
     void                       *priv     = request->open.private_data;
+
+    /* Bind the open-time access grant computed by the lookup gate (POSIX
+     * rights retention; only set on the gated non-create path). */
+    if (error_code == CHIMERA_VFS_OK && oh && request->open.granted_valid) {
+        chimera_vfs_handle_stamp_access(oh, request->open.granted_access);
+    }
 
     chimera_vfs_request_free(thread, request);
 
@@ -254,12 +241,22 @@ chimera_vfs_open_lookup_complete(
         }
 
         /* Authorize the requested read/write access against the file. */
-        if (chimera_vfs_gate_needed(request->module->capabilities, request->cred) &&
-            chimera_vfs_gate(attr, request->cred,
-                             chimera_vfs_open_required_access(f)) != CHIMERA_VFS_OK) {
-            chimera_vfs_request_free(thread, request);
-            callback(CHIMERA_VFS_EACCES, NULL, NULL, priv);
-            return;
+        if (chimera_vfs_gate_needed(request->module->capabilities, request->cred)) {
+            if (chimera_vfs_gate(attr, request->cred,
+                                 chimera_vfs_open_required_access(f)) != CHIMERA_VFS_OK) {
+                chimera_vfs_request_free(thread, request);
+                callback(CHIMERA_VFS_EACCES, NULL, NULL, priv);
+                return;
+            }
+
+            /* POSIX binds I/O rights at open: capture the effective grant
+             * now and stamp it on the handle once it exists (see
+             * chimera_vfs_open_root_complete), so later I/O through the
+             * descriptor is immune to subsequent mode changes. */
+            request->open.granted_access =
+                chimera_vfs_access_check(attr, request->cred,
+                                         CHIMERA_ACE_MASK_ALL);
+            request->open.granted_valid = 1;
         }
     }
 
@@ -307,8 +304,9 @@ chimera_vfs_open(
             return;
         }
 
-        request->open.callback     = callback;
-        request->open.private_data = private_data;
+        request->open.callback      = callback;
+        request->open.private_data  = private_data;
+        request->open.granted_valid = 0;
 
         chimera_vfs_open_fh(
             thread,
@@ -340,12 +338,13 @@ chimera_vfs_open(
     memcpy(request->plugin_data, path, pathlen);
     ((char *) request->plugin_data)[pathlen] = '\0';
 
-    request->open.path         = request->plugin_data;
-    request->open.pathlen      = pathlen;
-    request->open.flags        = flags;
-    request->open.attr_mask    = attr_mask;
-    request->open.callback     = callback;
-    request->open.private_data = private_data;
+    request->open.path          = request->plugin_data;
+    request->open.pathlen       = pathlen;
+    request->open.flags         = flags;
+    request->open.attr_mask     = attr_mask;
+    request->open.callback      = callback;
+    request->open.private_data  = private_data;
+    request->open.granted_valid = 0;
 
     /* A non-create open may pass no set_attr, but open_at (the path-op / deep
      * path-only dispatch) requires a non-NULL one; hand it a zeroed stand-in. */

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -106,6 +106,102 @@ chimera_vfs_open_root_complete(
     callback(error_code, oh, NULL, priv);
 } /* chimera_vfs_open_root_complete */
 
+/* ----------------------------------------------------------------------------
+ * Final-symlink follow on the create (parent + open_at) leg.
+ *
+ * open_at opens the named entry itself; when that entry is a symlink and the
+ * open wants to follow (no O_NOFOLLOW, no O_PATH), POSIX resolution must
+ * continue through the link: an existing target is opened, a dangling target
+ * is created (O_CREAT), and a loop is ELOOP.  Implemented by reading the
+ * link and restarting chimera_vfs_open() on the rewritten path; the hop
+ * count rides the high byte of the (internal) open flags so a chain of
+ * links terminates at SYMLOOP_MAX with ELOOP.
+ * ------------------------------------------------------------------------- */
+
+#define CHIMERA_VFS_OPEN_HOPS_SHIFT 24
+#define CHIMERA_VFS_OPEN_HOPS_MASK  (0xffu << CHIMERA_VFS_OPEN_HOPS_SHIFT)
+#define CHIMERA_VFS_OPEN_HOPS(f) (((f)&CHIMERA_VFS_OPEN_HOPS_MASK) >> \
+                                  CHIMERA_VFS_OPEN_HOPS_SHIFT)
+#define CHIMERA_VFS_OPEN_SYMLOOP    8
+
+struct chimera_vfs_open_follow_ctx {
+    struct chimera_vfs_thread      *thread;
+    const struct chimera_vfs_cred  *cred;
+    struct chimera_vfs_open_handle *oh;         /* handle on the symlink */
+    chimera_vfs_open_callback_t     callback;
+    void                           *private_data;
+    unsigned int                    flags;      /* original + bumped hops */
+    uint64_t                        attr_mask;
+    struct chimera_vfs_attrs        set_attr;   /* copy: the original may
+                                                 * live in the request */
+    int                             root_fh_len;
+    int                             parent_len;
+    uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
+    char                            parent[CHIMERA_VFS_PATH_MAX];
+    char                            target[CHIMERA_VFS_PATH_MAX];
+};
+
+static void
+chimera_vfs_open_follow_done(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct chimera_vfs_open_follow_ctx *ctx = private_data;
+
+    ctx->callback(error_code, oh, attr, ctx->private_data);
+    free(ctx);
+} /* chimera_vfs_open_follow_done */
+
+static void
+chimera_vfs_open_follow_readlink_complete(
+    enum chimera_vfs_error    error_code,
+    int                       targetlen,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_open_follow_ctx *ctx = private_data;
+    char                                newpath[CHIMERA_VFS_PATH_MAX];
+    int                                 newlen;
+
+    chimera_vfs_release(ctx->thread, ctx->oh);
+
+    if (error_code != CHIMERA_VFS_OK) {
+        ctx->callback(error_code, NULL, NULL, ctx->private_data);
+        free(ctx);
+        return;
+    }
+
+    ctx->target[targetlen] = '\0';
+
+    if (ctx->target[0] == '/' || ctx->parent_len == 0) {
+        newlen = snprintf(newpath, sizeof(newpath), "%s", ctx->target);
+    } else {
+        newlen = snprintf(newpath, sizeof(newpath), "%.*s/%s",
+                          ctx->parent_len, ctx->parent, ctx->target);
+    }
+
+    if (newlen >= (int) sizeof(newpath)) {
+        ctx->callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL,
+                      ctx->private_data);
+        free(ctx);
+        return;
+    }
+
+    chimera_vfs_open(ctx->thread,
+                     ctx->cred,
+                     ctx->root_fh,
+                     ctx->root_fh_len,
+                     newpath,
+                     newlen,
+                     ctx->flags,
+                     &ctx->set_attr,
+                     ctx->attr_mask,
+                     chimera_vfs_open_follow_done,
+                     ctx);
+} /* chimera_vfs_open_follow_readlink_complete */
+
 static void
 chimera_vfs_open_op_complete(
     enum chimera_vfs_error          error_code,
@@ -120,6 +216,58 @@ chimera_vfs_open_op_complete(
     struct chimera_vfs_thread  *thread   = request->thread;
     chimera_vfs_open_callback_t callback = request->open.callback;
     void                       *priv     = request->open.private_data;
+
+    /* The named entry is a symlink and the open follows: resolve through
+     * it (see the block comment above).  SMB (AUTH_ATTR) handles reparse
+     * points in its own model and is exempt. */
+    if (error_code == CHIMERA_VFS_OK && oh && attr &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISLNK(attr->va_mode) &&
+        !(request->open.flags & (CHIMERA_VFS_OPEN_NOFOLLOW |
+                                 CHIMERA_VFS_OPEN_PATH)) &&
+        request->cred->flavor != CHIMERA_VFS_AUTH_ATTR) {
+
+        unsigned int hops = CHIMERA_VFS_OPEN_HOPS(request->open.flags);
+
+        if (hops >= CHIMERA_VFS_OPEN_SYMLOOP) {
+            chimera_vfs_release(thread, oh);
+            chimera_vfs_release(thread, request->open.parent_handle);
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_ELOOP, NULL, NULL, priv);
+            return;
+        }
+
+        struct chimera_vfs_open_follow_ctx *ctx = malloc(sizeof(*ctx));
+
+        ctx->thread       = thread;
+        ctx->cred         = request->cred;
+        ctx->oh           = oh;
+        ctx->callback     = callback;
+        ctx->private_data = priv;
+        ctx->flags        =
+            (request->open.flags & ~(unsigned int)
+             CHIMERA_VFS_OPEN_HOPS_MASK) |
+            ((hops + 1) << CHIMERA_VFS_OPEN_HOPS_SHIFT);
+        ctx->attr_mask = request->open.attr_mask;
+        /* Copy: the original may live inside the request being freed. */
+        ctx->set_attr = *request->open.set_attr;
+
+        memcpy(ctx->root_fh, request->fh, request->fh_len);
+        ctx->root_fh_len = request->fh_len;
+
+        ctx->parent_len = request->open.parent_len;
+        memcpy(ctx->parent, request->open.path, request->open.parent_len);
+
+        chimera_vfs_release(thread, request->open.parent_handle);
+        chimera_vfs_request_free(thread, request);
+
+        chimera_vfs_readlink(thread, ctx->cred, ctx->oh,
+                             ctx->target, sizeof(ctx->target) - 1,
+                             0,
+                             chimera_vfs_open_follow_readlink_complete,
+                             ctx);
+        return;
+    }
 
     chimera_vfs_release(thread, request->open.parent_handle);
     chimera_vfs_request_free(thread, request);

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -94,8 +94,15 @@ chimera_vfs_open_at_hdl_callback(
         uint32_t               mode   = request->open_at.r_attr.va_mode;
         enum chimera_vfs_error status = CHIMERA_VFS_OK;
 
-        if (S_ISLNK(mode) && (f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+        if (S_ISLNK(mode) && !(f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
             !(f & CHIMERA_VFS_OPEN_PATH)) {
+            /* A symlink the open will FOLLOW (chimera_vfs_open's create
+             * leg restarts resolution on the link target): neither type
+             * checks nor the access gate apply to the link itself -- a
+             * symlink's permission bits are never consulted, and the
+             * restarted open authorizes the real target. */
+        } else if (S_ISLNK(mode) && (f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+                   !(f & CHIMERA_VFS_OPEN_PATH)) {
             status = CHIMERA_VFS_ELOOP;
         } else if (S_ISDIR(mode) &&
                    (f & (CHIMERA_VFS_OPEN_WRITE_ONLY |

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -13,22 +13,21 @@
 #include "vfs_attr_cache.h"
 #include "common/macros.h"
 
-/* Whether the engine authorizes this open at completion (see the gate in
- * chimera_vfs_open_at_hdl_callback): engine-authoritative backend, a
- * non-exempt caller, a real (non-INFERRED) open.  SMB (AUTH_ATTR) evaluates
- * its own access model and is exempt, as are internal INFERRED opens (NFS3
- * create and the path-setattr plumbing), which keep their protocol-specific
+/* Whether the engine applies POSIX open semantics (type checks and, for
+ * non-exempt credentials, the access gate) to this open at completion --
+ * see chimera_vfs_open_at_hdl_callback.  SMB (AUTH_ATTR) evaluates its own
+ * access model and legitimately opens directories with write-ish desired
+ * access, so it is exempt; so are internal INFERRED opens (NFS3 create and
+ * the path-setattr plumbing), which keep their protocol-specific
  * per-operation semantics. */
 static inline int
-chimera_vfs_open_at_gated(
-    const struct chimera_vfs_module *module,
-    const struct chimera_vfs_cred   *cred,
-    unsigned int                     flags)
+chimera_vfs_open_at_checked(
+    const struct chimera_vfs_cred *cred,
+    unsigned int                   flags)
 {
     return !(flags & CHIMERA_VFS_OPEN_INFERRED) &&
-           cred->flavor != CHIMERA_VFS_AUTH_ATTR &&
-           chimera_vfs_gate_needed(module->capabilities, cred);
-} /* chimera_vfs_open_at_gated */
+           cred->flavor != CHIMERA_VFS_AUTH_ATTR;
+} /* chimera_vfs_open_at_checked */
 
 static void
 chimera_vfs_open_at_hdl_callback(
@@ -72,34 +71,63 @@ chimera_vfs_open_at_hdl_callback(
         handle->r_created = request->open_at.r_created;
     }
 
-    /* POSIX (and the NFSv4/SMB stateful-open models) bind I/O rights at
-     * open.  Authorize the requested access against the just-returned
-     * attrs -- an existing file the caller may not access this way fails
-     * EACCES, while a freshly created file grants the requested access
-     * unconditionally (no permission check applies to a file that did not
-     * exist) -- and stamp the effective grant on the handle so subsequent
-     * I/O is immune to later mode changes. */
+    /* POSIX open semantics, evaluated against the just-returned attrs
+     * (mirroring the checks the plain-open wrapper applies on its lookup
+     * path, which this create/openat path previously skipped entirely):
+     *
+     *  - O_NOFOLLOW and the object is a symlink -> ELOOP (an O_PATH-style
+     *    open of the link itself is allowed);
+     *  - a directory opened with write intent -> EISDIR;
+     *  - a FIFO/socket/device opened with data access -> ENXIO (no
+     *    blocking-open or device semantics behind a NAS client);
+     *  - for non-exempt credentials, authorize the requested access:
+     *    an existing file the caller may not access this way fails
+     *    EACCES, while a freshly created file grants the requested
+     *    access unconditionally (no permission check applies to a file
+     *    that did not exist).  The effective grant is stamped on the
+     *    handle so subsequent I/O is immune to later mode changes. */
     if (request->status == CHIMERA_VFS_OK && handle &&
-        chimera_vfs_open_at_gated(request->module, request->cred,
-                                  request->open_at.flags) &&
+        chimera_vfs_open_at_checked(request->cred, request->open_at.flags) &&
         (request->open_at.r_attr.va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
 
-        uint32_t required = chimera_vfs_open_required_access(
-            request->open_at.flags);
-        uint32_t granted = chimera_vfs_access_check(&request->open_at.r_attr,
-                                                    request->cred,
-                                                    CHIMERA_ACE_MASK_ALL);
+        unsigned int           f      = request->open_at.flags;
+        uint32_t               mode   = request->open_at.r_attr.va_mode;
+        enum chimera_vfs_error status = CHIMERA_VFS_OK;
 
-        if (request->open_at.r_created) {
-            granted |= required;
+        if (S_ISLNK(mode) && (f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+            !(f & CHIMERA_VFS_OPEN_PATH)) {
+            status = CHIMERA_VFS_ELOOP;
+        } else if (S_ISDIR(mode) &&
+                   (f & (CHIMERA_VFS_OPEN_WRITE_ONLY |
+                         CHIMERA_VFS_OPEN_TRUNCATE))) {
+            status = CHIMERA_VFS_EISDIR;
+        } else if (!S_ISREG(mode) && !S_ISDIR(mode) && !S_ISLNK(mode) &&
+                   (f & (CHIMERA_VFS_OPEN_READ_ONLY |
+                         CHIMERA_VFS_OPEN_WRITE_ONLY))) {
+            status = CHIMERA_VFS_ENXIO;
+        } else if (chimera_vfs_gate_needed(request->module->capabilities,
+                                           request->cred)) {
+            uint32_t required = chimera_vfs_open_required_access(f);
+            uint32_t granted  =
+                chimera_vfs_access_check(&request->open_at.r_attr,
+                                         request->cred,
+                                         CHIMERA_ACE_MASK_ALL);
+
+            if (request->open_at.r_created) {
+                granted |= required;
+            }
+
+            if ((granted & required) != required) {
+                status = CHIMERA_VFS_EACCES;
+            } else {
+                chimera_vfs_handle_stamp_access(handle, granted);
+            }
         }
 
-        if ((granted & required) != required) {
+        if (status != CHIMERA_VFS_OK) {
             chimera_vfs_release(thread, handle);
             handle          = NULL;
-            request->status = CHIMERA_VFS_EACCES;
-        } else {
-            chimera_vfs_handle_stamp_access(handle, granted);
+            request->status = status;
         }
     }
 
@@ -270,9 +298,10 @@ chimera_vfs_open_at_hs(
     request->open_at.r_created          = 0;
     request->open_at.r_attr.va_req_mask = attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
 
-    /* The completion gate needs mode/uid/gid (and a native ACL, if any) to
-     * authorize the open; make sure the backend returns them. */
-    if (chimera_vfs_open_at_gated(handle->vfs_module, cred, flags)) {
+    /* The completion checks need the mode (and, for the access gate,
+     * uid/gid plus a native ACL if any); make sure the backend returns
+     * them. */
+    if (chimera_vfs_open_at_checked(cred, flags)) {
         request->open_at.r_attr.va_req_mask |=
             CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL;
     }

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -5,11 +5,30 @@
 #include <string.h>
 #include "vfs_procs.h"
 #include "vfs_internal.h"
+#include "vfs_release.h"
+#include "vfs_access.h"
 #include "common/misc.h"
 #include "vfs_open_cache.h"
 #include "vfs_name_cache.h"
 #include "vfs_attr_cache.h"
 #include "common/macros.h"
+
+/* Whether the engine authorizes this open at completion (see the gate in
+ * chimera_vfs_open_at_hdl_callback): engine-authoritative backend, a
+ * non-exempt caller, a real (non-INFERRED) open.  SMB (AUTH_ATTR) evaluates
+ * its own access model and is exempt, as are internal INFERRED opens (NFS3
+ * create and the path-setattr plumbing), which keep their protocol-specific
+ * per-operation semantics. */
+static inline int
+chimera_vfs_open_at_gated(
+    const struct chimera_vfs_module *module,
+    const struct chimera_vfs_cred   *cred,
+    unsigned int                     flags)
+{
+    return !(flags & CHIMERA_VFS_OPEN_INFERRED) &&
+           cred->flavor != CHIMERA_VFS_AUTH_ATTR &&
+           chimera_vfs_gate_needed(module->capabilities, cred);
+} /* chimera_vfs_open_at_gated */
 
 static void
 chimera_vfs_open_at_hdl_callback(
@@ -51,6 +70,37 @@ chimera_vfs_open_at_hdl_callback(
 
     if (handle) {
         handle->r_created = request->open_at.r_created;
+    }
+
+    /* POSIX (and the NFSv4/SMB stateful-open models) bind I/O rights at
+     * open.  Authorize the requested access against the just-returned
+     * attrs -- an existing file the caller may not access this way fails
+     * EACCES, while a freshly created file grants the requested access
+     * unconditionally (no permission check applies to a file that did not
+     * exist) -- and stamp the effective grant on the handle so subsequent
+     * I/O is immune to later mode changes. */
+    if (request->status == CHIMERA_VFS_OK && handle &&
+        chimera_vfs_open_at_gated(request->module, request->cred,
+                                  request->open_at.flags) &&
+        (request->open_at.r_attr.va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
+
+        uint32_t required = chimera_vfs_open_required_access(
+            request->open_at.flags);
+        uint32_t granted = chimera_vfs_access_check(&request->open_at.r_attr,
+                                                    request->cred,
+                                                    CHIMERA_ACE_MASK_ALL);
+
+        if (request->open_at.r_created) {
+            granted |= required;
+        }
+
+        if ((granted & required) != required) {
+            chimera_vfs_release(thread, handle);
+            handle          = NULL;
+            request->status = CHIMERA_VFS_EACCES;
+        } else {
+            chimera_vfs_handle_stamp_access(handle, granted);
+        }
     }
 
     chimera_vfs_complete(request);
@@ -208,17 +258,24 @@ chimera_vfs_open_at_hs(
         return;
     }
 
-    request->opcode                              = CHIMERA_VFS_OP_OPEN_AT;
-    request->complete                            = chimera_vfs_open_complete;
-    request->open_at.handle                      = handle;
-    request->open_at.name                        = name;
-    request->open_at.namelen                     = namelen;
-    request->open_at.name_hash                   = chimera_vfs_hash(name, namelen);
-    request->open_at.flags                       = flags;
-    request->open_at.set_attr                    = set_attr;
-    request->open_at.handle_state                = handle_state;
-    request->open_at.r_created                   = 0;
-    request->open_at.r_attr.va_req_mask          = attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->opcode                     = CHIMERA_VFS_OP_OPEN_AT;
+    request->complete                   = chimera_vfs_open_complete;
+    request->open_at.handle             = handle;
+    request->open_at.name               = name;
+    request->open_at.namelen            = namelen;
+    request->open_at.name_hash          = chimera_vfs_hash(name, namelen);
+    request->open_at.flags              = flags;
+    request->open_at.set_attr           = set_attr;
+    request->open_at.handle_state       = handle_state;
+    request->open_at.r_created          = 0;
+    request->open_at.r_attr.va_req_mask = attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+
+    /* The completion gate needs mode/uid/gid (and a native ACL, if any) to
+     * authorize the open; make sure the backend returns them. */
+    if (chimera_vfs_open_at_gated(handle->vfs_module, cred, flags)) {
+        request->open_at.r_attr.va_req_mask |=
+            CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL;
+    }
     request->open_at.r_attr.va_set_mask          = 0;
     request->open_at.r_dir_pre_attr.va_req_mask  = pre_attr_mask;
     request->open_at.r_dir_pre_attr.va_set_mask  = 0;

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -451,14 +451,15 @@ chimera_vfs_setattr_gate_complete(
     free(gate);
 } /* chimera_vfs_setattr_gate_complete */
 
-SYMBOL_EXPORT void
-chimera_vfs_setattr(
+static void
+chimera_vfs_setattr_common(
     struct chimera_vfs_thread      *thread,
     const struct chimera_vfs_cred  *cred,
     struct chimera_vfs_open_handle *handle,
     struct chimera_vfs_attrs       *set_attr,
     uint64_t                        pre_attr_mask,
     uint64_t                        post_attr_mask,
+    int                             fd_rights,
     chimera_vfs_setattr_callback_t  callback,
     void                           *private_data)
 {
@@ -474,6 +475,23 @@ chimera_vfs_setattr(
          * decide whether the pre-step is needed.  The real check in the gate
          * callback recomputes once the current owner/group is known. */
         required = chimera_vfs_setattr_required(set_attr, NULL);
+
+        /* POSIX binds I/O rights at open: a descriptor-originated mutation
+         * whose entire requirement is WRITE_DATA (ftruncate,
+         * futimens-to-now through a writable descriptor) is authorized by
+         * the handle's open-time grant and stays valid across later mode
+         * changes.  Only fd_rights callers (chimera_vfs_fsetattr) qualify:
+         * path-based setattr (truncate, utimensat) must check the file's
+         * current permissions even though the internal path-open may share
+         * a cached handle with a user descriptor.  Anything needing more
+         * than WRITE_DATA (chmod/chown/explicit timestamps) keeps the
+         * per-operation owner rules -- ownership does not bind at open. */
+        if (fd_rights && required != 0 &&
+            (required & ~(uint32_t) CHIMERA_ACE_WRITE_DATA) == 0 &&
+            handle->granted_valid &&
+            (handle->granted_access & CHIMERA_ACE_WRITE_DATA)) {
+            required = 0;
+        }
 
         if (required) {
             gate = malloc(sizeof(*gate));
@@ -497,4 +515,40 @@ chimera_vfs_setattr(
     chimera_vfs_setattr_dispatch(thread, cred, handle, set_attr,
                                  pre_attr_mask, post_attr_mask,
                                  callback, private_data);
+} /* chimera_vfs_setattr_common */
+
+SYMBOL_EXPORT void
+chimera_vfs_setattr(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_attrs       *set_attr,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    chimera_vfs_setattr_callback_t  callback,
+    void                           *private_data)
+{
+    chimera_vfs_setattr_common(thread, cred, handle, set_attr,
+                               pre_attr_mask, post_attr_mask, 0,
+                               callback, private_data);
 } /* chimera_vfs_setattr */
+
+/* Descriptor-originated setattr (ftruncate/futimens family): mutations whose
+ * whole requirement is WRITE_DATA are authorized by the descriptor's
+ * open-time grant (POSIX rights retention) instead of the file's current
+ * mode.  Everything else behaves exactly like chimera_vfs_setattr. */
+SYMBOL_EXPORT void
+chimera_vfs_fsetattr(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_attrs       *set_attr,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    chimera_vfs_setattr_callback_t  callback,
+    void                           *private_data)
+{
+    chimera_vfs_setattr_common(thread, cred, handle, set_attr,
+                               pre_attr_mask, post_attr_mask, 1,
+                               callback, private_data);
+} /* chimera_vfs_fsetattr */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -294,6 +294,20 @@ chimera_vfs_setattr(
     chimera_vfs_setattr_callback_t  callback,
     void                           *private_data);
 
+/* Descriptor-originated variant: WRITE_DATA-only mutations (ftruncate,
+ * futimens-to-now) are authorized by the handle's open-time access grant
+ * rather than the file's current mode (POSIX rights retention). */
+void
+chimera_vfs_fsetattr(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_attrs       *set_attr,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    chimera_vfs_setattr_callback_t  callback,
+    void                           *private_data);
+
 void
 chimera_vfs_readdir(
     struct chimera_vfs_thread      *thread,

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -181,6 +181,10 @@ chimera_vfs_link(
     int                            fhlen,
     const char                    *old_path,
     int                            old_pathlen,
+    /* CHIMERA_VFS_LOOKUP_FOLLOW resolves a final-component symlink in
+     * old_path and links its target (linkat AT_SYMLINK_FOLLOW); 0 links
+     * the symlink itself. */
+    unsigned int                   source_lookup_flags,
     const char                    *new_path,
     int                            new_pathlen,
     unsigned int                   replace,


### PR DESCRIPTION
Thirty fixes found by a Quint model-based POSIX conformance suite driving the
chimera_posix_* client API against memfs, diskfs and cairn (directly and, for
later fixes, behind loopback NFS).  The test harness itself is not included
here; each commit stands alone and names the divergence that exposed it.

**Descriptor semantics (posix client)**
- dup/dup2 share one open file description (offset and status flags)
- descriptor access modes enforced on read/write paths; O_APPEND honored
- fcntl F_DUPFD/F_GETFL/F_SETFL implemented; lowest free fd allocation
- copy_file_range/clone_file_range enforce descriptor access modes
- shutdown closes leaked descriptors instead of hanging

**Permissions and open-time rights**
- I/O rights bind at open time and are retained across chmod (POSIX rights
  retention); type checks (EISDIR/ENXIO/ELOOP) applied on both open paths
- faccessat checks the chimera credential (not the host process), resolves
  symlinks; fstatat honors AT_SYMLINK_NOFOLLOW; linkat implements
  AT_SYMLINK_FOLLOW

**Mode-bit side effects (memfs, diskfs, cairn)**
- chown clears setuid/setgid on regular files (including id restates)
- truncation clears setuid/setgid, including O_TRUNC of an already-empty file
- setgid parent directories force the new node's group in every create path

**Namespace and paths**
- creating opens follow a final symlink instead of writing through it
- followed-symlink paths splice in a scratch buffer (fixes an ASan
  memcpy-param-overlap on two-hop chains)
- stat/lstat and mkdir apply the XBD 4.16 trailing-slash rules
- namespace gates report ENOTDIR for non-directory targets

**Data-path validation**
- copy_range rejects overlapping ranges within one file (all backends,
  enforced at the common VFS entry); memfs copy_range preserves source holes
- diskfs read of a directory is EISDIR; out-of-range SEEK_DATA/SEEK_HOLE is
  ENXIO
- UTIME_OMIT permission tiers in utimensat/futimens; chown(-1,-1) still
  applies the ownership rule