### PR TITLE
vfs/memfs: range-copy & directory-read conformance

### DIFF
--- a/src/client/client_copy_range.h
+++ b/src/client/client_copy_range.h
@@ -42,6 +42,7 @@ chimera_dispatch_copy_range(
         request->copy_range.dst_handle,
         request->copy_range.dst_offset,
         request->copy_range.length,
+        request->copy_range.flags,
         0,
         0,
         chimera_copy_range_complete,

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -389,6 +389,7 @@ struct chimera_client_request {
             uint64_t                        dst_offset;
             uint64_t                        length;
             uint64_t                        r_length;
+            uint32_t                        flags;
             chimera_copy_range_callback_t   callback;
             void                           *private_data;
         } copy_range;

--- a/src/posix/posix_copy_file_range.c
+++ b/src/posix/posix_copy_file_range.c
@@ -84,6 +84,22 @@ chimera_posix_copy_file_range(
     src_off = off_in ? *off_in : (off_t) in_entry->ofd->offset;
     dst_off = off_out ? *off_out : (off_t) out_entry->ofd->offset;
 
+    /* copy_file_range(2): overlapping source and destination ranges within one
+     * file are EINVAL.  This is a POSIX rule -- SMB copychunk, NFS4 COPY and S3
+     * copy permit overlap -- so the check lives here in the POSIX layer, keyed
+     * on file-handle identity so every backend agrees.  len == 0 already
+     * returned above. */
+    if (in_entry->handle->fh_len == out_entry->handle->fh_len &&
+        memcmp(in_entry->handle->fh, out_entry->handle->fh,
+               in_entry->handle->fh_len) == 0 &&
+        src_off < dst_off + (off_t) len &&
+        dst_off < src_off + (off_t) len) {
+        chimera_posix_fd_release(out_entry, 0);
+        chimera_posix_fd_release(in_entry, 0);
+        errno = EINVAL;
+        return -1;
+    }
+
     chimera_posix_completion_init(&st.comp, &req);
     st.bytes_copied = 0;
 

--- a/src/posix/posix_copy_file_range.c
+++ b/src/posix/posix_copy_file_range.c
@@ -94,6 +94,7 @@ chimera_posix_copy_file_range(
     req.copy_range.dst_offset   = (uint64_t) dst_off;
     req.copy_range.length       = len;
     req.copy_range.r_length     = 0;
+    req.copy_range.flags        = CHIMERA_VFS_COPY_PRESERVE_HOLES;
     req.copy_range.callback     = chimera_posix_copy_file_range_callback;
     req.copy_range.private_data = &st;
 

--- a/src/server/nfs/nfs4_proc_copy.c
+++ b/src/server/nfs/nfs4_proc_copy.c
@@ -323,6 +323,7 @@ chimera_nfs4_copy(
                                refs->remaining,
                                0,
                                0,
+                               0,
                                chimera_nfs4_copy_complete,
                                req);
     } else {

--- a/src/server/s3/s3_copy.c
+++ b/src/server/s3/s3_copy.c
@@ -535,6 +535,7 @@ chimera_s3_copy_step(struct chimera_s3_copy_ctx *ctx)
                 request->file_handle,
                 ctx->offset,
                 chunk,
+                0,
                 0, 0,
                 chimera_s3_copy_copy_callback,
                 ctx);

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -1299,6 +1299,7 @@ chimera_s3_upc_step(struct chimera_s3_upload_copy_ctx *ctx)
             request->file_handle,
             ctx->copied,
             chunk,
+            0,
             0, 0,
             chimera_s3_upc_copy_callback,
             ctx);
@@ -2306,6 +2307,7 @@ chimera_s3_complete_assemble_next(struct chimera_s3_complete_ctx *ctx)
                 request->file_handle,
                 ctx->write_offset,
                 remaining,
+                0,
                 0, 0,
                 chimera_s3_complete_copy_callback,
                 ctx);

--- a/src/server/smb/smb_proc_copychunk.c
+++ b/src/server/smb/smb_proc_copychunk.c
@@ -237,6 +237,7 @@ chimera_smb_copychunk_next(struct chimera_smb_request *request)
         request->ioctl.cc_dst_open_file->handle,
         request->ioctl.cc_chunks[i].dst_offset,
         request->ioctl.cc_chunks[i].length,
+        0,                     /* flags: copychunk materializes holes */
         0,
         0,
         chimera_smb_copychunk_cb,

--- a/src/server/smb/smb_proc_copyoffload.c
+++ b/src/server/smb/smb_proc_copyoffload.c
@@ -151,6 +151,7 @@ chimera_smb_duplicate_extents_clone_cb(
             request->ioctl.de_dst_open_file->handle,
             request->ioctl.de_dst_offset,
             request->ioctl.de_length,
+            0,
             0, 0,
             chimera_smb_duplicate_extents_copy_cb,
             request);
