### PR TITLE
ci: harden the oras CLI fetch against transient download failures

### DIFF
--- a/.github/actions/fetch-oras/action.yml
+++ b/.github/actions/fetch-oras/action.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+name: Fetch oras CLI
+description: >
+  Download the static oras binary onto the runner and leave it at
+  <workspace>/oras, ready to be mounted into a build container.  The download
+  is retried on transient failures, so a truncated body or an HTTP error page
+  fails loudly here instead of surfacing as a confusing error further down the
+  job.
+
+inputs:
+  arch:
+    description: >
+      Architecture as named in the oras release assets: amd64 or arm64.
+    required: true
+  version:
+    description: oras release version.
+    required: false
+    default: "1.2.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Download oras
+      shell: bash
+      env:
+        ORAS_VERSION: ${{ inputs.version }}
+        ORAS_ARCH: ${{ inputs.arch }}
+        ORAS_DEST: ${{ github.workspace }}
+      run: |
+        set -euo pipefail
+
+        url="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}"
+        url="${url}/oras_${ORAS_VERSION}_linux_${ORAS_ARCH}.tar.gz"
+
+        tarball="$(mktemp)"
+        trap 'rm -f "${tarball}"' EXIT
+
+        # Download to a file rather than piping into tar: a rate-limit page or a
+        # half-delivered body otherwise reaches tar as its input, which reports
+        # the misleading "stdin: not in gzip format" instead of a fetch error.
+        # --fail turns an HTTP error into a curl error, and --retry-all-errors
+        # covers both those and a connection dropped mid-transfer.
+        if ! curl --fail --location --silent --show-error \
+                  --connect-timeout 20 --max-time 180 \
+                  --retry 5 --retry-delay 2 --retry-all-errors --retry-connrefused \
+                  --output "${tarball}" "${url}"; then
+          echo "::error::could not download ${url}"
+          exit 1
+        fi
+
+        tar -xzf "${tarball}" -C "${ORAS_DEST}" oras
+        chmod +x "${ORAS_DEST}/oras"
+
+        # Prove the binary actually runs before the job depends on it.
+        "${ORAS_DEST}/oras" version

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -414,11 +414,9 @@ jobs:
       # Fetch the static oras binary on the runner and mount it into the
       # build container.
       - name: Fetch oras CLI
-        run: |
-          ORAS_VERSION=1.2.0
-          curl -sSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${{ matrix.arch }}.tar.gz" \
-            | tar -xz -C "${{ github.workspace }}" oras
-          chmod +x "${{ github.workspace }}/oras"
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: ${{ matrix.arch }}
 
       - name: Configure and build inside the container
         run: |
@@ -689,11 +687,9 @@ jobs:
 
       # oras is needed at configure time: KVM_TESTING=ON probes for it.
       - name: Fetch oras CLI
-        run: |
-          ORAS_VERSION=1.2.0
-          curl -sSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${{ matrix.arch }}.tar.gz" \
-            | tar -xz -C "${{ github.workspace }}" oras
-          chmod +x "${{ github.workspace }}/oras"
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: ${{ matrix.arch }}
 
       - name: Configure and build inside the container
         run: |
@@ -791,11 +787,9 @@ jobs:
           submodules: recursive
 
       - name: Fetch oras CLI
-        run: |
-          ORAS_VERSION=1.2.0
-          curl -sSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${{ matrix.arch }}.tar.gz" \
-            | tar -xz -C "${{ github.workspace }}" oras
-          chmod +x "${{ github.workspace }}/oras"
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: ${{ matrix.arch }}
 
       - name: Download build tree from Nexus scratch
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -502,11 +502,9 @@ jobs:
 
       # KVM guest images are pulled from GHCR with oras (see build-test.yml).
       - name: Fetch oras CLI
-        run: |
-          ORAS_VERSION=1.2.0
-          curl -sSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${{ matrix.arch }}.tar.gz" \
-            | tar -xz -C "${{ github.workspace }}" oras
-          chmod +x "${{ github.workspace }}/oras"
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: ${{ matrix.arch }}
 
       - name: Configure, build, and test inside the container
         run: |


### PR DESCRIPTION
I noticed the merge pipeline was having transient failures yesterday, this PR should make the pipeline more reliable about handling transient failures although a full outage preventing downloads from github will still fail. Even in the presence of a full outage the failure should be clearer.

Before this fix four jobs fetched the oras binary onto the runner before building, and each did it with a bare

    curl -sSL <github release url> | tar -xz ...

which has no --fail, no retries, and pipes the response body straight into tar.  When the download hiccups, tar is handed the failure: an HTTP error page or a short body surfaces as "gzip: stdin: not in gzip format", which says nothing about the fetch having failed.  A single blip took out six otherwise-passing test jobs in one merge queue run and bounced the PR out of the queue.

Replace the four copies with a composite action that downloads to a file, retries on transient failures, and smoke-tests the extracted binary before the job depends on it.  An HTTP error page can no longer reach tar, a connection dropped mid-transfer is retried rather than extracted, and a failure names the URL and the reason.  The oras version lives in one place now instead of four, overridable per call site.