### PR TITLE
vfs: move the FH magic registry into a standalone MIT-licensed header

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -594,7 +594,7 @@ chimera_vfs_init(
 
     /* Find the KV module among those already registered. */
     vfs->kv_module = NULL;
-    for (int i = 0; i < CHIMERA_VFS_FH_MAGIC_MAX; i++) {
+    for (int i = 0; i < CHIMERA_VFS_MAX_MODULES; i++) {
         if (vfs->modules[i] && strcmp(vfs->modules[i]->name, effective_kv_module) == 0) {
             vfs->kv_module = vfs->modules[i];
             break;
@@ -893,7 +893,7 @@ chimera_vfs_destroy(struct chimera_vfs *vfs)
 
     chimera_vfs_pnfs_destroy(vfs->pnfs);
 
-    for (i = 0; i < CHIMERA_VFS_FH_MAGIC_MAX; i++) {
+    for (i = 0; i < CHIMERA_VFS_MAX_MODULES; i++) {
         module = vfs->modules[i];
 
         if (!module) {
@@ -1154,7 +1154,7 @@ chimera_vfs_thread_init(
 
     evpl_add_doorbell(evpl, &thread->doorbell, chimera_vfs_process_completion);
 
-    for (i = 0; i < CHIMERA_VFS_FH_MAGIC_MAX; i++) {
+    for (i = 0; i < CHIMERA_VFS_MAX_MODULES; i++) {
         module = vfs->modules[i];
 
         if (!module) {
@@ -1183,7 +1183,7 @@ chimera_vfs_thread_destroy(struct chimera_vfs_thread *thread)
 
     evpl_remove_doorbell(thread->evpl, &thread->doorbell);
 
-    for (i = 0; i < CHIMERA_VFS_FH_MAGIC_MAX; i++) {
+    for (i = 0; i < CHIMERA_VFS_MAX_MODULES; i++) {
         module = thread->vfs->modules[i];
 
         if (!module) {

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <sys/time.h>
 #include <uthash.h>
+#include "vfs_fh_magic.h"
 #include "vfs_attrs.h"
 #include "vfs_dump.h"
 #include "vfs_error.h"
@@ -18,8 +19,12 @@
 #include "common/tcp_flavor.h"
 #include "oteltracing.h"
 
-#define CHIMERA_VFS_PATH_MAX 4096
-#define CHIMERA_VFS_NAME_MAX 256
+#define CHIMERA_VFS_PATH_MAX    4096
+#define CHIMERA_VFS_NAME_MAX    256
+
+/* Module tables are indexed by the one-byte fh_magic, so they span the
+ * full 8-bit range (see vfs_fh_magic.h for reserved values). */
+#define CHIMERA_VFS_MAX_MODULES 256
 struct evpl;
 
 struct chimera_vfs;
@@ -1168,34 +1173,6 @@ struct chimera_vfs_request {
 
 
 
-/* Each module must have a unique FH_MAGIC value
- * that can never be changed.  They can be reserved
- * here.
- *
- * The 1-byte magic must be the first byte of all
- * file handles returned by the plugin to ensure
- * uniqueness across plugins.
- *
- */
-
-enum CHIMERA_FS_FH_MAGIC {
-    /* Reserved for internal use by chimera */
-    CHIMERA_VFS_FH_MAGIC_ROOT     = 0,
-    CHIMERA_VFS_FH_MAGIC_MEMFS    = 1,
-    CHIMERA_VFS_FH_MAGIC_LINUX    = 2,
-    CHIMERA_VFS_FH_MAGIC_IO_URING = 3,
-    CHIMERA_VFS_FH_MAGIC_CAIRN    = 4,
-    CHIMERA_VFS_FH_MAGIC_DISKFS   = 5,
-    CHIMERA_VFS_FH_MAGIC_NFS      = 6,
-    /* KV-only backends (no filesystem; never serve a file handle, but occupy a
-     * module slot so they can be selected as the default KV module). */
-    CHIMERA_VFS_FH_MAGIC_MEMKV    = 7,
-    CHIMERA_VFS_FH_MAGIC_SQLITE   = 8,
-    CHIMERA_VFS_FH_MAGIC_SMB      = 9,
-    CHIMERA_VFS_FH_MAGIC_MAX      = 10
-
-};
-
 /* If set, module requires open handles for path operations
  * such as mkdir, remove, open_at, etc.  Equivalent to POSIX open
  * with O_PATH flag.
@@ -1397,7 +1374,7 @@ struct chimera_vfs_module {
     const char *name;
 
     /* Required
-     * Set to CHIMERA_FS_FH_MAGIC value reserved above
+     * Set to CHIMERA_FS_FH_MAGIC value reserved in vfs_fh_magic.h
      */
 
     uint8_t     fh_magic;
@@ -1550,8 +1527,8 @@ struct chimera_vfs_state;
 struct chimera_vfs_pnfs;
 
 struct chimera_vfs {
-    struct chimera_vfs_module            *modules[CHIMERA_VFS_FH_MAGIC_MAX];
-    void                                 *module_private[CHIMERA_VFS_FH_MAGIC_MAX];
+    struct chimera_vfs_module            *modules[CHIMERA_VFS_MAX_MODULES];
+    void                                 *module_private[CHIMERA_VFS_MAX_MODULES];
     struct chimera_vfs_module            *kv_module;
     struct vfs_open_cache                *vfs_open_path_cache;
     struct vfs_open_cache                *vfs_open_file_cache;
@@ -1583,7 +1560,7 @@ struct chimera_vfs {
 struct chimera_vfs_thread {
     struct evpl                         *evpl;
     struct chimera_vfs                  *vfs;
-    void                                *module_private[CHIMERA_VFS_FH_MAGIC_MAX];
+    void                                *module_private[CHIMERA_VFS_MAX_MODULES];
     /* Thread-local recycle magazines for the fungible RCU caches. */
     struct chimera_rcu_magazine          rcu_magazines[CHIMERA_RCU_POOL_COUNT];
     struct chimera_vfs_find_result      *free_find_results;

--- a/src/vfs/vfs_fh_magic.h
+++ b/src/vfs/vfs_fh_magic.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+/* Each module must have a unique FH_MAGIC value
+ * that can never be changed.  They can be reserved
+ * here.
+ *
+ * The 1-byte magic must be the first byte of all
+ * file handles returned by the plugin to ensure
+ * uniqueness across plugins.
+ *
+ * This header is MIT licensed, unlike the rest of chimera, so that
+ * out-of-tree VFS modules under any license may modify it if desired
+ * to name the VENDOR magic values differently.
+ */
+
+enum CHIMERA_FS_FH_MAGIC {
+    /* Reserved for internal use by chimera */
+    CHIMERA_VFS_FH_MAGIC_ROOT     = 0,
+    CHIMERA_VFS_FH_MAGIC_MEMFS    = 1,
+    CHIMERA_VFS_FH_MAGIC_LINUX    = 2,
+    CHIMERA_VFS_FH_MAGIC_IO_URING = 3,
+    CHIMERA_VFS_FH_MAGIC_CAIRN    = 4,
+    CHIMERA_VFS_FH_MAGIC_DISKFS   = 5,
+    CHIMERA_VFS_FH_MAGIC_NFS      = 6,
+    /* KV-only backends (no filesystem; never serve a file handle, but occupy a
+     * module slot so they can be selected as the default KV module). */
+    CHIMERA_VFS_FH_MAGIC_MEMKV    = 7,
+    CHIMERA_VFS_FH_MAGIC_SQLITE   = 8,
+    CHIMERA_VFS_FH_MAGIC_SMB      = 9,
+
+    /* The last 16 values (240-255) are reserved for proprietary
+     * out-of-tree VFS modules and will never be assigned to
+     * in-tree modules. */
+    CHIMERA_VFS_FH_MAGIC_VENDOR0  = 240,
+    CHIMERA_VFS_FH_MAGIC_VENDOR1  = 241,
+    CHIMERA_VFS_FH_MAGIC_VENDOR2  = 242,
+    CHIMERA_VFS_FH_MAGIC_VENDOR3  = 243,
+    CHIMERA_VFS_FH_MAGIC_VENDOR4  = 244,
+    CHIMERA_VFS_FH_MAGIC_VENDOR5  = 245,
+    CHIMERA_VFS_FH_MAGIC_VENDOR6  = 246,
+    CHIMERA_VFS_FH_MAGIC_VENDOR7  = 247,
+    CHIMERA_VFS_FH_MAGIC_VENDOR8  = 248,
+    CHIMERA_VFS_FH_MAGIC_VENDOR9  = 249,
+    CHIMERA_VFS_FH_MAGIC_VENDOR10 = 250,
+    CHIMERA_VFS_FH_MAGIC_VENDOR11 = 251,
+    CHIMERA_VFS_FH_MAGIC_VENDOR12 = 252,
+    CHIMERA_VFS_FH_MAGIC_VENDOR13 = 253,
+    CHIMERA_VFS_FH_MAGIC_VENDOR14 = 254,
+    CHIMERA_VFS_FH_MAGIC_VENDOR15 = 255
+};

--- a/src/vfs/vfs_proc_mount.c
+++ b/src/vfs/vfs_proc_mount.c
@@ -207,7 +207,7 @@ chimera_vfs_mount(
         mount_path++;
     }
 
-    for (i = 0; i < CHIMERA_VFS_FH_MAGIC_MAX; i++) {
+    for (i = 0; i < CHIMERA_VFS_MAX_MODULES; i++) {
         module = vfs->modules[i];
 
         if (!module) {
@@ -219,7 +219,7 @@ chimera_vfs_mount(
         }
     }
 
-    if (i == CHIMERA_VFS_FH_MAGIC_MAX) {
+    if (i == CHIMERA_VFS_MAX_MODULES) {
         chimera_vfs_error("chimera_vfs_mount: module %s not found",
                           module_name);
         callback(thread, CHIMERA_VFS_ENOENT, private_data);


### PR DESCRIPTION
The CHIMERA_FS_FH_MAGIC enum is the registry an out-of-tree VFS module must consult to claim a file handle namespace, but it lived in the LGPL-2.1 vfs.h, so a proprietary module could not include it. Move it into vfs_fh_magic.h under MIT (with LICENSES/MIT.txt added for reuse-lint) so modules under any license can include it; vfs.h includes the new header, so in-tree code is unchanged.

Reserve the last 16 magic values (VENDOR0-VENDOR15 = 240-255) for proprietary out-of-tree modules; in-tree modules will never be assigned them.

Drop CHIMERA_VFS_FH_MAGIC_MAX from the enum: it existed only to size the magic-indexed module tables, and those must now span the full 8-bit range anyway for vendor magics to register without indexing out of bounds. Size the tables with an internal CHIMERA_VFS_MAX_MODULES (256) instead. The full-range scans this widens are all cold paths (mount by name, thread init/destroy, shutdown).