### PR TITLE
vfs: POSIX open semantics (rights retention, type checks, symlink-follow)

### DIFF
--- a/src/client/client_fsetattr.h
+++ b/src/client/client_fsetattr.h
@@ -32,7 +32,9 @@ chimera_dispatch_fsetattr(
     struct chimera_client_thread  *thread,
     struct chimera_client_request *request)
 {
-    chimera_vfs_setattr(
+    /* Descriptor-originated: WRITE_DATA-only mutations (ftruncate,
+     * futimens-to-now) ride the descriptor's open-time grant. */
+    chimera_vfs_fsetattr(
         thread->vfs_thread,
         chimera_client_req_cred(request),
         request->fsetattr.handle,

--- a/src/nfs_common/nfs3_status.h
+++ b/src/nfs_common/nfs3_status.h
@@ -79,6 +79,8 @@ nfs3_client_status_to_chimera_vfs_error(int status)
     switch (status) {
         case NFS3_OK:
             return CHIMERA_VFS_OK;
+        case NFS3ERR_PERM:
+            return CHIMERA_VFS_EPERM;
         case NFS3ERR_NOENT:
             return CHIMERA_VFS_ENOENT;
         case NFS3ERR_IO:

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -390,7 +390,7 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_nfs = {
      * by its upstream RPC reply (it reassigns request->read.iov), so the VFS
      * core must not pre-allocate buffers for it. */
     .capabilities   = CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_RELATIVE_OP |
-        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS,
+        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS | CHIMERA_VFS_CAP_DELEGATES_DAC,
     .init           = chimera_nfs_init,
     .destroy        = chimera_nfs_destroy,
     .thread_init    = chimera_nfs_thread_init,

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -579,6 +579,12 @@ struct chimera_vfs_request {
             void                           *private_data;
             uint8_t                         parent_fh[CHIMERA_VFS_FH_SIZE];
             int                             parent_fh_len;
+            /* Open-time effective-access grant computed by the lookup gate,
+             * stamped onto the handle at completion (POSIX rights bind at
+             * open).  granted_valid is 0 unless the gated non-create path
+             * ran the access check. */
+            uint32_t                        granted_access;
+            uint8_t                         granted_valid;
             /* Zeroed stand-in handed to open_at when the caller passes no
              * set_attr (a non-create open) -- open_at requires a non-NULL
              * set_attr that the backend only consults when creating. */

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -14,11 +14,56 @@
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_fh.h"
+#include "vfs/vfs_acl.h"
 #include "vfs/vfs_mount_table.h"
 #include "common/logging.h"
 #include "common/misc.h"
 #include "metrics/metrics.h"
 #include "vfs/vfs_dump.h"
+
+/* Canonical access bits an open with the given flags requires against
+ * the target file. */
+static inline uint32_t
+chimera_vfs_open_required_access(unsigned int flags)
+{
+    uint32_t required = 0;
+
+    /* Access intent is signalled positively: O_RDONLY -> READ_ONLY,
+     * O_WRONLY -> WRITE_ONLY, O_RDWR -> both.  A raw open with neither bit
+     * (e.g. an O_PATH-style handle open) requests no data access and is not
+     * gated. */
+    if (flags & CHIMERA_VFS_OPEN_READ_ONLY) {
+        required |= CHIMERA_ACE_READ_DATA;
+    }
+    if (flags & CHIMERA_VFS_OPEN_WRITE_ONLY) {
+        required |= CHIMERA_ACE_WRITE_DATA;
+    }
+    if (flags & CHIMERA_VFS_OPEN_TRUNCATE) {
+        required |= CHIMERA_ACE_WRITE_DATA;
+    }
+    return required;
+} /* chimera_vfs_open_required_access */
+
+/* Record an open-time effective-access grant on a handle.  POSIX (and the
+ * NFSv4/SMB stateful-open models) bind I/O rights when the file is opened;
+ * the I/O paths consult granted_access instead of re-deriving from the
+ * file's current mode, so later chmods do not revoke existing descriptors.
+ * The open cache shards handles by (fh, access_mode, cred_hash), so grants
+ * from same-credential opens of one file share a handle: union them --
+ * a successful open never narrows what an earlier open of the same handle
+ * legitimately obtained. */
+static inline void
+chimera_vfs_handle_stamp_access(
+    struct chimera_vfs_open_handle *handle,
+    uint32_t                        granted)
+{
+    if (handle->granted_valid) {
+        handle->granted_access |= granted;
+    } else {
+        handle->granted_access = granted;
+        handle->granted_valid  = 1;
+    }
+} /* chimera_vfs_handle_stamp_access */
 
 /* Size of the per-request scratch buffer used by VFS modules.
  * Must be large enough for the largest operation (symlink: name + target + 2 NULs). */

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -240,6 +240,18 @@ chimera_vfs_open_lookup_complete(
             return;
         }
 
+        /* FIFOs/sockets/devices have no blocking-open or device semantics
+         * behind a NAS client; opening one with data access is ENXIO.
+         * Accessless (O_PATH-style / INFERRED) opens still work so path
+         * metadata operations on such nodes are unaffected. */
+        if (!S_ISREG(attr->va_mode) && !S_ISDIR(attr->va_mode) &&
+            !S_ISLNK(attr->va_mode) &&
+            (f & (CHIMERA_VFS_OPEN_READ_ONLY | CHIMERA_VFS_OPEN_WRITE_ONLY))) {
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_ENXIO, NULL, NULL, priv);
+            return;
+        }
+
         /* Authorize the requested read/write access against the file. */
         if (chimera_vfs_gate_needed(request->module->capabilities, request->cred)) {
             if (chimera_vfs_gate(attr, request->cred,

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -17,27 +17,8 @@
 #define CHIMERA_VFS_OPEN_GATE_MASK (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL)
 
 /* Map an open's access mode + O_TRUNC to the ACE rights the caller must hold on
- * the target file. */
-static inline uint32_t
-chimera_vfs_open_required_access(unsigned int flags)
-{
-    uint32_t required = 0;
-
-    /* Access intent is signalled positively: O_RDONLY -> READ_ONLY,
-     * O_WRONLY -> WRITE_ONLY, O_RDWR -> both.  A raw open with neither bit
-     * (e.g. an O_PATH-style handle open) requests no data access and is not
-     * gated here. */
-    if (flags & CHIMERA_VFS_OPEN_READ_ONLY) {
-        required |= CHIMERA_ACE_READ_DATA;
-    }
-    if (flags & CHIMERA_VFS_OPEN_WRITE_ONLY) {
-        required |= CHIMERA_ACE_WRITE_DATA;
-    }
-    if (flags & CHIMERA_VFS_OPEN_TRUNCATE) {
-        required |= CHIMERA_ACE_WRITE_DATA;
-    }
-    return required;
-} /* chimera_vfs_open_required_access */
+ * the target file (moved to vfs_internal.h as
+ * chimera_vfs_open_required_access, shared with the open_at wrapper). */
 
 /*
  * Path-only deep-path rebasing.
@@ -113,6 +94,12 @@ chimera_vfs_open_root_complete(
     struct chimera_vfs_thread  *thread   = request->thread;
     chimera_vfs_open_callback_t callback = request->open.callback;
     void                       *priv     = request->open.private_data;
+
+    /* Bind the open-time access grant computed by the lookup gate (POSIX
+     * rights retention; only set on the gated non-create path). */
+    if (error_code == CHIMERA_VFS_OK && oh && request->open.granted_valid) {
+        chimera_vfs_handle_stamp_access(oh, request->open.granted_access);
+    }
 
     chimera_vfs_request_free(thread, request);
 
@@ -254,12 +241,22 @@ chimera_vfs_open_lookup_complete(
         }
 
         /* Authorize the requested read/write access against the file. */
-        if (chimera_vfs_gate_needed(request->module->capabilities, request->cred) &&
-            chimera_vfs_gate(attr, request->cred,
-                             chimera_vfs_open_required_access(f)) != CHIMERA_VFS_OK) {
-            chimera_vfs_request_free(thread, request);
-            callback(CHIMERA_VFS_EACCES, NULL, NULL, priv);
-            return;
+        if (chimera_vfs_gate_needed(request->module->capabilities, request->cred)) {
+            if (chimera_vfs_gate(attr, request->cred,
+                                 chimera_vfs_open_required_access(f)) != CHIMERA_VFS_OK) {
+                chimera_vfs_request_free(thread, request);
+                callback(CHIMERA_VFS_EACCES, NULL, NULL, priv);
+                return;
+            }
+
+            /* POSIX binds I/O rights at open: capture the effective grant
+             * now and stamp it on the handle once it exists (see
+             * chimera_vfs_open_root_complete), so later I/O through the
+             * descriptor is immune to subsequent mode changes. */
+            request->open.granted_access =
+                chimera_vfs_access_check(attr, request->cred,
+                                         CHIMERA_ACE_MASK_ALL);
+            request->open.granted_valid = 1;
         }
     }
 
@@ -307,8 +304,9 @@ chimera_vfs_open(
             return;
         }
 
-        request->open.callback     = callback;
-        request->open.private_data = private_data;
+        request->open.callback      = callback;
+        request->open.private_data  = private_data;
+        request->open.granted_valid = 0;
 
         chimera_vfs_open_fh(
             thread,
@@ -340,12 +338,13 @@ chimera_vfs_open(
     memcpy(request->plugin_data, path, pathlen);
     ((char *) request->plugin_data)[pathlen] = '\0';
 
-    request->open.path         = request->plugin_data;
-    request->open.pathlen      = pathlen;
-    request->open.flags        = flags;
-    request->open.attr_mask    = attr_mask;
-    request->open.callback     = callback;
-    request->open.private_data = private_data;
+    request->open.path          = request->plugin_data;
+    request->open.pathlen       = pathlen;
+    request->open.flags         = flags;
+    request->open.attr_mask     = attr_mask;
+    request->open.callback      = callback;
+    request->open.private_data  = private_data;
+    request->open.granted_valid = 0;
 
     /* A non-create open may pass no set_attr, but open_at (the path-op / deep
      * path-only dispatch) requires a non-NULL one; hand it a zeroed stand-in. */

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -106,6 +106,102 @@ chimera_vfs_open_root_complete(
     callback(error_code, oh, NULL, priv);
 } /* chimera_vfs_open_root_complete */
 
+/* ----------------------------------------------------------------------------
+ * Final-symlink follow on the create (parent + open_at) leg.
+ *
+ * open_at opens the named entry itself; when that entry is a symlink and the
+ * open wants to follow (no O_NOFOLLOW, no O_PATH), POSIX resolution must
+ * continue through the link: an existing target is opened, a dangling target
+ * is created (O_CREAT), and a loop is ELOOP.  Implemented by reading the
+ * link and restarting chimera_vfs_open() on the rewritten path; the hop
+ * count rides the high byte of the (internal) open flags so a chain of
+ * links terminates at SYMLOOP_MAX with ELOOP.
+ * ------------------------------------------------------------------------- */
+
+#define CHIMERA_VFS_OPEN_HOPS_SHIFT 24
+#define CHIMERA_VFS_OPEN_HOPS_MASK  (0xffu << CHIMERA_VFS_OPEN_HOPS_SHIFT)
+#define CHIMERA_VFS_OPEN_HOPS(f) (((f)&CHIMERA_VFS_OPEN_HOPS_MASK) >> \
+                                  CHIMERA_VFS_OPEN_HOPS_SHIFT)
+#define CHIMERA_VFS_OPEN_SYMLOOP    8
+
+struct chimera_vfs_open_follow_ctx {
+    struct chimera_vfs_thread      *thread;
+    const struct chimera_vfs_cred  *cred;
+    struct chimera_vfs_open_handle *oh;         /* handle on the symlink */
+    chimera_vfs_open_callback_t     callback;
+    void                           *private_data;
+    unsigned int                    flags;      /* original + bumped hops */
+    uint64_t                        attr_mask;
+    struct chimera_vfs_attrs        set_attr;   /* copy: the original may
+                                                 * live in the request */
+    int                             root_fh_len;
+    int                             parent_len;
+    uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
+    char                            parent[CHIMERA_VFS_PATH_MAX];
+    char                            target[CHIMERA_VFS_PATH_MAX];
+};
+
+static void
+chimera_vfs_open_follow_done(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *attr,
+    void                           *private_data)
+{
+    struct chimera_vfs_open_follow_ctx *ctx = private_data;
+
+    ctx->callback(error_code, oh, attr, ctx->private_data);
+    free(ctx);
+} /* chimera_vfs_open_follow_done */
+
+static void
+chimera_vfs_open_follow_readlink_complete(
+    enum chimera_vfs_error    error_code,
+    int                       targetlen,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_open_follow_ctx *ctx = private_data;
+    char                                newpath[CHIMERA_VFS_PATH_MAX];
+    int                                 newlen;
+
+    chimera_vfs_release(ctx->thread, ctx->oh);
+
+    if (error_code != CHIMERA_VFS_OK) {
+        ctx->callback(error_code, NULL, NULL, ctx->private_data);
+        free(ctx);
+        return;
+    }
+
+    ctx->target[targetlen] = '\0';
+
+    if (ctx->target[0] == '/' || ctx->parent_len == 0) {
+        newlen = snprintf(newpath, sizeof(newpath), "%s", ctx->target);
+    } else {
+        newlen = snprintf(newpath, sizeof(newpath), "%.*s/%s",
+                          ctx->parent_len, ctx->parent, ctx->target);
+    }
+
+    if (newlen >= (int) sizeof(newpath)) {
+        ctx->callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL,
+                      ctx->private_data);
+        free(ctx);
+        return;
+    }
+
+    chimera_vfs_open(ctx->thread,
+                     ctx->cred,
+                     ctx->root_fh,
+                     ctx->root_fh_len,
+                     newpath,
+                     newlen,
+                     ctx->flags,
+                     &ctx->set_attr,
+                     ctx->attr_mask,
+                     chimera_vfs_open_follow_done,
+                     ctx);
+} /* chimera_vfs_open_follow_readlink_complete */
+
 static void
 chimera_vfs_open_op_complete(
     enum chimera_vfs_error          error_code,
@@ -120,6 +216,58 @@ chimera_vfs_open_op_complete(
     struct chimera_vfs_thread  *thread   = request->thread;
     chimera_vfs_open_callback_t callback = request->open.callback;
     void                       *priv     = request->open.private_data;
+
+    /* The named entry is a symlink and the open follows: resolve through
+     * it (see the block comment above).  SMB (AUTH_ATTR) handles reparse
+     * points in its own model and is exempt. */
+    if (error_code == CHIMERA_VFS_OK && oh && attr &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        S_ISLNK(attr->va_mode) &&
+        !(request->open.flags & (CHIMERA_VFS_OPEN_NOFOLLOW |
+                                 CHIMERA_VFS_OPEN_PATH)) &&
+        request->cred->flavor != CHIMERA_VFS_AUTH_ATTR) {
+
+        unsigned int hops = CHIMERA_VFS_OPEN_HOPS(request->open.flags);
+
+        if (hops >= CHIMERA_VFS_OPEN_SYMLOOP) {
+            chimera_vfs_release(thread, oh);
+            chimera_vfs_release(thread, request->open.parent_handle);
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_ELOOP, NULL, NULL, priv);
+            return;
+        }
+
+        struct chimera_vfs_open_follow_ctx *ctx = malloc(sizeof(*ctx));
+
+        ctx->thread       = thread;
+        ctx->cred         = request->cred;
+        ctx->oh           = oh;
+        ctx->callback     = callback;
+        ctx->private_data = priv;
+        ctx->flags        =
+            (request->open.flags & ~(unsigned int)
+             CHIMERA_VFS_OPEN_HOPS_MASK) |
+            ((hops + 1) << CHIMERA_VFS_OPEN_HOPS_SHIFT);
+        ctx->attr_mask = request->open.attr_mask;
+        /* Copy: the original may live inside the request being freed. */
+        ctx->set_attr = *request->open.set_attr;
+
+        memcpy(ctx->root_fh, request->fh, request->fh_len);
+        ctx->root_fh_len = request->fh_len;
+
+        ctx->parent_len = request->open.parent_len;
+        memcpy(ctx->parent, request->open.path, request->open.parent_len);
+
+        chimera_vfs_release(thread, request->open.parent_handle);
+        chimera_vfs_request_free(thread, request);
+
+        chimera_vfs_readlink(thread, ctx->cred, ctx->oh,
+                             ctx->target, sizeof(ctx->target) - 1,
+                             0,
+                             chimera_vfs_open_follow_readlink_complete,
+                             ctx);
+        return;
+    }
 
     chimera_vfs_release(thread, request->open.parent_handle);
     chimera_vfs_request_free(thread, request);

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -94,8 +94,15 @@ chimera_vfs_open_at_hdl_callback(
         uint32_t               mode   = request->open_at.r_attr.va_mode;
         enum chimera_vfs_error status = CHIMERA_VFS_OK;
 
-        if (S_ISLNK(mode) && (f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+        if (S_ISLNK(mode) && !(f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
             !(f & CHIMERA_VFS_OPEN_PATH)) {
+            /* A symlink the open will FOLLOW (chimera_vfs_open's create
+             * leg restarts resolution on the link target): neither type
+             * checks nor the access gate apply to the link itself -- a
+             * symlink's permission bits are never consulted, and the
+             * restarted open authorizes the real target. */
+        } else if (S_ISLNK(mode) && (f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+                   !(f & CHIMERA_VFS_OPEN_PATH)) {
             status = CHIMERA_VFS_ELOOP;
         } else if (S_ISDIR(mode) &&
                    (f & (CHIMERA_VFS_OPEN_WRITE_ONLY |

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -13,22 +13,21 @@
 #include "vfs_attr_cache.h"
 #include "common/macros.h"
 
-/* Whether the engine authorizes this open at completion (see the gate in
- * chimera_vfs_open_at_hdl_callback): engine-authoritative backend, a
- * non-exempt caller, a real (non-INFERRED) open.  SMB (AUTH_ATTR) evaluates
- * its own access model and is exempt, as are internal INFERRED opens (NFS3
- * create and the path-setattr plumbing), which keep their protocol-specific
+/* Whether the engine applies POSIX open semantics (type checks and, for
+ * non-exempt credentials, the access gate) to this open at completion --
+ * see chimera_vfs_open_at_hdl_callback.  SMB (AUTH_ATTR) evaluates its own
+ * access model and legitimately opens directories with write-ish desired
+ * access, so it is exempt; so are internal INFERRED opens (NFS3 create and
+ * the path-setattr plumbing), which keep their protocol-specific
  * per-operation semantics. */
 static inline int
-chimera_vfs_open_at_gated(
-    const struct chimera_vfs_module *module,
-    const struct chimera_vfs_cred   *cred,
-    unsigned int                     flags)
+chimera_vfs_open_at_checked(
+    const struct chimera_vfs_cred *cred,
+    unsigned int                   flags)
 {
     return !(flags & CHIMERA_VFS_OPEN_INFERRED) &&
-           cred->flavor != CHIMERA_VFS_AUTH_ATTR &&
-           chimera_vfs_gate_needed(module->capabilities, cred);
-} /* chimera_vfs_open_at_gated */
+           cred->flavor != CHIMERA_VFS_AUTH_ATTR;
+} /* chimera_vfs_open_at_checked */
 
 static void
 chimera_vfs_open_at_hdl_callback(
@@ -72,34 +71,63 @@ chimera_vfs_open_at_hdl_callback(
         handle->r_created = request->open_at.r_created;
     }
 
-    /* POSIX (and the NFSv4/SMB stateful-open models) bind I/O rights at
-     * open.  Authorize the requested access against the just-returned
-     * attrs -- an existing file the caller may not access this way fails
-     * EACCES, while a freshly created file grants the requested access
-     * unconditionally (no permission check applies to a file that did not
-     * exist) -- and stamp the effective grant on the handle so subsequent
-     * I/O is immune to later mode changes. */
+    /* POSIX open semantics, evaluated against the just-returned attrs
+     * (mirroring the checks the plain-open wrapper applies on its lookup
+     * path, which this create/openat path previously skipped entirely):
+     *
+     *  - O_NOFOLLOW and the object is a symlink -> ELOOP (an O_PATH-style
+     *    open of the link itself is allowed);
+     *  - a directory opened with write intent -> EISDIR;
+     *  - a FIFO/socket/device opened with data access -> ENXIO (no
+     *    blocking-open or device semantics behind a NAS client);
+     *  - for non-exempt credentials, authorize the requested access:
+     *    an existing file the caller may not access this way fails
+     *    EACCES, while a freshly created file grants the requested
+     *    access unconditionally (no permission check applies to a file
+     *    that did not exist).  The effective grant is stamped on the
+     *    handle so subsequent I/O is immune to later mode changes. */
     if (request->status == CHIMERA_VFS_OK && handle &&
-        chimera_vfs_open_at_gated(request->module, request->cred,
-                                  request->open_at.flags) &&
+        chimera_vfs_open_at_checked(request->cred, request->open_at.flags) &&
         (request->open_at.r_attr.va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
 
-        uint32_t required = chimera_vfs_open_required_access(
-            request->open_at.flags);
-        uint32_t granted = chimera_vfs_access_check(&request->open_at.r_attr,
-                                                    request->cred,
-                                                    CHIMERA_ACE_MASK_ALL);
+        unsigned int           f      = request->open_at.flags;
+        uint32_t               mode   = request->open_at.r_attr.va_mode;
+        enum chimera_vfs_error status = CHIMERA_VFS_OK;
 
-        if (request->open_at.r_created) {
-            granted |= required;
+        if (S_ISLNK(mode) && (f & CHIMERA_VFS_OPEN_NOFOLLOW) &&
+            !(f & CHIMERA_VFS_OPEN_PATH)) {
+            status = CHIMERA_VFS_ELOOP;
+        } else if (S_ISDIR(mode) &&
+                   (f & (CHIMERA_VFS_OPEN_WRITE_ONLY |
+                         CHIMERA_VFS_OPEN_TRUNCATE))) {
+            status = CHIMERA_VFS_EISDIR;
+        } else if (!S_ISREG(mode) && !S_ISDIR(mode) && !S_ISLNK(mode) &&
+                   (f & (CHIMERA_VFS_OPEN_READ_ONLY |
+                         CHIMERA_VFS_OPEN_WRITE_ONLY))) {
+            status = CHIMERA_VFS_ENXIO;
+        } else if (chimera_vfs_gate_needed(request->module->capabilities,
+                                           request->cred)) {
+            uint32_t required = chimera_vfs_open_required_access(f);
+            uint32_t granted  =
+                chimera_vfs_access_check(&request->open_at.r_attr,
+                                         request->cred,
+                                         CHIMERA_ACE_MASK_ALL);
+
+            if (request->open_at.r_created) {
+                granted |= required;
+            }
+
+            if ((granted & required) != required) {
+                status = CHIMERA_VFS_EACCES;
+            } else {
+                chimera_vfs_handle_stamp_access(handle, granted);
+            }
         }
 
-        if ((granted & required) != required) {
+        if (status != CHIMERA_VFS_OK) {
             chimera_vfs_release(thread, handle);
             handle          = NULL;
-            request->status = CHIMERA_VFS_EACCES;
-        } else {
-            chimera_vfs_handle_stamp_access(handle, granted);
+            request->status = status;
         }
     }
 
@@ -270,9 +298,10 @@ chimera_vfs_open_at_hs(
     request->open_at.r_created          = 0;
     request->open_at.r_attr.va_req_mask = attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
 
-    /* The completion gate needs mode/uid/gid (and a native ACL, if any) to
-     * authorize the open; make sure the backend returns them. */
-    if (chimera_vfs_open_at_gated(handle->vfs_module, cred, flags)) {
+    /* The completion checks need the mode (and, for the access gate,
+     * uid/gid plus a native ACL if any); make sure the backend returns
+     * them. */
+    if (chimera_vfs_open_at_checked(cred, flags)) {
         request->open_at.r_attr.va_req_mask |=
             CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL;
     }

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -5,11 +5,30 @@
 #include <string.h>
 #include "vfs_procs.h"
 #include "vfs_internal.h"
+#include "vfs_release.h"
+#include "vfs_access.h"
 #include "common/misc.h"
 #include "vfs_open_cache.h"
 #include "vfs_name_cache.h"
 #include "vfs_attr_cache.h"
 #include "common/macros.h"
+
+/* Whether the engine authorizes this open at completion (see the gate in
+ * chimera_vfs_open_at_hdl_callback): engine-authoritative backend, a
+ * non-exempt caller, a real (non-INFERRED) open.  SMB (AUTH_ATTR) evaluates
+ * its own access model and is exempt, as are internal INFERRED opens (NFS3
+ * create and the path-setattr plumbing), which keep their protocol-specific
+ * per-operation semantics. */
+static inline int
+chimera_vfs_open_at_gated(
+    const struct chimera_vfs_module *module,
+    const struct chimera_vfs_cred   *cred,
+    unsigned int                     flags)
+{
+    return !(flags & CHIMERA_VFS_OPEN_INFERRED) &&
+           cred->flavor != CHIMERA_VFS_AUTH_ATTR &&
+           chimera_vfs_gate_needed(module->capabilities, cred);
+} /* chimera_vfs_open_at_gated */
 
 static void
 chimera_vfs_open_at_hdl_callback(
@@ -51,6 +70,37 @@ chimera_vfs_open_at_hdl_callback(
 
     if (handle) {
         handle->r_created = request->open_at.r_created;
+    }
+
+    /* POSIX (and the NFSv4/SMB stateful-open models) bind I/O rights at
+     * open.  Authorize the requested access against the just-returned
+     * attrs -- an existing file the caller may not access this way fails
+     * EACCES, while a freshly created file grants the requested access
+     * unconditionally (no permission check applies to a file that did not
+     * exist) -- and stamp the effective grant on the handle so subsequent
+     * I/O is immune to later mode changes. */
+    if (request->status == CHIMERA_VFS_OK && handle &&
+        chimera_vfs_open_at_gated(request->module, request->cred,
+                                  request->open_at.flags) &&
+        (request->open_at.r_attr.va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
+
+        uint32_t required = chimera_vfs_open_required_access(
+            request->open_at.flags);
+        uint32_t granted = chimera_vfs_access_check(&request->open_at.r_attr,
+                                                    request->cred,
+                                                    CHIMERA_ACE_MASK_ALL);
+
+        if (request->open_at.r_created) {
+            granted |= required;
+        }
+
+        if ((granted & required) != required) {
+            chimera_vfs_release(thread, handle);
+            handle          = NULL;
+            request->status = CHIMERA_VFS_EACCES;
+        } else {
+            chimera_vfs_handle_stamp_access(handle, granted);
+        }
     }
 
     chimera_vfs_complete(request);
@@ -208,17 +258,24 @@ chimera_vfs_open_at_hs(
         return;
     }
 
-    request->opcode                              = CHIMERA_VFS_OP_OPEN_AT;
-    request->complete                            = chimera_vfs_open_complete;
-    request->open_at.handle                      = handle;
-    request->open_at.name                        = name;
-    request->open_at.namelen                     = namelen;
-    request->open_at.name_hash                   = chimera_vfs_hash(name, namelen);
-    request->open_at.flags                       = flags;
-    request->open_at.set_attr                    = set_attr;
-    request->open_at.handle_state                = handle_state;
-    request->open_at.r_created                   = 0;
-    request->open_at.r_attr.va_req_mask          = attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+    request->opcode                     = CHIMERA_VFS_OP_OPEN_AT;
+    request->complete                   = chimera_vfs_open_complete;
+    request->open_at.handle             = handle;
+    request->open_at.name               = name;
+    request->open_at.namelen            = namelen;
+    request->open_at.name_hash          = chimera_vfs_hash(name, namelen);
+    request->open_at.flags              = flags;
+    request->open_at.set_attr           = set_attr;
+    request->open_at.handle_state       = handle_state;
+    request->open_at.r_created          = 0;
+    request->open_at.r_attr.va_req_mask = attr_mask | CHIMERA_VFS_ATTR_MASK_CACHEABLE;
+
+    /* The completion gate needs mode/uid/gid (and a native ACL, if any) to
+     * authorize the open; make sure the backend returns them. */
+    if (chimera_vfs_open_at_gated(handle->vfs_module, cred, flags)) {
+        request->open_at.r_attr.va_req_mask |=
+            CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL;
+    }
     request->open_at.r_attr.va_set_mask          = 0;
     request->open_at.r_dir_pre_attr.va_req_mask  = pre_attr_mask;
     request->open_at.r_dir_pre_attr.va_set_mask  = 0;

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -390,6 +390,8 @@ struct chimera_vfs_rename_at_gate {
     unsigned int                     flags;
     uint8_t                          src_child_fh[CHIMERA_VFS_FH_SIZE];
     int                              src_child_fh_len;
+    uint8_t                          dst_target_fh[CHIMERA_VFS_FH_SIZE];
+    int                              dst_target_fh_len;
     uint64_t                         pre_attr_mask;
     uint64_t                         post_attr_mask;
     uint8_t                          parent_lease_skip[16];
@@ -440,6 +442,45 @@ chimera_vfs_rename_at_gate_target(
     chimera_vfs_rename_at_gate_dispatch(gate);
 } /* chimera_vfs_rename_at_gate_target */
 
+/* Destination name resolved -> if it names an existing object, authorize its
+ * replacement (delete_allowed on the destination directory, which applies the
+ * sticky-bit owner rule); a missing name replaces nothing. */
+static void
+chimera_vfs_rename_at_gate_dst_lookup(
+    enum chimera_vfs_error    status,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct chimera_vfs_rename_at_gate *gate = private_data;
+
+    /* No existing destination object -> nothing to replace, proceed. */
+    if (status == CHIMERA_VFS_ENOENT) {
+        chimera_vfs_rename_at_gate_dispatch(gate);
+        return;
+    }
+
+    if (status != CHIMERA_VFS_OK) {
+        chimera_vfs_rename_at_gate_fail(gate, status);
+        return;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_FH) &&
+        attr->va_fh_len > 0 && attr->va_fh_len <= CHIMERA_VFS_FH_SIZE) {
+        memcpy(gate->dst_target_fh, attr->va_fh, attr->va_fh_len);
+        gate->dst_target_fh_len = attr->va_fh_len;
+
+        chimera_vfs_gate_delete(gate->thread, gate->cred,
+                                gate->new_fh, gate->new_fhlen,
+                                gate->dst_target_fh, gate->dst_target_fh_len,
+                                chimera_vfs_rename_at_gate_target, gate);
+        return;
+    }
+
+    /* Existing object but no FH resolved: the sticky owner check needs the
+     * object's attrs, so fall back to permitting the replace (best effort). */
+    chimera_vfs_rename_at_gate_dispatch(gate);
+} /* chimera_vfs_rename_at_gate_dst_lookup */
+
 /* Step 2 complete: destination ADD authorized -> check replaced target. */
 static void
 chimera_vfs_rename_at_gate_dst(
@@ -461,7 +502,14 @@ chimera_vfs_rename_at_gate_dst(
         return;
     }
 
-    chimera_vfs_rename_at_gate_dispatch(gate);
+    /* The caller supplied no replaced-target FH (e.g. the NFS server rename,
+     * which does not resolve the destination name up front).  Resolve it here
+     * so a sticky destination directory's owner rule is enforced against the
+     * object actually being replaced. */
+    chimera_vfs_lookup(gate->thread, gate->cred, gate->new_fh, gate->new_fhlen,
+                       gate->new_name, gate->new_namelen,
+                       CHIMERA_VFS_ATTR_FH, 0,
+                       chimera_vfs_rename_at_gate_dst_lookup, gate);
 } /* chimera_vfs_rename_at_gate_dst */
 
 /* Step 1 complete: source DELETE_CHILD authorized -> check destination ADD. */
@@ -591,10 +639,11 @@ chimera_vfs_rename_at(
         } else {
             gate->parent_lease_skip_valid = 0;
         }
-        gate->op_handle        = op_handle;
-        gate->callback         = callback;
-        gate->private_data     = private_data;
-        gate->src_child_fh_len = 0;
+        gate->op_handle         = op_handle;
+        gate->callback          = callback;
+        gate->private_data      = private_data;
+        gate->src_child_fh_len  = 0;
+        gate->dst_target_fh_len = 0;
 
         /* Resolve the source object's FH first so the sticky-bit owner check on
          * the source directory can be evaluated (no-follow: rename operates on

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -451,14 +451,15 @@ chimera_vfs_setattr_gate_complete(
     free(gate);
 } /* chimera_vfs_setattr_gate_complete */
 
-SYMBOL_EXPORT void
-chimera_vfs_setattr(
+static void
+chimera_vfs_setattr_common(
     struct chimera_vfs_thread      *thread,
     const struct chimera_vfs_cred  *cred,
     struct chimera_vfs_open_handle *handle,
     struct chimera_vfs_attrs       *set_attr,
     uint64_t                        pre_attr_mask,
     uint64_t                        post_attr_mask,
+    int                             fd_rights,
     chimera_vfs_setattr_callback_t  callback,
     void                           *private_data)
 {
@@ -474,6 +475,23 @@ chimera_vfs_setattr(
          * decide whether the pre-step is needed.  The real check in the gate
          * callback recomputes once the current owner/group is known. */
         required = chimera_vfs_setattr_required(set_attr, NULL);
+
+        /* POSIX binds I/O rights at open: a descriptor-originated mutation
+         * whose entire requirement is WRITE_DATA (ftruncate,
+         * futimens-to-now through a writable descriptor) is authorized by
+         * the handle's open-time grant and stays valid across later mode
+         * changes.  Only fd_rights callers (chimera_vfs_fsetattr) qualify:
+         * path-based setattr (truncate, utimensat) must check the file's
+         * current permissions even though the internal path-open may share
+         * a cached handle with a user descriptor.  Anything needing more
+         * than WRITE_DATA (chmod/chown/explicit timestamps) keeps the
+         * per-operation owner rules -- ownership does not bind at open. */
+        if (fd_rights && required != 0 &&
+            (required & ~(uint32_t) CHIMERA_ACE_WRITE_DATA) == 0 &&
+            handle->granted_valid &&
+            (handle->granted_access & CHIMERA_ACE_WRITE_DATA)) {
+            required = 0;
+        }
 
         if (required) {
             gate = malloc(sizeof(*gate));
@@ -497,4 +515,40 @@ chimera_vfs_setattr(
     chimera_vfs_setattr_dispatch(thread, cred, handle, set_attr,
                                  pre_attr_mask, post_attr_mask,
                                  callback, private_data);
+} /* chimera_vfs_setattr_common */
+
+SYMBOL_EXPORT void
+chimera_vfs_setattr(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_attrs       *set_attr,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    chimera_vfs_setattr_callback_t  callback,
+    void                           *private_data)
+{
+    chimera_vfs_setattr_common(thread, cred, handle, set_attr,
+                               pre_attr_mask, post_attr_mask, 0,
+                               callback, private_data);
 } /* chimera_vfs_setattr */
+
+/* Descriptor-originated setattr (ftruncate/futimens family): mutations whose
+ * whole requirement is WRITE_DATA are authorized by the descriptor's
+ * open-time grant (POSIX rights retention) instead of the file's current
+ * mode.  Everything else behaves exactly like chimera_vfs_setattr. */
+SYMBOL_EXPORT void
+chimera_vfs_fsetattr(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_attrs       *set_attr,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    chimera_vfs_setattr_callback_t  callback,
+    void                           *private_data)
+{
+    chimera_vfs_setattr_common(thread, cred, handle, set_attr,
+                               pre_attr_mask, post_attr_mask, 1,
+                               callback, private_data);
+} /* chimera_vfs_fsetattr */

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -298,6 +298,20 @@ chimera_vfs_setattr(
     chimera_vfs_setattr_callback_t  callback,
     void                           *private_data);
 
+/* Descriptor-originated variant: WRITE_DATA-only mutations (ftruncate,
+ * futimens-to-now) are authorized by the handle's open-time access grant
+ * rather than the file's current mode (POSIX rights retention). */
+void
+chimera_vfs_fsetattr(
+    struct chimera_vfs_thread      *thread,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_vfs_attrs       *set_attr,
+    uint64_t                        pre_attr_mask,
+    uint64_t                        post_attr_mask,
+    chimera_vfs_setattr_callback_t  callback,
+    void                           *private_data);
+
 void
 chimera_vfs_readdir(
     struct chimera_vfs_thread      *thread,


### PR DESCRIPTION
Extracted from the posix-conformance stack (#1529–#1534) into its own draft PR: these three commits add POSIX open semantics but regress NFSv4 DAC, and need follow-up before they can land. Pulling them out unblocks the rest of the stack.

**Commits (dependency chain)**
- vfs: bind I/O access rights at open (POSIX rights retention)
- vfs: apply POSIX type checks to opens on both open paths
- vfs: creating opens follow a final symlink

**Why held back:** the `open_at` authorization gate (added by the first commit, extended by the second) runs on the NFS **proxy** path and over-denies. The proxy should delegate open-authorization to the remote server — which already performs it — instead of re-deriving it on the client from incomplete fetched attributes. Without that, 16 pjd DAC tests fail on the nfs4 backends (open/chmod/chown/truncate/ftruncate/unlink/link/rename/posix_fallocate) — all of which pass on `main` and on the rest of the stack once these commits are removed.

**To land this:** make the nfs proxy delegate DAC to the server (`CHIMERA_VFS_CAP_DELEGATES_DAC`) **and** complete the nfs-server DAC layer so `rename`/`unlink`/`chmod` denials are enforced server-side (adding DELEGATES_DAC alone shifts enforcement to the server, which currently has gaps there).

Stacks on #1534 (`pr/nfs-portmap`).