@@ -449,6 +450,7 @@ chimera_smb_offload_write_clone_cb(
             request->ioctl.od_dst_open_file->handle,
             request->ioctl.od_file_offset,
             request->ioctl.od_copy_length,
+            0,
             0, 0,
             chimera_smb_offload_write_copy_cb,
             request);

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -1337,8 +1337,11 @@ diskfs_read_inode_cb(
         return;
     }
 
+    /* read() of a directory is EISDIR; other non-regular types are EINVAL. */
     if (unlikely(!S_ISREG(inode->mode))) {
-        diskfs_op_fail(request, diskfs_private->txn, CHIMERA_VFS_EINVAL);
+        diskfs_op_fail(request, diskfs_private->txn,
+                       S_ISDIR(inode->mode) ?
+                       CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL);
         return;
     }
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -3953,8 +3953,32 @@ memfs_copy_range(
         return;
     }
 
-    src_inode = (struct memfs_inode *) request->copy_range.src_handle->vfs_private;
-    dst_inode = (struct memfs_inode *) request->copy_range.dst_handle->vfs_private;
+    /* The handle's vfs_private points at the inode for a real backend open, but
+    * memfs advertises no OPEN_FILE_REQUIRED, so a caller that only needs to
+    * read (e.g. an O_RDONLY copy_file_range source) can hold a no-backend-open
+    * handle whose vfs_private is 0.  Fall back to resolving the inode from the
+    * handle's file handle, exactly as memfs_resolve_io does for read/write;
+    * without this the source resolves to NULL and a valid copy fails EINVAL. */
+    src_inode = (struct memfs_inode *) (uintptr_t) request->copy_range.src_handle->vfs_private;
+    if (!src_inode) {
+        /* memfs_inode_get_fh returns the inode locked and gen-validated, but
+         * copy_range takes both inode locks itself in address order below (to
+         * avoid AB/BA deadlock), so drop the lock and let that path re-take it. */
+        src_inode = memfs_inode_get_fh(shared, request->copy_range.src_handle->fh,
+                                       request->copy_range.src_handle->fh_len);
+        if (src_inode) {
+            pthread_mutex_unlock(&src_inode->lock);
+        }
+    }
+
+    dst_inode = (struct memfs_inode *) (uintptr_t) request->copy_range.dst_handle->vfs_private;
+    if (!dst_inode) {
+        dst_inode = memfs_inode_get_fh(shared, request->copy_range.dst_handle->fh,
+                                       request->copy_range.dst_handle->fh_len);
+        if (dst_inode) {
+            pthread_mutex_unlock(&dst_inode->lock);
+        }
+    }
 
     if (!src_inode || !dst_inode) {
         request->status = CHIMERA_VFS_EINVAL;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4070,6 +4070,45 @@ memfs_copy_range(
         }
 
         old_block = dst_inode->file.blocks[bi];
+
+        /* Full-destination-block copies preserve source holes: when every
+         * source block covering this destination block is absent, drop the
+         * destination block instead of materializing zeroes, so SEEK_HOLE
+         * still sees the hole after the copy.  (Partial edges keep the
+         * copy-through-zeroes behavior; byte overlap between source and
+         * destination was rejected above, so freeing here cannot free a
+         * block the source side still needs.)  This is POSIX
+         * copy_file_range() semantics, requested via CHIMERA_VFS_COPY_PRESERVE_HOLES;
+         * SMB copychunk, NFS4 COPY and S3 copy leave the flag clear and get
+         * the materializing behavior their conformance suites expect. */
+        if ((request->copy_range.flags & CHIMERA_VFS_COPY_PRESERVE_HOLES) &&
+            block_offset == 0 && block_len == block_size) {
+            uint64_t s_off  = src_offset + copied;
+            uint64_t s_bi   = s_off >> block_shift;
+            uint64_t s_last = (s_off + block_len - 1) >> block_shift;
+            int      hole   = 1;
+
+            for (uint64_t sb = s_bi; sb <= s_last; sb++) {
+                if (sb < src_inode->file.num_blocks &&
+                    src_inode->file.blocks &&
+                    src_inode->file.blocks[sb]) {
+                    hole = 0;
+                    break;
+                }
+            }
+
+            if (hole) {
+                if (old_block) {
+                    memfs_block_free(thread, old_block);
+                    dst_inode->file.blocks[bi] = NULL;
+                }
+                copied      += block_len;
+                left        -= block_len;
+                block_offset = 0;
+                continue;
+            }
+        }
+
         new_block = memfs_block_alloc(thread);
 
         if (!new_block) {

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1944,6 +1944,10 @@ memfs_setattr(
             request->cred->flavor != CHIMERA_VFS_AUTH_ATTR) {
             chimera_vfs_realtime(&inode->mtime);
         }
+        /* POSIX kill-priv: truncation by an unprivileged writer clears
+         * set-user-ID (and set-group-ID when group-executable), exactly
+         * like the write path does. */
+        inode->mode        = chimera_vfs_killpriv_mode(request->cred, inode->mode);
         attr->va_set_mask &= ~CHIMERA_VFS_ATTR_SIZE;
         memfs_apply_attrs(inode, attr);
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
@@ -3299,6 +3303,15 @@ memfs_read(
         return;
     }
 
+    /* read() of a directory is EISDIR (the previous behavior fabricated
+     * zero-filled bytes from the empty data fork). */
+    if (unlikely(!stream && S_ISDIR(inode->mode))) {
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_EISDIR;
+        request->complete(request);
+        return;
+    }
+
     fork      = stream ? &stream->fork : &inode->file;
     fork_size = stream ? stream->size : inode->size;
 
@@ -4370,6 +4383,19 @@ memfs_clone_range(
     } else {
         pthread_mutex_lock(&dst_inode->lock);
         pthread_mutex_lock(&src_inode->lock);
+    }
+
+    /* The source range must lie within the source file (FICLONERANGE
+     * contract: EINVAL otherwise).  Checked under the inode lock so the
+     * size cannot move underneath the decision. */
+    if (src_offset + length > src_inode->size) {
+        if (src_inode != dst_inode) {
+            pthread_mutex_unlock(&src_inode->lock);
+        }
+        pthread_mutex_unlock(&dst_inode->lock);
+        request->status = CHIMERA_VFS_EINVAL;
+        request->complete(request);
+        return;
     }
 
     memfs_map_pre_attr(shared, &request->clone_range.r_pre_attr, dst_inode,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -163,6 +163,15 @@ struct chimera_vfs_mount_options {
 /* Allocate flags */
 #define CHIMERA_VFS_ALLOCATE_DEALLOCATE 0x01
 
+/* Copy-range flags */
+/* Preserve source holes: when a full destination block's source is entirely a
+ * hole, drop the destination block rather than materializing zeroes, so
+ * SEEK_HOLE still sees the hole after the copy.  This is POSIX
+ * copy_file_range() semantics; the POSIX client sets it.  SMB copychunk, NFS4
+ * COPY and S3 copy leave it clear and get the materializing behavior their
+ * conformance suites expect. */
+#define CHIMERA_VFS_COPY_PRESERVE_HOLES 0x01
+
 /* Lock types */
 #define CHIMERA_VFS_LOCK_READ           0 /* shared / read lock */
 #define CHIMERA_VFS_LOCK_WRITE          1 /* exclusive / write lock */
@@ -1017,6 +1026,7 @@ struct chimera_vfs_request {
             uint64_t                        dst_offset;
             uint64_t                        length;
             uint64_t                        r_length;
+            uint32_t                        flags;
             struct chimera_vfs_attrs        r_pre_attr;
             struct chimera_vfs_attrs        r_post_attr;
         } copy_range;

--- a/src/vfs/vfs_proc_copy_range.c
+++ b/src/vfs/vfs_proc_copy_range.c
@@ -294,6 +294,7 @@ chimera_vfs_copy_range(
     struct chimera_vfs_open_handle   *dst_handle,
     uint64_t                          dst_offset,
     uint64_t                          length,
+    uint32_t                          flags,
     uint64_t                          pre_attr_mask,
     uint64_t                          post_attr_mask,
     chimera_vfs_copy_range_callback_t callback,
@@ -339,6 +340,7 @@ chimera_vfs_copy_range(
     request->copy_range.dst_offset              = dst_offset;
     request->copy_range.length                  = length;
     request->copy_range.r_length                = 0;
+    request->copy_range.flags                   = flags;
     request->copy_range.r_pre_attr.va_req_mask  = pre_attr_mask;
     request->copy_range.r_pre_attr.va_set_mask  = 0;
     request->copy_range.r_post_attr.va_req_mask = post_attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -907,6 +907,7 @@ chimera_vfs_copy_range(
     struct chimera_vfs_open_handle   *dst_handle,
     uint64_t                          dst_offset,
     uint64_t                          length,
+    uint32_t                          flags,
     uint64_t                          pre_attr_mask,
     uint64_t                          post_attr_mask,
     chimera_vfs_copy_range_callback_t callback,


### PR DESCRIPTION
Part 4/6 (replaces #1516). **Stacks on #1529 → https://github.com/chimera-nas/chimera/pull/1530 → https://github.com/chimera-nas/chimera/pull/1531** — review the top 7 commits.

- copy_range preserves source holes and rejects overlapping ranges within one file
- copy_range resolves the inode from the handle FH for open-less handles (read-only source no longer fails EINVAL)
- reading a directory is EISDIR; memfs conformance trio; cairn/copyright cleanup

_🤖 organized with [Claude Code](https://claude.com/claude-code)_