### PR TITLE
posix/vfs: metadata — ownership, mode bits, timestamps, seek

### DIFF
--- a/src/posix/posix_faccessat.c
+++ b/src/posix/posix_faccessat.c
@@ -33,9 +33,8 @@ chimera_posix_faccessat_callback(
     void                         *private_data)
 {
     struct chimera_posix_faccessat_state *state = private_data;
-    int                                   r, w, x;
-    uid_t                                 proc_uid;
-    gid_t                                 proc_gid;
+    const struct chimera_vfs_cred        *cred;
+    int                                   r, w, x, in_group;
     mode_t                                mode;
 
     if (status != CHIMERA_VFS_OK) {
@@ -48,20 +47,41 @@ chimera_posix_faccessat_callback(
         return;
     }
 
-    proc_uid = getuid();
-    proc_gid = getgid();
-    mode     = st->st_mode;
+    /* Evaluate the XBD 4.5 file access permission algorithm against the
+     * chimera credential the operation runs as -- the caller's effective
+     * credential captured into the request by completion_init (this
+     * callback runs on a worker thread, so the thread-local override must
+     * not be consulted here), else the client-global credential.  NOT the
+     * host process's uid/gid, which have nothing to do with the identity
+     * chimera authorizes.  The chimera credential carries a single
+     * identity, so the real-vs-effective distinction (AT_EACCESS) is
+     * vacuous here.  Class selection is exclusive: the owner class
+     * applies whenever the uid matches, even if its bits deny what
+     * another class would grant. */
+    if (state->comp.request->has_cred) {
+        cred = &state->comp.request->req_cred;
+    } else {
+        cred = &chimera_posix_get_global()->client->cred;
+    }
 
-    if (proc_uid == 0) {
-        /* Root can read/write anything; execute requires at least one x bit */
+    mode = st->st_mode;
+
+    in_group = (cred->gid == st->st_gid);
+    for (uint32_t i = 0; !in_group && i < cred->ngids; i++) {
+        in_group = (cred->gids[i] == st->st_gid);
+    }
+
+    if (cred->uid == 0) {
+        /* Privilege grants read/write outright; execute needs the file to
+         * be a directory or carry at least one execute bit. */
         r = 1;
         w = 1;
-        x = !!(mode & (S_IXUSR | S_IXGRP | S_IXOTH));
-    } else if ((uint64_t) proc_uid == st->st_uid) {
+        x = S_ISDIR(mode) || !!(mode & (S_IXUSR | S_IXGRP | S_IXOTH));
+    } else if (cred->uid == st->st_uid) {
         r = !!(mode & S_IRUSR);
         w = !!(mode & S_IWUSR);
         x = !!(mode & S_IXUSR);
-    } else if ((uint64_t) proc_gid == st->st_gid) {
+    } else if (in_group) {
         r = !!(mode & S_IRGRP);
         w = !!(mode & S_IWGRP);
         x = !!(mode & S_IXGRP);

--- a/src/posix/posix_lseek.c
+++ b/src/posix/posix_lseek.c
@@ -59,7 +59,10 @@ chimera_posix_lseek_hole_data(
     struct chimera_posix_seek_ctx  ctx;
 
     if (offset < 0) {
-        errno = EINVAL;
+        /* No data or hole can exist at a negative offset; this is the same
+         * out-of-range condition as an offset at/past EOF, which POSIX and
+         * Linux report as ENXIO (not EINVAL) for SEEK_DATA/SEEK_HOLE. */
+        errno = ENXIO;
         return -1;
     }
 

--- a/src/posix/posix_lseek.c
+++ b/src/posix/posix_lseek.c
@@ -98,7 +98,10 @@ chimera_posix_lseek_hole_data(
     chimera_posix_completion_destroy(&ctx.comp);
 
     if (err) {
-        errno = err;
+        /* POSIX/Linux: SEEK_DATA/SEEK_HOLE on a file system that does not
+         * implement them fail with EINVAL, not ENOTSUP (e.g. the NFSv3
+         * backend, which has no SEEK operation). */
+        errno = (err == ENOTSUP) ? EINVAL : err;
         return -1;
     }
 

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -108,12 +108,13 @@ chimera_posix_open(
     /* O_TRUNC: truncate an existing writable file to zero length on open.
      * The VFS open path does not yet honor CHIMERA_VFS_OPEN_TRUNCATE, so apply
      * it here for regular files opened for writing.  Truncation failures on
-     * non-regular targets are ignored (O_TRUNC is unspecified for them). */
+     * non-regular targets are ignored (O_TRUNC is unspecified for them).
+     * This runs even when the file is already empty: O_TRUNC marks
+     * mtime/ctime and clears set-user/group-ID regardless of the size. */
     if ((flags & O_TRUNC) && (flags & O_ACCMODE) != O_RDONLY) {
         struct stat st;
 
-        if (chimera_posix_fstat(fd, &st) == 0 && S_ISREG(st.st_mode) &&
-            st.st_size != 0) {
+        if (chimera_posix_fstat(fd, &st) == 0 && S_ISREG(st.st_mode)) {
             (void) chimera_posix_ftruncate(fd, 0);
         }
     }

--- a/src/posix/posix_utimensat.c
+++ b/src/posix/posix_utimensat.c
@@ -31,9 +31,10 @@ chimera_posix_fill_utimes(
     const struct timespec     times[2])
 {
     sa->va_req_mask = 0;
-    sa->va_set_mask = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
+    sa->va_set_mask = 0;
 
     if (times == NULL) {
+        sa->va_set_mask      = CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME;
         sa->va_atime.tv_sec  = 0;
         sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_NOW;
         sa->va_mtime.tv_sec  = 0;
@@ -41,26 +42,40 @@ chimera_posix_fill_utimes(
         return;
     }
 
+    /* An omitted field must not appear in the set mask at all: a stray
+     * OMIT sentinel under CHIMERA_VFS_ATTR_ATIME/MTIME made the setattr
+     * permission gate treat it as an EXPLICIT timestamp, demanding
+     * ownership (EPERM) for calls POSIX tiers by write access -- e.g. a
+     * to-now update paired with one omitted field, or a both-omitted
+     * no-op. */
     if (times[0].tv_nsec == UTIME_NOW) {
+        sa->va_set_mask     |= CHIMERA_VFS_ATTR_ATIME;
         sa->va_atime.tv_sec  = 0;
         sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_NOW;
-    } else if (times[0].tv_nsec == UTIME_OMIT) {
-        sa->va_atime.tv_sec  = 0;
-        sa->va_atime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
-    } else {
-        sa->va_atime = times[0];
+    } else if (times[0].tv_nsec != UTIME_OMIT) {
+        sa->va_set_mask |= CHIMERA_VFS_ATTR_ATIME;
+        sa->va_atime     = times[0];
     }
 
     if (times[1].tv_nsec == UTIME_NOW) {
+        sa->va_set_mask     |= CHIMERA_VFS_ATTR_MTIME;
         sa->va_mtime.tv_sec  = 0;
         sa->va_mtime.tv_nsec = CHIMERA_VFS_TIME_NOW;
-    } else if (times[1].tv_nsec == UTIME_OMIT) {
-        sa->va_mtime.tv_sec  = 0;
-        sa->va_mtime.tv_nsec = CHIMERA_VFS_TIME_OMIT;
-    } else {
-        sa->va_mtime = times[1];
+    } else if (times[1].tv_nsec != UTIME_OMIT) {
+        sa->va_set_mask |= CHIMERA_VFS_ATTR_MTIME;
+        sa->va_mtime     = times[1];
     }
 } /* chimera_posix_fill_utimes */
+
+/* Both fields omitted: POSIX requires no ownership or permission check and
+ * no timestamp change -- only resolution/descriptor errors may surface. */
+static inline int
+chimera_posix_utimes_noop(const struct timespec times[2])
+{
+    return times != NULL &&
+           times[0].tv_nsec == UTIME_OMIT &&
+           times[1].tv_nsec == UTIME_OMIT;
+} /* chimera_posix_utimes_noop */
 
 /* ---- futimens(fd, times) : fsetattr on the open handle ---- */
 
@@ -99,6 +114,13 @@ chimera_posix_futimens(
     if (!entry) {
         errno = EBADF;
         return -1;
+    }
+
+    if (chimera_posix_utimes_noop(times)) {
+        /* The descriptor is valid and a both-omitted call changes
+         * nothing; POSIX forbids any further permission check. */
+        chimera_posix_fd_release(entry, 0);
+        return 0;
     }
 
     chimera_posix_completion_init(&comp, &req);
@@ -146,6 +168,9 @@ struct chimera_posix_utimensat_ctx {
     struct chimera_vfs_open_handle *file_handle;
     struct chimera_vfs_attrs        set_attr;
     uint32_t                        lookup_flags;   /* CHIMERA_VFS_LOOKUP_FOLLOW or 0 */
+    /* Both timestamps omitted: validate the path resolution, change
+     * nothing (see chimera_posix_utimes_noop). */
+    int                             validate_only;
     int                             start_fh_len;
     uint8_t                         start_fh[CHIMERA_VFS_FH_SIZE + 16];
     char                            path[CHIMERA_VFS_PATH_MAX];
@@ -207,6 +232,12 @@ chimera_posix_utimensat_lookup_complete(
         return;
     }
 
+    if (ctx->validate_only) {
+        /* Resolution succeeded; a both-omitted call changes nothing. */
+        chimera_posix_complete(&ctx->comp, CHIMERA_VFS_OK);
+        return;
+    }
+
     chimera_vfs_open_fh(
         request->thread->vfs_thread,
         chimera_client_req_cred(request),
@@ -253,7 +284,8 @@ chimera_posix_utimensat(
 
     chimera_posix_completion_init(&ctx.comp, &req);
 
-    ctx.file_handle = NULL;
+    ctx.file_handle   = NULL;
+    ctx.validate_only = chimera_posix_utimes_noop(times);
 
     /* By default follow a final symlink and set times on its target; with
      * AT_SYMLINK_NOFOLLOW operate on the symlink itself. */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1850,6 +1850,20 @@ cairn_apply_attrs(
         inode->gid         = attr->va_gid;
     }
 
+    /* POSIX chown(): changing (or restating) a regular file's owner or group
+    * clears set-user-ID, and set-group-ID when group-executable (a S_ISGID
+    * bit without group-exec marks mandatory locking and is preserved).  This
+    * applies to privileged callers too, matching Linux.  An explicit mode in
+    * the same setattr wins outright, so the clear only fires without one. */
+    if ((set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) &&
+        !(set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISREG(inode->mode)) {
+        inode->mode &= ~(uint32_t) S_ISUID;
+        if (inode->mode & S_IXGRP) {
+            inode->mode &= ~(uint32_t) S_ISGID;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1994,6 +1994,13 @@ cairn_setattr(
         cairn_punch_hole(thread, shared, inode, new_size, old_size - new_size);
     }
 
+    /* POSIX kill-priv: truncation by an unprivileged caller clears
+     * set-user-ID (and set-group-ID when group-executable), exactly like
+     * the write path does. */
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        inode->mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
+    }
+
     /* cairn_apply_attrs() rewrites set_attr->va_set_mask down to the scalar
      * bits it consumes (it drops the ACL bit), so capture the caller's original
      * mask first -- the ACL-coherence block below keys off it. */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2364,7 +2364,9 @@ cairn_mkdir_at(
     inode.size        = 4096;
     inode.space_used  = 4096;
     inode.uid         = request->cred->uid;
-    inode.gid         = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode.gid         = (parent_inode->mode & S_ISGID) ?
+        parent_inode->gid : request->cred->gid;
     inode.nlink       = 2;
     inode.refcnt      = 1;   /* open reference; without it rmdir underflows the
                               * count and never frees the inode (stale handle) */
@@ -2480,7 +2482,9 @@ cairn_mknod_at(
     inode.size        = 0;
     inode.space_used  = 0;
     inode.uid         = request->cred->uid;
-    inode.gid         = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode.gid         = (parent_inode->mode & S_ISGID) ?
+        parent_inode->gid : request->cred->gid;
     inode.nlink       = 1;
     inode.refcnt      = 1;   /* open reference (see cairn_open_at); without it
                               * unlink underflows the count and leaks the inode */
@@ -3018,13 +3022,16 @@ cairn_open_at(
         new_inode.size       = 0;
         new_inode.space_used = 0;
         new_inode.uid        = request->cred->uid;
-        new_inode.gid        = request->cred->gid;
-        new_inode.nlink      = 1;
-        new_inode.rdev       = 0;
-        new_inode.mode       = S_IFREG |  0644;
-        new_inode.atime      = now;
-        new_inode.mtime      = now;
-        new_inode.ctime      = now;
+        /* POSIX: a set-group-ID parent directory forces the new file's
+         * group. */
+        new_inode.gid = (parent_inode->mode & S_ISGID) ?
+            parent_inode->gid : request->cred->gid;
+        new_inode.nlink = 1;
+        new_inode.rdev  = 0;
+        new_inode.mode  = S_IFREG |  0644;
+        new_inode.atime = now;
+        new_inode.mtime = now;
+        new_inode.ctime = now;
         new_inode.change++;
         new_inode.btime          = now;
         new_inode.dos_attributes = 0;
@@ -3930,7 +3937,9 @@ cairn_symlink_at(
     new_inode.size       = request->symlink_at.targetlen;
     new_inode.space_used = request->symlink_at.targetlen;
     new_inode.uid        = request->cred->uid;
-    new_inode.gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    new_inode.gid        = (parent_inode->mode & S_ISGID) ?
+        parent_inode->gid : request->cred->gid;
     new_inode.nlink      = 1;
     new_inode.refcnt     = 1;   /* open reference (see cairn_open_at); without it
                                  * unlink underflows the count and leaks the inode */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2365,16 +2365,16 @@ cairn_mkdir_at(
     inode.space_used  = 4096;
     inode.uid         = request->cred->uid;
     /* POSIX: a set-group-ID parent directory forces the new node's group. */
-    inode.gid         = (parent_inode->mode & S_ISGID) ?
+    inode.gid = (parent_inode->mode & S_ISGID) ?
         parent_inode->gid : request->cred->gid;
-    inode.nlink       = 2;
-    inode.refcnt      = 1;   /* open reference; without it rmdir underflows the
+    inode.nlink  = 2;
+    inode.refcnt = 1;        /* open reference; without it rmdir underflows the
                               * count and never frees the inode (stale handle) */
-    inode.rdev        = 0;
-    inode.mode        = S_IFDIR | 0755;
-    inode.atime       = now;
-    inode.mtime       = now;
-    inode.ctime       = now;
+    inode.rdev   = 0;
+    inode.mode   = S_IFDIR | 0755;
+    inode.atime  = now;
+    inode.mtime  = now;
+    inode.ctime  = now;
     inode.change++;
     inode.btime          = now;
     inode.dos_attributes = 0;
@@ -2483,15 +2483,15 @@ cairn_mknod_at(
     inode.space_used  = 0;
     inode.uid         = request->cred->uid;
     /* POSIX: a set-group-ID parent directory forces the new node's group. */
-    inode.gid         = (parent_inode->mode & S_ISGID) ?
+    inode.gid = (parent_inode->mode & S_ISGID) ?
         parent_inode->gid : request->cred->gid;
-    inode.nlink       = 1;
-    inode.refcnt      = 1;   /* open reference (see cairn_open_at); without it
+    inode.nlink  = 1;
+    inode.refcnt = 1;        /* open reference (see cairn_open_at); without it
                               * unlink underflows the count and leaks the inode */
-    inode.rdev        = 0;
-    inode.atime       = now;
-    inode.mtime       = now;
-    inode.ctime       = now;
+    inode.rdev   = 0;
+    inode.atime  = now;
+    inode.mtime  = now;
+    inode.ctime  = now;
     inode.change++;
     inode.btime          = now;
     inode.dos_attributes = 0;
@@ -3938,16 +3938,16 @@ cairn_symlink_at(
     new_inode.space_used = request->symlink_at.targetlen;
     new_inode.uid        = request->cred->uid;
     /* POSIX: a set-group-ID parent directory forces the new node's group. */
-    new_inode.gid        = (parent_inode->mode & S_ISGID) ?
+    new_inode.gid = (parent_inode->mode & S_ISGID) ?
         parent_inode->gid : request->cred->gid;
-    new_inode.nlink      = 1;
-    new_inode.refcnt     = 1;   /* open reference (see cairn_open_at); without it
+    new_inode.nlink  = 1;
+    new_inode.refcnt = 1;       /* open reference (see cairn_open_at); without it
                                  * unlink underflows the count and leaks the inode */
-    new_inode.rdev       = 0;
-    new_inode.mode       = S_IFLNK | 0755;
-    new_inode.atime      = now;
-    new_inode.mtime      = now;
-    new_inode.ctime      = now;
+    new_inode.rdev   = 0;
+    new_inode.mode   = S_IFLNK | 0755;
+    new_inode.atime  = now;
+    new_inode.mtime  = now;
+    new_inode.ctime  = now;
     new_inode.change++;
     new_inode.btime          = now;
     new_inode.dos_attributes = 0;

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -860,6 +860,14 @@ diskfs_setattr_inode_cb(
 
     diskfs_map_attrs(thread, &request->setattr.r_pre_attr, inode);
 
+    /* POSIX kill-priv: truncation by an unprivileged caller clears
+     * set-user-ID (and set-group-ID when group-executable), exactly like
+     * the write path; both the truncate chain and the direct apply path
+     * below see the cleared mode, and the setattr txn journals it. */
+    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
+        inode->mode = chimera_vfs_killpriv_mode(request->cred, inode->mode);
+    }
+
     if (orig_mask & CHIMERA_VFS_ATTR_SIZE) {
         chimera_diskfs_info("setattr SIZE inum=%lu cur=%lu new=%lu mask=0x%lx (%s)",
                             (unsigned long) inode->inum,

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -4994,6 +4994,20 @@ diskfs_apply_attrs(
         inode->gid         = attr->va_gid;
     }
 
+    /* POSIX chown(): changing (or restating) a regular file's owner or group
+    * clears set-user-ID, and set-group-ID when group-executable (a S_ISGID
+    * bit without group-exec marks mandatory locking and is preserved).  This
+    * applies to privileged callers too, matching Linux.  An explicit mode in
+    * the same setattr wins outright, so the clear only fires without one. */
+    if ((set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) &&
+        !(set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISREG(inode->mode)) {
+        inode->mode &= ~(uint32_t) S_ISUID;
+        if (inode->mode & S_IXGRP) {
+            inode->mode &= ~(uint32_t) S_ISGID;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -791,7 +791,9 @@ diskfs_mkdir_at_alloc_cb(
     inode->space_used = 4096;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 2;
     inode->mode       = S_IFDIR | 0755;
     inode->atime_sec  = now.tv_sec;
@@ -979,7 +981,9 @@ diskfs_mknod_at_alloc_cb(
     inode->space_used = 0;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 1;
     inode->rdev       = 0;
     inode->atime_sec  = now.tv_sec;
@@ -1884,7 +1888,9 @@ diskfs_open_at_alloc_cb(
     inode->space_used = 0;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 1;
     inode->mode       = S_IFREG | 0644;
     inode->atime_sec  = now.tv_sec;
@@ -2269,7 +2275,9 @@ diskfs_symlink_at_alloc_cb(
     inode->space_used = request->symlink_at.targetlen;
     inode->alloc_size = 0;
     inode->uid        = request->cred->uid;
-    inode->gid        = request->cred->gid;
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    inode->gid = (parent->mode & S_ISGID) ?
+        parent->gid : request->cred->gid;
     inode->nlink      = 1;
     inode->mode       = S_IFLNK | 0755;
     inode->atime_sec  = now.tv_sec;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1563,6 +1563,20 @@ memfs_apply_attrs(
         inode->gid         = attr->va_gid;
     }
 
+    /* POSIX chown(): changing (or restating) a regular file's owner or group
+    * clears set-user-ID, and set-group-ID when group-executable (a S_ISGID
+    * bit without group-exec marks mandatory locking and is preserved).  This
+    * applies to privileged callers too, matching Linux.  An explicit mode in
+    * the same setattr wins outright, so the clear only fires without one. */
+    if ((set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) &&
+        !(set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISREG(inode->mode)) {
+        inode->mode &= ~(uint32_t) S_ISUID;
+        if (inode->mode & S_IXGRP) {
+            inode->mode &= ~(uint32_t) S_ISGID;
+        }
+    }
+
     if (set_mask & CHIMERA_VFS_ATTR_SIZE) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
         inode->size        = attr->va_size;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2399,6 +2399,11 @@ memfs_mkdir_at(
     inode->dir.parent_inum = parent_inode->inum;
     inode->dir.parent_gen  = parent_inode->gen;
 
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    if (parent_inode->mode & S_ISGID) {
+        inode->gid = parent_inode->gid;
+    }
+
     /* Inherit the parent's inheritable ACEs (or seed a Windows default DACL for
      * SMB creates); refresh the child's attrs since the mode may have changed. */
     memfs_inherit_acl(inode, parent_inode,
@@ -2521,6 +2526,12 @@ memfs_mknod_at(
         memfs_inode_free(thread, inode);
         memfs_dirent_free(thread, dirent);
         return;
+    }
+
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    if (parent_inode->mode & S_ISGID) {
+        inode->gid = parent_inode->gid;
+        memfs_map_attrs(shared, r_attr, inode, request->fh);
     }
 
     memfs_map_pre_attr(shared, r_dir_pre_attr, parent_inode, request->fh);
@@ -2986,12 +2997,15 @@ memfs_open_at(
         inode->size       = 0;
         inode->space_used = 0;
         inode->uid        = request->cred->uid;
-        inode->gid        = request->cred->gid;
-        inode->nlink      = 1;
-        inode->mode       = S_IFREG |  0644;
-        inode->atime      = now;
-        inode->mtime      = now;
-        inode->ctime      = now;
+        /* POSIX: a set-group-ID parent directory forces the new file's
+         * group; the parent lock is held throughout the create. */
+        inode->gid = (parent_inode->mode & S_ISGID) ?
+            parent_inode->gid : request->cred->gid;
+        inode->nlink = 1;
+        inode->mode  = S_IFREG |  0644;
+        inode->atime = now;
+        inode->mtime = now;
+        inode->ctime = now;
         inode->change++;
         inode->file.blocks     = NULL;
         inode->file.max_blocks = 0;
@@ -4685,6 +4699,12 @@ memfs_symlink_at(
         memfs_inode_free(thread, inode);
         memfs_dirent_free(thread, dirent);
         return;
+    }
+
+    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    if (parent_inode->mode & S_ISGID) {
+        inode->gid = parent_inode->gid;
+        memfs_map_attrs(shared, &request->symlink_at.r_attr, inode, request->fh);
     }
 
     rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);


### PR DESCRIPTION
Part 3/6 (replaces #1516). **Stacks on #1529 → https://github.com/chimera-nas/chimera/pull/1530** — review the top 11 commits.

Metadata/permission conformance:
- setuid/setgid cleared on chown and truncate; setgid parent forces the new node's group (memfs, diskfs, cairn)
- chown with both ids -1; faccessat checks the chimera credential
- UTIME_OMIT tiers; O_TRUNC on already-empty files
- out-of-range SEEK_DATA/SEEK_HOLE is ENXIO; SEEK on a backend without SEEK is EINVAL

_🤖 organized with [Claude Code](https://claude.com/claude-code)_