### PR TITLE
cairn: close by vfs_private, not the (absent) file handle

### DIFF
--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3155,7 +3155,18 @@ cairn_close(
     struct cairn_inode       *inode;
     int                       rc;
 
-    rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
+    /* Close names an open instance, not a path: chimera_vfs_close builds its
+     * request with no file handle at all (fh = NULL, fh_len = 0) and passes
+     * only the vfs_private cookie this backend returned from open -- for
+     * cairn, the inode number.  Reading request->fh here instead decoded
+     * whatever bytes the recycled request struct happened to hold, so the
+     * lookup missed, every close returned ENOENT without dropping the refcnt,
+     * and a file unlinked while open was never reclaimed.
+     *
+     * Resolving by inum alone (no generation check) is sound because an open
+     * handle holds a refcnt and the branch below only removes an inode once
+     * that reaches zero, so an inum cannot be recycled under a live handle. */
+    rc = cairn_inode_get_inum(thread, request->close.vfs_private, &ih);
 
     if (rc) {
         request->status = CHIMERA_VFS_ENOENT;

--- a/src/vfs/vfs_proc_close.c
+++ b/src/vfs/vfs_proc_close.c
@@ -16,6 +16,21 @@ chimera_vfs_close_complete(struct chimera_vfs_request *request)
 
     chimera_vfs_complete(request);
 
+    /* A failed close is never routine: whatever the handle pinned in the
+     * backend (a descriptor, an inode reference, a deferred unlink) stays
+     * pinned, so the effect is a silent leak rather than a returned error.
+     * Most closes originate in the open-handle cache -- idle eviction, the
+     * shutdown sweep, a detached-handle drop -- and pass no callback at all,
+     * and the close thread's callback only decrements its pending count, so
+     * without this the status has no reader anywhere.  Report it here, where
+     * every caller funnels through. */
+    if (unlikely(request->status != CHIMERA_VFS_OK)) {
+        chimera_vfs_error("close failed on %s handle %lx: error %d",
+                          request->module ? request->module->name : "(none)",
+                          request->close.vfs_private,
+                          request->status);
+    }
+
     if (callback) {
         callback(request->status, request->proto_private_data);
     }


### PR DESCRIPTION
## Problem

`chimera_vfs_close` builds its request with **no file handle** — `fh = NULL, fh_len = 0` — because close names an *open instance*, not a path. The only thing identifying the target is the `vfs_private` cookie the backend returned from open. For cairn that cookie is the inode number.

`cairn_close` ignored it and called `cairn_inode_get_fh()` on `request->fh`, which for a close request holds whatever bytes were left over in the recycled request struct:

```c
rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
```

The decode produced a garbage inum, the lookup missed, and every close returned `ENOENT` having dropped no refcnt.

Nothing surfaced that, so the symptom was silent rather than an error: an inode's `refcnt` only ever climbed, the `refcnt == 0 && nlink == 0` branch never ran, and **a file unlinked while open kept its inode, extents and ACL in the metadb forever**.

## Fix

Resolve the inode by inum, which is exactly what open stored:

```c
rc = cairn_inode_get_inum(thread, request->close.vfs_private, &ih);
```

Skipping the generation check is sound here: an open handle holds a refcnt, and an inode is only removed once that refcnt reaches zero, so an inum cannot be recycled underneath a live handle.

The `0xdeadbeef` sentinel cairn stores for `CHIMERA_VFS_OPEN_INFERRED` opens never reaches close — those handles are synthesized without a cache insert and carry `CHIMERA_VFS_OPEN_HANDLE_NO_BACKEND_OPEN`, which `chimera_vfs_open_handle_needs_backend_close()` filters on.

## Also: the VFS now reports a failed close

This bug survived because a close failure has no reader anywhere. Most closes originate in the open-handle cache — idle eviction, the shutdown sweep, a detached-handle drop — and pass `NULL` for the callback; the close thread's callback only decrements a pending count. So a backend could fail *every* close without a trace.

`chimera_vfs_close_complete()` now logs it. A failed close is never routine: whatever the handle pinned in the backend stays pinned, so the effect is a silent leak rather than a returned error.

The two changes verify each other. With only the logging applied, a cthon `basic_1` run against cairn reports **155 failed closes** — one per file the test creates. With the cairn fix applied as well: **zero**.

## Testing

- `chimera/vfs` ctest suite: all pass except `zerorange_diskfs_io_uring`, which fails identically on unmodified `main` in this environment (io_uring SEGV in libevpl).
- POSIX suites driven directly against cairn, memfs and diskfs_aio: cthon `basic_1`, `special_op_unlk` (unlink-while-open, which exercises the delete-on-close path this fix re-enables), `openat`, plus chmod/chown/dup/exdev/fstat/link/mkdir/rename/stat/symlink/unlink/truncate/fsstress. Zero failed closes across all backends.
- The two failures seen in the sweep (`dirstress` on both backends, `exdev` on memfs) were confirmed to fail identically on unmodified `main` here.
- `make syntax-check`, `reuse-lint`, and the Release build all clean.

Worth noting this re-enables cairn's delete-on-close path (`cairn_remove_inode` / `cairn_remove_file_extents` / `cairn_remove_acl`), which had effectively never executed — hence the emphasis on `special_op_unlk` above.