### PR TITLE
nfs: server DAC (owner-override) & object-type correctness

### DIFF
--- a/src/posix/posix_mknod.c
+++ b/src/posix/posix_mknod.c
@@ -41,6 +41,22 @@ chimera_posix_mknod(
     const char                     *slash;
     int                             path_len;
 
+    /* POSIX permits mknod() to create a regular file (type S_IFREG, or an
+     * unspecified type which defaults to regular).  NFS has no wire form for
+     * this via MKNOD -- NFS3 MKNOD and NFS4 CREATE cover special files only,
+     * regular files are made with CREATE3 / OPEN -- so route it through the
+     * ordinary create path, which every backend supports.  O_EXCL preserves
+     * mknod's EEXIST-on-existing-name semantics. */
+    if (S_ISREG(mode) || (mode & S_IFMT) == 0) {
+        int fd = chimera_posix_open(path, O_CREAT | O_EXCL | O_WRONLY, mode);
+
+        if (fd < 0) {
+            return -1;
+        }
+        chimera_posix_close(fd);
+        return 0;
+    }
+
     path_len = chimera_posix_check_path(path);
     if (path_len < 0) {
         return -1;

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -855,10 +855,23 @@ chimera_nfs4_open_unchecked_lookup_complete(
     struct OPEN4res                *res           = &req->res_compound.resarray[req->index].opopen;
     struct chimera_vfs_open_handle *parent_handle = req->handle;
 
-    (void) existing_attr;
     (void) dir_attr;
 
     if (error_code == CHIMERA_VFS_OK) {
+        /* The object already exists.  Classify special objects by type before
+         * the backend tries to open them -- a native open of a FIFO, socket,
+         * or device can block or report a backend-specific errno (ENXIO on a
+         * FIFO with no peer), where RFC 7530 §16.16.6 / RFC 8881 §18.16.4
+         * require the protocol-level type error.  Mirrors the NOCREATE path. */
+        if ((existing_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+            !S_ISREG(existing_attr->va_mode)) {
+            res->status = chimera_nfs4_open_nonreg_status(req->minorversion,
+                                                          existing_attr->va_mode);
+            chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+            chimera_nfs4_open_complete(req, res->status);
+            return;
+        }
+
         /* RFC 7530 OPEN/UNCHECKED recreate: create attrs are ignored for an
          * existing object, except size=0 truncates the file. */
         if ((ctx->attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
@@ -1123,7 +1136,7 @@ chimera_nfs4_open_parent_complete(
                                       parent_handle,
                                       args->claim.file.data,
                                       args->claim.file.len,
-                                      0,
+                                      CHIMERA_VFS_ATTR_MODE,
                                       0,
                                       chimera_nfs4_open_unchecked_lookup_complete,
                                       ctx);

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -890,6 +890,13 @@ struct chimera_vfs_request {
             uint32_t                        flags;        /* CHIMERA_VFS_REMOVE_* type assertion */
             const uint8_t                  *child_fh;     /* Optional: child FH if known */
             int                             child_fh_len; /* 0 if child_fh not provided */
+            /* Owned copy of the child FH.  The source pointer may not outlive
+             * this async op -- a name-resolved sticky FH lives in a gate struct
+             * that is freed the moment dispatch returns -- so dispatch copies
+             * the FH here and points child_fh at it.  (The completion path
+             * hashes child_fh for the FILE_DELETE notify, well after the gate
+             * is gone.) */
+            uint8_t                         child_fh_store[CHIMERA_VFS_FH_SIZE];
             /* Inode-scoped removal: when set (with child_fh), the backend MUST
              * only unlink the name while it still resolves to child_fh -- if the
              * original object was removed and a new one created with the same

--- a/src/vfs/vfs_proc_remove.c
+++ b/src/vfs/vfs_proc_remove.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <string.h>
+#include <sys/stat.h>
 #include "vfs_procs.h"
 #include "vfs_internal.h"
 #include "vfs_release.h"
@@ -93,6 +94,27 @@ chimera_vfs_remove_child_lookup_complete(
     if (error_code == CHIMERA_VFS_OK) {
         memcpy(request->remove.child_fh, attr->va_fh, attr->va_fh_len);
         request->remove.child_fh_len = attr->va_fh_len;
+
+        /* Enforce the caller's type assertion (rmdir vs unlink) here, once, for
+         * every backend.  Engine backends re-check it themselves, but the NFS
+         * proxy backends cannot: NFSv4 REMOVE is type-agnostic on the wire, and
+         * an NFSv3 unlink of an *open* directory would otherwise be silly-
+         * renamed (a legal RENAME) instead of failing.  We already hold the
+         * child's mode from the resolve above, so this adds no round trip. */
+        if (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
+            int is_dir = S_ISDIR(attr->va_mode);
+
+            if (((request->remove.flags & CHIMERA_VFS_REMOVE_ISDIR) && !is_dir) ||
+                ((request->remove.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) && is_dir)) {
+                chimera_vfs_remove_callback_t callback = request->remove.callback;
+                void                         *priv     = request->remove.private_data;
+
+                chimera_vfs_release(thread, request->remove.parent_handle);
+                chimera_vfs_request_free(thread, request);
+                callback(is_dir ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_ENOTDIR, priv);
+                return;
+            }
+        }
     } else if (error_code == CHIMERA_VFS_ENOENT) {
         /* Child doesn't exist - proceed with no child FH, remove_at will
          * return the appropriate error */
@@ -170,7 +192,7 @@ chimera_vfs_remove_parent_open_complete(
         oh,
         request->remove.path + request->remove.name_offset,
         request->remove.pathlen - request->remove.name_offset,
-        CHIMERA_VFS_ATTR_FH,
+        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
         0,
         chimera_vfs_remove_child_lookup_complete,
         request);

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -145,14 +145,21 @@ chimera_vfs_remove_at_dispatch(
         return;
     }
 
-    request->opcode                   = CHIMERA_VFS_OP_REMOVE_AT;
-    request->complete                 = chimera_vfs_remove_at_complete;
-    request->remove_at.handle         = handle;
-    request->remove_at.name           = name;
-    request->remove_at.namelen        = namelen;
-    request->remove_at.name_hash      = chimera_vfs_hash(name, namelen);
-    request->remove_at.flags          = flags;
-    request->remove_at.child_fh       = child_fh;
+    request->opcode              = CHIMERA_VFS_OP_REMOVE_AT;
+    request->complete            = chimera_vfs_remove_at_complete;
+    request->remove_at.handle    = handle;
+    request->remove_at.name      = name;
+    request->remove_at.namelen   = namelen;
+    request->remove_at.name_hash = chimera_vfs_hash(name, namelen);
+    request->remove_at.flags     = flags;
+    /* Copy the child FH into request-owned storage: the caller's or
+     * gate-resolved source may be freed before this async op completes. */
+    if (child_fh && child_fh_len > 0) {
+        memcpy(request->remove_at.child_fh_store, child_fh, child_fh_len);
+        request->remove_at.child_fh = request->remove_at.child_fh_store;
+    } else {
+        request->remove_at.child_fh = NULL;
+    }
     request->remove_at.child_fh_len   = child_fh_len;
     request->remove_at.match_child_fh = match_child_fh ? 1 : 0;
     request->remove_at.r_unmatched    = 0;
@@ -203,7 +210,51 @@ struct chimera_vfs_remove_at_gate {
     uint8_t                          parent_lease_skip_valid;
     chimera_vfs_remove_at_callback_t callback;
     void                            *private_data;
+    /* Storage for a child FH resolved by name (sticky-dir owner check) when
+     * the caller did not supply one. */
+    uint8_t                          child_fh_buf[CHIMERA_VFS_FH_SIZE];
+    /* The child FH was resolved by our sticky-lookup, not supplied by the
+     * caller.  It authorizes the delete gate, but must NOT be handed to the
+     * dispatch's io_recall: a name-based delete (the caller passed no FH --
+     * e.g. SMB delete-on-close) recalls via the post-unlink FILE_REMOVED
+     * notify, and also recalling the resolved FH pre-unlink would break the
+     * holder's lease twice (smbtorture smb2.lease.unlink: count 0x2 vs 0x1). */
+    uint8_t                          child_fh_resolved;
 };
+
+static void chimera_vfs_remove_at_gate_complete(
+    enum chimera_vfs_error status,
+    void                  *private_data);
+
+/* When a gate is needed but the caller gave no child FH (e.g. an NFS
+ * name-based REMOVE), resolve the child by name so the sticky-directory owner
+ * rule and any per-object DELETE grant can be evaluated -- otherwise a sticky
+ * directory's owner check is silently skipped. */
+static void
+chimera_vfs_remove_at_sticky_lookup(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_remove_at_gate *gate = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        /* Name absent/unreadable: surface the natural removal error (ENOENT). */
+        gate->callback(error_code, NULL, NULL, gate->private_data);
+        free(gate);
+        return;
+    }
+
+    memcpy(gate->child_fh_buf, attr->va_fh, attr->va_fh_len);
+    gate->child_fh          = gate->child_fh_buf;
+    gate->child_fh_len      = attr->va_fh_len;
+    gate->child_fh_resolved = 1;
+
+    chimera_vfs_gate_delete(gate->thread, gate->cred,
+                            gate->handle->fh, gate->handle->fh_len,
+                            gate->child_fh, gate->child_fh_len,
+                            chimera_vfs_remove_at_gate_complete, gate);
+} /* chimera_vfs_remove_at_sticky_lookup */
 
 static void
 chimera_vfs_remove_at_gate_complete(
@@ -218,8 +269,15 @@ chimera_vfs_remove_at_gate_complete(
         return;
     }
 
+    /* Only a caller-supplied FH drives the dispatch's io_recall.  A
+     * sticky-resolved FH authorized the gate above but is withheld here so the
+     * name-based delete recalls once (via the post-unlink notify), matching the
+     * pre-sticky-lookup behavior. */
     chimera_vfs_remove_at_dispatch(gate->thread, gate->cred, gate->handle,
-                                   gate->name, gate->namelen, gate->child_fh,
+                                   gate->name, gate->namelen,
+                                   gate->child_fh_resolved ? NULL :
+                                   gate->child_fh,
+                                   gate->child_fh_resolved ? 0 :
                                    gate->child_fh_len, gate->match_child_fh,
                                    gate->flags,
                                    gate->pre_attr_mask,
@@ -267,18 +325,19 @@ chimera_vfs_remove_at_common(
     }
 
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
-        gate                 = malloc(sizeof(*gate));
-        gate->thread         = thread;
-        gate->cred           = cred;
-        gate->handle         = handle;
-        gate->name           = name;
-        gate->namelen        = namelen;
-        gate->child_fh       = child_fh;
-        gate->child_fh_len   = child_fh_len;
-        gate->match_child_fh = match_child_fh;
-        gate->flags          = flags;
-        gate->pre_attr_mask  = pre_attr_mask;
-        gate->post_attr_mask = post_attr_mask;
+        gate                    = malloc(sizeof(*gate));
+        gate->thread            = thread;
+        gate->cred              = cred;
+        gate->handle            = handle;
+        gate->name              = name;
+        gate->namelen           = namelen;
+        gate->child_fh          = child_fh;
+        gate->child_fh_len      = child_fh_len;
+        gate->child_fh_resolved = 0;
+        gate->match_child_fh    = match_child_fh;
+        gate->flags             = flags;
+        gate->pre_attr_mask     = pre_attr_mask;
+        gate->post_attr_mask    = post_attr_mask;
         if (parent_lease_skip) {
             memcpy(gate->parent_lease_skip, parent_lease_skip, 16);
             gate->parent_lease_skip_valid = 1;
@@ -293,12 +352,12 @@ chimera_vfs_remove_at_common(
                                     child_fh, child_fh_len,
                                     chimera_vfs_remove_at_gate_complete, gate);
         } else {
-            /* No child FH available: authorize on the parent's DELETE_CHILD
-             * grant alone (the per-object DELETE and sticky owner checks need
-             * the child's attrs). */
-            chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
-                                CHIMERA_ACE_DELETE_CHILD,
-                                chimera_vfs_remove_at_gate_complete, gate);
+            /* No child FH from the caller (e.g. an NFS name-based REMOVE):
+            * resolve it by name so the sticky-directory owner rule and any
+            * per-object DELETE grant are honored, not silently skipped. */
+            chimera_vfs_lookup(thread, cred, handle->fh, handle->fh_len,
+                               name, namelen, CHIMERA_VFS_ATTR_FH, 0,
+                               chimera_vfs_remove_at_sticky_lookup, gate);
         }
         return;
     }


### PR DESCRIPTION
Part 5/6 (new fixes from the NFS quint MBT work). **Stacks on #1529 → #1530 → #1531 → #1532** — review the top 4 commits.

- **owner-override (MAY_OWNER_OVERRIDE):** the NFS servers grant the file owner READ/WRITE of data regardless of mode bits (owner_override cred flag, honored in the VFS access check on both the mode and ACL paths; nfs client delegates DAC to the server; NFS3ERR_PERM→EPERM)
- **rmdir/unlink type assertion** enforced once in the generic remove path (NFSv4 REMOVE is type-agnostic; NFSv3 unlink of an open dir was silly-renamed)
- **mknod of a regular file** routes through the create path (NFS3 MKNOD / NFS4 CREATE only carry special types)
- **NFS4 OPEN of an existing non-regular object** returns NFS4ERR_SYMLINK / NFS4ERR_WRONG_TYPE instead of NXIO

_🤖 organized with [Claude Code](https://claude.com/claude-code)_