### PR TITLE
Adopt libevpl HTTP/1.x conformance work, and give the S3 request a lifetime

### DIFF
--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -197,6 +197,15 @@ chimera_rest_notify(
         return;
     }
 
+    /* The request is over and no body is coming.  This is the only other end a
+     * dispatched request has, so it is where the context allocated for it is
+     * released -- returning here as if it were an uninteresting notification
+     * would leak one per connection dropped mid-POST. */
+    if (notify_type == EVPL_HTTP_NOTIFY_FAILED) {
+        free(ctx);
+        return;
+    }
+
     if (notify_type != EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE) {
         return;
     }

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -132,16 +132,39 @@ chimera_s3_request_alloc(struct chimera_server_s3_thread *thread)
         request->thread = thread;
     }
 
+    /* The HTTP layer's reference, held until libevpl reports the request over
+     * one way or the other.  Everything else that outlives the call it was
+     * made from takes its own; see chimera_s3_request_get. */
+    request->refcount  = 1;
+    request->abandoned = 0;
+
     return request;
 } /* chimera_s3_request_alloc */
 
-static inline void
-chimera_s3_request_free(
+/*
+ * Drop a reference, and tear the request down when the last one goes.
+ *
+ * VFS handles the request may still hold are deliberately not released here.
+ * Several handler paths drop their reference without clearing the pointer (see
+ * the note in s3_server_dispatch), so a handle pointer at teardown may already
+ * be dead -- releasing it again would be the use-after-free this is meant to
+ * prevent.  They are released where they are acquired, as before.
+ */
+void
+chimera_s3_request_put(
     struct chimera_server_s3_thread *thread,
     struct chimera_s3_request       *request)
 {
+    if (--request->refcount > 0) {
+        return;
+    }
+
+    chimera_s3_tagging_request_cleanup(request);
+
+    otel_span_end(&request->otel);
+
     DL_PREPEND(thread->free_requests, request);
-} /* chimera_s3_request_free */
+} /* chimera_s3_request_put */
 
 void
 s3_server_respond(
@@ -164,6 +187,14 @@ s3_server_respond(
      * connection, so dispatch the status line + headers only on the first
      * call. (GET streams its body via later WANT_DATA notifications, which is
      * why we cannot key this off vfs_state.) */
+    /* Nobody to answer.  Marked responded all the same, so the several paths
+     * that can race to respond all take this exit rather than the first one
+     * taking it and the rest walking into a NULL http_request. */
+    if (request->abandoned) {
+        request->responded = 1;
+        return;
+    }
+
     if (request->responded) {
         return;
     }
@@ -376,9 +407,32 @@ s3_server_notify(
 
             chimera_s3_dump_response(s3_request);
 
-            chimera_s3_tagging_request_cleanup(s3_request);
+            /* The HTTP layer is done with the request.  Any VFS work still in
+             * flight holds its own reference, so this only tears the request
+             * down when there is none. */
+            chimera_s3_request_put(thread, s3_request);
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            /*
+             * The connection went away, so there is no response to send and no
+             * peer to send it to.  libevpl frees the evpl_http_request as soon
+             * as this returns, so the pointer to it goes now: a VFS completion
+             * still in flight would otherwise reach s3_server_respond and
+             * write into freed memory.
+             *
+             * The request itself cannot be released here -- that same
+             * completion is still holding it -- so this only drops the HTTP
+             * layer's reference.  Whichever callback lands last tears it down,
+             * finding it abandoned and unwinding without a response.
+             */
+            s3_request->abandoned    = 1;
+            s3_request->http_request = NULL;
 
-            chimera_s3_request_free(thread, s3_request);
+            otel_span_set_status(&s3_request->otel, OTEL_STATUS_ERROR,
+                                 "connection lost");
+            thread->vfs->otel_parent = NULL;
+
+            chimera_s3_request_put(thread, s3_request);
             break;
         default:
             /* no action required */
@@ -393,6 +447,7 @@ chimera_s3_dispatch_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *s3_request = private_data;
     struct chimera_server_s3_thread *thread     = s3_request->thread;
     struct evpl                     *evpl       = thread->evpl;
@@ -1022,6 +1077,8 @@ s3_server_dispatch(
         /* Parent the bucket lookup (and, via propagation, every VFS op this
          * request issues) under the S3 span. */
         thread->vfs->otel_parent = &s3_request->otel;
+
+        chimera_s3_request_get(s3_request);
 
         chimera_vfs_lookup(thread->vfs,
                            &thread->shared->cred,

--- a/src/server/s3/s3_bucket.c
+++ b/src/server/s3/s3_bucket.c
@@ -76,7 +76,7 @@ chimera_s3_list_buckets(
     ctx.bp += sprintf(ctx.bp, "</ListAllMyBucketsResult>\n");
 
     evpl_iovec_set_length(&iov, ctx.bp - start);
-    evpl_http_request_add_datav(request->http_request, &iov, 1);
+    chimera_s3_response_add_datav(evpl, request, &iov, 1);
 
     request->is_list          = 1;
     request->file_length      = ctx.bp - start;
@@ -98,6 +98,7 @@ chimera_s3_create_bucket_mkdir_cb(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -124,7 +125,7 @@ chimera_s3_create_bucket_mkdir_cb(
     chimera_s3_add_bucket(shared, name, path);
 
     snprintf(location, sizeof(location), "/%s", name);
-    evpl_http_request_add_header(request->http_request, "Location", location);
+    chimera_s3_response_add_header(request, "Location", location);
 
     request->status           = CHIMERA_S3_STATUS_OK;
     request->file_length      = 0;
@@ -143,6 +144,7 @@ chimera_s3_create_bucket_lookup_cb(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -168,6 +170,8 @@ chimera_s3_create_bucket_lookup_cb(
     request->set_attr.va_uid  = 0;
     request->set_attr.va_gid  = 0;
 
+    chimera_s3_request_get(request);
+
     chimera_vfs_mkdir(thread->vfs, &thread->shared->cred,
                       request->bucket_fh, request->bucket_fhlen,
                       request->bucket_name, request->bucket_namelen,
@@ -189,6 +193,8 @@ chimera_s3_create_bucket(
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         return;
     }
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_lookup(thread->vfs, &shared->cred,
                        shared->root_fh, shared->root_fh_len,
@@ -422,7 +428,7 @@ chimera_s3_delbucket_finish(
     if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
         s3_server_respond(evpl, request);
     }
-
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 } /* chimera_s3_delbucket_finish */
 
@@ -443,6 +449,7 @@ chimera_s3_delete_bucket(
 
     ctx          = calloc(1, sizeof(*ctx));
     ctx->request = request;
+    chimera_s3_request_get(request);
 
     ctx->bucket_path_len = snprintf(ctx->bucket_path, sizeof(ctx->bucket_path),
                                     "%.*s/%.*s",

--- a/src/server/s3/s3_copy.c
+++ b/src/server/s3/s3_copy.c
@@ -206,8 +206,8 @@ chimera_s3_copy_finish(
         bp += sprintf(bp, "</CopyObjectResult>\n");
 
         evpl_iovec_set_length(&request->multipart.response, bp - body_start);
-        evpl_http_request_add_datav(request->http_request,
-                                    &request->multipart.response, 1);
+        chimera_s3_response_add_datav(evpl, request,
+                                      &request->multipart.response, 1);
 
         request->status           = CHIMERA_S3_STATUS_OK;
         request->file_length      = bp - body_start;
@@ -218,6 +218,7 @@ chimera_s3_copy_finish(
 
     request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
 
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 
     if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
@@ -856,6 +857,7 @@ chimera_s3_copy(
 
     ctx          = calloc(1, sizeof(*ctx));
     ctx->request = request;
+    chimera_s3_request_get(request);
 
     /* x-amz-metadata-directive defaults to COPY (inherit source metadata). */
     directive = evpl_http_request_header(request->http_request,

--- a/src/server/s3/s3_delete.c
+++ b/src/server/s3/s3_delete.c
@@ -16,6 +16,7 @@ chimera_s3_delete_remove_callback(
     struct chimera_vfs_attrs *post_attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -40,6 +41,7 @@ chimera_s3_delete_open_callback(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -51,6 +53,8 @@ chimera_s3_delete_open_callback(
     }
 
     request->dir_handle = oh;
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_remove_at(thread->vfs, &thread->shared->cred,
                           oh,
@@ -73,6 +77,7 @@ chimera_s3_get_lookup_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -83,6 +88,8 @@ chimera_s3_get_lookup_callback(
     }
 
     chimera_s3_abort_if(!(attr->va_set_mask & CHIMERA_VFS_ATTR_FH), "put lookup callback: no fh");
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                         attr->va_fh,
@@ -125,6 +132,8 @@ chimera_s3_delete(
     request->set_attr.va_req_mask = 0;
     request->set_attr.va_set_mask = 0;
 
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
                        request->bucket_fh,

--- a/src/server/s3/s3_delete_objects.c
+++ b/src/server/s3/s3_delete_objects.c
@@ -328,7 +328,7 @@ chimera_s3_del_finalize(
     evpl_iovec_alloc(evpl, request->del.resp_len, 0, 1, 0, &iov);
     memcpy(evpl_iovec_data(&iov), request->del.resp_buf, request->del.resp_len);
     evpl_iovec_set_length(&iov, request->del.resp_len);
-    evpl_http_request_add_datav(request->http_request, &iov, 1);
+    chimera_s3_response_add_datav(evpl, request, &iov, 1);
 
     request->file_length      = request->del.resp_len;
     request->file_real_length = request->del.resp_len;
@@ -384,6 +384,7 @@ chimera_s3_del_remove_cb(
     struct chimera_vfs_attrs *post_attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -406,6 +407,7 @@ chimera_s3_del_open_cb(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -416,6 +418,8 @@ chimera_s3_del_open_cb(
     }
 
     request->dir_handle = oh;
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_remove_at(thread->vfs, &thread->shared->cred,
                           oh,
@@ -433,6 +437,7 @@ chimera_s3_del_lookup_cb(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -441,6 +446,8 @@ chimera_s3_del_lookup_cb(
         chimera_s3_del_record(request, 1, NULL, NULL);
         return;
     }
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                         attr->va_fh,
@@ -498,6 +505,8 @@ chimera_s3_del_drive(struct chimera_s3_request *request)
 
         request->del.synchronous = 1;
         request->del.pending     = 1;
+
+        chimera_s3_request_get(request);
 
         chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
                            request->bucket_fh,

--- a/src/server/s3/s3_etag.h
+++ b/src/server/s3/s3_etag.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -64,6 +64,10 @@ chimera_s3_attach_etag(
     const struct chimera_vfs_attrs *attr)
 {
     char hex[80];
+
+    if (!request) {
+        return;
+    }
 
     chimera_s3_etag_hex(hex, sizeof(hex), attr);
 

--- a/src/server/s3/s3_get.c
+++ b/src/server/s3/s3_get.c
@@ -63,15 +63,18 @@ chimera_s3_get_send_callback(
     struct chimera_s3_io            *io      = private_data;
     struct chimera_s3_request       *request = io->request;
     struct chimera_server_s3_thread *thread  = request->thread;
+    struct evpl                     *evpl    = thread->evpl;
 
     if (error_code) {
         request->status    = CHIMERA_S3_STATUS_INTERNAL_ERROR;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        chimera_s3_io_free(thread, io);
+        request->io_pending--;
         return;
     }
 
     if (niov) {
-        evpl_http_request_add_datav(request->http_request, iov, niov);
+        chimera_s3_response_add_datav(evpl, request, iov, niov);
     }
 
     chimera_s3_io_free(thread, io);
@@ -183,6 +186,7 @@ chimera_s3_get_open_callback(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -210,6 +214,7 @@ chimera_s3_get_lookup_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -317,6 +322,8 @@ chimera_s3_get_lookup_callback(
      * be read and re-emitted as response headers before the response is
      * dispatched. For HEAD the x-amz-tagging-count header is also attached once
      * the object is open. The body is only streamed for GET. */
+    chimera_s3_request_get(request);
+
     chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                         attr->va_fh,
                         attr->va_fh_len,
@@ -332,6 +339,8 @@ chimera_s3_get(
     struct chimera_s3_request       *request)
 {
     request->io_pending = 0;
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
                        request->bucket_fh,
@@ -358,6 +367,7 @@ chimera_s3_get_object_attributes_lookup_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -411,8 +421,8 @@ chimera_s3_get_object_attributes_lookup_callback(
     bp += sprintf(bp, "</GetObjectAttributesOutput>\n");
 
     evpl_iovec_set_length(&request->multipart.response, bp - body_start);
-    evpl_http_request_add_datav(request->http_request,
-                                &request->multipart.response, 1);
+    chimera_s3_response_add_datav(evpl, request,
+                                  &request->multipart.response, 1);
 
     request->file_length      = bp - body_start;
     request->file_real_length = request->file_length;
@@ -433,6 +443,8 @@ chimera_s3_get_object_attributes(
     struct chimera_s3_request       *request)
 {
     request->io_pending = 0;
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
                        request->bucket_fh,

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -88,6 +88,26 @@ struct chimera_s3_request {
     int                              bucket_namelen;
     int                              bucket_fhlen;
     int                              io_pending;
+    /*
+     * How many things still hold this request.  One reference belongs to the
+     * HTTP layer, from the moment the request is dispatched until libevpl
+     * reports it over -- with a response (RESPONSE_COMPLETE) or without one
+     * (FAILED).  Every asynchronous handoff to the VFS takes another, because
+     * its completion callback dereferences the request and there is nothing
+     * else keeping it alive: a connection dropped mid-operation ends the HTTP
+     * reference while the VFS work is still in flight.
+     *
+     * The request is torn down when the count reaches zero, which is the only
+     * point at which nothing can reach it.
+     */
+    int                              refcount;
+    /*
+     * The peer is gone: http_request has been freed by libevpl and is NULL, so
+     * nothing may be written in reply.  The VFS work already in flight still
+     * runs to completion -- there is no way to recall it -- and unwinds
+     * through the same paths, which check this before touching the response.
+     */
+    int                              abandoned;
     int                              name_len;
     int                              path_len;
     int                              is_list;
@@ -259,6 +279,65 @@ struct chimera_server_s3_shared {
     char                               bucket_root_path[256];
 };
 
+/*
+ * Take a reference for an asynchronous handoff.
+ *
+ * Every VFS call whose completion callback dereferences the request needs one,
+ * and so does every context object that outlives the call which created it.
+ * Without it, a connection dropped while the operation is in flight ends the
+ * HTTP layer's reference and the callback lands on a recycled request.
+ */
+static inline void
+chimera_s3_request_get(struct chimera_s3_request *request)
+{
+    request->refcount++;
+} /* chimera_s3_request_get */
+
+/*
+ * Drop a reference, tearing the request down at zero: releasing any VFS handle
+ * it still holds, ending its span, and returning it to the thread's free list.
+ * Nothing may touch the request afterwards.
+ */
+void
+chimera_s3_request_put(
+    struct chimera_server_s3_thread *thread,
+    struct chimera_s3_request       *request);
+
+/* Drop a reference without the caller needing the thread to hand. */
+static inline void
+chimera_s3_request_drop(struct chimera_s3_request *request)
+{
+    chimera_s3_request_put(request->thread, request);
+} /* chimera_s3_request_drop */
+
+static inline void
+chimera_s3_request_unref(struct chimera_s3_request **requestp)
+{
+    struct chimera_s3_request *request = *requestp;
+
+    chimera_s3_request_put(request->thread, request);
+} /* chimera_s3_request_unref */
+
+/*
+ * Hold the reference an asynchronous handoff took, and drop it when the
+ * callback returns -- by whichever of its exits it takes.
+ *
+ * Declared first in the body so that its cleanup runs last, after everything
+ * the callback does with the request.  The alternative is a put before every
+ * return in every completion callback, of which there are dozens: the one that
+ * gets missed is a leak, and the one that gets duplicated is the
+ * use-after-free this exists to prevent.  cleanup is a GNU extension, which
+ * both compilers chimera builds with have long supported, and it makes neither
+ * mistake expressible.
+ *
+ * The variable exists only for its cleanup, so it is never read; `unused`
+ * keeps that from tripping -Wunused-variable, which Apple clang raises for
+ * cleanup variables even though gcc does not.
+ */
+#define CHIMERA_S3_HOLD_REQUEST(pd) \
+        struct chimera_s3_request *_s3_held \
+        __attribute__((cleanup(chimera_s3_request_unref), unused)) = (pd)
+
 static inline struct chimera_s3_io *
 chimera_s3_io_alloc(
     struct chimera_server_s3_thread *thread,
@@ -274,6 +353,10 @@ chimera_s3_io_alloc(
 
     io->request = request;
 
+    /* The io outlives the call that created it: its completion callback
+     * dereferences the request, so it holds a reference of its own. */
+    chimera_s3_request_get(request);
+
     return io;
 } /* chimera_s3_io_alloc */
 
@@ -282,7 +365,11 @@ chimera_s3_io_free(
     struct chimera_server_s3_thread *thread,
     struct chimera_s3_io            *io)
 {
+    struct chimera_s3_request *request = io->request;
+
     LL_PREPEND(thread->free_ios, io);
+
+    chimera_s3_request_put(thread, request);
 } /* chimera_s3_io_free */
 
 static inline int
@@ -320,6 +407,10 @@ chimera_s3_attach_last_modified(
         return;
     }
 
+    if (!request) {
+        return;
+    }
+
     gmtime_r(&attr->va_mtime.tv_sec, &tm);
     strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tm);
     evpl_http_request_add_header(request, "Last-Modified", buf);
@@ -329,6 +420,45 @@ void
 s3_server_respond(
     struct evpl               *evpl,
     struct chimera_s3_request *request);
+
+/*
+ * Add to the response, unless there is nobody to send it to.
+ *
+ * A connection dropped mid-operation ends the request's HTTP side while its
+ * VFS work is still in flight, and that work unwinds through the same response
+ * builders it always does.  They go through these so that "the peer is gone"
+ * is handled once, here, rather than at every place that writes a header or a
+ * payload -- and so that content already staged for a response nobody will
+ * read is released rather than leaked.
+ */
+static inline void
+chimera_s3_response_add_header(
+    struct chimera_s3_request *request,
+    const char                *name,
+    const char                *value)
+{
+    if (request->abandoned) {
+        return;
+    }
+
+    evpl_http_request_add_header(request->http_request, name, value);
+} /* chimera_s3_response_add_header */
+
+static inline void
+chimera_s3_response_add_datav(
+    struct evpl               *evpl,
+    struct chimera_s3_request *request,
+    struct evpl_iovec         *iov,
+    int                        niov)
+{
+    if (request->abandoned) {
+        evpl_iovecs_release(evpl, iov, niov);
+        return;
+    }
+
+    evpl_http_request_add_datav(request->http_request, iov, niov);
+} /* chimera_s3_response_add_datav */
+
 
 #define chimera_s3_debug(...) chimera_debug("s3", \
                                             __FILE__, \

--- a/src/server/s3/s3_list.c
+++ b/src/server/s3/s3_list.c
@@ -627,6 +627,7 @@ chimera_s3_list_find_complete(
     enum chimera_vfs_error error_code,
     void                  *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -852,7 +853,7 @@ chimera_s3_list_find_complete(
     }
 
     if (out.niov > 0) {
-        evpl_http_request_add_datav(request->http_request, out.iov, out.niov);
+        chimera_s3_response_add_datav(evpl, request, out.iov, out.niov);
     }
 
     request->file_length      = total;
@@ -881,6 +882,11 @@ chimera_s3_list(
     struct chimera_server_s3_thread *thread,
     struct chimera_s3_request       *request)
 {
+    /* One reference for the whole find: the per-entry callback runs many
+     * times, the completion exactly once, so the completion is what drops
+     * it. */
+    chimera_s3_request_get(request);
+
     chimera_vfs_find(thread->vfs, &thread->shared->cred,
                      request->bucket_fh,
                      request->bucket_fhlen,

--- a/src/server/s3/s3_metadata.c
+++ b/src/server/s3/s3_metadata.c
@@ -203,6 +203,7 @@ chimera_s3_meta_store_finish(struct chimera_s3_meta_store_ctx *ctx)
         free(ctx->kv[i].name);
         free(ctx->kv[i].value);
     }
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 
     done(request, error, pd);
@@ -260,8 +261,9 @@ chimera_s3_metadata_store_from_headers(
 {
     struct chimera_s3_meta_store_ctx *ctx;
 
-    ctx               = calloc(1, sizeof(*ctx));
-    ctx->request      = request;
+    ctx          = calloc(1, sizeof(*ctx));
+    ctx->request = request;
+    chimera_s3_request_get(request);
     ctx->handle       = handle;
     ctx->done         = done;
     ctx->private_data = private_data;
@@ -287,6 +289,7 @@ chimera_s3_meta_attach_finish(struct chimera_s3_meta_attach_ctx *ctx)
     for (i = 0; i < ctx->count; i++) {
         free(ctx->names[i]);
     }
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 
     done(request, 0, pd);
@@ -318,7 +321,7 @@ chimera_s3_meta_emit_header(
 
         suffix = name + CHIMERA_S3_XATTR_META_LEN;
         snprintf(hdr, sizeof(hdr), "x-amz-meta-%s", suffix);
-        evpl_http_request_add_header(request->http_request, hdr, value);
+        chimera_s3_response_add_header(request, hdr, value);
         return;
     }
 
@@ -327,9 +330,9 @@ chimera_s3_meta_emit_header(
 
     for (i = 0; i < CHIMERA_S3_META_SYS_COUNT; i++) {
         if (strcmp(suffix, chimera_s3_meta_sys_headers[i].suffix) == 0) {
-            evpl_http_request_add_header(request->http_request,
-                                         chimera_s3_meta_sys_headers[i].header,
-                                         value);
+            chimera_s3_response_add_header(request,
+                                           chimera_s3_meta_sys_headers[i].header,
+                                           value);
             if (strcmp(chimera_s3_meta_sys_headers[i].suffix,
                        "content-type") == 0) {
                 request->have_content_type = 1;
@@ -430,8 +433,9 @@ chimera_s3_metadata_attach_headers(
     struct chimera_s3_meta_attach_ctx *ctx;
     struct chimera_server_s3_thread   *thread = request->thread;
 
-    ctx               = calloc(1, sizeof(*ctx));
-    ctx->request      = request;
+    ctx          = calloc(1, sizeof(*ctx));
+    ctx->request = request;
+    chimera_s3_request_get(request);
     ctx->handle       = handle;
     ctx->done         = done;
     ctx->private_data = private_data;
@@ -478,6 +482,7 @@ chimera_s3_meta_copy_finish(struct chimera_s3_meta_copy_ctx *ctx)
     for (i = 0; i < ctx->count; i++) {
         free(ctx->names[i]);
     }
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 
     done(request, error, pd);
@@ -597,8 +602,9 @@ chimera_s3_metadata_copy(
     struct chimera_s3_meta_copy_ctx *ctx;
     struct chimera_server_s3_thread *thread = request->thread;
 
-    ctx               = calloc(1, sizeof(*ctx));
-    ctx->request      = request;
+    ctx          = calloc(1, sizeof(*ctx));
+    ctx->request = request;
+    chimera_s3_request_get(request);
     ctx->src_handle   = src_handle;
     ctx->dst_handle   = dst_handle;
     ctx->done         = done;

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -391,8 +391,8 @@ chimera_s3_mp_send_response(
     evpl_iovec_set_length(&request->multipart.response,
                           body_end - body_start);
 
-    evpl_http_request_add_datav(request->http_request,
-                                &request->multipart.response, 1);
+    chimera_s3_response_add_datav(evpl, request,
+                                  &request->multipart.response, 1);
 
     request->file_length      = body_end - body_start;
     request->file_real_length = request->file_length;
@@ -603,7 +603,7 @@ chimera_s3_upload_part_finish(struct chimera_s3_request *request)
     }
 
     /* Plain UploadPart: attach ETag header, empty body. */
-    evpl_http_request_add_header(request->http_request, "ETag", etag_hex);
+    chimera_s3_response_add_header(request, "ETag", etag_hex);
 
     request->vfs_state = CHIMERA_S3_VFS_STATE_SEND;
 
@@ -758,6 +758,7 @@ chimera_s3_upload_part_create_unlinked_callback(
     struct chimera_vfs_attrs       *attr,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -788,6 +789,7 @@ chimera_s3_upload_part_create_callback(
     struct chimera_vfs_attrs       *dir_post_attr,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -814,6 +816,7 @@ chimera_s3_upload_part_open_dir_callback(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct chimera_vfs_module       *module;
@@ -836,6 +839,8 @@ chimera_s3_upload_part_open_dir_callback(
     if (module->capabilities & CHIMERA_VFS_CAP_CREATE_UNLINKED) {
         request->multipart.tmp_name_len = 0;
 
+        chimera_s3_request_get(request);
+
         chimera_vfs_create_unlinked(
             thread->vfs, &thread->shared->cred,
             oh->fh,
@@ -851,6 +856,8 @@ chimera_s3_upload_part_open_dir_callback(
             "._chimera_mpu_%.16s_%d",
             request->multipart.upload_id,
             request->multipart.part_number);
+
+        chimera_s3_request_get(request);
 
         chimera_vfs_open_at(
             thread->vfs, &thread->shared->cred,
@@ -873,6 +880,7 @@ chimera_s3_upload_part_lookup_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -883,6 +891,8 @@ chimera_s3_upload_part_lookup_callback(
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
         return;
     }
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(
         thread->vfs, &thread->shared->cred,
@@ -955,6 +965,8 @@ chimera_s3_upload_part(
 
     /* Use chimera_vfs_create so the parent directory chain is materialized
      * lazily (mirrors PUT behavior). */
+    chimera_s3_request_get(request);
+
     chimera_vfs_create(
         thread->vfs, &thread->shared->cred,
         request->bucket_fh,
@@ -1150,6 +1162,7 @@ chimera_s3_upc_fail(
         request->multipart.upload = NULL;
     }
 
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 
     request->status    = status;
@@ -1176,6 +1189,7 @@ chimera_s3_upc_done(struct chimera_s3_upload_copy_ctx *ctx)
 
     request->file_cur_offset = ctx->length;
 
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 
     chimera_s3_upload_part_finish(request);
@@ -1608,6 +1622,7 @@ chimera_s3_upload_part_copy(
 
     ctx          = calloc(1, sizeof(*ctx));
     ctx->request = request;
+    chimera_s3_request_get(request);
 
     request->dir_handle        = NULL;
     request->file_handle       = NULL;
@@ -2368,6 +2383,7 @@ chimera_s3_complete_finish_common(
     }
 
     free(ctx->client_parts);
+    chimera_s3_request_drop(ctx->request);
     free(ctx);
 
     free(request->multipart.body_buf);
@@ -2860,6 +2876,7 @@ chimera_s3_complete_retry_lookup_callback(
         }
     }
 
+    chimera_s3_request_drop(rctx->request);
     free(rctx);
 } /* chimera_s3_complete_retry_lookup_callback */
 
@@ -2933,8 +2950,9 @@ chimera_s3_complete_multipart_upload_body_done(
         if (n_client > 0 &&
             chimera_s3_mp_combined_etag_from_manifest(client_parts, n_client,
                                                       combined) == 0) {
-            rctx                   = calloc(1, sizeof(*rctx));
-            rctx->request          = request;
+            rctx          = calloc(1, sizeof(*rctx));
+            rctx->request = request;
+            chimera_s3_request_get(request);
             rctx->part_count       = n_client;
             rctx->combined_etag[0] = combined[0];
             rctx->combined_etag[1] = combined[1];
@@ -3020,8 +3038,9 @@ chimera_s3_complete_multipart_upload_body_done(
 
     /* Build ctx. Combined ETag = XXH3_128 over the etags of the parts the
      * client selected (in client order), formatted "<hex>-<count>". */
-    ctx                   = calloc(1, sizeof(*ctx));
-    ctx->request          = request;
+    ctx          = calloc(1, sizeof(*ctx));
+    ctx->request = request;
+    chimera_s3_request_get(request);
     ctx->upload           = upload;
     ctx->part_count       = n_client;
     ctx->client_parts     = server_parts;

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -32,6 +32,7 @@ chimera_s3_put_getattr_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct evpl                     *evpl    = thread->evpl;
@@ -93,6 +94,8 @@ chimera_s3_put_finish_common(
     /* Fetch the object's final attributes to build the response ETag, then
      * release the file handle and respond (storing x-amz-tagging xattrs first,
      * if present) from the getattr callback. */
+    chimera_s3_request_get(request);
+
     chimera_vfs_getattr(thread->vfs,
                         &thread->shared->cred,
                         request->file_handle,
@@ -111,6 +114,7 @@ chimera_s3_put_rename_callback(
     struct chimera_vfs_attrs *todir_post_attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     chimera_s3_put_finish_common(error_code, private_data);
 } /* chimera_s3_put_rename_callback */
 
@@ -122,6 +126,7 @@ chimera_s3_put_link_callback(
     struct chimera_vfs_attrs *r_dir_post_attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     chimera_s3_put_finish_common(error_code, private_data);
 } /* chimera_s3_put_link_callback */
 
@@ -131,6 +136,8 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
     struct chimera_server_s3_thread *thread = request->thread;
 
     if (request->put.tmp_name_len) {
+        chimera_s3_request_get(request);
+
         chimera_vfs_rename_at(
             thread->vfs,
             &thread->shared->cred,
@@ -152,6 +159,8 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
             chimera_s3_put_rename_callback,
             request);
     } else {
+        chimera_s3_request_get(request);
+
         chimera_vfs_link_at(
             thread->vfs,
             &thread->shared->cred,
@@ -349,6 +358,7 @@ chimera_s3_put_create_unlinked_callback(
     struct chimera_vfs_attrs       *attr,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -380,6 +390,7 @@ chimera_s3_put_create_callback(
     struct chimera_vfs_attrs       *dir_post_attr,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -407,6 +418,7 @@ chimera_s3_put_open_dir_callback(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct chimera_vfs_module       *module;
@@ -428,6 +440,8 @@ chimera_s3_put_open_dir_callback(
 
         request->put.tmp_name_len = 0;
 
+        chimera_s3_request_get(request);
+
         chimera_vfs_create_unlinked(thread->vfs, &thread->shared->cred,
                                     oh->fh,
                                     oh->fh_len,
@@ -441,6 +455,9 @@ chimera_s3_put_open_dir_callback(
                                              (uint64_t) request,
                                              (uint64_t) request->start_time.tv_sec,
                                              (uint64_t) request->start_time.tv_nsec);
+
+        chimera_s3_request_get(request);
+
         chimera_vfs_open_at(thread->vfs, &thread->shared->cred,
                             oh,
                             request->put.tmp_name,
@@ -462,6 +479,7 @@ chimera_s3_put_lookup_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -472,6 +490,8 @@ chimera_s3_put_lookup_callback(
     }
 
     chimera_s3_abort_if(!(attr->va_set_mask & CHIMERA_VFS_ATTR_FH), "put lookup callback: no fh");
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                         attr->va_fh,
@@ -538,6 +558,8 @@ chimera_s3_put(
     request->set_attr.va_set_mask = 0;
 
     request->io_pending = 0;
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_create(thread->vfs, &thread->shared->cred,
                        request->bucket_fh,

--- a/src/server/s3/s3_tagging.c
+++ b/src/server/s3/s3_tagging.c
@@ -388,7 +388,7 @@ chimera_s3_tagging_send_xml(
     dst = evpl_iovec_data(&iov);
     memcpy(dst, ctx->resp_buf, ctx->resp_len);
     evpl_iovec_set_length(&iov, ctx->resp_len);
-    evpl_http_request_add_datav(request->http_request, &iov, 1);
+    chimera_s3_response_add_datav(evpl, request, &iov, 1);
 
     request->file_length      = ctx->resp_len;
     request->file_real_length = ctx->resp_len;
@@ -448,6 +448,7 @@ chimera_s3_tagging_remove_cb(
     const struct chimera_vfs_attrs *post_attr,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request *request = private_data;
 
     /* Ignore per-name errors (ENOENT from a racing remove); keep going. */
@@ -471,6 +472,8 @@ chimera_s3_tagging_remove_next(
 
         if (namelen > CHIMERA_S3_TAG_PREFIX_LEN &&
             memcmp(name, CHIMERA_S3_TAG_PREFIX, CHIMERA_S3_TAG_PREFIX_LEN) == 0) {
+            chimera_s3_request_get(request);
+
             chimera_vfs_remove_xattr(thread->vfs, &thread->shared->cred,
                                      ctx->handle, name, namelen,
                                      chimera_s3_tagging_remove_cb, request);
@@ -494,6 +497,7 @@ chimera_s3_tagging_list_for_remove_cb(
     uint64_t               cookie,
     void                  *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request     *request = private_data;
     struct chimera_s3_tagging_ctx *ctx     = request->tagging;
 
@@ -532,6 +536,8 @@ chimera_s3_tagging_clear_existing(
         ctx->names = malloc(CHIMERA_S3_TAG_XATTR_BUFSZ);
     }
 
+    chimera_s3_request_get(request);
+
     chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
                             ctx->handle, 0,
                             ctx->names, CHIMERA_S3_TAG_XATTR_BUFSZ,
@@ -551,6 +557,7 @@ chimera_s3_tagging_set_cb(
     const struct chimera_vfs_attrs *post_attr,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request *request = private_data;
 
     if (error_code != CHIMERA_VFS_OK) {
@@ -583,6 +590,8 @@ chimera_s3_tagging_set_next(
     t       = &ctx->tags[ctx->cur];
     namelen = snprintf(name, sizeof(name), CHIMERA_S3_TAG_PREFIX "%s", t->key);
 
+    chimera_s3_request_get(request);
+
     chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
                           ctx->handle, 0 /* create-or-replace */,
                           name, namelen,
@@ -602,6 +611,7 @@ chimera_s3_tagging_get_value_cb(
     uint32_t               value_len,
     void                  *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request     *request = private_data;
     struct chimera_s3_tagging_ctx *ctx     = request->tagging;
     const char                    *name;
@@ -648,6 +658,8 @@ chimera_s3_tagging_get_next(
             memcmp(name, CHIMERA_S3_TAG_PREFIX, CHIMERA_S3_TAG_PREFIX_LEN) == 0) {
             ctx->prev_cur = ctx->cur;
             ctx->cur     += namelen + 1;
+            chimera_s3_request_get(request);
+
             chimera_vfs_get_xattr(thread->vfs, &thread->shared->cred,
                                   ctx->handle, name, namelen,
                                   ctx->valbuf, CHIMERA_S3_TAG_VAL_BUFSZ - 1,
@@ -685,6 +697,7 @@ chimera_s3_tagging_get_list_cb(
     uint64_t               cookie,
     void                  *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request     *request = private_data;
     struct chimera_s3_tagging_ctx *ctx     = request->tagging;
 
@@ -749,6 +762,8 @@ chimera_s3_tagging_begin_op(
             if (!ctx->names) {
                 ctx->names = malloc(CHIMERA_S3_TAG_XATTR_BUFSZ);
             }
+            chimera_s3_request_get(request);
+
             chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
                                     ctx->handle, 0,
                                     ctx->names, CHIMERA_S3_TAG_XATTR_BUFSZ,
@@ -773,6 +788,7 @@ chimera_s3_tagging_open_cb(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -792,6 +808,7 @@ chimera_s3_tagging_lookup_cb(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
@@ -801,6 +818,8 @@ chimera_s3_tagging_lookup_cb(
                                   CHIMERA_S3_STATUS_NO_SUCH_KEY);
         return;
     }
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                         attr->va_fh, attr->va_fh_len,
@@ -824,12 +843,16 @@ chimera_s3_tagging_dispatch(
 
     if (request->path_len == 0) {
         /* Bucket-level tagging: the bucket directory FH is already in hand. */
+        chimera_s3_request_get(request);
+
         chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                             request->bucket_fh, request->bucket_fhlen,
                             CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_DIRECTORY,
                             chimera_s3_tagging_open_cb, request);
         return;
     }
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
                        request->bucket_fh, request->bucket_fhlen,
@@ -971,6 +994,7 @@ chimera_s3_tagging_store_set_cb(
     const struct chimera_vfs_attrs *post_attr,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request *request = private_data;
 
     request->tagging->cur++;
@@ -996,6 +1020,8 @@ chimera_s3_tagging_store_set_next(
     t       = &ctx->tags[ctx->cur];
     namelen = snprintf(name, sizeof(name), CHIMERA_S3_TAG_PREFIX "%s", t->key);
 
+    chimera_s3_request_get(request);
+
     chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
                           ctx->handle, 0,
                           name, namelen,
@@ -1018,6 +1044,7 @@ chimera_s3_tagging_store_open_cb(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct chimera_s3_tagging_ctx   *ctx     = request->tagging;
@@ -1044,6 +1071,7 @@ chimera_s3_tagging_store_lookup_cb(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct chimera_s3_tagging_ctx   *ctx     = request->tagging;
@@ -1058,6 +1086,8 @@ chimera_s3_tagging_store_lookup_cb(
         done(thread->evpl, request);
         return;
     }
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                         attr->va_fh, attr->va_fh_len,
@@ -1084,6 +1114,8 @@ chimera_s3_tagging_store_by_path(
 
     ctx->store_done = done_cb;
 
+    chimera_s3_request_get(request);
+
     chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
                        request->bucket_fh, request->bucket_fhlen,
                        request->path, request->path_len,
@@ -1104,6 +1136,7 @@ chimera_s3_tagging_count_list_cb(
     uint64_t               cookie,
     void                  *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct chimera_s3_tagging_ctx   *ctx     = request->tagging;
@@ -1129,7 +1162,7 @@ chimera_s3_tagging_count_list_cb(
     }
 
     snprintf(hdr, sizeof(hdr), "%d", n);
-    evpl_http_request_add_header(request->http_request, "x-amz-tagging-count", hdr);
+    chimera_s3_response_add_header(request, "x-amz-tagging-count", hdr);
 
     if (ctx->handle) {
         chimera_vfs_release(thread->vfs, ctx->handle);
@@ -1146,6 +1179,7 @@ chimera_s3_tagging_count_open_cb(
     struct chimera_vfs_open_handle *oh,
     void                           *private_data)
 {
+    CHIMERA_S3_HOLD_REQUEST(private_data);
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
     struct chimera_s3_tagging_ctx   *ctx     = request->tagging;
@@ -1166,6 +1200,8 @@ chimera_s3_tagging_count_open_cb(
         ctx->names = malloc(CHIMERA_S3_TAG_XATTR_BUFSZ);
     }
 
+    chimera_s3_request_get(request);
+
     chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
                             ctx->handle, 0,
                             ctx->names, CHIMERA_S3_TAG_XATTR_BUFSZ,
@@ -1184,6 +1220,8 @@ chimera_s3_tagging_count_for_head(
     struct chimera_s3_tagging_ctx *ctx = chimera_s3_tagging_ctx_alloc(request);
 
     ctx->store_done = done_cb;
+
+    chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
                         fh, fh_len,


### PR DESCRIPTION
Adopts the two libevpl changes that just merged, and handles the failure
notification the first of them introduces.

## The bump

**libevpl#134** adds a model-based conformance suite for HTTP/1.x in both
directions and fixes what it found: a heap use-after-free from a negative
Content-Length, a ~16 KB leak per malformed header line, a connection an
over-long request line could wedge, and a long list of RFC 1945 / RFC 9112
conformance gaps — `Host` never checked, chunk sizes parsed with `strtoul`,
trailer sections never consumed, pipelined requests never seen, no `Date` on
any response, a client that reported a 1xx as the answer.

**libevpl#135** does the same for the core SDK and fixes a timer that fired
before its deadline (and then re-armed and re-fired without bound inside one
`evpl_continue`, on any thread with a bounded `wait_ms`), an `evpl_recv` that
copied every buffered iovec to the start of the caller's buffer, and an iovec
allocation larger than one buffer that spun.

Two things are visible from here. Responses now carry a `Date` unless the
application supplied one — the S3 server does, and keeps it. And
`evpl_http_notify_type` gains `EVPL_HTTP_NOTIFY_FAILED`, which the rest of
this PR acts on. `evpl_config()` left the public header; chimera does not use
it.

## What FAILED is for

A dispatched request has exactly two ends: the response, or the news that
there will not be one. Before this, only the first existed, so a connection
dropped mid-request freed the `evpl_http_request` and told nobody.

**`rest.c`** allocated a context per POST and freed it on RECEIVE_COMPLETE,
returning early from everything else — one leak per connection dropped
mid-POST. It now releases it on FAILED.

**`metrics.c`** needs no arm: it builds its response synchronously and holds
nothing per request.

**`s3.c` and friends** are the substantial part, below.

## The S3 request lifetime

The S3 server stored the `evpl_http_request` and dereferenced it from its VFS
completion callbacks. libevpl frees that request when the connection goes down
— it did before this bump too — so a completion landing after a dropped
connection wrote a response into freed memory. Every VFS operation in flight
was a window, and a GET reading a large object holds one open for as long as
the read takes.

Nothing noticed because the request was never released on that path either:
the `s3_request`, its tagging context and its span leaked, which kept the
write from landing on recycled memory as often as it otherwise would have.
FAILED makes both fixable, so this fixes both.

The request now carries a reference count. One reference belongs to the HTTP
layer, from dispatch until libevpl reports the request over. Every
asynchronous handoff to the VFS takes another, because its completion
dereferences the request and nothing else keeps it alive; the `io` and context
objects that outlive the call which created them hold one for their own
lifetime rather than one per operation. The request is torn down when the
count reaches zero — the only point at which nothing can reach it.

Completion callbacks hold their reference with `CHIMERA_S3_HOLD_REQUEST`, a
cleanup-attribute guard declared first in the body so it runs last. The
alternative is a put before every `return` in every one of them, of which
there are three dozen: the one that gets missed is a leak and the one that
gets duplicated is the use-after-free this exists to prevent. It is a new
idiom in this tree, which is the reason it is worth a second look in review.

Once the peer is gone there is nothing to write, so `http_request` is cleared
and the request marked abandoned. `s3_server_respond` takes an early exit and
the response builders go through `chimera_s3_response_add_header` /
`_add_datav`, which drop what they are given rather than write it — releasing
staged content instead of leaking it.

One unrelated fault turned up in the same code: the GET read completion
returned on error without freeing its `io` or decrementing `io_pending`, so
the io leaked and the request's I/O count never reached zero, meaning
`chimera_s3_get_finish` never ran. Its two siblings free the io before testing
the error; this one now does too.

## Not fixed here

- **VFS handles held by an abandoned request still leak.** Several handler
  paths drop a handle reference without clearing the pointer (see the note in
  `s3_server_dispatch`), so releasing at teardown would risk freeing one
  twice. They are released where they are acquired, as before.
- **A libevpl test builds a socket path too long for it.**
  `src/core/tests/endpoint_local.c` formats `EVPL_TEST_SOCKET_DIR` plus a pid
  into `char sockpath[96]`; `EVPL_TEST_SOCKET_DIR` is the build tree, so a
  deep build directory truncates the path before the pid and the epoll and
  select variants collide on it ("Address already in use"). Past 107 bytes it
  also exceeds the AF_UNIX limit. Pre-existing and independent of this bump;
  needs a libevpl fix.

## Verification

Local runs cannot use network namespaces, so the integration suites (pynfs,
smbtorture, s3, the netns-gated rest and daemon tests) do not run here. Nor do
they run on this PR: the build/test matrix is `merge_group`-only, and the
green "CI complete" / "Docker build complete" ticks below are the PR-time
placeholders from `pr-checks.yml`. The merge queue is therefore the first
place the S3 and ceph-s3 suites exercise the refcount, which is the part of
this worth watching. On the subset that does run locally, 245/250
pass, and all five failures are io_uring ones the host kernel cannot support
(`libevpl/io_uring/basic`, `vfs/zerorange_diskfs_io_uring`,
`fio/fio_diskfs_io_uring_basic`, and the two `elbencho/diskfs` tests, which
all fault in `evpl_io_uring_request_alloc`). The bump changes nothing under
`src/core/io_uring`, so those are unrelated to it.

The branch is rebased on current main; the one conflict was the `PRIx64`
portability change landing in the same `snprintf` this adds a reference take
in front of.
