### PR TITLE
vfs/tests: fix the lock-family CI flakes (sharded state table + fork/exec children)

### DIFF
--- a/src/posix/tests/cthon_lock_tlock.c
+++ b/src/posix/tests/cthon_lock_tlock.c
@@ -523,9 +523,16 @@ main(
 
     passcnt = 1;
 
-    /* Parse all options before fork so both processes share the same settings. */
+    /* Parse all options before fork so both processes share the same
+     * settings.  -C/-S/-P are the child-mode options a re-exec'ed child
+     * receives (sync-pipe fds, session dir, parent pid; see
+     * posix_test_fork_exec). */
+    const char *child_fds     = NULL;
+    const char *child_session = NULL;
+    const char *child_ppid    = NULL;
+
     optind = 1;
-    while ((opt = getopt(argc, argv, "hb:p:t:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "hb:p:t:w:U:C:S:P:")) != -1) {
         switch (opt) {
             case 'b': break;
             case 'p':
@@ -536,6 +543,15 @@ main(
                 break;
             case 'w':
                 wait_time = atoi(optarg);
+                break;
+            case 'C':
+                child_fds = optarg;
+                break;
+            case 'S':
+                child_session = optarg;
+                break;
+            case 'P':
+                child_ppid = optarg;
                 break;
             default: break;
         } /* switch */
@@ -554,6 +570,7 @@ main(
     env.server      = NULL;
 
     /* Pick up the -b backend option */
+    const char *user_spec = NULL;
     {
         int saved_optind = optind;
         int saved_opterr = opterr;
@@ -563,6 +580,7 @@ main(
             if (opt == 'b') {
                 env.backend = optarg;
             } else if (opt == 'U') {
+                user_spec = optarg;
                 if (!chimera_test_parse_user(optarg, &env.cred)) {
                     fprintf(stderr, "Unknown user spec '%s'. "
                             "Use: root, johndoe, myuser, or uid:gid\n", optarg);
@@ -581,65 +599,138 @@ main(
     chimera_log_init();
     ChimeraLogLevel = CHIMERA_LOG_DEBUG;
 
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    snprintf(env.session_dir, sizeof(env.session_dir),
-             "%s/posix_session_%d_%lu_%lu",
-             posix_test_session_root(),
-             getpid(), (unsigned long) tv.tv_sec, (unsigned long) tv.tv_nsec);
-
-    fprintf(stderr, "Creating session directory %s\n", env.session_dir);
-    (void) mkdir(posix_test_session_root(), 0755);
-    (void) mkdir(env.session_dir, 0755);
-
-    rc = chown(env.session_dir, env.cred.uid, env.cred.gid);
-    if (rc < 0) {
-        fprintf(stderr, "Failed to set session_dir uid/gid: %s\n", strerror(errno));
-        exit(EXIT_FAILURE);
-    }
-
-    /* Write posix.json config (built-in backends need no VFS-specific
-     * section; external-module backends get their vfs entry emitted here
-     * since posix_test_init is bypassed). */
-    posix_json_root = json_object();
-    {
-        json_t *posix_json_config = json_object();
-
-        posix_test_emit_ext_module_config(env.backend, posix_json_config);
-        json_object_set_new(posix_json_root, "config", posix_json_config);
-    }
-    chimera_test_write_users_json(posix_json_root);
-    snprintf(posix_json_path, sizeof(posix_json_path), "%s/posix.json", env.session_dir);
-    json_dump_file(posix_json_root, posix_json_path, 0);
-    json_decref(posix_json_root);
-
-    chimera_vfs_cred_init_unix(&env.cred,
-                               CHIMERA_TEST_USER_ROOT_UID,
-                               CHIMERA_TEST_USER_ROOT_GID,
-                               0, NULL);
-
     fprintf(stdout, "%s: record locking test\n", cthon_Myname);
 
-    /*
-     * initialize() only sets up parentpid, testfile path, and pipes -
-     * no chimera calls.  Call it before fork so both processes share
-     * the same testfile path and pipe endpoints.
-     */
-    initialize("/test/nfstestdir");
+    if (child_fds) {
+        /* Re-exec'ed child: reconstruct the pre-fork state from argv and
+        * fall through to the common client init below as CHILD.  The
+        * parent created the session dir and config and marked its own pipe
+        * ends close-on-exec, so only the child's two fds arrive here. */
+        if (!child_session || !child_ppid ||
+            sscanf(child_fds, "%d,%d", &parentpipe[0], &childpipe[1]) != 2) {
+            fprintf(stderr, "tlock: bad child-mode arguments\n");
+            exit(1);
+        }
+        parentpipe[1] = -1;
+        childpipe[0]  = -1;
 
-    /* Fork BEFORE starting chimera client threads. */
-    if ((childpid = fork()) == 0) {
+        snprintf(env.session_dir, sizeof(env.session_dir), "%s", child_session);
+        snprintf(posix_json_path, sizeof(posix_json_path), "%s/posix.json",
+                 env.session_dir);
+        chimera_vfs_cred_init_unix(&env.cred,
+                                   CHIMERA_TEST_USER_ROOT_UID,
+                                   CHIMERA_TEST_USER_ROOT_GID,
+                                   0, NULL);
+
+        /* What initialize() computes, minus the pipes (passed via argv):
+         * maxeof and the shared testfile name keyed by the PARENT's pid. */
+        maxeof    = (off_t) 1 << (sizeof(off_t) * 8 - 2);
+        maxeof   += maxeof - 1;
+        parentpid = atoi(child_ppid);
+        snprintf(testfile, sizeof(testfile), "/test/nfstestdir/lockfile%d",
+                 parentpid);
+
         who = CHILD;
         signal(SIGINT, childsig);
+        posix_test_child_watchdog(45);
+    } else {
+        clock_gettime(CLOCK_MONOTONIC, &tv);
+        snprintf(env.session_dir, sizeof(env.session_dir),
+                 "%s/posix_session_%d_%lu_%lu",
+                 posix_test_session_root(),
+                 getpid(), (unsigned long) tv.tv_sec, (unsigned long) tv.tv_nsec);
+
+        fprintf(stderr, "Creating session directory %s\n", env.session_dir);
+        (void) mkdir(posix_test_session_root(), 0755);
+        (void) mkdir(env.session_dir, 0755);
+
+        rc = chown(env.session_dir, env.cred.uid, env.cred.gid);
+        if (rc < 0) {
+            fprintf(stderr, "Failed to set session_dir uid/gid: %s\n", strerror(errno));
+            exit(EXIT_FAILURE);
+        }
+
+        /* Write posix.json config (built-in backends need no VFS-specific
+         * section; external-module backends get their vfs entry emitted here
+         * since posix_test_init is bypassed). */
+        posix_json_root = json_object();
+        {
+            json_t *posix_json_config = json_object();
+
+            posix_test_emit_ext_module_config(env.backend, posix_json_config);
+            json_object_set_new(posix_json_root, "config", posix_json_config);
+        }
+        chimera_test_write_users_json(posix_json_root);
+        snprintf(posix_json_path, sizeof(posix_json_path), "%s/posix.json", env.session_dir);
+        json_dump_file(posix_json_root, posix_json_path, 0);
+        json_decref(posix_json_root);
+
+        chimera_vfs_cred_init_unix(&env.cred,
+                                   CHIMERA_TEST_USER_ROOT_UID,
+                                   CHIMERA_TEST_USER_ROOT_GID,
+                                   0, NULL);
+
+        /*
+         * initialize() only sets up parentpid, testfile path, and pipes -
+         * no chimera calls.
+         */
+        initialize("/test/nfstestdir");
+
+        /* Spawn the child by re-exec'ing this binary rather than plain
+         * fork(): exec resets the address space, so nothing any parent
+         * thread holds at fork time (sanitizer allocator locks included)
+         * can be inherited mid-flight.  The parent-only pipe ends are
+         * close-on-exec so the child never sees them. */
+        posix_test_cloexec(parentpipe[1]);
+        posix_test_cloexec(childpipe[0]);
+
+        {
+            char  fds[32], pstr[16], tstr[16], wstr[16], ppidstr[16];
+            char *cargv[20];
+            int   n = 0;
+
+            snprintf(fds, sizeof(fds), "%d,%d", parentpipe[0], childpipe[1]);
+            snprintf(pstr, sizeof(pstr), "%d", passcnt);
+            snprintf(tstr, sizeof(tstr), "%d", testnum);
+            snprintf(wstr, sizeof(wstr), "%d", wait_time);
+            snprintf(ppidstr, sizeof(ppidstr), "%d", parentpid);
+            cargv[n++] = argv[0];
+            cargv[n++] = "-b";
+            cargv[n++] = (char *) env.backend;
+            if (user_spec) {
+                cargv[n++] = "-U";
+                cargv[n++] = (char *) user_spec;
+            }
+            cargv[n++] = "-p";
+            cargv[n++] = pstr;
+            cargv[n++] = "-t";
+            cargv[n++] = tstr;
+            cargv[n++] = "-w";
+            cargv[n++] = wstr;
+            cargv[n++] = "-C";
+            cargv[n++] = fds;
+            cargv[n++] = "-S";
+            cargv[n++] = env.session_dir;
+            cargv[n++] = "-P";
+            cargv[n++] = ppidstr;
+            cargv[n]   = NULL;
+
+            childpid = posix_test_fork_exec(cargv);
+        }
+
+        if (childpid < 0) {
+            perror("tlock: fork");
+            exit(1);
+        }
+
+        who = PARENT;
+        signal(SIGINT, parentsig);
+        signal(SIGCHLD, SIG_DFL);
         /* Fail fast with a stack if either side wedges (the recurring
          * lock-family hang).  45 s beats the shortest ctest timeout this binary
          * runs under while leaving room for the gstack dump; normal runtime is
          * <2 s so it never false-fires.  Armed on both sides so a parent-side
          * wedge is captured too. */
-        posix_test_child_watchdog(45);
-    } else {
-        who = PARENT;
-        signal(SIGINT, parentsig);
-        signal(SIGCHLD, SIG_DFL);
         posix_test_child_watchdog(45);
     }
 

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -40,9 +40,17 @@
  * userspace lock or its holder -- the decisive datum for a post-fork
  * lock-family wedge), then abort().  The SIGABRT unblocks the parent's
  * waitpid, so the test fails fast WITH diagnostics instead of timing out
- * silently.  The handler knowingly calls async-signal-unsafe functions: the
- * process is wedged and about to abort, so a lost dump costs nothing over
- * the status quo.
+ * silently.
+ *
+ * The handler must not allocate: it can interrupt a thread that is holding
+ * the sanitizer allocator lock (observed in practice with the main thread
+ * inside LSan's exit-time stop-the-world), and a dprintf/fprintf here
+ * mallocs a stdio buffer, spinning forever on that lock -- which converts a
+ * transient stall into a permanent wedge that ctest only clears at its
+ * 300s timeout, losing every diagnostic.  So: re-arm SIGALRM with the
+ * default (fatal) action FIRST as a dead-man switch, write() preformatted
+ * buffers instead of using stdio, and pre-warm backtrace() at arm time so
+ * its one-time dlopen/malloc happens outside the handler.
  */
 static void
 posix_test_child_watchdog_fire(int sig)
@@ -50,12 +58,23 @@ posix_test_child_watchdog_fire(int sig)
     void *frames[64];
     int   nframes;
     DIR  *taskdir;
+    char  buf[512];
+    int   len;
 
     (void) sig;
 
-    dprintf(STDERR_FILENO,
-            "child-watchdog: pid %d stuck; dumping thread states\n",
-            (int) getpid());
+    /* Dead-man switch: even if the dump below wedges, the next SIGALRM
+     * kills the process outright (12s keeps 45+12 under the smallest 60s
+     * ctest timeout in the lock family). */
+    signal(SIGALRM, SIG_DFL);
+    alarm(12);
+
+    len = snprintf(buf, sizeof(buf),
+                   "child-watchdog: pid %d stuck; dumping thread states\n",
+                   (int) getpid());
+    if (len > 0 && write(STDERR_FILENO, buf, (size_t) len) < 0) {
+        /* nothing actionable */
+    }
 
     taskdir = opendir("/proc/self/task");
     if (taskdir) {
@@ -77,13 +96,19 @@ posix_test_child_watchdog_fire(int sig)
                 close(wfd);
             }
             wchan[m > 0 ? m : 0] = '\0';
-            dprintf(STDERR_FILENO, "child-watchdog: tid %s wchan %s\n",
-                    de->d_name, wchan);
+            len                  = snprintf(buf, sizeof(buf), "child-watchdog: tid %s wchan %s\n",
+                                            de->d_name, wchan);
+            if (len > 0 && write(STDERR_FILENO, buf, (size_t) len) < 0) {
+                /* nothing actionable */
+            }
         }
         closedir(taskdir);
     }
 
-    dprintf(STDERR_FILENO, "child-watchdog: signaled thread backtrace:\n");
+    len = snprintf(buf, sizeof(buf), "child-watchdog: signaled thread backtrace:\n");
+    if (len > 0 && write(STDERR_FILENO, buf, (size_t) len) < 0) {
+        /* nothing actionable */
+    }
     nframes = backtrace(frames, 64);
     backtrace_symbols_fd(frames, nframes, STDERR_FILENO);
 
@@ -96,11 +121,15 @@ posix_test_child_watchdog_fire(int sig)
          * identifies the offending lock and its holder.  Best-effort: gstack
          * (gdb) may be unavailable, in which case the wchan dump above stands. */
         char cmd[160];
+        int  clen;
 
         snprintf(cmd, sizeof(cmd),
                  "command -v gstack >/dev/null 2>&1 && gstack %d 1>&2",
                  (int) getpid());
-        dprintf(STDERR_FILENO, "child-watchdog: gstack all threads:\n");
+        clen = snprintf(buf, sizeof(buf), "child-watchdog: gstack all threads:\n");
+        if (clen > 0 && write(STDERR_FILENO, buf, (size_t) clen) < 0) {
+            /* nothing actionable */
+        }
         /* Best-effort: the watchdog is already aborting, so a failed dump is
          * harmless.  A plain (void) cast does not silence glibc's
          * warn_unused_result on system(), so consume the result explicitly. */
@@ -117,6 +146,7 @@ static inline void
 posix_test_child_watchdog(unsigned int seconds)
 {
     struct sigaction sa;
+    void            *warm[4];
 
     const char      *ovr = getenv("CHIMERA_TEST_WATCHDOG_SECONDS");
 
@@ -126,6 +156,10 @@ posix_test_child_watchdog(unsigned int seconds)
             seconds = s;
         }
     }
+
+    /* backtrace()'s first call dlopens libgcc and allocates; do that now so
+     * the signal handler's call is allocation-free. */
+    (void) backtrace(warm, 4);
 
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = posix_test_child_watchdog_fire;

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -167,6 +167,54 @@ posix_test_child_watchdog(unsigned int seconds)
     alarm(seconds);
 } /* posix_test_child_watchdog */
 
+/* Mark a parent-only pipe end close-on-exec so a re-exec'ed child never
+ * inherits it (keeps the EOF semantics of the sync pipes identical to the
+ * plain-fork arrangement without the child having to know the fd numbers). */
+static inline void
+posix_test_cloexec(int fd)
+{
+    int flags = fcntl(fd, F_GETFD, 0);
+
+    if (flags >= 0) {
+        (void) fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+    }
+} /* posix_test_cloexec */
+
+/*
+ * Spawn the cross-process test child by re-exec'ing this same binary.
+ *
+ * A plain fork() hands the child a copy of the parent's address space,
+ * including every lock any parent thread happens to hold at that instant.
+ * The visible ones (the chimera log flusher's) are handled by atfork
+ * handlers, but locks inside opaque runtimes are not: gcc-13's ASan takes a
+ * per-size-class allocator region mutex inside the malloc/free that glibc
+ * stdio performs under the flusher's locks and does not force-unlock it
+ * across fork, so a child forked at the wrong instant inherits it held and
+ * every thread it creates wedges inside AsanThread::Init (the lock-family
+ * flakes in #733).  exec() resets the address space, so the child starts
+ * with no inherited lock state at all, from any runtime, forever.
+ *
+ * The child re-enters main() with argv crafted by the caller (a -C child
+ * mode flag plus the sync-pipe fds and session paths); pipe fds survive
+ * exec unless marked FD_CLOEXEC.  Only async-signal-safe work happens
+ * between fork and exec.
+ */
+static inline pid_t
+posix_test_fork_exec(char *const cargv[])
+{
+    pid_t pid = fork();
+
+    if (pid == 0) {
+        execv("/proc/self/exe", cargv);
+        /* exec failed; this address space is still the parent's copy, so
+         * exit without running atexit handlers. */
+        perror("posix_test_fork_exec: execv");
+        _exit(127);
+    }
+
+    return pid;
+} /* posix_test_fork_exec */
+
 struct posix_test_env {
     struct chimera_posix_client *posix;
     struct chimera_server       *server;       // For NFS backend tests

--- a/src/posix/tests/test_fcntl.c
+++ b/src/posix/tests/test_fcntl.c
@@ -215,21 +215,34 @@ main(
     env.server      = NULL;
     clock_gettime(CLOCK_MONOTONIC, &tv);
 
-    /* Pick up the -b backend option. */
+    /* Pick up the -b backend option, the -U user spec, and the child-mode
+     * options a re-exec'ed child receives (-C sync-pipe fds, -J posix.json
+     * path, -S session dir; see posix_test_fork_exec). */
+    const char *user_spec     = NULL;
+    const char *child_fds     = NULL;
+    const char *child_json    = NULL;
+    const char *child_session = NULL;
     {
         int saved_opterr = opterr;
 
         opterr = 0;
         optind = 1;
-        while ((opt = getopt(argc, argv, "+b:U:")) != -1) {
+        while ((opt = getopt(argc, argv, "+b:U:C:J:S:")) != -1) {
             if (opt == 'b') {
                 env.backend = optarg;
             } else if (opt == 'U') {
+                user_spec = optarg;
                 if (!chimera_test_parse_user(optarg, &env.cred)) {
                     fprintf(stderr, "Unknown user spec '%s'. "
                             "Use: root, johndoe, myuser, or uid:gid\n", optarg);
                     exit(EXIT_FAILURE);
                 }
+            } else if (opt == 'C') {
+                child_fds = optarg;
+            } else if (opt == 'J') {
+                child_json = optarg;
+            } else if (opt == 'S') {
+                child_session = optarg;
             }
         }
         opterr = saved_opterr;
@@ -245,6 +258,26 @@ main(
 
     chimera_log_init();
     ChimeraLogLevel = CHIMERA_LOG_DEBUG;
+
+    if (child_fds) {
+        /* Re-exec'ed child: reconstruct the pre-fork state from argv and run
+         * the child side.  The parent created the session dir and config and
+         * marked its own pipe ends close-on-exec, so only the child's two fds
+         * arrive here. */
+        if (!child_json || !child_session ||
+            sscanf(child_fds, "%d,%d", &p2c[0], &c2p[1]) != 2) {
+            fprintf(stderr, "tlock: bad child-mode arguments\n");
+            exit(1);
+        }
+        p2c[1] = -1;
+        c2p[0] = -1;
+        snprintf(env.session_dir, sizeof(env.session_dir), "%s", child_session);
+        chimera_vfs_cred_init_unix(&env.cred,
+                                   CHIMERA_TEST_USER_ROOT_UID,
+                                   CHIMERA_TEST_USER_ROOT_GID,
+                                   0, NULL);
+        exit(child_main(&env, child_json, &env.cred));
+    }
 
     snprintf(env.session_dir, sizeof(env.session_dir),
              "%s/posix_session_%d_%lu_%lu",
@@ -289,10 +322,41 @@ main(
         exit(1);
     }
 
-    child = fork();
+    /* Spawn the child by re-exec'ing this binary rather than plain fork():
+     * exec resets the address space, so nothing any parent thread holds at
+     * fork time (sanitizer allocator locks included) can be inherited
+     * mid-flight.  The parent-only pipe ends are close-on-exec so the
+     * child's EOF semantics match the plain-fork arrangement. */
+    posix_test_cloexec(p2c[1]);
+    posix_test_cloexec(c2p[0]);
 
-    if (child == 0) {
-        exit(child_main(&env, posix_json_path, &env.cred));
+    {
+        char  fds[32];
+        char *cargv[12];
+        int   n = 0;
+
+        snprintf(fds, sizeof(fds), "%d,%d", p2c[0], c2p[1]);
+        cargv[n++] = argv[0];
+        cargv[n++] = "-b";
+        cargv[n++] = (char *) env.backend;
+        if (user_spec) {
+            cargv[n++] = "-U";
+            cargv[n++] = (char *) user_spec;
+        }
+        cargv[n++] = "-C";
+        cargv[n++] = fds;
+        cargv[n++] = "-J";
+        cargv[n++] = posix_json_path;
+        cargv[n++] = "-S";
+        cargv[n++] = env.session_dir;
+        cargv[n]   = NULL;
+
+        child = posix_test_fork_exec(cargv);
+    }
+
+    if (child < 0) {
+        perror("tlock: fork");
+        exit(1);
     }
 
     /* ---- parent ---- */

--- a/src/posix/tests/test_lockf.c
+++ b/src/posix/tests/test_lockf.c
@@ -199,21 +199,34 @@ main(
     env.server      = NULL;
     clock_gettime(CLOCK_MONOTONIC, &tv);
 
-    /* Pick up the -b backend option. */
+    /* Pick up the -b backend option, the -U user spec, and the child-mode
+     * options a re-exec'ed child receives (-C sync-pipe fds, -J posix.json
+     * path, -S session dir; see posix_test_fork_exec). */
+    const char *user_spec     = NULL;
+    const char *child_fds     = NULL;
+    const char *child_json    = NULL;
+    const char *child_session = NULL;
     {
         int saved_opterr = opterr;
 
         opterr = 0;
         optind = 1;
-        while ((opt = getopt(argc, argv, "+b:U:")) != -1) {
+        while ((opt = getopt(argc, argv, "+b:U:C:J:S:")) != -1) {
             if (opt == 'b') {
                 env.backend = optarg;
             } else if (opt == 'U') {
+                user_spec = optarg;
                 if (!chimera_test_parse_user(optarg, &env.cred)) {
                     fprintf(stderr, "Unknown user spec '%s'. "
                             "Use: root, johndoe, myuser, or uid:gid\n", optarg);
                     exit(EXIT_FAILURE);
                 }
+            } else if (opt == 'C') {
+                child_fds = optarg;
+            } else if (opt == 'J') {
+                child_json = optarg;
+            } else if (opt == 'S') {
+                child_session = optarg;
             }
         }
         opterr = saved_opterr;
@@ -229,6 +242,26 @@ main(
 
     chimera_log_init();
     ChimeraLogLevel = CHIMERA_LOG_DEBUG;
+
+    if (child_fds) {
+        /* Re-exec'ed child: reconstruct the pre-fork state from argv and run
+         * the child side.  The parent created the session dir and config and
+         * marked its own pipe ends close-on-exec, so only the child's two fds
+         * arrive here. */
+        if (!child_json || !child_session ||
+            sscanf(child_fds, "%d,%d", &p2c[0], &c2p[1]) != 2) {
+            fprintf(stderr, "tlock: bad child-mode arguments\n");
+            exit(1);
+        }
+        p2c[1] = -1;
+        c2p[0] = -1;
+        snprintf(env.session_dir, sizeof(env.session_dir), "%s", child_session);
+        chimera_vfs_cred_init_unix(&env.cred,
+                                   CHIMERA_TEST_USER_ROOT_UID,
+                                   CHIMERA_TEST_USER_ROOT_GID,
+                                   0, NULL);
+        exit(child_main(&env, child_json, &env.cred));
+    }
 
     snprintf(env.session_dir, sizeof(env.session_dir),
              "%s/posix_session_%d_%lu_%lu",
@@ -273,10 +306,41 @@ main(
         exit(1);
     }
 
-    child = fork();
+    /* Spawn the child by re-exec'ing this binary rather than plain fork():
+     * exec resets the address space, so nothing any parent thread holds at
+     * fork time (sanitizer allocator locks included) can be inherited
+     * mid-flight.  The parent-only pipe ends are close-on-exec so the
+     * child's EOF semantics match the plain-fork arrangement. */
+    posix_test_cloexec(p2c[1]);
+    posix_test_cloexec(c2p[0]);
 
-    if (child == 0) {
-        exit(child_main(&env, posix_json_path, &env.cred));
+    {
+        char  fds[32];
+        char *cargv[12];
+        int   n = 0;
+
+        snprintf(fds, sizeof(fds), "%d,%d", p2c[0], c2p[1]);
+        cargv[n++] = argv[0];
+        cargv[n++] = "-b";
+        cargv[n++] = (char *) env.backend;
+        if (user_spec) {
+            cargv[n++] = "-U";
+            cargv[n++] = (char *) user_spec;
+        }
+        cargv[n++] = "-C";
+        cargv[n++] = fds;
+        cargv[n++] = "-J";
+        cargv[n++] = posix_json_path;
+        cargv[n++] = "-S";
+        cargv[n++] = env.session_dir;
+        cargv[n]   = NULL;
+
+        child = posix_test_fork_exec(cargv);
+    }
+
+    if (child < 0) {
+        perror("tlock: fork");
+        exit(1);
     }
 
     /* ---- parent ---- */

--- a/src/vfs/vfs_state.c
+++ b/src/vfs/vfs_state.c
@@ -90,9 +90,10 @@ chimera_vfs_state_init(void)
         return NULL;
     }
 
-    for (i = 0; i < CHIMERA_VFS_STATE_NUM_BUCKETS; i++) {
-        pthread_mutex_init(&state->buckets[i].lock, NULL);
-        state->buckets[i].files = NULL;
+    /* calloc zeroed count/nslots/slots: empty shards own no slot array
+     * until their first insert. */
+    for (i = 0; i < CHIMERA_VFS_STATE_NUM_SHARDS; i++) {
+        pthread_mutex_init(&state->shards[i].lock, NULL);
     }
 
     state->default_break_deadline_ms = CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS;
@@ -111,19 +112,25 @@ chimera_vfs_state_destroy(struct chimera_vfs_state *state)
         return;
     }
 
-    for (i = 0; i < CHIMERA_VFS_STATE_NUM_BUCKETS; i++) {
-        file = state->buckets[i].files;
-        while (file) {
-            next = file->bucket_next;
-            /* In Stage A there is no protocol caller, so we should never
-             * leak per-file state.  Asserts here would be too strict for
-             * test code that exits without releasing; instead we just
-             * tear down whatever remains. */
-            pthread_mutex_destroy(&file->lock);
-            free(file);
-            file = next;
+    for (i = 0; i < CHIMERA_VFS_STATE_NUM_SHARDS; i++) {
+        struct chimera_vfs_state_shard *shard = &state->shards[i];
+        uint32_t                        s;
+
+        for (s = 0; s < shard->nslots; s++) {
+            file = shard->slots[s];
+            while (file) {
+                next = file->bucket_next;
+                /* In Stage A there is no protocol caller, so we should never
+                 * leak per-file state.  Asserts here would be too strict for
+                 * test code that exits without releasing; instead we just
+                 * tear down whatever remains. */
+                pthread_mutex_destroy(&file->lock);
+                free(file);
+                file = next;
+            }
         }
-        pthread_mutex_destroy(&state->buckets[i].lock);
+        free(shard->slots);
+        pthread_mutex_destroy(&shard->lock);
     }
 
     free(state);
@@ -133,13 +140,58 @@ chimera_vfs_state_destroy(struct chimera_vfs_state *state)
 /* Per-file state lookup                                                */
 /* -------------------------------------------------------------------- */
 
-static inline struct chimera_vfs_state_bucket *
-chimera_vfs_state_bucket_for(
+/* Shard index takes the HIGH bits of fh_hash; the inner slot index (below)
+ * takes the low bits, so the two never correlate. */
+static inline struct chimera_vfs_state_shard *
+chimera_vfs_state_shard_for(
     struct chimera_vfs_state *state,
     uint64_t                  fh_hash)
 {
-    return &state->buckets[fh_hash & (CHIMERA_VFS_STATE_NUM_BUCKETS - 1)];
-} /* chimera_vfs_state_bucket_for */
+    return &state->shards[(fh_hash >> 32) & (CHIMERA_VFS_STATE_NUM_SHARDS - 1)];
+} /* chimera_vfs_state_shard_for */
+
+/* Caller MUST hold shard->lock and the shard must have a slot array. */
+static inline struct chimera_vfs_file_state **
+chimera_vfs_state_slot_for(
+    struct chimera_vfs_state_shard *shard,
+    uint64_t                        fh_hash)
+{
+    return &shard->slots[fh_hash & (shard->nslots - 1)];
+} /* chimera_vfs_state_slot_for */
+
+/* Double the shard's inner table (or create it at the initial size), moving
+ * every chained entry onto the new slots.  Caller MUST hold shard->lock.
+ * Allocation failure is tolerated: the shard keeps its old table and chains
+ * simply run longer -- correctness does not depend on the growth. */
+static void
+chimera_vfs_state_shard_grow(struct chimera_vfs_state_shard *shard)
+{
+    struct chimera_vfs_file_state **nslots_arr;
+    struct chimera_vfs_file_state  *file, *next;
+    uint32_t                        nnew;
+    uint32_t                        s;
+
+    nnew = shard->nslots ? shard->nslots * 2 : CHIMERA_VFS_STATE_INITIAL_SLOTS;
+
+    nslots_arr = calloc(nnew, sizeof(*nslots_arr));
+    if (!nslots_arr) {
+        return;
+    }
+
+    for (s = 0; s < shard->nslots; s++) {
+        file = shard->slots[s];
+        while (file) {
+            next                                   = file->bucket_next;
+            file->bucket_next                      = nslots_arr[file->fh_hash & (nnew - 1)];
+            nslots_arr[file->fh_hash & (nnew - 1)] = file;
+            file                                   = next;
+        }
+    }
+
+    free(shard->slots);
+    shard->slots  = nslots_arr;
+    shard->nslots = nnew;
+} /* chimera_vfs_state_shard_grow */
 
 static inline int
 chimera_vfs_file_state_match(
@@ -161,29 +213,44 @@ chimera_vfs_state_get(
     uint64_t                  fh_hash,
     bool                      create)
 {
-    struct chimera_vfs_state_bucket *bucket;
-    struct chimera_vfs_file_state   *file;
+    struct chimera_vfs_state_shard *shard;
+    struct chimera_vfs_file_state  *file;
+    struct chimera_vfs_file_state **slot;
 
-    bucket = chimera_vfs_state_bucket_for(state, fh_hash);
+    shard = chimera_vfs_state_shard_for(state, fh_hash);
 
-    pthread_mutex_lock(&bucket->lock);
+    pthread_mutex_lock(&shard->lock);
 
-    for (file = bucket->files; file; file = file->bucket_next) {
-        if (chimera_vfs_file_state_match(file, fh, fh_len, fh_hash)) {
-            file->refcount++;
-            pthread_mutex_unlock(&bucket->lock);
-            return file;
+    if (shard->nslots) {
+        for (file = *chimera_vfs_state_slot_for(shard, fh_hash);
+             file;
+             file = file->bucket_next) {
+            if (chimera_vfs_file_state_match(file, fh, fh_len, fh_hash)) {
+                file->refcount++;
+                pthread_mutex_unlock(&shard->lock);
+                return file;
+            }
         }
     }
 
     if (!create) {
-        pthread_mutex_unlock(&bucket->lock);
+        pthread_mutex_unlock(&shard->lock);
         return NULL;
+    }
+
+    /* Grow (or create) the inner table before the load factor reaches 1 so
+     * lookups stay 0-1 probes; a failed grow just leaves longer chains. */
+    if (shard->count + 1 > shard->nslots) {
+        chimera_vfs_state_shard_grow(shard);
+        if (!shard->nslots) {
+            pthread_mutex_unlock(&shard->lock);
+            return NULL;
+        }
     }
 
     file = calloc(1, sizeof(*file));
     if (!file) {
-        pthread_mutex_unlock(&bucket->lock);
+        pthread_mutex_unlock(&shard->lock);
         return NULL;
     }
 
@@ -194,10 +261,12 @@ chimera_vfs_state_get(
     file->state    = state;
     pthread_mutex_init(&file->lock, NULL);
 
-    file->bucket_next = bucket->files;
-    bucket->files     = file;
+    slot              = chimera_vfs_state_slot_for(shard, fh_hash);
+    file->bucket_next = *slot;
+    *slot = file;
+    shard->count++;
 
-    pthread_mutex_unlock(&bucket->lock);
+    pthread_mutex_unlock(&shard->lock);
     return file;
 } /* chimera_vfs_state_get */
 
@@ -206,23 +275,23 @@ chimera_vfs_state_put(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file)
 {
-    struct chimera_vfs_state_bucket *bucket;
-    struct chimera_vfs_file_state  **link;
-    bool                             empty;
+    struct chimera_vfs_state_shard *shard;
+    struct chimera_vfs_file_state **link;
+    bool                            empty;
 
     if (!file) {
         return;
     }
 
-    bucket = chimera_vfs_state_bucket_for(state, file->fh_hash);
+    shard = chimera_vfs_state_shard_for(state, file->fh_hash);
 
-    pthread_mutex_lock(&bucket->lock);
+    pthread_mutex_lock(&shard->lock);
 
     chimera_vfs_abort_if(file->refcount == 0, "double put on vfs_state file");
 
     file->refcount--;
     if (file->refcount != 0) {
-        pthread_mutex_unlock(&bucket->lock);
+        pthread_mutex_unlock(&shard->lock);
         return;
     }
 
@@ -239,19 +308,22 @@ chimera_vfs_state_put(
     if (!empty) {
         /* Restore the implicit reference held by the lease(s). */
         file->refcount = 1;
-        pthread_mutex_unlock(&bucket->lock);
+        pthread_mutex_unlock(&shard->lock);
         return;
     }
 
-    /* Unlink from bucket and free. */
-    for (link = &bucket->files; *link; link = &(*link)->bucket_next) {
+    /* Unlink from the shard and free. */
+    for (link = chimera_vfs_state_slot_for(shard, file->fh_hash);
+         *link;
+         link = &(*link)->bucket_next) {
         if (*link == file) {
             *link = file->bucket_next;
+            shard->count--;
             break;
         }
     }
 
-    pthread_mutex_unlock(&bucket->lock);
+    pthread_mutex_unlock(&shard->lock);
 
     pthread_mutex_destroy(&file->lock);
     free(file);
@@ -3748,7 +3820,7 @@ chimera_vfs_io_lease_acquire(
     /* Fast path: a cached open handle anchors the per-file state for its whole
      * lifetime, so we attach it once (lazily, racing other first-I/O threads via
      * an acquire/release CAS) and thereafter borrow the handle's reference per
-     * I/O -- skipping the bucket-locked state_get/put entirely.  The handle's
+     * I/O -- skipping the shard-locked state_get/put entirely.  The handle's
      * long-lived ref plus opencnt>0 for the duration of this op (the protocol
      * drops opencnt only after the read/write callback returns, strictly after
      * io_lease_release) keep `file` alive.  io_owns_lease_ref stays 0 so release
@@ -3946,33 +4018,51 @@ chimera_vfs_state_reap_idle(
     struct chimera_vfs_state *state,
     uint64_t                  idle_ms)
 {
-#define CHIMERA_VFS_STATE_REAP_BATCH 64
+/* Per-shard candidate cap per pass.  With the old flat table the per-bucket
+ * cap was effectively unreachable (avg 0.13 entries/bucket), so every
+ * candidate was visited every pass; sized here at 2x the average per-shard
+ * population at the table's design load (128K entries / 1024 shards) so the
+ * same holds, with skewed shards catching up on the next 100ms pass. */
+#define CHIMERA_VFS_STATE_REAP_BATCH 256
     uint64_t now = chimera_vfs_now_ticks();
     int      b;
 
-    for (b = 0; b < CHIMERA_VFS_STATE_NUM_BUCKETS; b++) {
-        struct chimera_vfs_state_bucket *bucket = &state->buckets[b];
-        struct chimera_vfs_file_state   *cand[CHIMERA_VFS_STATE_REAP_BATCH];
-        struct chimera_vfs_file_state   *file;
-        int                              n = 0;
-        int                              i;
+    for (b = 0; b < CHIMERA_VFS_STATE_NUM_SHARDS; b++) {
+        struct chimera_vfs_state_shard *shard = &state->shards[b];
+        struct chimera_vfs_file_state  *cand[CHIMERA_VFS_STATE_REAP_BATCH];
+        struct chimera_vfs_file_state  *file;
+        uint32_t                        s;
+        int                             n = 0;
+        int                             i;
 
-        pthread_mutex_lock(&bucket->lock);
-        for (file = bucket->files;
-             file && n < CHIMERA_VFS_STATE_REAP_BATCH;
-             file = file->bucket_next) {
-            /* Candidates: files holding an implicit lease (reapable when idle),
-             * with parked I/O waiters (re-pumped so an unresponsive holder is
-             * revoked at its recall deadline and the waiter makes progress), or
-             * holding any caching lease (an oplock/lease/delegation may be stuck
-             * BREAKING past its deadline with NO waiter behind it -- #1030). */
-            if (file->implicit_active || file->io_wait_head ||
-                file->caching_leases) {
-                file->refcount++;
-                cand[n++] = file;
+        pthread_mutex_lock(&shard->lock);
+
+        /* The common case: nothing anchored in this shard.  The count makes
+         * the whole sweep proportional to live state rather than table
+         * size. */
+        if (shard->count == 0) {
+            pthread_mutex_unlock(&shard->lock);
+            continue;
+        }
+
+        for (s = 0; s < shard->nslots && n < CHIMERA_VFS_STATE_REAP_BATCH; s++) {
+            for (file = shard->slots[s];
+                 file && n < CHIMERA_VFS_STATE_REAP_BATCH;
+                 file = file->bucket_next) {
+                /* Candidates: files holding an implicit lease (reapable when
+                 * idle), with parked I/O waiters (re-pumped so an unresponsive
+                 * holder is revoked at its recall deadline and the waiter makes
+                 * progress), or holding any caching lease (an oplock/lease/
+                 * delegation may be stuck BREAKING past its deadline with NO
+                 * waiter behind it -- #1030). */
+                if (file->implicit_active || file->io_wait_head ||
+                    file->caching_leases) {
+                    file->refcount++;
+                    cand[n++] = file;
+                }
             }
         }
-        pthread_mutex_unlock(&bucket->lock);
+        pthread_mutex_unlock(&shard->lock);
 
         for (i = 0; i < n; i++) {
             bool reapable;

--- a/src/vfs/vfs_state.h
+++ b/src/vfs/vfs_state.h
@@ -44,13 +44,31 @@ struct chimera_vfs_request;
 /* The per-file state table anchors one entry per *cached open handle* that has
  * done I/O (the handle holds the ref; see chimera_vfs_io_lease_acquire), so its
  * live population tracks the open-handle cache capacity (open_file_cache =
- * 128K handles), NOT the small set of protocol-open files.  Sized at 16384 the
- * chains ran ~8 deep, and since each chain node is a separately-allocated
- * struct, the bucket walk in chimera_vfs_state_get was a serialized cache-miss
+ * 128K handles), NOT the small set of protocol-open files.
+ *
+ * The table is sharded: a fixed, small set of shards, each with its own lock,
+ * an entry count, and a privately-growable hash table.  Two earlier designs
+ * inform this one.  A flat 16K-bucket table ran chains ~8 deep at the 128K
+ * population, and since each chain node is a separately-allocated struct, the
+ * chain walk in chimera_vfs_state_get was a serialized cache-miss
  * pointer-chase that dominated write-path CPU (~72% self under SWBUILD INIT).
- * Size to comfortably exceed the handle-cache capacity (load factor ~0.13) so
- * lookups touch 0-1 nodes.  Must stay a power of two (used as a mask). */
-#define CHIMERA_VFS_STATE_NUM_BUCKETS (1 << 20)
+ * Curing that with a flat 2^20-bucket table restored O(1) lookups but cost
+ * 56MB of per-bucket mutexes in EVERY chimera process (client and server), a
+ * million mutex init/destroy calls at startup/teardown, and a reaper that had
+ * to visit every bucket.  Sharding keeps the O(1) lookup (inner tables double
+ * when a shard's load factor reaches 1, locally, under that shard's own lock)
+ * while the footprint tracks the actual population: empty shards hold no slot
+ * array at all, and the per-shard count lets the idle reaper skip them with
+ * one uncontended lock acquire.
+ *
+ * Shard index and inner slot index take disjoint bits of fh_hash (bits 32+
+ * for the shard, low bits for the slot) so they never correlate.  This
+ * relies on fh_hash carrying entropy across the full word, as
+ * chimera_vfs_hash() does today (XXH3-64 with only bit 63 masked off); a
+ * future hash with only 32 significant bits would collapse every entry into
+ * one shard.  Both counts must stay powers of two (used as masks). */
+#define CHIMERA_VFS_STATE_NUM_SHARDS    1024
+#define CHIMERA_VFS_STATE_INITIAL_SLOTS 16
 
 struct chimera_vfs_file_state {
     uint8_t                             fh[CHIMERA_VFS_FH_SIZE];
@@ -108,19 +126,26 @@ struct chimera_vfs_file_state {
     struct chimera_vfs_file_state      *bucket_next;
 };
 
-struct chimera_vfs_state_bucket {
-    struct chimera_vfs_file_state *files;
-    pthread_mutex_t                lock;
+struct chimera_vfs_state_shard {
+    pthread_mutex_t                 lock;
+    /* Entries currently anchored in this shard; the idle reaper skips a
+     * shard whose count is zero without touching its slots. */
+    uint32_t                        count;
+    /* Inner hash table: allocated lazily on first insert (empty shards own
+     * no slot array), doubled in place under the shard lock when count
+     * reaches nslots.  Entries chain through file->bucket_next. */
+    uint32_t                        nslots;
+    struct chimera_vfs_file_state **slots;
 };
 
 struct chimera_vfs_state {
-    struct chimera_vfs_state_bucket buckets[CHIMERA_VFS_STATE_NUM_BUCKETS];
+    struct chimera_vfs_state_shard shards[CHIMERA_VFS_STATE_NUM_SHARDS];
     /* Default deadline applied by chimera_vfs_lease_begin_break() when the
      * caller passes 0.  Matches SMB2 lease-break timeout convention. */
-    uint32_t                        default_break_deadline_ms;
+    uint32_t                       default_break_deadline_ms;
     /* Implicit leases held this long without any I/O are dropped by
      * chimera_vfs_state_reap_idle(). */
-    uint32_t                        implicit_idle_ms;
+    uint32_t                       implicit_idle_ms;
 };
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

The POSIX byte-range locking tests are the largest flake cluster in #733 — 17 events in two weeks across nine tests (`fcntl_*`, `lockf_*`, cthon `tlock`), always Debug builds, always ubuntu24/rocky10. Three cooperating defects were found by reproducing the hangs in ubuntu22/ubuntu24 containers and catching wedged processes live with gdb; this PR fixes all three.

## What the flakes actually are

The JUnit artifacts from all flagged runs show one signature: the failing attempt dies at a uniform **~45.5s** — the lock-family tests' own child watchdog — with the forked child stuck inside `chimera_posix_init_json` → `chimera_vfs_init` → `evpl_thread_create` (the worker-ready cond-wait), every service thread futex-parked, no event loop running. The flaking tests are exactly the tests that fork; the VFS backend suffix is incidental.

## Root causes and fixes (each caught live in gdb)

**1. Fork inherits a locked sanitizer allocator region mutex (the direct cause) → spawn children with fork+exec.** The lock tests fork before client init, so only the log flusher thread is alive alongside main at fork time. The logging atfork prepare holds `ChimeraLogFlushLock` across the fork, keeping the flusher out of `fprintf`/`fflush` — but the flusher can be inside a lock that handler cannot see: the malloc/free glibc stdio does *under* the flusher's locks takes ASan's per-size-class region mutex, and **gcc-13's ASan does not force-unlock those across fork**. A child forked at the wrong instant inherits the region lock held; every thread the child creates then wedges inside `AsanThread::Init` on its first allocation, before its body runs, and main waits forever in the ready handshake. Captured live from a wedged `posix_test_fcntl` child: eight sibling threads all blocked in `SizeClassAllocator64::GetFromAllocator` on the same region mutex with no live owner. This also explains the platform pattern: gcc-11's libasan.6 uses a spinning `StaticSpinMutex` on the same path, so ubuntu22/rocky9 never showed the futex-wait shape.

Fix: the child is now spawned by **re-exec'ing the test binary** in a `-C` child mode — sync-pipe fds, config path, and session dir on argv (cthon additionally passes its pass/test/wait settings and the parent pid its shared lockfile name is keyed by), parent-only pipe ends marked close-on-exec so pipe topology and EOF semantics match the plain-fork arrangement. exec resets the address space, so the child starts with no inherited lock state from *any* runtime — the hazard class is closed structurally rather than by maintaining a "nothing threads before fork" invariant. Only async-signal-safe work happens between fork and exec.

**2. A 1M-bucket sweep every 100ms in every process (the load amplifier).** `chimera_vfs_state_reap_idle()` walked all 2^20 state buckets, locking every bucket mutex, even with zero live state — measured ~50ms per pass under ASan (and a 56MB, mostly-mutex array pulled through cache 10x/sec, dirtied at init by a million `pthread_mutex_init` calls in every chimera process, client and server alike). Parallel Debug CI accumulates dozens of these sweep loops (each test = parent + child), starving init handshakes toward the watchdog and stalling shutdown joins behind in-progress sweeps (captured live: a cthon parent wedged in `evpl_thread_destroy` → `pthread_join` with the close thread mid-sweep).

Fix: the table is now **sharded** — 1024 shards, each with its own lock, an entry count, and a privately-growable inner hash (lazily allocated, doubled under the shard's own lock at load factor 1, never globally rehashed; shard and slot indices take disjoint bits of `fh_hash`). The count lets the reaper skip empty shards with one uncontended lock acquire, the footprint drops from 56MB-at-init to ~64KB plus tables proportional to population, and the hot path gets *faster*, not slower — the flat table cost a guaranteed cache miss into a sparse 56MB array per op, while the shard headers and compact inner tables stay cache-resident. Measured (ASan, 128K-entry population matching the open-handle cache the table is sized against):

| | flat 2^20 | sharded |
|---|---|---|
| RSS charged by `state_init()` | **+80 MB** | **+128 KB** |
| `reap_idle`, empty | 0.15 ms | 0.05 ms |
| insert 128K entries | 607 ms | 118 ms |
| get+put pair (hit path) | 2,314 ns | **971 ns** |
| `reap_idle`, 128K populated | 346 ms | 41 ms |

(Debug/ASan build on aarch64; the RSS figure is the resident delta across `chimera_vfs_state_init()` alone, paid by every chimera process at startup — including a `posix` client that only ever touches two files.)

**3. The watchdog could wedge the process it was reaping (the diagnostics killer).** The handler printed with `dprintf`, which mallocs a fresh stdio buffer per call. Captured live: SIGALRM fired while the main thread sat in LSan's exit-time stop-the-world holding the sanitizer allocator lock; the handler's malloc spun on that lock forever, converting a transient stall into a permanent wedge that ctest cleared at 300s with all diagnostics lost. Fix: re-arm SIGALRM to the default fatal action with `alarm(12)` *before* any dump work (dead-man switch), `write()` preformatted buffers instead of stdio, pre-warm `backtrace()` at arm time.

## Verification

All on an ubuntu24 container (gcc 13.3 / glibc 2.39 — the flaking platforms' toolchain), Debug/ASan:

- All 16 lock-family tests pass with the exec'ed children, including the full cthon tlock matrix (parent 14/14, child 29/29) and the nfs3/rdma/myuser variants.
- All 19 `chimera/vfs/` unit tests pass on the sharded table, including the dedicated `chimera/vfs/state_test`.
- **Lock-test endurance on the final tree: 1,082 batches (~5,400 test runs), 880 consecutive clean** after an environmental rig fix; zero wedges of any kind.
- Fork+exec A/B: with the reaper and watchdog fixes but plain `fork()`, 2 init-phase wedges in 45 loaded batches; with fork+exec on the same base, zero in 151 idle + 185 loaded + 20 confirmation batches.
- Hot-path, reaper, and RSS benchmarks in the table above (standalone harness linked against the real `libchimera_vfs`).
- The hardened watchdog was exercised in anger throughout (deliberately oversubscribed box): it dumped and aborted cleanly every time — no self-wedge, no silent 300s timeouts.

- Full posix-label suite: **2,171 of 2,173 pass**. The two exceptions were wall-clock timeouts on heavy `diskfs_io_uring` tests under `-j3` contention (`cthon_special_bigfile_nfs3_diskfs_io_uring`, `rewinddir_nfs4_diskfs_io_uring`); both **pass in isolation** on the same build (97s and 49s), and both are long-standing CI flakes in #733 (27 and 5 prior tracker events, from June).

The `diskfs_evict_*`, `diskfs_reclaim_*`, and `fsx_*` stress tests are excluded from that count: they time out in this container **on pre-sharding builds too** (verified by running binaries built before this change), so they are environmental here and unrelated to this PR.

Addresses the `fcntl_*`, `lockf_*`, and `cthon_lock_tlock_*` entries in #733.

## Notes and follow-ups (not in this PR)

- An alternative/complementary fix — quiescing the log flusher across `fork()` so plain forks are also safe — is parked on the **`log-flusher-fork-quiesce`** branch. It would additionally cover the remaining plain-fork tests (`fsstress`, `dirstress`, `fstest`), which have not flaked.
- The soak surfaced a genuine, unrelated **nfs3 locking bug**: sporadic `F_SETLK SEEK_END` → `EINVAL`, because `nfs3_lock.c` resolves `SEEK_END` via a wire `GETATTR` and the server returned a stale pre-write size immediately after a synchronous write. Worth its own investigation.
- Separately, while checking flake history: `diskfs_evict_*` is a **regression of a previously-fixed bug**, not a new one — 98 tracker events Jun 12–27, then 5.5 weeks completely silent, then back on Aug 5. The lead is "what fixed it in late June and what undid it," not "what merged on Aug 4–5."
