### PR TITLE
daemon: hard-exit on startup-validation failure to fix config_test hang

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -38,6 +38,22 @@ signal_handler(int sig)
     SigInt = sig;
 } /* signal_handler */
 
+/* Terminate on a startup-validation failure.  By the time the config is
+ * being validated, service threads (metrics, listener, log flusher) are
+ * already running, and a plain exit() would run libevpl's atexit cleanup,
+ * which frees the shared allocator and registries out from under those
+ * threads.  The resulting crash storm usually still ends the process, but
+ * the concurrent faulting threads can wedge the sanitizer's crash reporting
+ * and leave a hung daemon that ignores SIGTERM.  Nothing needs unwinding on
+ * a bad config: flush the log buffer so the error reaches the user, then
+ * exit without running atexit handlers. */
+static void __attribute__((noreturn))
+startup_validation_fail(void)
+{
+    chimera_log_flush();
+    _exit(1);
+} /* startup_validation_fail */
+
 static int
 generate_self_signed_cert(
     const char *cert_path,
@@ -409,7 +425,7 @@ main(
         if (v < 1 || v > CHIMERA_NFS_EXPORT_ID_MAX) {
             chimera_server_error("Invalid nfs_max_exports (expected integer "
                                  "1..%u)", CHIMERA_NFS_EXPORT_ID_MAX);
-            exit(1);
+            startup_validation_fail();
         }
         chimera_server_config_set_nfs_max_exports(server_config, (uint32_t) v);
     }
@@ -1058,7 +1074,7 @@ main(
                      * or wrong target. */
                     chimera_server_error("Failed to create mount path %s://%s for /%s",
                                          module, path, name);
-                    exit(1);
+                    startup_validation_fail();
                 }
             }
 
