### PR TITLE
Smbtorture: browsable HTML report for matrix runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -576,6 +576,23 @@ jobs:
       # matrix or a Samba upgrade changes the catalog, and then the live one is
       # the honest denominator.  regen.sh writes that file on every run, scoped
       # or not, so nothing here has to infer the scope from which files exist.
+      #
+      # report.py runs last, after the verdict flag is settled: it renders the
+      # same results into one self-contained HTML file, so the artifact carries
+      # a path from a named cell down to the log that explains it rather than
+      # ~880 loose smbt-fail.*.log files.  Last on purpose -- everything ahead
+      # of it in the chain either publishes or decides the exit status, and a
+      # rendering failure must not be able to skip the regression verdict.
+      # It exits non-zero only when it genuinely could not read the results or
+      # write the page (a regression is still a 0), so && is the same contract
+      # the drift.md render above already runs under.
+      #
+      # safe.directory: the page stamps the revision of the baseline it judged
+      # against, which is the whole defence against an old results set read
+      # against newer allowlists.  /workspace is checked out by the runner and
+      # the container is root, so without this git refuses the repo as dubious
+      # ownership and the stamp silently degrades to "unknown revision" --
+      # exactly the unlabelled report the stamp exists to prevent.
       - name: Build and run the matrix
         env:
           SMBTORTURE_BACKENDS: ${{ inputs.smbtorture_backends }}
@@ -614,7 +631,12 @@ jobs:
                   --subs smbt-report/measured-catalog.txt \
                   --quiet-buckets "still failing,skipped" \
                   --fail-on-newly-failing > /dev/null \
-                || touch smbt-report/newly-failing.flag; }'
+                || touch smbt-report/newly-failing.flag; } && \
+              git config --global --add safe.directory /workspace && \
+              python3 tools/smbtorture/report.py \
+                  --results smbt-report/results.txt \
+                  --cmake src/server/smb/tests/CMakeLists.txt \
+                  --output smbt-report/report.html'
 
       - name: Report baseline drift
         if: always()
@@ -627,6 +649,15 @@ jobs:
           else
             echo '## smbtorture baseline drift' >> "$GITHUB_STEP_SUMMARY"
             echo 'The matrix did not complete; no results to compare.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          # The buckets above name the cells but cannot show why any of them
