### PR TITLE
posix/vfs: symlink & trailing-slash path resolution

### DIFF
--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -226,6 +226,10 @@ struct chimera_client_request {
             struct chimera_vfs_open_handle *dest_parent_handle;
             chimera_link_callback_t         callback;
             void                           *private_data;
+            /* CHIMERA_VFS_LOOKUP_FOLLOW to resolve a final-component
+             * symlink in source_path and link its target
+             * (linkat AT_SYMLINK_FOLLOW); 0 links the symlink itself. */
+            unsigned int                    source_lookup_flags;
             int                             source_path_len;
             int                             source_parent_len;
             int                             source_name_offset;

--- a/src/client/client_link.h
+++ b/src/client/client_link.h
@@ -41,6 +41,7 @@ chimera_dispatch_link(
         thread->client->root_fh_len,
         request->link.source_path,
         request->link.source_path_len,
+        request->link.source_lookup_flags,
         request->link.dest_path,
         request->link.dest_path_len,
         0,

--- a/src/posix/posix_faccessat.c
+++ b/src/posix/posix_faccessat.c
@@ -136,7 +136,11 @@ chimera_posix_faccessat(
     req.opcode            = CHIMERA_CLIENT_OP_STAT;
     req.stat.callback     = chimera_posix_faccessat_callback;
     req.stat.private_data = &state;
-    req.stat.path_len     = path_len;
+    /* access()/faccessat() check the file a symlink resolves to, so the
+     * underlying stat must follow (a dangling link is ENOENT, a loop
+     * ELOOP).  This was previously left uninitialized. */
+    req.stat.flags    = CHIMERA_VFS_LOOKUP_FOLLOW;
+    req.stat.path_len = path_len;
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_faccessat_exec);
 

--- a/src/posix/posix_fstatat.c
+++ b/src/posix/posix_fstatat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_fstatat.c
+++ b/src/posix/posix_fstatat.c
@@ -54,9 +54,6 @@ chimera_posix_fstatat(
     struct chimera_posix_completion comp;
     int                             path_len;
 
-    // Note: AT_SYMLINK_NOFOLLOW is not yet implemented (would need lstat)
-    (void) flags;
-
     // For now, only support AT_FDCWD
     if (dirfd != AT_FDCWD) {
         errno = ENOSYS;
@@ -79,7 +76,11 @@ chimera_posix_fstatat(
     req.opcode            = CHIMERA_CLIENT_OP_STAT;
     req.stat.callback     = chimera_posix_fstatat_callback;
     req.stat.private_data = &comp;
-    req.stat.path_len     = path_len;
+    /* AT_SYMLINK_NOFOLLOW selects lstat semantics; the flag was previously
+     * ignored and req.stat.flags left uninitialized. */
+    req.stat.flags = (flags & AT_SYMLINK_NOFOLLOW) ?
+        0 : CHIMERA_VFS_LOOKUP_FOLLOW;
+    req.stat.path_len = path_len;
 
     chimera_posix_worker_enqueue(worker, &req, chimera_posix_fstatat_exec);
 

--- a/src/posix/posix_link.c
+++ b/src/posix/posix_link.c
@@ -52,13 +52,16 @@ chimera_posix_link(
     source_slash = rindex(oldpath, '/');
     dest_slash   = rindex(newpath, '/');
 
-    req.opcode                 = CHIMERA_CLIENT_OP_LINK;
-    req.link.callback          = chimera_posix_link_callback;
-    req.link.private_data      = &comp;
-    req.link.source_path_len   = source_path_len;
-    req.link.source_parent_len = source_slash ? source_slash - oldpath : source_path_len;
-    req.link.dest_path_len     = dest_path_len;
-    req.link.dest_parent_len   = dest_slash ? dest_slash - newpath : dest_path_len;
+    req.opcode            = CHIMERA_CLIENT_OP_LINK;
+    req.link.callback     = chimera_posix_link_callback;
+    req.link.private_data = &comp;
+    /* link() links the symlink itself (Linux semantics; linkat with
+     * AT_SYMLINK_FOLLOW is the follow variant). */
+    req.link.source_lookup_flags = 0;
+    req.link.source_path_len     = source_path_len;
+    req.link.source_parent_len   = source_slash ? source_slash - oldpath : source_path_len;
+    req.link.dest_path_len       = dest_path_len;
+    req.link.dest_parent_len     = dest_slash ? dest_slash - newpath : dest_path_len;
 
     while (dest_slash && *dest_slash == '/') {
         dest_slash++;

--- a/src/posix/posix_linkat.c
+++ b/src/posix/posix_linkat.c
@@ -9,8 +9,12 @@
 #include "../client/client_link.h"
 
 #ifndef AT_FDCWD
-#define AT_FDCWD -100
+#define AT_FDCWD          -100
 #endif /* ifndef AT_FDCWD */
+
+#ifndef AT_SYMLINK_FOLLOW
+#define AT_SYMLINK_FOLLOW 0x400
+#endif /* ifndef AT_SYMLINK_FOLLOW */
 
 static void
 chimera_posix_linkat_callback(
@@ -46,9 +50,6 @@ chimera_posix_linkat(
     int                             old_path_len, new_path_len;
     const char                     *new_slash;
 
-    // Note: flags like AT_SYMLINK_FOLLOW are not yet implemented
-    (void) flags;
-
     // For now, only support AT_FDCWD for both paths
     if (olddirfd != AT_FDCWD || newdirfd != AT_FDCWD) {
         errno = ENOSYS;
@@ -70,6 +71,10 @@ chimera_posix_linkat(
 
     req.link.source_path_len   = old_path_len;
     req.link.source_parent_len = old_path_len;
+    /* AT_SYMLINK_FOLLOW resolves a final-component symlink in oldpath and
+     * links its target; without it the symlink itself is linked. */
+    req.link.source_lookup_flags = (flags & AT_SYMLINK_FOLLOW) ?
+        CHIMERA_VFS_LOOKUP_FOLLOW : 0;
 
     // Build dest path
     if (newpath[0] == '/') {

--- a/src/posix/posix_lstat.c
+++ b/src/posix/posix_lstat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_lstat.c
+++ b/src/posix/posix_lstat.c
@@ -44,9 +44,17 @@ chimera_posix_lstat(
     struct chimera_posix_completion comp;
     int                             path_len;
 
-    chimera_posix_completion_init(&comp, &req);
-
     path_len = strlen(path);
+
+    /* XBD 4.16: a trailing slash forces a final symlink to be followed
+     * (the slash names the directory the link resolves to) and requires
+     * the result to be a directory -- so lstat("lnk/") behaves as
+     * stat("lnk/"), including its ENOTDIR check. */
+    if (path_len > 1 && path[path_len - 1] == '/') {
+        return chimera_posix_stat(path, st);
+    }
+
+    chimera_posix_completion_init(&comp, &req);
 
     req.opcode            = CHIMERA_CLIENT_OP_STAT;
     req.stat.callback     = chimera_posix_lstat_callback;

--- a/src/posix/posix_mkdir.c
+++ b/src/posix/posix_mkdir.c
@@ -83,9 +83,46 @@ chimera_posix_mkdir(
              * errno. */
             struct stat st;
 
-            if (chimera_posix_stat(path, &st) < 0 &&
-                (errno == ENOTDIR || errno == ELOOP)) {
-                return -1;
+            if (chimera_posix_stat(path, &st) < 0) {
+                if (errno == ENOTDIR || errno == ELOOP) {
+                    return -1;
+                }
+                if (errno == ENOENT) {
+                    /* The final component is a symbolic link whose target does
+                     * not exist.  The trailing slash resolves through the link
+                     * (XBD 4.16), so mkdir(2) must create the link's *target*,
+                     * not fail EEXIST on the link itself.  Read the link and
+                     * retry the create on the resolved path. */
+                    char    link[CHIMERA_VFS_PATH_MAX];
+                    char    tgt[CHIMERA_VFS_PATH_MAX];
+                    char    full[CHIMERA_VFS_PATH_MAX];
+                    ssize_t n;
+                    int     llen = path_len;
+
+                    while (llen > 1 && path[llen - 1] == '/') {
+                        llen--;
+                    }
+                    memcpy(link, path, llen);
+                    link[llen] = '\0';
+
+                    n = chimera_posix_readlink(link, tgt, sizeof(tgt) - 1);
+                    if (n > 0) {
+                        tgt[n] = '\0';
+                        if (tgt[0] == '/') {
+                            return chimera_posix_mkdir(tgt, mode);
+                        } else {
+                            const char *ls   = rindex(link, '/');
+                            int         dlen = ls ? (int) (ls - link) : 0;
+
+                            if (snprintf(full, sizeof(full), "%.*s/%s", dlen,
+                                         link, tgt) >= (int) sizeof(full)) {
+                                errno = ENAMETOOLONG;
+                                return -1;
+                            }
+                            return chimera_posix_mkdir(full, mode);
+                        }
+                    }
+                }
             }
         }
         errno = err;

--- a/src/posix/posix_mkdir.c
+++ b/src/posix/posix_mkdir.c
@@ -71,6 +71,23 @@ chimera_posix_mkdir(
     chimera_posix_completion_destroy(&comp);
 
     if (err) {
+        if ((err == EEXIST || err == EACCES) &&
+            path_len > 1 && path[path_len - 1] == '/') {
+            /* The backend judged the slash-stripped name.  XBD 4.16: a
+             * trailing slash makes the pathname resolve through the final
+             * component -- a non-directory there is ENOTDIR and a symlink
+             * loop is ELOOP, and resolution errors precede the operation's
+             * own existence/permission errors.  stat() with the slash
+             * preserved applies exactly those rules; any other stat
+             * outcome (a directory, a dangling link) keeps the backend's
+             * errno. */
+            struct stat st;
+
+            if (chimera_posix_stat(path, &st) < 0 &&
+                (errno == ENOTDIR || errno == ELOOP)) {
+                return -1;
+            }
+        }
         errno = err;
         return -1;
     }

--- a/src/posix/posix_stat.c
+++ b/src/posix/posix_stat.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 

--- a/src/posix/posix_stat.c
+++ b/src/posix/posix_stat.c
@@ -63,6 +63,13 @@ chimera_posix_stat(
 
     if (!err) {
         chimera_posix_fill_stat(st, &req.sync_stat);
+
+        /* XBD 4.16: a pathname with a trailing slash must resolve to a
+         * directory; anything else is ENOTDIR. */
+        if (path_len > 1 && path[path_len - 1] == '/' &&
+            !S_ISDIR(st->st_mode)) {
+            err = ENOTDIR;
+        }
     }
 
     chimera_posix_completion_destroy(&comp);

--- a/src/server/rest/rest_debug.c
+++ b/src/server/rest/rest_debug.c
@@ -251,7 +251,7 @@ chimera_rest_handle_debug_fsop(
         }
         snprintf(ctx->path2, sizeof(ctx->path2), "%s", path2);
         chimera_vfs_link(ctx->vfs_thread, cred, root_fh, root_fh_len,
-                         ctx->path, strlen(ctx->path),
+                         ctx->path, strlen(ctx->path), 0,
                          ctx->path2, strlen(ctx->path2),
                          0, 0, rest_fsop_link_cb, ctx);
     } else if (strcmp(op, "chmod") == 0) {

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -49,6 +49,15 @@ chimera_vfs_gate_fh_getattr(
 
     if (error_code != CHIMERA_VFS_OK) {
         status = error_code;
+    } else if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+               !S_ISDIR(attr->va_mode)) {
+        /* Every gate_fh caller gates a directory (the parent of a create/
+         * remove, a rename/link destination, a lookup dir); reaching a
+         * non-directory means the caller resolved through a non-directory
+         * descriptor or handle.  Report POSIX's ENOTDIR ahead of the
+         * access evaluation, so the type error is not masked as EACCES
+         * for callers the backend's own type check never reaches. */
+        status = CHIMERA_VFS_ENOTDIR;
     } else {
         status = chimera_vfs_gate(attr, ctx->cred, ctx->required);
     }

--- a/src/vfs/vfs_proc_link.c
+++ b/src/vfs/vfs_proc_link.c
@@ -150,6 +150,7 @@ chimera_vfs_link(
     int                            fhlen,
     const char                    *old_path,
     int                            old_pathlen,
+    unsigned int                   source_lookup_flags,
     const char                    *new_path,
     int                            new_pathlen,
     unsigned int                   replace,
@@ -231,7 +232,9 @@ chimera_vfs_link(
         memcpy(request->link.dest_parent_fh, fh, fhlen);
         request->link.dest_parent_fh_len = fhlen;
 
-        /* Still need to resolve source path to get source FH */
+        /* Still need to resolve source path to get source FH; the caller's
+         * lookup flags decide whether a final-component symlink is
+         * followed (linkat AT_SYMLINK_FOLLOW) or linked itself. */
         chimera_vfs_lookup(
             thread,
             cred,
@@ -240,7 +243,7 @@ chimera_vfs_link(
             request->link.path,
             request->link.pathlen,
             CHIMERA_VFS_ATTR_FH,
-            0,
+            source_lookup_flags & CHIMERA_VFS_LOOKUP_FOLLOW,
             chimera_vfs_link_source_lookup_fast_complete,
             request);
     } else {
@@ -257,7 +260,8 @@ chimera_vfs_link(
             request->link.new_name_offset = 0;
         }
 
-        /* Resolve source (full path) to get source FH */
+        /* Resolve source (full path) to get source FH; follow semantics
+         * as above. */
         chimera_vfs_lookup(
             thread,
             cred,
@@ -266,7 +270,7 @@ chimera_vfs_link(
             request->link.path,
             request->link.pathlen,
             CHIMERA_VFS_ATTR_FH,
-            0,
+            source_lookup_flags & CHIMERA_VFS_LOOKUP_FOLLOW,
             chimera_vfs_link_source_lookup_complete,
             request);
     }

--- a/src/vfs/vfs_proc_lookup.c
+++ b/src/vfs/vfs_proc_lookup.c
@@ -188,7 +188,13 @@ chimera_vfs_lookup_readlink_complete(
         start_fh_len = lp_request->lookup.parent_fh_len;
     }
 
-    /* Construct new path in plugin_data buffer */
+    /* Construct new path in the plugin_data buffer.  After the first
+     * followed link the current path (and the readlink target stored just
+     * past it) already live in plugin_data, so assemble the spliced path in
+     * a scratch buffer before copying it back to avoid overlapping the
+     * sources with the destination. */
+    char scratch[CHIMERA_VFS_PATH_MAX];
+
     new_path = lp_request->plugin_data;
 
     if (remaining_len > 0) {
@@ -201,16 +207,17 @@ chimera_vfs_lookup_readlink_complete(
             chimera_vfs_request_free(thread, lp_request);
             return;
         }
-        memcpy(new_path, target, target_length);
-        new_path[target_length] = '/';
-        memcpy(new_path + target_length + 1, lp_request->lookup.pathc, remaining_len);
-        new_path[new_pathlen] = '\0';
+        memcpy(scratch, target, target_length);
+        scratch[target_length] = '/';
+        memcpy(scratch + target_length + 1, lp_request->lookup.pathc, remaining_len);
     } else {
         /* Just the target */
         new_pathlen = target_length;
-        memcpy(new_path, target, target_length);
-        new_path[new_pathlen] = '\0';
+        memcpy(scratch, target, target_length);
     }
+
+    memcpy(new_path, scratch, new_pathlen);
+    new_path[new_pathlen] = '\0';
 
     /* Reset path pointer */
     lp_request->lookup.path    = new_path;

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -181,6 +181,10 @@ chimera_vfs_link(
     int                            fhlen,
     const char                    *old_path,
     int                            old_pathlen,
+    /* CHIMERA_VFS_LOOKUP_FOLLOW resolves a final-component symlink in
+     * old_path and links its target (linkat AT_SYMLINK_FOLLOW); 0 links
+     * the symlink itself. */
+    unsigned int                   source_lookup_flags,
     const char                    *new_path,
     int                            new_pathlen,
     unsigned int                   replace,


### PR DESCRIPTION
Part 2/6 (replaces #1516). **Stacks on #1529** — review the top 10 commits; the diff shows #1529's commits until it merges.

Symlink and trailing-slash resolution fixes:
- faccessat/fstatat honor symlink following and AT_SYMLINK_NOFOLLOW
- stat/lstat and mkdir apply the XBD 4.16 trailing-slash rule (incl. following a *dangling* symlink target on mkdir)
- linkat implements AT_SYMLINK_FOLLOW; creating opens follow a final symlink
- POSIX type checks on both open paths; namespace gates report ENOTDIR

_🤖 organized with [Claude Code](https://claude.com/claude-code)_