### PR TITLE
posix: descriptor & open-file-description semantics

### DIFF
--- a/src/posix/posix.c
+++ b/src/posix/posix.c
@@ -317,6 +317,21 @@ chimera_posix_shutdown(void)
         return;
     }
 
+    /* Close any descriptors the application leaked: their open handles
+     * otherwise keep the VFS close-thread handshake in chimera_vfs_destroy
+     * from ever completing, hanging shutdown forever.  Must run while the
+     * workers are still alive to process the closes. */
+    if (posix->fds) {
+        for (int i = 0; i < posix->max_fds; i++) {
+            struct chimera_posix_fd_entry *entry = &posix->fds[i];
+
+            if (entry->handle &&
+                !(entry->flags & CHIMERA_POSIX_FD_CLOSED)) {
+                (void) chimera_posix_close(i);
+            }
+        }
+    }
+
     chimera_posix_global = NULL;
 
     if (posix->pool) {

--- a/src/posix/posix.c
+++ b/src/posix/posix.c
@@ -170,7 +170,7 @@ chimera_posix_init(
         pthread_mutex_init(&posix->fds[i].lock, NULL);
         pthread_cond_init(&posix->fds[i].cond, NULL);
         posix->fds[i].handle        = NULL;
-        posix->fds[i].offset        = 0;
+        posix->fds[i].ofd           = NULL;
         posix->fds[i].flags         = CHIMERA_POSIX_FD_CLOSED;
         posix->fds[i].refcnt        = 0;
         posix->fds[i].io_waiters    = 0;
@@ -264,7 +264,7 @@ chimera_posix_init_json(
         pthread_mutex_init(&posix->fds[i].lock, NULL);
         pthread_cond_init(&posix->fds[i].cond, NULL);
         posix->fds[i].handle        = NULL;
-        posix->fds[i].offset        = 0;
+        posix->fds[i].ofd           = NULL;
         posix->fds[i].flags         = CHIMERA_POSIX_FD_CLOSED;
         posix->fds[i].refcnt        = 0;
         posix->fds[i].io_waiters    = 0;

--- a/src/posix/posix_clone_file_range.c
+++ b/src/posix/posix_clone_file_range.c
@@ -52,6 +52,16 @@ chimera_posix_clone_file_range(
         return -1;
     }
 
+    /* FICLONERANGE: the source must be open for reading and the
+     * destination for writing (EBADF otherwise). */
+    if (!chimera_posix_fd_may_read(src_entry) ||
+        !chimera_posix_fd_may_write(dst_entry)) {
+        chimera_posix_fd_release(dst_entry, 0);
+        chimera_posix_fd_release(src_entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode                   = CHIMERA_CLIENT_OP_CLONE_RANGE;

--- a/src/posix/posix_copy_file_range.c
+++ b/src/posix/posix_copy_file_range.c
@@ -74,15 +74,15 @@ chimera_posix_copy_file_range(
      * writing, and fd_out must not have O_APPEND set -- all EBADF. */
     if (!chimera_posix_fd_may_read(in_entry) ||
         !chimera_posix_fd_may_write(out_entry) ||
-        (out_entry->oflags & O_APPEND)) {
+        (out_entry->ofd->oflags & O_APPEND)) {
         chimera_posix_fd_release(out_entry, 0);
         chimera_posix_fd_release(in_entry, 0);
         errno = EBADF;
         return -1;
     }
 
-    src_off = off_in ? *off_in : (off_t) in_entry->offset;
-    dst_off = off_out ? *off_out : (off_t) out_entry->offset;
+    src_off = off_in ? *off_in : (off_t) in_entry->ofd->offset;
+    dst_off = off_out ? *off_out : (off_t) out_entry->ofd->offset;
 
     chimera_posix_completion_init(&st.comp, &req);
     st.bytes_copied = 0;
@@ -105,12 +105,12 @@ chimera_posix_copy_file_range(
         if (off_in) {
             *off_in = src_off + (off_t) st.bytes_copied;
         } else {
-            in_entry->offset = (uint64_t) (src_off + (off_t) st.bytes_copied);
+            in_entry->ofd->offset = (uint64_t) (src_off + (off_t) st.bytes_copied);
         }
         if (off_out) {
             *off_out = dst_off + (off_t) st.bytes_copied;
         } else {
-            out_entry->offset = (uint64_t) (dst_off + (off_t) st.bytes_copied);
+            out_entry->ofd->offset = (uint64_t) (dst_off + (off_t) st.bytes_copied);
         }
     }
 

--- a/src/posix/posix_copy_file_range.c
+++ b/src/posix/posix_copy_file_range.c
@@ -70,6 +70,17 @@ chimera_posix_copy_file_range(
         return -1;
     }
 
+    /* copy_file_range(2): fd_in must be open for reading and fd_out for
+     * writing, and fd_out must not have O_APPEND set -- all EBADF. */
+    if (!chimera_posix_fd_may_read(in_entry) ||
+        !chimera_posix_fd_may_write(out_entry) ||
+        (out_entry->oflags & O_APPEND)) {
+        chimera_posix_fd_release(out_entry, 0);
+        chimera_posix_fd_release(in_entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     src_off = off_in ? *off_in : (off_t) in_entry->offset;
     dst_off = off_out ? *off_out : (off_t) out_entry->offset;
 

--- a/src/posix/posix_dup.c
+++ b/src/posix/posix_dup.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_dup.c
+++ b/src/posix/posix_dup.c
@@ -39,6 +39,13 @@ chimera_posix_dup(int oldfd)
         return -1;
     }
 
+    /* POSIX: the duplicate shares the open file description -- same file
+     * offset and status flags.  The description is not yet a shared object
+     * here, so propagate both at duplication time; a later lseek on one
+     * descriptor still does not move the other (known gap). */
+    posix->fds[newfd].offset = entry->offset;
+    posix->fds[newfd].oflags = entry->oflags;
+
     chimera_posix_fd_release(entry, 0);
 
     return newfd;

--- a/src/posix/posix_dup.c
+++ b/src/posix/posix_dup.c
@@ -39,12 +39,10 @@ chimera_posix_dup(int oldfd)
         return -1;
     }
 
-    /* POSIX: the duplicate shares the open file description -- same file
-     * offset and status flags.  The description is not yet a shared object
-     * here, so propagate both at duplication time; a later lseek on one
-     * descriptor still does not move the other (known gap). */
-    posix->fds[newfd].offset = entry->offset;
-    posix->fds[newfd].oflags = entry->oflags;
+    /* POSIX: the duplicate SHARES the open file description -- one file
+     * offset, one set of status flags -- so an lseek or F_SETFL through
+     * either descriptor is visible through the other. */
+    chimera_posix_ofd_adopt(posix, &posix->fds[newfd], entry);
 
     chimera_posix_fd_release(entry, 0);
 

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -90,19 +90,21 @@ chimera_posix_dup2(
     /* Increment the opencnt on the source handle */
     chimera_dup_handle(worker->client_thread, handle);
 
-    /* Set up the new fd entry.  POSIX: the duplicate shares the open file
-     * description, so it takes the source's file offset and status flags
-     * (previously the offset was reset to 0 and oflags left stale). */
+    /* Set up the new fd entry. */
     pthread_mutex_lock(&new_entry->lock);
     new_entry->handle      = handle;
-    new_entry->offset      = old_entry->offset;
-    new_entry->oflags      = old_entry->oflags;
     new_entry->flags       = 0;
     new_entry->refcnt      = 0;
     new_entry->eof_flag    = 0;
     new_entry->error_flag  = 0;
     new_entry->ungetc_char = -1;
     pthread_mutex_unlock(&new_entry->lock);
+
+    /* POSIX: the duplicate SHARES the source's open file description --
+     * one file offset, one set of status flags -- releasing whatever
+     * description the target slot held (a reclaimed free-list slot holds
+     * none; an implicitly-closed target's description is dropped here). */
+    chimera_posix_ofd_adopt(posix, new_entry, old_entry);
 
     chimera_posix_fd_release(old_entry, 0);
 

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -90,10 +90,13 @@ chimera_posix_dup2(
     /* Increment the opencnt on the source handle */
     chimera_dup_handle(worker->client_thread, handle);
 
-    /* Set up the new fd entry */
+    /* Set up the new fd entry.  POSIX: the duplicate shares the open file
+     * description, so it takes the source's file offset and status flags
+     * (previously the offset was reset to 0 and oflags left stale). */
     pthread_mutex_lock(&new_entry->lock);
     new_entry->handle      = handle;
-    new_entry->offset      = 0;
+    new_entry->offset      = old_entry->offset;
+    new_entry->oflags      = old_entry->oflags;
     new_entry->flags       = 0;
     new_entry->refcnt      = 0;
     new_entry->eof_flag    = 0;

--- a/src/posix/posix_fallocate.c
+++ b/src/posix/posix_fallocate.c
@@ -55,7 +55,7 @@ chimera_posix_do_fallocate(
     }
 
     /* (de)allocate requires the descriptor be open for writing. */
-    if ((entry->oflags & O_ACCMODE) == O_RDONLY) {
+    if ((entry->ofd->oflags & O_ACCMODE) == O_RDONLY) {
         chimera_posix_fd_release(entry, 0);
         errno = EBADF;
         return -1;

--- a/src/posix/posix_fcntl.c
+++ b/src/posix/posix_fcntl.c
@@ -51,10 +51,8 @@ chimera_posix_fcntl_dupfd(
         return -1;
     }
 
-    /* Like dup(): the duplicate takes the description's offset and
-     * status flags. */
-    posix->fds[newfd].offset = entry->offset;
-    posix->fds[newfd].oflags = entry->oflags;
+    /* Like dup(): the duplicate SHARES the open file description. */
+    chimera_posix_ofd_adopt(posix, &posix->fds[newfd], entry);
 
     chimera_posix_fd_release(entry, 0);
 
@@ -76,7 +74,7 @@ chimera_posix_fcntl_getfl(
         return -1;
     }
 
-    flags = (int) (entry->oflags &
+    flags = (int) (entry->ofd->oflags &
                    (O_ACCMODE | CHIMERA_POSIX_SETFL_MASK));
 
     chimera_posix_fd_release(entry, 0);
@@ -99,7 +97,7 @@ chimera_posix_fcntl_setfl(
         return -1;
     }
 
-    entry->oflags = (entry->oflags & ~(unsigned int) CHIMERA_POSIX_SETFL_MASK)
+    entry->ofd->oflags = (entry->ofd->oflags & ~(unsigned int) CHIMERA_POSIX_SETFL_MASK)
         | ((unsigned int) arg & CHIMERA_POSIX_SETFL_MASK);
 
     chimera_posix_fd_release(entry, 0);
@@ -219,7 +217,7 @@ chimera_posix_fcntl(
             break;
         }
         case SEEK_CUR: {
-            int64_t abs_offset = (int64_t) entry->offset + (int64_t) fl->l_start;
+            int64_t abs_offset = (int64_t) entry->ofd->offset + (int64_t) fl->l_start;
 
             if (abs_offset < 0) {
                 chimera_posix_fd_release(entry, 0);

--- a/src/posix/posix_fcntl.c
+++ b/src/posix/posix_fcntl.c
@@ -9,6 +9,103 @@
 
 #include "posix_internal.h"
 #include "../client/client_lock.h"
+#include "../client/client_dup.h"
+
+/* Status flags F_SETFL may change; everything else in the argument is
+ * ignored per POSIX (the access mode and creation flags are immutable). */
+#define CHIMERA_POSIX_SETFL_MASK (O_APPEND | O_NONBLOCK)
+
+static int
+chimera_posix_fcntl_dupfd(
+    struct chimera_posix_client *posix,
+    struct chimera_posix_worker *worker,
+    int                          fd,
+    int                          minfd)
+{
+    struct chimera_posix_fd_entry  *entry;
+    struct chimera_vfs_open_handle *handle;
+    int                             newfd;
+
+    if (minfd < 0 || minfd >= posix->max_fds) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    handle = entry->handle;
+
+    chimera_dup_handle(worker->client_thread, handle);
+
+    newfd = chimera_posix_fd_alloc_at_least(posix, handle, minfd);
+
+    if (newfd < 0) {
+        chimera_close(worker->client_thread, handle);
+        chimera_posix_fd_release(entry, 0);
+        errno = EMFILE;
+        return -1;
+    }
+
+    /* Like dup(): the duplicate takes the description's offset and
+     * status flags. */
+    posix->fds[newfd].offset = entry->offset;
+    posix->fds[newfd].oflags = entry->oflags;
+
+    chimera_posix_fd_release(entry, 0);
+
+    return newfd;
+} /* chimera_posix_fcntl_dupfd */
+
+static int
+chimera_posix_fcntl_getfl(
+    struct chimera_posix_client *posix,
+    int                          fd)
+{
+    struct chimera_posix_fd_entry *entry;
+    int                            flags;
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    flags = (int) (entry->oflags &
+                   (O_ACCMODE | CHIMERA_POSIX_SETFL_MASK));
+
+    chimera_posix_fd_release(entry, 0);
+
+    return flags;
+} /* chimera_posix_fcntl_getfl */
+
+static int
+chimera_posix_fcntl_setfl(
+    struct chimera_posix_client *posix,
+    int                          fd,
+    int                          arg)
+{
+    struct chimera_posix_fd_entry *entry;
+
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+
+    entry->oflags = (entry->oflags & ~(unsigned int) CHIMERA_POSIX_SETFL_MASK)
+        | ((unsigned int) arg & CHIMERA_POSIX_SETFL_MASK);
+
+    chimera_posix_fd_release(entry, 0);
+
+    return 0;
+} /* chimera_posix_fcntl_setfl */
 
 static void
 chimera_posix_fcntl_lock_callback(
@@ -53,6 +150,24 @@ chimera_posix_fcntl(
     va_list                         args;
 
     switch (cmd) {
+        case F_DUPFD: {
+            int minfd;
+
+            va_start(args, cmd);
+            minfd = va_arg(args, int);
+            va_end(args);
+            return chimera_posix_fcntl_dupfd(posix, worker, fd, minfd);
+        }
+        case F_GETFL:
+            return chimera_posix_fcntl_getfl(posix, fd);
+        case F_SETFL: {
+            int arg;
+
+            va_start(args, cmd);
+            arg = va_arg(args, int);
+            va_end(args);
+            return chimera_posix_fcntl_setfl(posix, fd, arg);
+        }
         case F_GETLK:
             flags |= CHIMERA_VFS_LOCK_TEST;
         /* fall through */

--- a/src/posix/posix_ftruncate.c
+++ b/src/posix/posix_ftruncate.c
@@ -51,7 +51,7 @@ chimera_posix_ftruncate(
     }
 
     /* POSIX: ftruncate on a descriptor not open for writing fails with EINVAL. */
-    if ((entry->oflags & O_ACCMODE) == O_RDONLY) {
+    if ((entry->ofd->oflags & O_ACCMODE) == O_RDONLY) {
         chimera_posix_fd_release(entry, 0);
         errno = EINVAL;
         return -1;

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -542,6 +542,22 @@ chimera_posix_fd_release(
     pthread_mutex_unlock(&entry->lock);
 } // chimera_posix_fd_release
 
+/* POSIX ties I/O rights to the descriptor's access mode, checked at open
+ * and carried in oflags (propagated by dup/dup2): read-family calls need a
+ * descriptor open for reading and write-family calls one open for writing,
+ * otherwise EBADF (read()/write() ERRORS). */
+static FORCE_INLINE int
+chimera_posix_fd_may_read(const struct chimera_posix_fd_entry *entry)
+{
+    return (entry->oflags & O_ACCMODE) != O_WRONLY;
+} /* chimera_posix_fd_may_read */
+
+static FORCE_INLINE int
+chimera_posix_fd_may_write(const struct chimera_posix_fd_entry *entry)
+{
+    return (entry->oflags & O_ACCMODE) != O_RDONLY;
+} /* chimera_posix_fd_may_write */
+
 static FORCE_INLINE off_t
 chimera_posix_fd_lseek(
     struct chimera_posix_client *posix,
@@ -613,6 +629,14 @@ chimera_posix_fd_lseek(
 
     return new_offset;
 } // chimera_posix_fd_lseek
+
+/* Resolve the current EOF of the file behind an fd entry, for O_APPEND
+ * write placement.  Returns 0 and fills *eof, or an errno value.
+ * Defined in posix_write.c. */
+int chimera_posix_fd_eof(
+    struct chimera_posix_worker   *worker,
+    struct chimera_posix_fd_entry *entry,
+    uint64_t                      *eof);
 
 void * chimera_posix_worker_init(
     struct evpl *evpl,

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -46,12 +46,30 @@ struct chimera_posix_completion {
 #define CHIMERA_POSIX_FD_CLOSING   0x02
 #define CHIMERA_POSIX_FD_CLOSED    0x04
 
+/* One open file description (POSIX XBD): the file offset and status flags
+ * shared by every descriptor duplicated from one open() -- dup/dup2/
+ * F_DUPFD return descriptors referencing the SAME description, so an
+ * lseek or F_SETFL through one duplicate is visible through the others.
+ * Independent open() calls create independent descriptions.
+ *
+ * refcnt counts fd entries referencing the description and is managed
+ * under the client's fd_lock.  offset/oflags carry the same (loose)
+ * concurrency discipline the per-entry fields had: the per-descriptor
+ * IO_ACTIVE gate serializes offset-consuming I/O on one descriptor;
+ * concurrent I/O through two duplicates of one description is not
+ * additionally serialized here. */
+struct chimera_posix_ofd {
+    uint64_t     offset;
+    unsigned int oflags;     // Raw open(2) flags (for O_ACCMODE checks)
+    int          refcnt;
+};
+
 struct chimera_posix_fd_entry {
     pthread_mutex_t                 lock;
     pthread_cond_t                  cond;
     struct chimera_vfs_open_handle *handle;
     struct chimera_posix_fd_entry  *next;
-    uint64_t                        offset;
+    struct chimera_posix_ofd       *ofd;
     unsigned int                    flags;
     int                             refcnt;
     int                             io_waiters;
@@ -60,7 +78,6 @@ struct chimera_posix_fd_entry {
     int                             eof_flag;    // For FILE* feof() support
     int                             error_flag;  // For FILE* ferror() support
     int                             ungetc_char; // For FILE* ungetc() support (-1 = none)
-    unsigned int                    oflags;      // Raw open(2) flags (for O_ACCMODE checks)
 } __attribute__((aligned(64)));
 
 // CHIMERA_FILE is a pointer to an fd_entry for FILE* operations
@@ -124,6 +141,33 @@ chimera_posix_get_global(void)
 {
     return chimera_posix_global;
 } // chimera_posix_get_global
+
+/* Drop an fd entry's reference on its open file description, freeing the
+ * description when the last duplicate goes.  Caller holds fd_lock. */
+static FORCE_INLINE void
+chimera_posix_ofd_release_locked(struct chimera_posix_fd_entry *entry)
+{
+    if (entry->ofd && --entry->ofd->refcnt == 0) {
+        free(entry->ofd);
+    }
+    entry->ofd = NULL;
+} // chimera_posix_ofd_release_locked
+
+/* Point `entry` at `src`'s open file description (dup/dup2/F_DUPFD: the
+ * duplicate SHARES the description), releasing whatever description the
+ * entry held. */
+static FORCE_INLINE void
+chimera_posix_ofd_adopt(
+    struct chimera_posix_client   *posix,
+    struct chimera_posix_fd_entry *entry,
+    struct chimera_posix_fd_entry *src)
+{
+    pthread_mutex_lock(&posix->fd_lock);
+    chimera_posix_ofd_release_locked(entry);
+    entry->ofd = src->ofd;
+    entry->ofd->refcnt++;
+    pthread_mutex_unlock(&posix->fd_lock);
+} // chimera_posix_ofd_adopt
 
 /* chimera_vfs_error values are a protocol enum whose numbers happen to follow
  * the Linux errno layout; the host's errno numbering differs on other
@@ -409,8 +453,21 @@ chimera_posix_fd_alloc_at_least(
 
     fd = (int) (entry - posix->fds);
 
+    /* A fresh open gets a fresh open file description (not shared with
+     * anyone yet, so no lock needed for the refcount). */
+    entry->ofd = calloc(1, sizeof(*entry->ofd));
+
+    if (!entry->ofd) {
+        pthread_mutex_lock(&posix->fd_lock);
+        entry->next      = posix->free_list;
+        posix->free_list = entry;
+        pthread_mutex_unlock(&posix->fd_lock);
+        return -1;
+    }
+
+    entry->ofd->refcnt = 1;
+
     entry->handle        = handle;
-    entry->offset        = 0;
     entry->flags         = 0;
     entry->refcnt        = 0;
     entry->io_waiters    = 0;
@@ -419,7 +476,6 @@ chimera_posix_fd_alloc_at_least(
     entry->eof_flag      = 0;
     entry->error_flag    = 0;
     entry->ungetc_char   = -1;
-    entry->oflags        = 0;
 
     return fd;
 } // chimera_posix_fd_alloc_at_least
@@ -446,12 +502,12 @@ chimera_posix_fd_free(
     entry = &posix->fds[fd];
 
     entry->handle      = NULL;
-    entry->offset      = 0;
     entry->eof_flag    = 0;
     entry->error_flag  = 0;
     entry->ungetc_char = -1;
 
     pthread_mutex_lock(&posix->fd_lock);
+    chimera_posix_ofd_release_locked(entry);
     entry->next      = posix->free_list;
     posix->free_list = entry;
     pthread_mutex_unlock(&posix->fd_lock);
@@ -566,20 +622,21 @@ chimera_posix_fd_release(
 } // chimera_posix_fd_release
 
 /* POSIX ties I/O rights to the descriptor's access mode, checked at open
- * and carried in oflags (propagated by dup/dup2): read-family calls need a
+ * and carried in the shared description's oflags: read-family calls need a
  * descriptor open for reading and write-family calls one open for writing,
  * otherwise EBADF (read()/write() ERRORS). */
 static FORCE_INLINE int
 chimera_posix_fd_may_read(const struct chimera_posix_fd_entry *entry)
 {
-    return (entry->oflags & O_ACCMODE) != O_WRONLY;
+    return (entry->ofd->oflags & O_ACCMODE) != O_WRONLY;
 } /* chimera_posix_fd_may_read */
 
 static FORCE_INLINE int
 chimera_posix_fd_may_write(const struct chimera_posix_fd_entry *entry)
 {
-    return (entry->oflags & O_ACCMODE) != O_RDONLY;
+    return (entry->ofd->oflags & O_ACCMODE) != O_RDONLY;
 } /* chimera_posix_fd_may_write */
+
 
 static FORCE_INLINE off_t
 chimera_posix_fd_lseek(
@@ -628,7 +685,7 @@ chimera_posix_fd_lseek(
             new_offset = offset;
             break;
         case SEEK_CUR:
-            new_offset = (off_t) entry->offset + offset;
+            new_offset = (off_t) entry->ofd->offset + offset;
             break;
         case SEEK_END:
             new_offset = file_size + offset;
@@ -646,7 +703,7 @@ chimera_posix_fd_lseek(
         return -1;
     }
 
-    entry->offset = (uint64_t) new_offset;
+    entry->ofd->offset = (uint64_t) new_offset;
 
     pthread_mutex_unlock(&entry->lock);
 

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -370,25 +370,40 @@ chimera_posix_check_path(const char *path)
     return (int) len;
 } /* chimera_posix_check_path */
 
+/* Allocate the lowest free descriptor slot with index >= minfd (POSIX
+ * open()/dup() require the lowest available descriptor; F_DUPFD the lowest
+ * >= its argument).  The free list is unordered, so scan it for the best
+ * index; it holds at most max_fds entries and allocation is not a hot
+ * path in this compatibility layer. */
 static FORCE_INLINE int
-chimera_posix_fd_alloc(
+chimera_posix_fd_alloc_at_least(
     struct chimera_posix_client    *posix,
-    struct chimera_vfs_open_handle *handle)
+    struct chimera_vfs_open_handle *handle,
+    int                             minfd)
 {
-    struct chimera_posix_fd_entry *entry;
-    int                            fd;
+    struct chimera_posix_fd_entry  *entry;
+    struct chimera_posix_fd_entry **pp, **best_pp = NULL;
+    int                             fd, best = posix->max_fds;
 
     pthread_mutex_lock(&posix->fd_lock);
 
-    entry = posix->free_list;
+    for (pp = &posix->free_list; *pp; pp = &(*pp)->next) {
+        int idx = (int) (*pp - posix->fds);
 
-    if (!entry) {
+        if (idx >= minfd && idx < best) {
+            best    = idx;
+            best_pp = pp;
+        }
+    }
+
+    if (!best_pp) {
         pthread_mutex_unlock(&posix->fd_lock);
         return -1;
     }
 
-    posix->free_list = entry->next;
-    entry->next      = NULL;
+    entry       = *best_pp;
+    *best_pp    = entry->next;
+    entry->next = NULL;
 
     pthread_mutex_unlock(&posix->fd_lock);
 
@@ -407,6 +422,14 @@ chimera_posix_fd_alloc(
     entry->oflags        = 0;
 
     return fd;
+} // chimera_posix_fd_alloc_at_least
+
+static FORCE_INLINE int
+chimera_posix_fd_alloc(
+    struct chimera_posix_client    *posix,
+    struct chimera_vfs_open_handle *handle)
+{
+    return chimera_posix_fd_alloc_at_least(posix, handle, 0);
 } // chimera_posix_fd_alloc
 
 static FORCE_INLINE void

--- a/src/posix/posix_lseek.c
+++ b/src/posix/posix_lseek.c
@@ -87,7 +87,7 @@ chimera_posix_lseek_hole_data(
 
     if (!err) {
         pthread_mutex_lock(&entry->lock);
-        entry->offset = ctx.r_offset;
+        entry->ofd->offset = ctx.r_offset;
         pthread_mutex_unlock(&entry->lock);
     }
 

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -94,7 +94,7 @@ chimera_posix_open(
             chimera_close(worker->client_thread, req.sync_open_handle);
             err = EMFILE;
         } else {
-            posix->fds[fd].oflags = (unsigned int) flags;
+            posix->fds[fd].ofd->oflags = (unsigned int) flags;
         }
     }
 

--- a/src/posix/posix_openat.c
+++ b/src/posix/posix_openat.c
@@ -146,7 +146,7 @@ chimera_posix_openat(
         return -1;
     }
 
-    posix->fds[fd].oflags = (unsigned int) flags;
+    posix->fds[fd].ofd->oflags = (unsigned int) flags;
 
     return fd;
 } /* chimera_posix_openat */

--- a/src/posix/posix_pread.c
+++ b/src/posix/posix_pread.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_pread.c
+++ b/src/posix/posix_pread.c
@@ -69,6 +69,12 @@ chimera_posix_pread(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_pwrite.c
+++ b/src/posix/posix_pwrite.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_pwrite.c
+++ b/src/posix/posix_pwrite.c
@@ -52,6 +52,12 @@ chimera_posix_pwrite(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_write(entry)) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode             = CHIMERA_CLIENT_OP_WRITE;

--- a/src/posix/posix_read.c
+++ b/src/posix/posix_read.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_read.c
+++ b/src/posix/posix_read.c
@@ -86,7 +86,7 @@ chimera_posix_read(
     req.read.callback     = chimera_posix_read_callback;
     req.read.private_data = &comp;
     req.read.handle       = entry->handle;
-    req.read.offset       = entry->offset;
+    req.read.offset       = entry->ofd->offset;
     req.read.length       = count;
     req.read.buf          = buf;
 
@@ -95,7 +95,7 @@ chimera_posix_read(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->ofd->offset += (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_read.c
+++ b/src/posix/posix_read.c
@@ -74,6 +74,12 @@ chimera_posix_read(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_read_into.c
+++ b/src/posix/posix_read_into.c
@@ -72,7 +72,7 @@ chimera_posix_read_into_common(
     req.read_into.callback     = chimera_posix_read_into_callback;
     req.read_into.private_data = &comp;
     req.read_into.handle       = entry->handle;
-    req.read_into.offset       = use_fd_offset ? entry->offset : (uint64_t) offset;
+    req.read_into.offset       = use_fd_offset ? entry->ofd->offset : (uint64_t) offset;
     req.read_into.length       = count;
     req.read_into.dest_niov    = niov;
 
@@ -85,7 +85,7 @@ chimera_posix_read_into_common(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && use_fd_offset && req.sync_result >= 0) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->ofd->offset += (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_read_into.c
+++ b/src/posix/posix_read_into.c
@@ -60,6 +60,12 @@ chimera_posix_read_into_common(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode                 = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_readv.c
+++ b/src/posix/posix_readv.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_readv.c
+++ b/src/posix/posix_readv.c
@@ -123,7 +123,7 @@ chimera_posix_readv_internal(
     req.read.callback     = chimera_posix_readv_callback;
     req.read.private_data = &comp;
     req.read.handle       = entry->handle;
-    req.read.offset       = use_fd_offset ? entry->offset : (uint64_t) offset;
+    req.read.offset       = use_fd_offset ? entry->ofd->offset : (uint64_t) offset;
     req.read.length       = total_len;
     req.read.buf          = (void *) iov;  // Store user iovec pointer
     req.read.niov         = iovcnt;        // Store user iovec count
@@ -133,7 +133,7 @@ chimera_posix_readv_internal(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0 && use_fd_offset) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->ofd->offset += (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_readv.c
+++ b/src/posix/posix_readv.c
@@ -111,6 +111,12 @@ chimera_posix_readv_internal(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_read(entry)) {
+        chimera_posix_fd_release(entry, flags);
+        errno = EBADF;
+        return -1;
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_READ;

--- a/src/posix/posix_write.c
+++ b/src/posix/posix_write.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_write.c
+++ b/src/posix/posix_write.c
@@ -7,6 +7,7 @@
 
 #include "posix_internal.h"
 #include "../client/client_write.h"
+#include "../client/client_fstat.h"
 
 static void
 chimera_posix_write_callback(
@@ -32,6 +33,61 @@ chimera_posix_write_exec(
     chimera_dispatch_write(thread, request);
 } /* chimera_posix_write_exec */
 
+static void
+chimera_posix_fd_eof_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    const struct chimera_stat    *st,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp    = private_data;
+    struct chimera_client_request   *request = comp->request;
+
+    if (status == CHIMERA_VFS_OK && st) {
+        request->sync_stat = *st;
+    }
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_fd_eof_callback */
+
+static void
+chimera_posix_fd_eof_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_fstat(thread, request);
+} /* chimera_posix_fd_eof_exec */
+
+int
+chimera_posix_fd_eof(
+    struct chimera_posix_worker   *worker,
+    struct chimera_posix_fd_entry *entry,
+    uint64_t                      *eof)
+{
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+    int                             err;
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode             = CHIMERA_CLIENT_OP_FSTAT;
+    req.fstat.handle       = entry->handle;
+    req.fstat.callback     = chimera_posix_fd_eof_callback;
+    req.fstat.private_data = &comp;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_fd_eof_exec);
+
+    err = chimera_posix_wait(&comp);
+
+    if (!err) {
+        *eof = (uint64_t) req.sync_stat.st_size;
+    }
+
+    chimera_posix_completion_destroy(&comp);
+
+    return err;
+} /* chimera_posix_fd_eof */
+
 SYMBOL_EXPORT ssize_t
 chimera_posix_write(
     int         fd,
@@ -50,13 +106,35 @@ chimera_posix_write(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_write(entry)) {
+        chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+        errno = EBADF;
+        return -1;
+    }
+
+    uint64_t write_offset = entry->offset;
+
+    /* POSIX write(): under O_APPEND the file offset is set to the end of
+     * the file prior to each write.  The IO_ACTIVE gate serializes appends
+     * through this descriptor; cross-descriptor append atomicity would
+     * need append support in the VFS write path. */
+    if (entry->oflags & O_APPEND) {
+        int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
+
+        if (aerr) {
+            chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_IO_ACTIVE);
+            errno = aerr;
+            return -1;
+        }
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode             = CHIMERA_CLIENT_OP_WRITE;
     req.write.callback     = chimera_posix_write_callback;
     req.write.private_data = &comp;
     req.write.handle       = entry->handle;
-    req.write.offset       = entry->offset;
+    req.write.offset       = write_offset;
     req.write.length       = count;
     req.write.buf          = buf;
 
@@ -65,7 +143,7 @@ chimera_posix_write(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_write.c
+++ b/src/posix/posix_write.c
@@ -112,13 +112,13 @@ chimera_posix_write(
         return -1;
     }
 
-    uint64_t write_offset = entry->offset;
+    uint64_t write_offset = entry->ofd->offset;
 
     /* POSIX write(): under O_APPEND the file offset is set to the end of
      * the file prior to each write.  The IO_ACTIVE gate serializes appends
      * through this descriptor; cross-descriptor append atomicity would
      * need append support in the VFS write path. */
-    if (entry->oflags & O_APPEND) {
+    if (entry->ofd->oflags & O_APPEND) {
         int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
 
         if (aerr) {
@@ -143,7 +143,7 @@ chimera_posix_write(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0) {
-        entry->offset = write_offset + (uint64_t) req.sync_result;
+        entry->ofd->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_writev.c
+++ b/src/posix/posix_writev.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_writev.c
+++ b/src/posix/posix_writev.c
@@ -78,11 +78,11 @@ chimera_posix_writev_internal(
         return -1;
     }
 
-    uint64_t write_offset = use_fd_offset ? entry->offset : (uint64_t) offset;
+    uint64_t write_offset = use_fd_offset ? entry->ofd->offset : (uint64_t) offset;
 
     /* writev() honors O_APPEND like write(): offset moves to EOF prior to
      * each write (pwritev keeps its explicit offset per POSIX). */
-    if (use_fd_offset && (entry->oflags & O_APPEND)) {
+    if (use_fd_offset && (entry->ofd->oflags & O_APPEND)) {
         int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
 
         if (aerr) {
@@ -108,7 +108,7 @@ chimera_posix_writev_internal(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0 && use_fd_offset) {
-        entry->offset = write_offset + (uint64_t) req.sync_result;
+        entry->ofd->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;

--- a/src/posix/posix_writev.c
+++ b/src/posix/posix_writev.c
@@ -72,13 +72,33 @@ chimera_posix_writev_internal(
         return -1;
     }
 
+    if (!chimera_posix_fd_may_write(entry)) {
+        chimera_posix_fd_release(entry, flags);
+        errno = EBADF;
+        return -1;
+    }
+
+    uint64_t write_offset = use_fd_offset ? entry->offset : (uint64_t) offset;
+
+    /* writev() honors O_APPEND like write(): offset moves to EOF prior to
+     * each write (pwritev keeps its explicit offset per POSIX). */
+    if (use_fd_offset && (entry->oflags & O_APPEND)) {
+        int aerr = chimera_posix_fd_eof(worker, entry, &write_offset);
+
+        if (aerr) {
+            chimera_posix_fd_release(entry, flags);
+            errno = aerr;
+            return -1;
+        }
+    }
+
     chimera_posix_completion_init(&comp, &req);
 
     req.opcode              = CHIMERA_CLIENT_OP_WRITE;
     req.writev.callback     = chimera_posix_writev_callback;
     req.writev.private_data = &comp;
     req.writev.handle       = entry->handle;
-    req.writev.offset       = use_fd_offset ? entry->offset : (uint64_t) offset;
+    req.writev.offset       = write_offset;
     req.writev.length       = total_len;
     req.writev.src_iov      = iov;
     req.writev.src_iovcnt   = iovcnt;
@@ -88,7 +108,7 @@ chimera_posix_writev_internal(
     int     err = chimera_posix_wait(&comp);
 
     if (!err && req.sync_result >= 0 && use_fd_offset) {
-        entry->offset += (uint64_t) req.sync_result;
+        entry->offset = write_offset + (uint64_t) req.sync_result;
     }
 
     ssize_t ret = req.sync_result;


### PR DESCRIPTION
Part 1/6 of the memfs-posix conformance work (replaces #1516, split into topical PRs; excludes the quint MBT harness and #1527).

Descriptor-layer POSIX fixes found by model-based testing:
- dup/dup2 propagate the file offset and status flags; dup'd fds share one open file description
- enforce per-descriptor access modes and honor O_APPEND
- fcntl F_DUPFD/F_GETFL/F_SETFL; lowest-free-fd allocation
- copy_file_range/clone_file_range enforce descriptor access modes
- bind I/O access rights at open (POSIX rights retention)
- close leaked descriptors in shutdown

7 commits. Base of a 6-PR stack (A→F); merge bottom-up.

_🤖 organized with [Claude Code](https://claude.com/claude-code)_