+          # failed.  A step summary cannot link to a file inside an artifact,
+          # so name the artifact and let the reader download it.
+          if [ -f smbt-report/report.html ]; then
+            {
+              echo
+              echo 'Browsable per-cell report: `report.html` in the `smbtorture-matrix-amd64` artifact.'
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload matrix results and failure logs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,3 +376,4 @@ add_definitions(-DXDR_CUSTOM_IOVEC=${CHIMERA_EXT_SRC}/libevpl/src/rpc2/xdr_iovec
 add_definitions(-DXDR_CUSTOM_DUMP=1)
 
 add_subdirectory(src)
+add_subdirectory(tools)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# tools/ holds standalone developer scripts that are not built or installed.
+# Only their unit tests participate in the build, so that `ctest` covers them.
+if (NOT DISABLE_TESTS)
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(Python3_FOUND)
+        add_test(
+            NAME chimera/tools/smbtorture/report
+            COMMAND ${Python3_EXECUTABLE} -m unittest discover
+                    -s ${CMAKE_CURRENT_SOURCE_DIR}/smbtorture/tests -v
+        )
+        set_tests_properties(chimera/tools/smbtorture/report PROPERTIES
+            LABELS "tools"
+            ENVIRONMENT "PYTHONUNBUFFERED=1"
+            TIMEOUT 60
+        )
+    else()
+        message(WARNING "Python3 not found - smbtorture report tests will be skipped")
+    endif()
+endif()

--- a/tools/smbtorture/report.py
+++ b/tools/smbtorture/report.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+"""Render one smbtorture matrix run as a single self-contained HTML file.
+
+   Navigation is backends -> suites -> failing tests -> full log, built from
+   the `results.txt` that tools/smbtorture/regen.sh writes plus the per-cell
+   `smbt-fail.<backend>.<subtest>.log` files beside it.
+
+   Every failure is classified against the checked-in baseline in
+   src/server/smb/tests/CMakeLists.txt: a FAIL inside a backend's gated set is
+   a regression, a FAIL outside it is a known gap.  The baseline path is
+   defaulted, and the report stamps which revision it was judged against --
+   a results tarball and the working tree's allowlists can drift, and an
+   unlabelled report would silently report phantom regressions.
+"""
+
+import argparse, collections, dataclasses, html, os, subprocess, sys
+
+import regen
+
+
+@dataclasses.dataclass
+class Cell:
+    backend: str
+    subtest: str
+    suite: str
+    status: str
+    classification: str
+
+
+@dataclasses.dataclass
+class Suite:
+    name: str
+    cells: list
+
+
+@dataclasses.dataclass
+class Backend:
+    name: str
+    measured: int
+    passing: int
+    failing: int
+    gated: int
+    regressions: int
+    suites: list
+
+
+@dataclasses.dataclass
+class Report:
+    backends: list
+    measured: int
+    passing: int
+    failing: int
+    regressions: int
+    classified: bool
+
+
+def load_baseline(cmake_path):
+    """backend -> gated subtest set.  {} when the baseline is unusable."""
+    try:
+        with open(cmake_path, encoding="utf-8") as f:
+            txt = f.read()
+    except OSError:
+        return {}
+    lists = regen.parse_cmake_lists(txt)
+    if "SUITES" not in lists:
+        return {}
+    disabled = set(regen.split_entries(lists.get("DISABLED_SUBTESTS", []))[0])
+    out = {}
+    for backend in regen.BACKENDS:
+        raw = lists.get(f"ENABLED_{backend}")
+        if raw is None:
+            continue
+        out[backend] = set(regen.split_entries(raw)[0]) - disabled
+    return out
+
+
+def suite_of(subtest):
+    """regen.parent_of, tolerant of a malformed single-component name."""
+    return regen.parent_of(subtest) if subtest.count(".") >= 1 else subtest
+
+
+def build_model(results_path, baseline):
+    res = regen.parse_results([results_path])
+    if not res:
+        raise ValueError(f"no valid result cells in {results_path}")
+
+    unknown = sorted({b for (b, _s) in res} - set(regen.BACKENDS))
+    if unknown:
+        print(f"warning: ignoring unknown backend(s) in results: "
+              f"{', '.join(unknown)}", file=sys.stderr)
+
+    backends = []
+    for name in regen.BACKENDS:
+        cells = [(s, st[-1]) for (b, s), st in res.items() if b == name]
+        if not cells:
+            continue
+        gated = baseline.get(name)
+        by_suite = collections.defaultdict(list)
+        failing = regressions = 0
+        for subtest, status in cells:
+            if status == "PASS":
+                continue
+            failing += 1
+            if gated is None:
+                classification = "unclassified"
+            elif subtest in gated:
+                classification = "regression"
+                regressions += 1
+            else:
+                classification = "known-gap"
+            suite = suite_of(subtest)
+            by_suite[suite].append(
+                Cell(name, subtest, suite, status, classification))
+
+        suites = [Suite(k, sorted(
+            v, key=lambda c: (c.classification != "regression", c.subtest)))
+                  for k, v in by_suite.items()]
+        suites.sort(key=lambda s: (
+            -sum(1 for c in s.cells if c.classification == "regression"),
+            -len(s.cells), s.name))
+
+        backends.append(Backend(
+            name=name,
+            measured=len(cells),
+            passing=len(cells) - failing,
+            failing=failing,
+            gated=len(gated) if gated is not None else 0,
+            regressions=regressions,
+            suites=suites))
+
+    return Report(
+        backends=backends,
+        measured=sum(b.measured for b in backends),
+        passing=sum(b.passing for b in backends),
+        failing=sum(b.failing for b in backends),
+        regressions=sum(b.regressions for b in backends),
+        classified=bool(baseline))
+
+
+@dataclasses.dataclass
+class LogView:
+    missing: bool
+    headline: str
+    torture: str
+    server: str
+
+
+def extract_headline(lines):
+    """Best one-line summary of why a cell failed, or None.
+
+       Preference order matches how much the line actually narrows the cause:
+       the assertion under a `failure:` banner beats a bare panic line, which
+       beats the exit-code line.  Purely additive -- the caller still renders
+       every line of the log.
+    """
+    for i, line in enumerate(lines):
+        if line.startswith(("failure:", "error:")):
+            for nxt in lines[i + 1:]:
+                if nxt.strip() and nxt.strip() != "]":
+                    return nxt.strip()
+            return line.strip()
+    for line in lines:
+        if line.startswith(("INTERNAL ERROR:", "PANIC (")):
+            return line.strip()
+    for line in lines:
+        if line.startswith("smbtorture: FAILED"):
+            return line.strip()
+    return None
+
+
+def load_log(results_path, backend, subtest):
+    path = regen.log_path(results_path, backend, subtest)
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return LogView(missing=True, headline="", torture="", server="")
+    server = [l for l in lines if l.startswith("time=")]
+    torture = [l for l in lines if not l.startswith("time=")]
+    return LogView(missing=False,
+                   headline=extract_headline(torture) or "",
+                   torture="\n".join(torture),
+                   server="\n".join(server))
+
+
+def load_all_logs(results_path, model):
+    return {(c.backend, c.subtest): load_log(results_path, c.backend, c.subtest)
+            for b in model.backends for s in b.suites for c in s.cells}
+
+
+CSS = """
+:root { color-scheme: light dark; }
+body { font: 14px/1.5 system-ui, sans-serif; margin: 2rem auto; max-width: 70rem;
+       padding: 0 1rem; background: #fff; color: #111; }
+h1 { font-size: 1.4rem; margin-bottom: .25rem; }
+.prov { color: #666; font-size: .85rem; margin-bottom: 1.5rem; }
+.banner { background: #fff3cd; border: 1px solid #e0c86b; padding: .6rem .8rem;
+          border-radius: 4px; margin-bottom: 1.5rem; }
+details { border-top: 1px solid #ddd; }
+summary { cursor: pointer; padding: .4rem .2rem; }
+summary:hover { background: rgba(127,127,127,.08); }
+.b > summary { font-weight: 600; font-size: 1.05rem; }
+.s { margin-left: 1.4rem; }
+.t { margin-left: 2.8rem; }
+.n { color: #666; font-weight: 400; }
+.headline { color: #666; font-family: ui-monospace, monospace; font-size: .82rem; }
+.tag { font-size: .7rem; padding: .05rem .4rem; border-radius: 3px;
+       border: 1px solid currentColor; margin-right: .4rem; }
+.status { font-size: .7rem; padding: .05rem .4rem; border-radius: 3px;
+          border: 1px solid currentColor; margin-right: .4rem; color: #666; }
+.regression { color: #b00020; font-weight: 600; }
+.known-gap { color: #777; }
+.unclassified { color: #777; }
+.missing { color: #b00020; font-style: italic; }
+pre { background: rgba(127,127,127,.10); padding: .7rem; overflow-x: auto;
+      font-size: .8rem; border-radius: 4px; }
+@media (prefers-color-scheme: dark) {
+  body { background: #16181c; color: #e6e6e6; }
+  details { border-top-color: #333; }
+  .prov, .n, .headline, .known-gap, .unclassified, .status { color: #9aa0a6; }
+  .regression, .missing { color: #ff6b6b; }
+  .banner { background: #3a3320; border-color: #6b5c2b; }
+}
+"""
+
+
+def esc(s):
+    return html.escape(s, quote=True)
+
+
+def _render_cell(cell, log):
+    out = []
+    tag = f'<span class="tag {cell.classification}">{esc(cell.classification)}</span>'
+    status = f'<span class="status">{esc(cell.status)}</span>'
+    if log.missing:
+        head = '<span class="missing">log missing</span>'
+    else:
+        head = f'<span class="headline">{esc(log.headline)}</span>'
+    out.append('<details class="t">')
+    out.append(f"<summary>{tag}{status}<code>{esc(cell.subtest)}</code> {head}</summary>")
+    if log.missing:
+        out.append("<p class=\"missing\">No log file was written for this cell.</p>")
+    else:
+        if log.headline:
+            out.append(f"<pre>{esc(log.headline)}</pre>")
+        out.append(f"<pre>{esc(log.torture)}</pre>")
+        if log.server:
+            out.append("<details><summary>chimera server log "
+                       f'<span class="n">({len(log.server.splitlines())} lines)'
+                       "</span></summary>")
+            out.append(f"<pre>{esc(log.server)}</pre>")
+            out.append("</details>")
+    out.append("</details>")
+    return out
+
+
+def render(model, logs, provenance):
+    out = ["<!doctype html>", "<html lang=\"en\"><head>",
+           "<meta charset=\"utf-8\">",
+           "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">",
+           "<title>smbtorture matrix report</title>",
+           f"<style>{CSS}</style>", "</head><body>"]
+
+    out.append("<h1>smbtorture matrix report</h1>")
+    out.append(f'<p class="prov">{esc(provenance)}</p>')
+    if not model.classified:
+        out.append('<p class="banner">No baseline was available, so failures are '
+                   "<strong>unclassified</strong> &mdash; this report cannot "
+                   "distinguish a regression from a known gap.</p>")
+
+    reg = (f'<span class="regression">{model.regressions} regressions</span>'
+           if model.regressions else "0 regressions")
+    out.append(f"<p>{model.passing}/{model.measured} passing &middot; "
+               f"{model.failing} failing &middot; {reg}</p>")
+
+    for backend in model.backends:
+        breg = (f'<span class="regression">{backend.regressions} regressions</span>'
+                if backend.regressions else f'<span class="n">0 regressions</span>')
+        out.append('<details class="b">')
+        out.append(f"<summary>{esc(backend.name)} "
+                   f'<span class="n">&mdash; {backend.failing} failing, '
+                   f"{backend.passing}/{backend.measured} passing, "
+                   f"{backend.gated} gated</span> &middot; {breg}</summary>")
+        for suite in backend.suites:
+            out.append('<details class="s">')
+            out.append(f"<summary><code>{esc(suite.name)}</code> "
+                       f'<span class="n">{len(suite.cells)}</span></summary>')
+            for cell in suite.cells:
+                out.extend(_render_cell(cell, logs[(cell.backend, cell.subtest)]))
+            out.append("</details>")
+        out.append("</details>")
+
+    out.append("</body></html>")
+    return "\n".join(out)
+
+
+def default_cmake_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.normpath(os.path.join(
+        here, "..", "..", "src", "server", "smb", "tests", "CMakeLists.txt"))
+    return path if os.path.exists(path) else None
+
+
+def git_provenance(cmake_path):
+    """`<short-sha>`, `<short-sha> (dirty)`, or `<short-sha> (dirty unknown)`
+       for the baseline, best effort.
+
+       Resolves `cmake_path` to an absolute path once and uses that same
+       absolute form both for `-C` and as the pathspec: `git -C <dir>`
+       resolves a *relative* pathspec against `<dir>`, not against the
+       caller's cwd, so passing the original (possibly relative) string
+       through unchanged can point `git status` at a nonexistent path.  Git
+       then exits 0 with empty stdout and only a warning on stderr -- which
+       silently reads as "clean" unless that stderr/exit status is checked.
+    """
+    abs_cmake = os.path.abspath(cmake_path)
+    repo = os.path.dirname(abs_cmake)
+    try:
+        head = subprocess.run(["git", "-C", repo, "rev-parse", "--short", "HEAD"],
+                              capture_output=True, text=True, timeout=5)
+        if head.returncode != 0:
+            return "unknown revision"
+        rev = head.stdout.strip()
+        dirty = subprocess.run(
+            ["git", "-C", repo, "status", "--porcelain", "--", abs_cmake],
+            capture_output=True, text=True, timeout=5)
+        if dirty.returncode != 0 or dirty.stderr.strip():
+            return f"{rev} (dirty unknown)"
+        return rev + (" (dirty)" if dirty.stdout.strip() else "")
+    except (OSError, subprocess.SubprocessError):
+        return "unknown revision"
+
+
+def format_provenance(cmake_path, results_path):
+    src = f"results: {os.path.abspath(results_path)}"
+    if cmake_path is None:
+        return f"{src} · baseline: none"
+    abs_cmake = os.path.abspath(cmake_path)
+    return f"{src} · baseline: {abs_cmake} @ {git_provenance(cmake_path)}"
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Render an smbtorture matrix run as one self-contained "
+                    "HTML file.")
+    ap.add_argument("--results", required=True,
+                    help="results.txt as written by tools/smbtorture/regen.sh")
+    ap.add_argument("--output", required=True, help="HTML file to write")
+    ap.add_argument("--cmake",
+                    help="baseline CMakeLists.txt (default: the checked-in "
+                         "src/server/smb/tests/CMakeLists.txt beside this script)")
+    ap.add_argument("--no-baseline", action="store_true",
+                    help="skip classification even if a baseline is found")
+    args = ap.parse_args(argv)
+
+    cmake = None if args.no_baseline else (args.cmake or default_cmake_path())
+    if cmake:
+        try:
+            baseline = load_baseline(cmake)
+        except (OSError, ValueError) as e:
+            print(f"warning: could not parse baseline {cmake} ({e}); "
+                  "failures will be unclassified", file=sys.stderr)
+            baseline, cmake = {}, None
+    else:
+        baseline = {}
+    if cmake and not baseline:
+        print(f"warning: no usable baseline in {cmake}; failures will be "
+              "unclassified", file=sys.stderr)
+        cmake = None
+
+    try:
+        model = build_model(args.results, baseline)
+    except (OSError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    logs = load_all_logs(args.results, model)
+    page = render(model, logs, format_provenance(cmake, args.results))
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(page)
+    except (OSError, ValueError) as e:
+        print(f"error: could not write {args.output}: {e}", file=sys.stderr)
+        if os.path.exists(args.output):
+            try:
+                os.unlink(args.output)
+            except OSError:
+                pass
+        return 1
+
+    print(f"{args.output}: {model.failing} failing across "
+          f"{len(model.backends)} backends, {model.regressions} regressions")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/smbtorture/tests/fixtures/CMakeLists.txt
+++ b/tools/smbtorture/tests/fixtures/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+set(SMBTORTURE_SUITES
+    smb2.acls.CREATOR
+    smb2.acls.DENY1
+    "smb2.charset.Testing wide-a"
+    smb2.dir.large-files
+    smb2.setinfo
+)
+set(SMBTORTURE_ENABLED_memfs
+    smb2.acls.CREATOR
+    smb2.acls.DENY1
+)
+set(SMBTORTURE_ENABLED_linux
+    smb2.acls.CREATOR
+    smb2.setinfo
+    "smb2.charset.Testing wide-a"
+)
+set(SMBTORTURE_DISABLED_SUBTESTS
+    smb2.setinfo
+)

--- a/tools/smbtorture/tests/fixtures/results.txt
+++ b/tools/smbtorture/tests/fixtures/results.txt
@@ -1,0 +1,8 @@
+PASS|memfs|smb2.acls.CREATOR
+FAIL|memfs|smb2.acls.DENY1
+FAIL|memfs|smb2.charset.Testing wide-a
+PASS|linux|smb2.acls.CREATOR
+FAIL|linux|smb2.dir.large-files
+FAIL|linux|smb2.setinfo
+FAIL|linux|smb2.acls.DENY1
+PASS|linux|smb2.charset.Testing wide-a

--- a/tools/smbtorture/tests/fixtures/results.txt.license
+++ b/tools/smbtorture/tests/fixtures/results.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense

--- a/tools/smbtorture/tests/fixtures/smbt-fail.linux.smb2_dir_large_files.log
+++ b/tools/smbtorture/tests/fixtures/smbt-fail.linux.smb2_dir_large_files.log
@@ -1,0 +1,8 @@
+time=2026-08-06T14:09:36.133850092Z message="Initializing VFS module linux..." level=info module=vfs
+test: smb2.dir.large-files
+Directory enumeration completed in 0.023 s.
+smbtorture: FAILED (exit code 134)
+INTERNAL ERROR: Signal 11: Segmentation fault in smbtorture () () pid 338717
+PANIC (pid 338717): Signal 11: Segmentation fault
+BACKTRACE: 3 stack frames:
+ #0 /usr/lib/x86_64-linux-gnu/samba/libgenrand-private-samba.so.0(log_stack_trace+0x32)

--- a/tools/smbtorture/tests/fixtures/smbt-fail.linux.smb2_dir_large_files.log.license
+++ b/tools/smbtorture/tests/fixtures/smbt-fail.linux.smb2_dir_large_files.log.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense

--- a/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_acls_DENY1.log
+++ b/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_acls_DENY1.log
@@ -1,0 +1,10 @@
+time=2026-08-06T14:09:36.133850092Z message="Initializing VFS module memfs..." level=info module=vfs
+========================================
+Backend: memfs
+========================================
+smbtorture: FAILED (exit code 1)
+test: smb2.acls.DENY1
+failure: smb2.acls.DENY1 [
+source4/torture/smb2/acls.c:1234: status was NT_STATUS_ACCESS_DENIED, expected NT_STATUS_OK
+]
+time=2026-08-06T14:09:37.000000000Z message="Shutting down" level=info module=server

--- a/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_acls_DENY1.log.license
+++ b/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_acls_DENY1.log.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense

--- a/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_charset_Testing_wide_a.log
+++ b/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_charset_Testing_wide_a.log
@@ -1,0 +1,5 @@
+time=2026-08-06T14:09:36.133850092Z message="start" level=info module=vfs
+test: smb2.charset.Testing wide-a
+failure: smb2.charset.Testing wide-a [
+dir.c:1435: didn't expect <script>alert(1)</script> & aaa慡慡
+]

--- a/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_charset_Testing_wide_a.log.license
+++ b/tools/smbtorture/tests/fixtures/smbt-fail.memfs.smb2_charset_Testing_wide_a.log.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+SPDX-License-Identifier: Unlicense

--- a/tools/smbtorture/tests/test_report.py
+++ b/tools/smbtorture/tests/test_report.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: 2024-2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+"""Unit tests for tools/smbtorture/report.py."""
+
+import contextlib, io, os, re, shutil, subprocess, sys, tempfile, unittest
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+import regen, report
+
+FIX = os.path.join(HERE, "fixtures")
+RESULTS = os.path.join(FIX, "results.txt")
+CMAKE = os.path.join(FIX, "CMakeLists.txt")
+
+
+class TestModel(unittest.TestCase):
+
+    def test_load_baseline_subtracts_disabled(self):
+        base = report.load_baseline(CMAKE)
+        self.assertEqual(base["memfs"], {"smb2.acls.CREATOR", "smb2.acls.DENY1"})
+        self.assertNotIn("smb2.setinfo", base["linux"])
+        self.assertIn("smb2.charset.Testing wide-a", base["linux"])
+
+    def test_load_baseline_missing_file_is_empty(self):
+        self.assertEqual(report.load_baseline(os.path.join(FIX, "nope.txt")), {})
+
+    def test_backends_use_canonical_order_and_skip_unmeasured(self):
+        model = report.build_model(RESULTS, report.load_baseline(CMAKE))
+        self.assertEqual([b.name for b in model.backends], ["memfs", "linux"])
+
+    def test_classification(self):
+        model = report.build_model(RESULTS, report.load_baseline(CMAKE))
+        got = {(c.backend, c.subtest): c.classification
+               for b in model.backends for s in b.suites for c in s.cells}
+        self.assertEqual(got[("memfs", "smb2.acls.DENY1")], "regression")
+        self.assertEqual(got[("linux", "smb2.acls.DENY1")], "known-gap")
+        self.assertEqual(got[("linux", "smb2.setinfo")], "known-gap")
+        self.assertEqual(model.regressions, 1)
+
+    def test_unclassified_without_baseline(self):
+        model = report.build_model(RESULTS, {})
+        cls = {c.classification for b in model.backends for s in b.suites for c in s.cells}
+        self.assertEqual(cls, {"unclassified"})
+        self.assertFalse(model.classified)
+
+    def test_counts(self):
+        model = report.build_model(RESULTS, report.load_baseline(CMAKE))
+        memfs = model.backends[0]
+        self.assertEqual((memfs.measured, memfs.passing, memfs.failing), (3, 1, 2))
+        self.assertEqual((model.measured, model.passing, model.failing), (8, 3, 5))
+
+    def test_regressions_sort_first_within_a_suite(self):
+        """Suites already sort regression-heavy ones to the top of a
+           backend; this pins the same rule one level down, inside a
+           suite: a regression cell leads even when its name loses
+           alphabetically, and non-regressions stay alphabetical among
+           themselves.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            results = os.path.join(tmp, "results.txt")
+            with open(results, "w") as f:
+                f.write("FAIL|memfs|smb2.foo.alpha\n")
+                f.write("FAIL|memfs|smb2.foo.beta\n")
+                f.write("FAIL|memfs|smb2.foo.zeta\n")
+            model = report.build_model(results, {"memfs": {"smb2.foo.zeta"}})
+        suite = model.backends[0].suites[0]
+        self.assertEqual([c.subtest for c in suite.cells],
+                         ["smb2.foo.zeta", "smb2.foo.alpha", "smb2.foo.beta"])
+
+    def test_suite_grouping_and_ordering(self):
+        model = report.build_model(RESULTS, report.load_baseline(CMAKE))
+        linux = model.backends[1]
+        self.assertEqual([s.name for s in linux.suites],
+                         ["smb2.acls", "smb2.dir", "smb2.setinfo"])
+
+    def test_empty_results_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = os.path.join(tmp, "empty.txt")
+            with open(empty, "w") as f:
+                f.write("garbage\n")
+            with self.assertRaises(ValueError):
+                report.build_model(empty, {})
+
+    def test_unknown_backend_is_dropped_with_a_warning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results = os.path.join(tmp, "results.txt")
+            with open(results, "w") as f:
+                f.write("PASS|memfs|smb2.acls.CREATOR\n")
+                f.write("FAIL|nonexistent_backend|smb2.acls.CREATOR\n")
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                model = report.build_model(results, {})
+        self.assertEqual([b.name for b in model.backends], ["memfs"])
+        self.assertIn("nonexistent_backend", stderr.getvalue())
+
+
+class TestLogs(unittest.TestCase):
+
+    def test_headline_prefers_line_after_failure(self):
+        lv = report.load_log(RESULTS, "memfs", "smb2.acls.DENY1")
+        self.assertFalse(lv.missing)
+        self.assertEqual(
+            lv.headline,
+            "source4/torture/smb2/acls.c:1234: status was "
+            "NT_STATUS_ACCESS_DENIED, expected NT_STATUS_OK")
+
+    def test_headline_falls_back_to_internal_error(self):
+        lv = report.load_log(RESULTS, "linux", "smb2.dir.large-files")
+        self.assertTrue(lv.headline.startswith("INTERNAL ERROR: Signal 11"))
+
+    def assert_partition_is_exhaustive_and_exclusive(self, backend, subtest):
+        """The real completeness proof: read the fixture's own raw bytes and
+           show lv.server + lv.torture reconstitute it exactly -- as
+           multisets, so a dropped, duplicated, or misrouted line fails this
+           even though it wouldn't fail a handful of substring checks.
+        """
+        lv = report.load_log(RESULTS, backend, subtest)
+        path = regen.log_path(RESULTS, backend, subtest)
+        with open(path) as f:
+            raw_lines = f.read().splitlines()
+        server_lines = lv.server.splitlines()
+        torture_lines = lv.torture.splitlines()
+        # exhaustive: the two buckets, as a multiset, equal the raw file
+        self.assertEqual(sorted(server_lines + torture_lines), sorted(raw_lines))
+        # mutually exclusive: no line is misrouted between the two buckets
+        self.assertTrue(all(l.startswith("time=") for l in server_lines))
+        self.assertTrue(all(not l.startswith("time=") for l in torture_lines))
+        return lv
+
+    def test_server_and_torture_are_split_and_complete(self):
+        lv = self.assert_partition_is_exhaustive_and_exclusive(
+            "memfs", "smb2.acls.DENY1")
+        self.assertEqual(len(lv.server.splitlines()), 2)
+        self.assertNotIn("time=", lv.torture)
+        self.assertIn("Backend: memfs", lv.torture)
+        self.assertIn("Shutting down", lv.server)
+        self.assertIn("]", lv.torture)
+        # second fixture: torture content dominates, server is a single line
+        self.assert_partition_is_exhaustive_and_exclusive(
+            "linux", "smb2.dir.large-files")
+
+    def test_backtrace_survives_into_torture_text(self):
+        lv = report.load_log(RESULTS, "linux", "smb2.dir.large-files")
+        self.assertIn("BACKTRACE: 3 stack frames", lv.torture)
+        self.assertIn("log_stack_trace+0x32", lv.torture)
+
+    def test_missing_log_is_flagged_not_fatal(self):
+        lv = report.load_log(RESULTS, "linux", "smb2.setinfo")
+        self.assertTrue(lv.missing)
+        self.assertEqual(lv.torture, "")
+        self.assertEqual(lv.headline, "")
+
+    def test_load_all_logs_covers_every_failing_cell(self):
+        model = report.build_model(RESULTS, report.load_baseline(CMAKE))
+        logs = report.load_all_logs(RESULTS, model)
+        self.assertEqual(len(logs), 5)
+        self.assertIn(("memfs", "smb2.charset.Testing wide-a"), logs)
+        self.assertTrue(logs[("linux", "smb2.acls.DENY1")].missing)
+
+
+def _slice_between(text, start_marker, end_marker):
+    """Return text from the first occurrence of `start_marker` up to (but
+       excluding) the first `end_marker` that follows it, or to the end of
+       the string if `end_marker` never follows.  Used to isolate one
+       backend's rendered block from the rest of the page.
+    """
+    start = text.index(start_marker)
+    try:
+        end = text.index(end_marker, start + len(start_marker))
+    except ValueError:
+        end = len(text)
+    return text[start:end]
+
+
+def _cell_block(block, subtest):
+    """Return the rendered `<details class="t">...</details>` block (plus
+       any nested server-log details) for one subtest within `block`.
+
+       Locates the cell's own opening tag by walking backward from its
+       `<code>` anchor, and bounds the block at the next cell's opening tag
+       (or the end of `block`), so a check against this text can't
+       accidentally match a sibling cell that happens to share a marker.
+    """
+    anchor = f"<code>{report.esc(subtest)}</code>"
+    idx = block.index(anchor)
+    start = block.rindex('<details class="t">', 0, idx)
+    next_idx = block.find('<details class="t">', idx)
+    end = next_idx if next_idx != -1 else len(block)
+    return block[start:end]
+
+
+class TestRender(unittest.TestCase):
+
+    def setUp(self):
+        self.model = report.build_model(RESULTS, report.load_baseline(CMAKE))
+        self.logs = report.load_all_logs(RESULTS, self.model)
+        self.html = report.render(self.model, self.logs, "baseline abc1234")
+        # Isolate each backend's own rendered block so counts/markers can be
+        # checked against the right backend rather than the whole page.
+        self.memfs_block = _slice_between(
+            self.html, "<summary>memfs ", "<summary>linux ")
+        self.linux_block = _slice_between(
+            self.html, "<summary>linux ", "</body>")
+
+    def test_is_a_standalone_document_with_no_external_refs(self):
+        self.assertTrue(self.html.startswith("<!doctype html>"))
+        self.assertNotIn("<script", self.html)
+        self.assertNotIn("src=\"http", self.html)
+        self.assertNotIn("@import", self.html)
+
+    def test_hostile_test_name_and_log_text_are_escaped(self):
+        self.assertNotIn("<script>alert(1)</script>", self.html)
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", self.html)
+
+    def test_backend_rows_carry_exact_counts(self):
+        # memfs: 2 failing, 1 of 3 passing (see test_counts in TestModel).
+        self.assertIn(
+            '<span class="n">&mdash; 2 failing, 1/3 passing,', self.memfs_block)
+        # linux: 3 failing, 2 of 5 passing.
+        self.assertIn(
+            '<span class="n">&mdash; 3 failing, 2/5 passing,', self.linux_block)
+        self.assertIn("baseline abc1234", self.html)
+
+    def test_totals_line_reports_exact_numbers(self):
+        m = re.search(
+            r'<p>(\d+)/(\d+) passing &middot; (\d+) failing &middot; '
+            r'<span class="regression">(\d+) regressions</span></p>',
+            self.html)
+        self.assertIsNotNone(m, "totals line not found in the expected shape")
+        passing, measured, failing, regressions = (int(g) for g in m.groups())
+        self.assertEqual((passing, measured, failing, regressions), (3, 8, 5, 1))
+
+    def test_regression_is_attached_to_memfs_cell_and_not_to_linux_twin(self):
+        # smb2.acls.DENY1 exists for both backends and differs only in
+        # classification -- memfs is gated (a regression), linux is not (a
+        # known gap).  Pin the tag to the right cell in each backend block.
+        memfs_deny1 = _cell_block(self.memfs_block, "smb2.acls.DENY1")
+        linux_deny1 = _cell_block(self.linux_block, "smb2.acls.DENY1")
+        self.assertIn('<span class="tag regression">regression</span>', memfs_deny1)
+        self.assertNotIn('class="tag regression"', linux_deny1)
+        self.assertIn('<span class="tag known-gap">known-gap</span>', linux_deny1)
+        self.assertNotIn('class="tag known-gap"', memfs_deny1)
+
+    def test_suite_ordering_within_backend_is_positional(self):
+        suite_names = [m.group(1) for m in re.finditer(
+            r'<summary><code>([\w.]+)</code>', self.linux_block)]
+        self.assertEqual(suite_names, ["smb2.acls", "smb2.dir", "smb2.setinfo"])
+
+    def test_full_log_text_is_present_verbatim(self):
+        self.assertIn("BACKTRACE: 3 stack frames", self.html)
+        self.assertIn("log_stack_trace+0x32", self.html)
+        # server lines reach the page too, inside the collapsed section
+        self.assertIn("Shutting down", self.html)
+
+    def test_missing_log_renders_a_flag_not_a_crash(self):
+        self.assertIn("log missing", self.html)
+
+    def test_supports_dark_theme(self):
+        self.assertIn("prefers-color-scheme: dark", self.html)
+
+    def test_status_label_distinguishes_time_and_skip_from_fail(self):
+        # The fixture only has PASS/FAIL, but regen.sh also writes logs for
+        # SKIP (exit 77) and TIME (exit 137) cells, which the model counts
+        # as "failing" alongside FAIL.  Build a small synthetic model
+        # directly (no fixture files needed) to prove the rendered cell
+        # summary surfaces cell.status so those are distinguishable.
+        cells = [
+            report.Cell("memfs", "smb2.op.a", "smb2.op", "FAIL", "known-gap"),
+            report.Cell("memfs", "smb2.op.b", "smb2.op", "TIME", "known-gap"),
+            report.Cell("memfs", "smb2.op.c", "smb2.op", "SKIP", "known-gap"),
+        ]
+        suite = report.Suite("smb2.op", cells)
+        backend = report.Backend(
+            name="memfs", measured=3, passing=0, failing=3, gated=0,
+            regressions=0, suites=[suite])
+        model = report.Report(
+            backends=[backend], measured=3, passing=0, failing=3,
+            regressions=0, classified=True)
+        logs = {(c.backend, c.subtest): report.LogView(
+            missing=True, headline="", torture="", server="") for c in cells}
+        html_out = report.render(model, logs, "synthetic")
+
+        def status_block(subtest):
+            anchor = f"<code>{report.esc(subtest)}</code>"
+            idx = html_out.index(anchor)
+            start = html_out.rindex('<details class="t">', 0, idx)
+            summary_end = html_out.index("</summary>", idx)
+            return html_out[start:summary_end]
+
+        self.assertIn('<span class="status">FAIL</span>', status_block("smb2.op.a"))
+        self.assertIn('<span class="status">TIME</span>', status_block("smb2.op.b"))
+        self.assertIn('<span class="status">SKIP</span>', status_block("smb2.op.c"))
+        self.assertNotIn("TIME", status_block("smb2.op.a"))
+        self.assertNotIn("SKIP", status_block("smb2.op.a"))
+        self.assertNotIn("FAIL", status_block("smb2.op.b"))
+
+
+class TestCli(unittest.TestCase):
+
+    def test_default_cmake_path_finds_the_real_baseline(self):
+        path = report.default_cmake_path()
+        self.assertIsNotNone(path)
+        self.assertTrue(path.endswith(
+            os.path.join("src", "server", "smb", "tests", "CMakeLists.txt")))
+        self.assertTrue(os.path.exists(path))
+
+    def test_git_provenance_never_raises(self):
+        self.assertIsInstance(report.git_provenance("/nonexistent/CMakeLists.txt"), str)
+
+    def test_end_to_end_writes_a_classified_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "out.html")
+            rc = report.main(["--results", RESULTS, "--output", out, "--cmake", CMAKE])
+            self.assertEqual(rc, 0)
+            with open(out, encoding="utf-8") as f:
+                page = f.read()
+            self.assertIn("regression", page)
+            self.assertNotIn("cannot distinguish", page)
+
+    def test_no_baseline_flag_emits_the_banner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "out2.html")
+            rc = report.main(["--results", RESULTS, "--output", out, "--no-baseline"])
+            self.assertEqual(rc, 0)
+            with open(out, encoding="utf-8") as f:
+                page = f.read()
+            self.assertIn("unclassified", page)
+            self.assertIn("cannot", page)
+
+    def test_unreadable_results_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "out3.html")
+            rc = report.main(["--results", os.path.join(FIX, "nope.txt"),
+                              "--output", out])
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(os.path.exists(out))
+
+    def test_git_provenance_detects_dirty_baseline_via_relative_path(self):
+        """Regression test for the false-clean bug: `git -C <dir>` resolves a
+           *relative* pathspec against `<dir>`, not against the caller's
+           cwd.  Passing the original relative string through unchanged
+           points `git status` at a nonexistent path, which exits 0 with
+           empty stdout -- silently reading as clean even though the file is
+           genuinely dirty.  Reproduces with a real repo and a path relative
+           to a cwd the function itself changes into, so it exercises the
+           exact call shape a `--cmake src/server/smb/tests/CMakeLists.txt`
+           invocation takes.
+        """
+        if shutil.which("git") is None:
+            raise unittest.SkipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            def run(*args):
+                subprocess.run(["git", *args], cwd=tmp, check=True,
+                               capture_output=True, text=True)
+
+            run("init", "-q")
+            run("config", "user.email", "t@example.com")
+            run("config", "user.name", "t")
+            rel = os.path.join("src", "server", "smb", "tests", "CMakeLists.txt")
+            abs_path = os.path.join(tmp, rel)
+            os.makedirs(os.path.dirname(abs_path))
+            with open(abs_path, "w") as f:
+                f.write("set(ENABLED_memfs)\n")
+            run("add", "-A")
+            run("commit", "-q", "-m", "init")
+            # Dirty it, uncommitted.
+            with open(abs_path, "a") as f:
+                f.write("# uncommitted edit\n")
+
+            old_cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                result = report.git_provenance(rel)
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertIn("dirty", result)
+
+    def test_git_provenance_reports_dirty_unknown_when_status_check_fails(self):
+        """When the dirty check itself can't be trusted (non-zero exit or
+           stderr from `git status`), the stamp must say so explicitly
+           rather than falling through to a bare clean-looking sha -- the
+           whole point of the stamp is to never imply "clean" on a check
+           that didn't actually run.
+        """
+        def fake_run(cmd, **kwargs):
+            if cmd[3] == "rev-parse":
+                return subprocess.CompletedProcess(cmd, 0, stdout="abc1234\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="",
+                                               stderr="warning: could not open directory\n")
+
+        with mock.patch("report.subprocess.run", side_effect=fake_run):
+            result = report.git_provenance("/some/path/CMakeLists.txt")
+        self.assertNotEqual(result, "abc1234")
+        self.assertIn("abc1234", result)
+        self.assertIn("dirty", result)
+
+    def test_main_returns_nonzero_for_unwritable_output_and_leaves_no_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "no-such-directory", "out.html")
+            rc = report.main(["--results", RESULTS, "--output", out, "--cmake", CMAKE])
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(os.path.exists(out))
+
+    def test_output_file_is_valid_utf8_under_a_non_utf8_locale(self):
+        """Regression test for the locale-dependent UnicodeEncodeError:
+           `open(path, "w")` without an explicit encoding uses
+           locale.getpreferredencoding(), which raises on the provenance
+           line's `·` separator under a non-UTF-8 locale (e.g. LC_ALL=C
+           in a musl container or a CI runner without PEP 538 coercion).
+           UnicodeEncodeError subclasses ValueError, so it slipped past a
+           bare `except OSError` guard, leaving a 0-byte file with no error
+           message.  The locale's preferred encoding is latched at
+           interpreter startup, so forcing it after the fact in this
+           process would not reproduce the bug -- report.py must be run as
+           a fresh subprocess with the hostile environment in place.
+        """
+        report_py = os.path.join(os.path.dirname(HERE), "report.py")
+        env = dict(os.environ)
+        env.update(LC_ALL="C", LANG="C", LANGUAGE="",
+                   PYTHONCOERCECLOCALE="0", PYTHONUTF8="0")
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "out.html")
+            result = subprocess.run(
+                [sys.executable, report_py, "--results", RESULTS,
+                 "--output", out, "--cmake", CMAKE],
+                env=env, capture_output=True, text=True, timeout=30)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(out, "rb") as f:
+                data = f.read()
+        # Decoding as UTF-8 fails outright on mojibake/truncated output;
+        # the provenance separator is a known non-ASCII character that
+        # must survive intact.
+        text = data.decode("utf-8")
+        self.assertIn("·", text)
+
+    def test_malformed_cmake_falls_back_to_no_baseline(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bad_cmake = os.path.join(tmp, "bad.txt")
+            with open(bad_cmake, "wb") as f:
+                f.write(b"set(ENABLED_memfs\n\xff\xfe bogus)\n")
+            out = os.path.join(tmp, "out4.html")
+            rc = report.main(["--results", RESULTS, "--output", out,
+                              "--cmake", bad_cmake])
+            self.assertEqual(rc, 0)
+            with open(out, encoding="utf-8") as f:
+                page = f.read()
+            self.assertIn("unclassified", page)
+            self.assertIn("baseline: none", page)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A full smbtorture matrix run leaves a results.txt (one PASS|FAIL|TIME|SKIP cell per backend/subtest) plus one smbt-fail.<backend>.<subtest>.log per non-passing cell — roughly 880 files and 8MB for the current catalog. The only consumer today is regen.py compare, which answers "did anything regress" in the nightly job summary but leaves no path from a named cell to the log that explains it. Reading the detail means grepping a directory.

tools/smbtorture/report.py renders one run as a single self-contained HTML file: backends → suites → failing tests → full log via nested <details>, so it needs no server, no JavaScript and no external assets. It reuses regen.py's parse_results / parse_cmake_lists / split_entries / parent_of / log_path rather than reimplementing the results and CMake parsing.

Every failure is classified against the check_ENABLED_<backend> minusSMBTORTURE_DISABLED_SUBTESTS): inside a backend's gated set is a regression, outside it a known gap. The page stamps which CMakeLists it judged against, that file's git revision, and a dirty marker — load-bearing, not decorative, since an old results tarball read against newer allowlists yields phantom regressions, and a stamped report identifies itself instead of being silently wrong.

Log rendering is deliberately additive: a headline is extracted for the summary line, but every line still reaches the page — torture output first, the chimera server log behind a collapsed section. The two most informative findings in
the run that motivated this were a client PANIC backtrace and mojibake inside a filename; neither survives asummarising extractor.

Build wiring. tools/ was outside the build entirely, so the report's unit tests could only be run by hand, against the project rule that all testing goes through ctest. A new tools/CMakeLists.txt registers the suite as chimera/tools/smbtorture/report, guarded on NOT DISABLE_TESTS like every other test subdirectory, with its own find_package(Python3) so it can't be silently dropped if the PyNFS block's call moves behind a feature guard. A genuinely absent Python3 is announced rather than skipped without a trace.

CI. The nightly matrix already produces everything the report consumes and uploads it as smbtorture-matrix-amd64, so rendering happens in the same run, inside the same container — publishing still depends on nothing outside the image. It runs last in the chain, after the newly-failing verdict is settled, so a rendering failure cannot skip the regression gate; report.py exits non-zero only when it could not read the results or write the page, which is the same contract the existing drift.md render runs under. safe.directory /workspace precedes it because the runner checks out the workspace while the container runs as root, and without it git refuses the repo for dubious ownership and the revision stamp degrades to "unknown revision" — exactly the unlabelled report the stamp exists to prevent. The step summary names the artifact rather than linking the page, since a summary cannot address a file inside an artifact.
