### PR TITLE
vfs: give close the file handle it operates on

### DIFF
--- a/src/server/smb/smb_durable.c
+++ b/src/server/smb/smb_durable.c
@@ -194,8 +194,8 @@ chimera_smb_durable_doc_remove_cb(
                           ctx->doc_info.name_len, ctx->doc_info.name, error_code);
     }
     chimera_vfs_release(ctx->vfs_thread, ctx->parent_handle);
-    chimera_vfs_close(ctx->vfs_thread, ctx->doc_info.close_module,
-                      ctx->doc_info.close_private, ctx->doc_info.close_hash, NULL, NULL);
+    chimera_vfs_close_ref_dispatch(ctx->vfs_thread, &ctx->doc_info.close_ref,
+                                   NULL, NULL);
     free(ctx);
 } /* chimera_smb_durable_doc_remove_cb */
 
@@ -210,8 +210,8 @@ chimera_smb_durable_doc_open_parent_cb(
     if (error_code != CHIMERA_VFS_OK) {
         chimera_smb_debug("durable delete-on-close: open parent failed for '%.*s' (error %d)",
                           ctx->doc_info.name_len, ctx->doc_info.name, error_code);
-        chimera_vfs_close(ctx->vfs_thread, ctx->doc_info.close_module,
-                          ctx->doc_info.close_private, ctx->doc_info.close_hash, NULL, NULL);
+        chimera_vfs_close_ref_dispatch(ctx->vfs_thread, &ctx->doc_info.close_ref,
+                                       NULL, NULL);
         free(ctx);
         return;
     }

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -97,12 +97,8 @@ chimera_smb_close_doc_remove_callback(
     chimera_vfs_release(vfs_thread, request->close.parent_handle);
 
     /* Close the backend VFS module handle that was detached from the cache */
-    chimera_vfs_close(vfs_thread,
-                      request->close.doc_info.close_module,
-                      request->close.doc_info.close_private,
-                      request->close.doc_info.close_hash,
-                      NULL,
-                      NULL);
+    chimera_vfs_close_ref_dispatch(vfs_thread, &request->close.doc_info.close_ref,
+                                   NULL, NULL);
 
     chimera_smb_open_file_release(request, request->close.open_file);
 
@@ -125,12 +121,8 @@ chimera_smb_close_doc_open_parent_callback(
                           request->close.doc_info.name,
                           error_code);
 
-        chimera_vfs_close(vfs_thread,
-                          request->close.doc_info.close_module,
-                          request->close.doc_info.close_private,
-                          request->close.doc_info.close_hash,
-                          NULL,
-                          NULL);
+        chimera_vfs_close_ref_dispatch(vfs_thread, &request->close.doc_info.close_ref,
+                                       NULL, NULL);
 
         chimera_smb_open_file_release(request, request->close.open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
@@ -194,12 +186,8 @@ struct chimera_smb_teardown_doc_ctx {
 static void
 chimera_smb_teardown_doc_close_backend(struct chimera_smb_teardown_doc_ctx *ctx)
 {
-    chimera_vfs_close(ctx->vfs_thread,
-                      ctx->doc_info.close_module,
-                      ctx->doc_info.close_private,
-                      ctx->doc_info.close_hash,
-                      NULL,
-                      NULL);
+    chimera_vfs_close_ref_dispatch(ctx->vfs_thread, &ctx->doc_info.close_ref,
+                                   NULL, NULL);
     free(ctx);
 } /* chimera_smb_teardown_doc_close_backend */
 
@@ -281,12 +269,8 @@ chimera_smb_teardown_doc_unlink(
     if (doc_info->parent_fh_len == 0) {
         /* No parent fh recorded — cannot unlink, just close the backend
          * handle that release_doc detached from the cache. */
-        chimera_vfs_close(thread->vfs_thread,
-                          doc_info->close_module,
-                          doc_info->close_private,
-                          doc_info->close_hash,
-                          NULL,
-                          NULL);
+        chimera_vfs_close_ref_dispatch(thread->vfs_thread, &doc_info->close_ref,
+                                       NULL, NULL);
         return;
     }
 
@@ -497,12 +481,8 @@ chimera_smb_close_release(struct chimera_smb_request *request)
     if (need_doc && open_file->share_file_state &&
         chimera_vfs_state_stream_holders(open_file->share_file_state) > 0) {
         chimera_vfs_state_set_delete_pending(open_file->share_file_state);
-        chimera_vfs_close(vfs_thread,
-                          request->close.doc_info.close_module,
-                          request->close.doc_info.close_private,
-                          request->close.doc_info.close_hash,
-                          NULL,
-                          NULL);
+        chimera_vfs_close_ref_dispatch(vfs_thread, &request->close.doc_info.close_ref,
+                                       NULL, NULL);
         chimera_smb_open_file_release(request, open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);
         return;
@@ -520,12 +500,8 @@ chimera_smb_close_release(struct chimera_smb_request *request)
     } else {
         if (need_doc) {
             /* DOC set but no parent fh — close backend handle directly */
-            chimera_vfs_close(vfs_thread,
-                              request->close.doc_info.close_module,
-                              request->close.doc_info.close_private,
-                              request->close.doc_info.close_hash,
-                              NULL,
-                              NULL);
+            chimera_vfs_close_ref_dispatch(vfs_thread, &request->close.doc_info.close_ref,
+                                           NULL, NULL);
         }
         chimera_smb_open_file_release(request, open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_SUCCESS);

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3155,13 +3155,10 @@ cairn_close(
     struct cairn_inode       *inode;
     int                       rc;
 
-    /* Close names an open instance, not a path: chimera_vfs_close builds its
-     * request with no file handle at all (fh = NULL, fh_len = 0) and passes
-     * only the vfs_private cookie this backend returned from open -- for
-     * cairn, the inode number.  Reading request->fh here instead decoded
-     * whatever bytes the recycled request struct happened to hold, so the
-     * lookup missed, every close returned ENOENT without dropping the refcnt,
-     * and a file unlinked while open was never reclaimed.
+    /* Close names an open instance, not a path, so resolve it through the
+     * vfs_private cookie this backend returned from open -- for cairn, the
+     * inode number -- rather than through request->fh, which names the object
+     * the handle was opened on.
      *
      * Resolving by inum alone (no generation check) is sound because an open
      * handle holds a refcnt and the branch below only removes an inode once

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -188,6 +188,8 @@ chimera_vfs_close_thread_sweep(
 
             chimera_vfs_close(thread,
                               handle->vfs_module,
+                              handle->fh,
+                              handle->fh_len,
                               handle->vfs_private,
                               handle->fh_hash,
                               chimera_vfs_close_thread_callback,

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -44,6 +44,51 @@ chimera_vfs_open_handle_needs_backend_close(const struct chimera_vfs_open_handle
     return !(handle->flags & CHIMERA_VFS_OPEN_HANDLE_NO_BACKEND_OPEN);
 } // chimera_vfs_open_handle_needs_backend_close
 
+/*
+ * A close is always issued after the shard lock is dropped, and by then the
+ * handle it applies to has usually been freed -- so everything the close needs
+ * is copied out first.  The file handle in particular has to be copied rather
+ * than pointed at, which is why this is a struct and not a pointer.
+ */
+struct chimera_vfs_close_ref {
+    struct chimera_vfs_module *module;
+    uint64_t                   vfs_private;
+    uint64_t                   fh_hash;
+    int                        fh_len;
+    int                        needs_close;
+    uint8_t                    fh[CHIMERA_VFS_FH_SIZE + 16];
+};
+
+static inline void
+chimera_vfs_close_ref_capture(
+    struct chimera_vfs_close_ref         *ref,
+    const struct chimera_vfs_open_handle *handle)
+{
+    ref->module      = handle->vfs_module;
+    ref->vfs_private = handle->vfs_private;
+    ref->fh_hash     = handle->fh_hash;
+    ref->fh_len      = handle->fh_len;
+    ref->needs_close = chimera_vfs_open_handle_needs_backend_close(handle);
+    memcpy(ref->fh, handle->fh, handle->fh_len);
+} /* chimera_vfs_close_ref_capture */
+
+/* No-op when the handle never had a backend open (synthesized handles), so
+ * callers do not repeat that test. */
+static inline void
+chimera_vfs_close_ref_dispatch(
+    struct chimera_vfs_thread          *thread,
+    const struct chimera_vfs_close_ref *ref,
+    chimera_vfs_close_callback_t        callback,
+    void                               *private_data)
+{
+    if (!ref->needs_close) {
+        return;
+    }
+
+    chimera_vfs_close(thread, ref->module, ref->fh, ref->fh_len,
+                      ref->vfs_private, ref->fh_hash, callback, private_data);
+} /* chimera_vfs_close_ref_dispatch */
+
 /* --- Shard linked-list helpers --- */
 
 static inline void
@@ -326,17 +371,13 @@ chimera_vfs_open_cache_release(
                 /* Detached handle: close immediately, do not add to pending_close.
                  * Do not decrement open_handles - the handle was already removed
                  * from the cache when it was detached by insert(). */
-                struct chimera_vfs_module *close_module  = handle->vfs_module;
-                uint64_t                   close_private = handle->vfs_private;
-                uint64_t                   close_hash    = handle->fh_hash;
-                int                        needs_close   = chimera_vfs_open_handle_needs_backend_close(handle);
+                struct chimera_vfs_close_ref close_ref;
+
+                chimera_vfs_close_ref_capture(&close_ref, handle);
                 chimera_vfs_open_cache_free(shard, handle);
                 pthread_mutex_unlock(&shard->lock);
                 chimera_vfs_open_cache_release_blocked(thread, requests, error_code);
-                if (needs_close) {
-                    chimera_vfs_close(thread, close_module, close_private,
-                                      close_hash, NULL, NULL);
-                }
+                chimera_vfs_close_ref_dispatch(thread, &close_ref, NULL, NULL);
                 return;
             }
             handle->timestamp = chimera_vfs_now_ticks();
@@ -418,9 +459,9 @@ chimera_vfs_open_cache_evict(
 
         if (handle->opencnt == 0) {
             /* Idle: remove from both lists and close (outside the lock). */
-            struct chimera_vfs_module *close_module  = handle->vfs_module;
-            uint64_t                   close_private = handle->vfs_private;
-            uint64_t                   close_hash    = handle->fh_hash;
+            struct chimera_vfs_close_ref close_ref;
+
+            chimera_vfs_close_ref_capture(&close_ref, handle);
 
             DL_DELETE(shard->pending_close, handle);
             chimera_vfs_open_cache_shard_remove(shard, handle);
@@ -428,8 +469,7 @@ chimera_vfs_open_cache_evict(
             chimera_vfs_open_cache_free(shard, handle);
 
             pthread_mutex_unlock(&shard->lock);
-            chimera_vfs_close(thread, close_module, close_private,
-                              close_hash, NULL, NULL);
+            chimera_vfs_close_ref_dispatch(thread, &close_ref, NULL, NULL);
         } else {
             /* In use: detach now, close on the final release. */
             chimera_vfs_open_cache_shard_remove(shard, handle);
@@ -584,20 +624,18 @@ chimera_vfs_open_cache_acquire(
             DL_DELETE(shard->pending_close, existing);
             chimera_vfs_open_cache_shard_remove(shard, existing);
 
-            struct chimera_vfs_module *close_module  = existing->vfs_module;
-            uint64_t                   close_private = existing->vfs_private;
-            uint64_t                   close_hash    = existing->fh_hash;
-            int                        needs_close   = chimera_vfs_open_handle_needs_backend_close(existing);
+            struct chimera_vfs_close_ref close_ref;
+
+            chimera_vfs_close_ref_capture(&close_ref, existing);
 
             prometheus_counter_increment(shard->acquire);
 
             chimera_vfs_open_cache_free(shard, existing);
             pthread_mutex_unlock(&shard->lock);
 
-            if (needs_close) {
-                chimera_vfs_close(thread, close_module, close_private,
-                                  close_hash,
-                                  chimera_vfs_open_cache_close_callback, handle);
+            if (close_ref.needs_close) {
+                chimera_vfs_close_ref_dispatch(thread, &close_ref,
+                                               chimera_vfs_open_cache_close_callback, handle);
             } else {
                 chimera_vfs_open_cache_close_callback(CHIMERA_VFS_OK, handle);
             }
@@ -685,17 +723,13 @@ chimera_vfs_open_cache_insert(
              * concurrent acquires from creating duplicate entries. */
             chimera_vfs_open_cache_shard_insert(shard, handle);
 
-            struct chimera_vfs_module *close_module  = existing->vfs_module;
-            uint64_t                   close_private = existing->vfs_private;
-            uint64_t                   close_hash    = existing->fh_hash;
-            int                        needs_close   = chimera_vfs_open_handle_needs_backend_close(existing);
+            struct chimera_vfs_close_ref close_ref;
+
+            chimera_vfs_close_ref_capture(&close_ref, existing);
 
             chimera_vfs_open_cache_free(shard, existing);
             pthread_mutex_unlock(&shard->lock);
-            if (needs_close) {
-                chimera_vfs_close(thread, close_module, close_private,
-                                  close_hash, NULL, NULL);
-            }
+            chimera_vfs_close_ref_dispatch(thread, &close_ref, NULL, NULL);
             callback(request, handle);
             return;
         } else {
@@ -717,17 +751,13 @@ chimera_vfs_open_cache_insert(
                  * concurrent acquires from creating duplicate entries. */
                 chimera_vfs_open_cache_shard_insert(shard, handle);
 
-                struct chimera_vfs_module      *close_module  = victim->vfs_module;
-                uint64_t                        close_private = victim->vfs_private;
-                uint64_t                        close_hash    = victim->fh_hash;
-                int                             needs_close   = chimera_vfs_open_handle_needs_backend_close(victim);
+                struct chimera_vfs_close_ref    close_ref;
+
+                chimera_vfs_close_ref_capture(&close_ref, victim);
 
                 chimera_vfs_open_cache_free(shard, victim);
                 pthread_mutex_unlock(&shard->lock);
-                if (needs_close) {
-                    chimera_vfs_close(thread, close_module, close_private,
-                                      close_hash, NULL, NULL);
-                }
+                chimera_vfs_close_ref_dispatch(thread, &close_ref, NULL, NULL);
                 callback(request, handle);
                 return;
             } else {
@@ -1003,15 +1033,13 @@ chimera_vfs_open_cache_clear_doc(
  * Otherwise performs a normal release and returns 0.
  */
 struct chimera_vfs_doc_info {
-    uint8_t                    parent_fh[CHIMERA_VFS_FH_SIZE];
-    char                       name[CHIMERA_VFS_NAME_MAX];
-    struct chimera_vfs_cred    cred;
-    uint16_t                   parent_fh_len;
-    uint16_t                   name_len;
-    /* Backend close state — caller must close after unlink */
-    struct chimera_vfs_module *close_module;
-    uint64_t                   close_private;
-    uint64_t                   close_hash;
+    uint8_t                      parent_fh[CHIMERA_VFS_FH_SIZE];
+    char                         name[CHIMERA_VFS_NAME_MAX];
+    struct chimera_vfs_cred      cred;
+    uint16_t                     parent_fh_len;
+    uint16_t                     name_len;
+    /* Backend close state -- the caller closes after the unlink */
+    struct chimera_vfs_close_ref close_ref;
 };
 
 static inline int
@@ -1046,9 +1074,7 @@ chimera_vfs_open_cache_release_doc(
         doc_out->parent_fh_len = handle->doc_parent_fh_len;
         doc_out->name_len      = handle->doc_name_len;
         doc_out->cred          = handle->doc_cred;
-        doc_out->close_module  = handle->vfs_module;
-        doc_out->close_private = handle->vfs_private;
-        doc_out->close_hash    = handle->fh_hash;
+        chimera_vfs_close_ref_capture(&doc_out->close_ref, handle);
         memcpy(doc_out->parent_fh, handle->doc_parent_fh,
                handle->doc_parent_fh_len);
         memcpy(doc_out->name, handle->doc_name, handle->doc_name_len);
@@ -1070,14 +1096,13 @@ chimera_vfs_open_cache_release_doc(
 
     if (handle->opencnt == 0) {
         if (handle->flags & CHIMERA_VFS_OPEN_HANDLE_DETACHED) {
-            struct chimera_vfs_module *close_module  = handle->vfs_module;
-            uint64_t                   close_private = handle->vfs_private;
-            uint64_t                   close_hash    = handle->fh_hash;
+            struct chimera_vfs_close_ref close_ref;
+
+            chimera_vfs_close_ref_capture(&close_ref, handle);
             chimera_vfs_open_cache_free(shard, handle);
             pthread_mutex_unlock(&shard->lock);
             chimera_vfs_open_cache_release_blocked(thread, requests, 0);
-            chimera_vfs_close(thread, close_module, close_private,
-                              close_hash, NULL, NULL);
+            chimera_vfs_close_ref_dispatch(thread, &close_ref, NULL, NULL);
             return 0;
         }
         handle->timestamp = chimera_vfs_now_ticks();

--- a/src/vfs/vfs_proc_close.c
+++ b/src/vfs/vfs_proc_close.c
@@ -42,6 +42,8 @@ SYMBOL_EXPORT void
 chimera_vfs_close(
     struct chimera_vfs_thread   *thread,
     struct chimera_vfs_module   *vfs_module,
+    const void                  *fh,
+    int                          fhlen,
     uint64_t                     vfs_private,
     uint64_t                     fh_hash,
     chimera_vfs_close_callback_t callback,
@@ -51,8 +53,8 @@ chimera_vfs_close(
 
     request = chimera_vfs_request_alloc_with_module(thread,
                                                     NULL,
-                                                    NULL,
-                                                    0,
+                                                    fh,
+                                                    fhlen,
                                                     fh_hash,
                                                     vfs_module);
 

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -414,10 +414,18 @@ typedef void (*chimera_vfs_close_callback_t)(
     enum chimera_vfs_error error_code,
     void                  *private_data);
 
+/* Close the open instance named by vfs_private -- the cookie the backend
+ * returned from open.  That cookie, not fh, is what identifies the instance;
+ * fh names the object it was opened on and is carried so a backend can tell
+ * which of its filesystems (or which mount) the close belongs to, and so the
+ * op appears in traces with the handle it applies to.  Both are supplied by
+ * the open-handle cache, which owns them for the handle's lifetime. */
 void
 chimera_vfs_close(
     struct chimera_vfs_thread   *thread,
     struct chimera_vfs_module   *vfs_module,
+    const void                  *fh,
+    int                          fhlen,
     uint64_t                     vfs_private,
     uint64_t                     fh_hash,
     chimera_vfs_close_callback_t callback,


### PR DESCRIPTION
## Why

`chimera_vfs_close` built its request with `fh = NULL, fh_len = 0`. Close names an *open instance* — the `vfs_private` cookie the backend returned from open — so it did not strictly need a file handle. But leaving it out cost more than it saved.

A backend that hosts more than one filesystem, or wants any context beyond the cookie, has nothing to key on, and `request->fh` is not merely empty: it holds whatever bytes were left in the recycled request struct. cairn read it and decoded garbage until #1525 fixed that, and it stays a trap for the next backend that reaches for it.

Traces were worse off too. Close was the one op whose file handle printed as leftovers:

```
Close 7c51112c4efc06e207bbb60a7df9edfec2fe0f01 hdl ef97b63996c8   <- after
```

The open-handle cache has both the handle and the cookie and owns them for the handle's lifetime, so every caller already had one to hand. This passes it.

## The refactor that comes with it

The closes that matter are all issued *after* the shard lock is dropped, by which point the handle is usually freed — so callers were already copying the module pointer, cookie and hash into locals first. That was the same four-line preamble in six places, plus three more fields on `chimera_vfs_doc_info` carrying the same values to the SMB delete-on-close path's own deferred close. Adding the file handle would have meant a `memcpy` in all nine.

So the lot is collected into `chimera_vfs_close_ref`, captured in one call and dispatched in another, with the `needs_backend_close` test folded into the dispatch instead of repeated at each site:

```c
struct chimera_vfs_close_ref close_ref;

chimera_vfs_close_ref_capture(&close_ref, handle);
chimera_vfs_open_cache_free(shard, handle);
pthread_mutex_unlock(&shard->lock);
chimera_vfs_close_ref_dispatch(thread, &close_ref, NULL, NULL);
```

`doc_info` embeds one in place of its three fields, and `smb_proc_close.c` loses a third of its closing boilerplate (net -24 lines there).

The cookie remains what identifies the open instance; the file handle is context, not the key. cairn still resolves by inum, and its comment now says so without the caveat about a handle that is not there.

## Testing

- `chimera/vfs` ctest suite, Debug and Release.
- POSIX suites against memfs, cairn and diskfs_aio — zero failed closes on any backend (using the reporting added in #1525, which is what would catch a regression here).
- SMB, where the `doc_info` rewrite lands: `delete_on_close2`, `oplock.doc`, `create.delete`, `streams.delete`, `lease.unlink` individually, plus an 11-test batch covering `delete-on-close-perms.*`, `sharemode.*`, `notify.close`, `rename.rename-open` and the `lease.initial_delete_*` pair. All pass.
- `make syntax-check`, `reuse-lint`, Release build: clean.

Two things I checked rather than assumed:

`smb2.durable-open.delete_on_close1` fails (`create_action` CREATED vs OPENED) — it fails identically on unmodified `main`, which is why it is absent from `SMBTORTURE_ENABLED_memfs` while `delete_on_close2` is present.

Large smbtorture batches (200+ names in one invocation) abort the harness at startup in this container before running anything — also reproduced on unmodified `main`, so it is an environment/harness limit rather than anything here. Hence the individual and small-batch runs above.

`zerorange_diskfs_io_uring` fails as it does on `main` (io_uring SEGV in libevpl).

## Follow-up

This unblocks removing three CLOSE special-cases in #1527, where memfs, cairn and diskfs each have to skip filesystem resolution because close arrived without a handle — and lets cairn count open handles per filesystem instead of pool-wide. I will rebase that PR on this one.