@@ -1084,7 +1100,7 @@ main(
     if (shares && json_object_size(shares) > 0 &&
         !chimera_server_config_get_smb_enabled(server_config)) {
         chimera_server_error("Config declares SMB shares but smb_enabled is false");
-        exit(1);
+        startup_validation_fail();
     }
 
     if (shares) {
@@ -1142,7 +1158,7 @@ main(
     if (exports && json_object_size(exports) > 0 &&
         !chimera_server_config_get_nfs_enabled(server_config)) {
         chimera_server_error("Config declares NFS exports but nfs_enabled is false");
-        exit(1);
+        startup_validation_fail();
     }
 
     /* Two passes over the exports object: entries pinning an explicit
@@ -1181,7 +1197,7 @@ main(
             if (!path) {
                 chimera_server_error("Export '%s': missing or non-string "
                                      "\"path\"", name);
-                exit(1);
+                startup_validation_fail();
             }
 
             /* The access mode key was renamed from "options" to "access".
@@ -1191,7 +1207,7 @@ main(
                 chimera_server_error("Export '%s': \"options\" has been "
                                      "renamed to \"access\"; update the config",
                                      name);
-                exit(1);
+                startup_validation_fail();
             }
 
             /* Access mode: "ro" | "rw" (default rw).  A value that doesn't
@@ -1206,7 +1222,7 @@ main(
                     chimera_server_error("Invalid export '%s' access value '%s' "
                                          "(expected ro/rw)", name,
                                          access_s ? access_s : "(not a string)");
-                    exit(1);
+                    startup_validation_fail();
                 }
             }
 
@@ -1227,7 +1243,7 @@ main(
                     chimera_server_error("Invalid export '%s' squash value '%s' "
                                          "(expected none/root/all)", name,
                                          squash_s ? squash_s : "(not a string)");
-                    exit(1);
+                    startup_validation_fail();
                 }
             } else {
                 /* The aliases must actually be booleans: a value like
@@ -1238,17 +1254,17 @@ main(
                 if (allsq_j && !json_is_boolean(allsq_j)) {
                     chimera_server_error("Export '%s': \"all_squash\" must be "
                                          "a boolean", name);
-                    exit(1);
+                    startup_validation_fail();
                 }
                 if (rsq_j && !json_is_boolean(rsq_j)) {
                     chimera_server_error("Export '%s': \"root_squash\" must be "
                                          "a boolean", name);
-                    exit(1);
+                    startup_validation_fail();
                 }
                 if (norsq_j && !json_is_boolean(norsq_j)) {
                     chimera_server_error("Export '%s': \"no_root_squash\" must "
                                          "be a boolean", name);
-                    exit(1);
+                    startup_validation_fail();
                 }
                 if (allsq_j && json_is_true(allsq_j)) {
                     squash = CHIMERA_NFS_SQUASH_ALL;
@@ -1269,7 +1285,7 @@ main(
                     chimera_server_error("Export '%s': invalid anonuid "
                                          "(expected integer 0..%u)",
                                          name, UINT32_MAX);
-                    exit(1);
+                    startup_validation_fail();
                 }
                 anonuid = (uint32_t) v;
             }
@@ -1280,7 +1296,7 @@ main(
                     chimera_server_error("Export '%s': invalid anongid "
                                          "(expected integer 0..%u)",
                                          name, UINT32_MAX);
-                    exit(1);
+                    startup_validation_fail();
                 }
                 anongid = (uint32_t) v;
             }
@@ -1298,7 +1314,7 @@ main(
                     chimera_server_error("Export '%s': invalid export_id "
                                          "(expected integer 1..%u)",
                                          name, CHIMERA_NFS_EXPORT_ID_MAX);
-                    exit(1);
+                    startup_validation_fail();
                 }
                 export_id = (uint32_t) v;
             }
@@ -1313,10 +1329,11 @@ main(
              * Kerberos-only export wide open to AUTH_SYS. */
             json_t  *sec_j    = json_object_get(export, "sec");
             uint32_t sec_mask = 0;
+
             if (sec_j && !json_is_array(sec_j)) {
                 chimera_server_error("Export '%s': \"sec\" must be an array "
                                      "of flavor strings", name);
-                exit(1);
+                startup_validation_fail();
             }
             if (sec_j) {
                 size_t  si;
@@ -1328,7 +1345,7 @@ main(
                     if (!f) {
                         chimera_server_error("Export '%s': \"sec\" entry %zu "
                                              "is not a string", name, si);
-                        exit(1);
+                        startup_validation_fail();
                     }
                     if (strcasecmp(f, "sys") == 0 || strcasecmp(f, "auth_sys") == 0) {
                         sec_mask |= CHIMERA_NFS_SEC_SYS;
@@ -1341,7 +1358,7 @@ main(
                     } else {
                         chimera_server_error("Invalid export '%s' sec flavor '%s' "
                                              "(expected sys/krb5/krb5i/krb5p)", name, f);
-                        exit(1);
+                        startup_validation_fail();
                     }
                 }
             }
@@ -1382,7 +1399,7 @@ main(
                  * which breaks cluster failover in a way clients only notice
                  * later.  Fail hard like the mount-path errors above. */
                 chimera_server_error("Failed to create export '%s'", name);
-                exit(1);
+                startup_validation_fail();
             }
         }
     }
@@ -1392,7 +1409,7 @@ main(
     if (buckets && json_object_size(buckets) > 0 &&
         !chimera_server_config_get_s3_enabled(server_config)) {
         chimera_server_error("Config declares S3 buckets but s3_enabled is false");
-        exit(1);
+        startup_validation_fail();
     }
 
     if (buckets) {

--- a/src/metrics/metrics.c
+++ b/src/metrics/metrics.c
@@ -136,8 +136,6 @@ chimera_metrics_thread_init(
 
     metrics->metrics = prometheus_metrics_create(NULL, NULL, 0);
 
-    metrics->endpoint = evpl_endpoint_create("0.0.0.0", metrics->port);
-
     metrics->agent = evpl_http_init(evpl);
 
     metrics->endpoint = evpl_endpoint_create("0.0.0.0", metrics->port);


### PR DESCRIPTION
## Summary

`chimera/daemon/config_test` is the top flake in #733 — 14 hits in the last two weeks, always Debug builds, always ubuntu22/rocky9. This PR removes the hang it trips over.

## What the flake actually is

The JUnit artifacts from all 14 flagged runs show the failing attempt never fails an assertion: the script stops producing output partway through the bad-config startup checks — at a **different** check each time — and is killed by ctest's 300 s timeout. The daemon under test survives `timeout 30`'s SIGTERM, so `timeout` waits forever (no `-k`), and the whole test wedges. So: any bad-config daemon start can occasionally hang instead of exiting 1.

## Root cause

Every config-validation failure in `daemon.c` calls `exit(1)`. By that point `evpl_init()` and `chimera_metrics_init()` have already spawned service threads (metrics event loop, listener, log flusher, allocator preallocators). `exit()` runs libevpl's `atexit` handler `evpl_cleanup()`, which tears down `evpl_shared` — allocator, metrics registry, stopwatches — out from under those still-running event loops. Every service thread then faults (visible as the `evpl_allocator_destroy: buffer ... has N leaked references` spam followed by ~16 concurrent `AddressSanitizer:DEADLYSIGNAL` lines).

Usually the crash storm still terminates the process with a nonzero exit and the test passes. The flake is the unlucky interleaving, captured with gdb from a hung daemon in an ubuntu22 (glibc 2.35, gcc 11 ASan) container:

- **main thread**: `exit(1)` → `_dl_fini` (**holds the glibc loader lock**) → libasan destructor → `__lsan::DoLeakCheck` → stop-the-world → blocks on ASan's thread-registry mutex
- **service thread**: faults on the torn-down `evpl_shared` stopwatch in `evpl_continue` → SEGV → `AsanOnDeadlySignal` → stack symbolization via `dl_iterate_phdr` → blocks on the **loader lock held by main**

ABBA deadlock. SIGTERM can't help — the handler only sets `SigInt`, which nothing on this path reads. ctest kills the test at 300 s and the retry passes → flake-gate.

## Fix

There is nothing to unwind on a bad config. `startup_validation_fail()` flushes the log ring (so the validation error still reaches the user) and calls `_exit(1)`, so atexit handlers never run underneath live service threads. All 19 validation-failure sites in `daemon.c` are converted, including the three protocol-enable consistency checks added by "server: serve protocols only when explicitly enabled". The normal shutdown path (which joins all threads before returning from `main`) is untouched.

Second commit removes a duplicated `evpl_endpoint_create()` in `chimera_metrics_thread_init()` that this investigation surfaced — the first endpoint was overwritten and leaked.

## Reproduction and verification

Reproduced in an ubuntu22.04 container (glibc 2.35, gcc 11 ASan — same userspace as the flaking CI jobs), driving the daemon with bad configs in 6 parallel netns loops:

| build | bad-config daemon starts | hangs |
|---|---|---|
| before | ~1,530 | **10** (all TERM-immune; all stacks show the lock cycle above) |
| after | 4,800 | **0** |

Confirmation of causality along the way: after rebasing onto current `main`, a verification loop produced exactly one more hang — through the then-unconverted `exit(1)` that the protocol-enable commit had just added, with an identical stack signature. Converting that site (included here) eliminated it; the final 1,800-start run alternates configs that fail the deep export validation and the new protocol-enable check, with zero hangs.

A bad-config start now exits in ~0.2 s (was ~0.8 s of crash-storm) with the validation error printed and rc=1. `chimera/daemon/config_test` passes repeatedly against the fixed build on current `main`.

Fixes the `daemon/config_test` entries in #733.
