### PR TITLE
vfs: take heap allocation out of the gated operation path

### DIFF
--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -2359,20 +2359,17 @@ chimera_io_uring_get_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_io_uring_thread *thread = private_data;
-    int                             fd     = (int) request->get_xattr.handle->vfs_private;
-    char                           *name;
+    struct chimera_io_uring_thread *thread  = private_data;
+    int                             fd      = (int) request->get_xattr.handle->vfs_private;
+    char                           *scratch = (char *) request->plugin_data;
     ssize_t                         rc;
 
     --thread->inflight;
 
-    name = malloc(request->get_xattr.namelen + 1);
-    memcpy(name, request->get_xattr.name, request->get_xattr.namelen);
-    name[request->get_xattr.namelen] = '\0';
+    TERM_STR(name, request->get_xattr.name, request->get_xattr.namelen, scratch);
 
     rc = fgetxattr(fd, name, request->get_xattr.value,
                    request->get_xattr.value_maxlen);
-    free(name);
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
@@ -2389,10 +2386,10 @@ chimera_io_uring_set_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_io_uring_thread *thread = private_data;
-    int                             fd     = (int) request->set_xattr.handle->vfs_private;
-    char                           *name;
-    int                             flags = 0;
+    struct chimera_io_uring_thread *thread  = private_data;
+    int                             fd      = (int) request->set_xattr.handle->vfs_private;
+    char                           *scratch = (char *) request->plugin_data;
+    int                             flags   = 0;
     int                             rc;
     struct stat                     st;
 
@@ -2411,13 +2408,10 @@ chimera_io_uring_set_xattr(
     }
     chimera_linux_stat_to_attr(&request->set_xattr.r_pre_attr, &st);
 
-    name = malloc(request->set_xattr.namelen + 1);
-    memcpy(name, request->set_xattr.name, request->set_xattr.namelen);
-    name[request->set_xattr.namelen] = '\0';
+    TERM_STR(name, request->set_xattr.name, request->set_xattr.namelen, scratch);
 
     rc = fsetxattr(fd, name, request->set_xattr.value,
                    request->set_xattr.value_len, flags);
-    free(name);
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
@@ -2476,9 +2470,9 @@ chimera_io_uring_remove_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_io_uring_thread *thread = private_data;
-    int                             fd     = (int) request->remove_xattr.handle->vfs_private;
-    char                           *name;
+    struct chimera_io_uring_thread *thread  = private_data;
+    int                             fd      = (int) request->remove_xattr.handle->vfs_private;
+    char                           *scratch = (char *) request->plugin_data;
     int                             rc;
     struct stat                     st;
 
@@ -2491,12 +2485,9 @@ chimera_io_uring_remove_xattr(
     }
     chimera_linux_stat_to_attr(&request->remove_xattr.r_pre_attr, &st);
 
-    name = malloc(request->remove_xattr.namelen + 1);
-    memcpy(name, request->remove_xattr.name, request->remove_xattr.namelen);
-    name[request->remove_xattr.namelen] = '\0';
+    TERM_STR(name, request->remove_xattr.name, request->remove_xattr.namelen, scratch);
 
     rc = fremovexattr(fd, name);
-    free(name);
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -1755,19 +1755,16 @@ chimera_linux_get_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    int     fd = (int) request->get_xattr.handle->vfs_private;
-    char   *name;
+    int     fd      = (int) request->get_xattr.handle->vfs_private;
+    char   *scratch = (char *) request->plugin_data;
     ssize_t rc;
 
     (void) private_data;
 
-    name = malloc(request->get_xattr.namelen + 1);
-    memcpy(name, request->get_xattr.name, request->get_xattr.namelen);
-    name[request->get_xattr.namelen] = '\0';
+    TERM_STR(name, request->get_xattr.name, request->get_xattr.namelen, scratch);
 
     rc = fgetxattr(fd, name, request->get_xattr.value,
                    request->get_xattr.value_maxlen);
-    free(name);
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
@@ -1784,9 +1781,9 @@ chimera_linux_set_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    int         fd = (int) request->set_xattr.handle->vfs_private;
-    char       *name;
-    int         flags = 0;
+    int         fd      = (int) request->set_xattr.handle->vfs_private;
+    char       *scratch = (char *) request->plugin_data;
+    int         flags   = 0;
     int         rc;
     struct stat st;
 
@@ -1805,13 +1802,10 @@ chimera_linux_set_xattr(
     }
     chimera_linux_stat_to_attr(&request->set_xattr.r_pre_attr, &st);
 
-    name = malloc(request->set_xattr.namelen + 1);
-    memcpy(name, request->set_xattr.name, request->set_xattr.namelen);
-    name[request->set_xattr.namelen] = '\0';
+    TERM_STR(name, request->set_xattr.name, request->set_xattr.namelen, scratch);
 
     rc = fsetxattr(fd, name, request->set_xattr.value,
                    request->set_xattr.value_len, flags);
-    free(name);
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
@@ -1869,8 +1863,8 @@ chimera_linux_remove_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    int         fd = (int) request->remove_xattr.handle->vfs_private;
-    char       *name;
+    int         fd      = (int) request->remove_xattr.handle->vfs_private;
+    char       *scratch = (char *) request->plugin_data;
     int         rc;
     struct stat st;
 
@@ -1883,12 +1877,9 @@ chimera_linux_remove_xattr(
     }
     chimera_linux_stat_to_attr(&request->remove_xattr.r_pre_attr, &st);
 
-    name = malloc(request->remove_xattr.namelen + 1);
-    memcpy(name, request->remove_xattr.name, request->remove_xattr.namelen);
-    name[request->remove_xattr.namelen] = '\0';
+    TERM_STR(name, request->remove_xattr.name, request->remove_xattr.namelen, scratch);
 
     rc = fremovexattr(fd, name);
-    free(name);
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -419,6 +419,13 @@ struct chimera_vfs_request_handle {
  * and the child + parent statx. */
 #define CHIMERA_VFS_REQUEST_MAX_HANDLES 4
 
+/* Size of the gate resume area carved out of a pooled request (see the `gate`
+ * arm of chimera_vfs_request).  Each gated wrapper static-asserts its own
+ * resume struct against this; raise it if one legitimately outgrows it.  It is
+ * a union member, so it costs nothing until it is the largest arm -- and the
+ * request union is already an order of magnitude bigger than this. */
+#define CHIMERA_VFS_GATE_SCRATCH_SIZE   384
+
 /* One enumerated named stream, packed back-to-back in the list_streams reply
  * buffer.  `name_len` bytes of (un-terminated) stream name follow this header;
  * the next record begins at the following 8-byte-aligned offset. */
@@ -539,6 +546,28 @@ struct chimera_vfs_request {
         struct chimera_vfs_open_handle *handle);
 
     union {
+        /*
+         * Resume state for an asynchronous access gate.
+         *
+         * A gated operation has to park its arguments somewhere while the
+         * gate's own nested requests (open, getattr) run, and it cannot use
+         * either of them: those come and go underneath it, and the real
+         * operation's request does not exist yet.  It can, however, have a
+         * request of its own.  A request holding this arm is never dispatched
+         * and never joins the active list -- chimera_vfs_gate_scratch_alloc()
+         * takes it straight off the thread's free list and
+         * chimera_vfs_gate_scratch_free() returns it -- which is what keeps a
+         * gated operation off the heap entirely.
+         *
+         * Each gated wrapper defines its own resume layout in its own
+         * translation unit and asserts that it fits; the union member gives the
+         * storage its alignment.
+         */
+        union {
+            uint64_t align;
+            uint8_t  data[CHIMERA_VFS_GATE_SCRATCH_SIZE];
+        } gate;
+
         struct {
             char                           *path;
             char                           *pathc;

--- a/src/vfs/vfs_access.h
+++ b/src/vfs/vfs_access.h
@@ -22,6 +22,7 @@
 struct chimera_vfs_attrs;
 struct chimera_vfs_cred;
 struct chimera_vfs_thread;
+struct chimera_vfs_open_handle;
 
 /*
  * Return the subset of `requested` (canonical CHIMERA_ACE_* mask bits) that is
@@ -106,8 +107,36 @@ typedef void (*chimera_vfs_gate_callback_t)(
     enum chimera_vfs_error status,
     void                  *private_data);
 
+/*
+ * Scratch the gate helpers use to carry their own state across the async
+ * open -> getattr -> evaluate -> release steps.  It is supplied by the caller
+ * rather than allocated internally: every gated operation already allocates a
+ * context to resume itself from, so embedding one of these in it makes a gated
+ * op cost a single allocation instead of two.
+ *
+ * The caller owns the storage and must keep it alive until the gate callback
+ * fires.  A caller that chains several gates in sequence (rename_at) may reuse
+ * one instance, since the helpers never run concurrently on the same context.
+ */
+struct chimera_vfs_gate_ctx {
+    struct chimera_vfs_thread      *thread;
+    const struct chimera_vfs_cred  *cred;
+    chimera_vfs_gate_callback_t     callback;
+    void                           *private_data;
+    struct chimera_vfs_open_handle *handle;  /* currently-open object */
+    uint32_t                        required;
+    /* gate_delete: the child is only fetched when the parent's DELETE_CHILD
+     * grant is absent or the parent is sticky. */
+    const void                     *child_fh;
+    int                             child_fhlen;
+    int                             dc;      /* parent grants DELETE_CHILD */
+    int                             sticky;
+    uint64_t                        parent_uid;
+};
+
 /* Require `required` (CHIMERA_ACE_* mask) on the object named by `fh`. */
 void chimera_vfs_gate_fh(
+    struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *fh,
@@ -120,6 +149,7 @@ void chimera_vfs_gate_fh(
  * backends -- for DAC the kernel cannot see on handle-based lookups (path-prefix
  * search, link/rename destination-directory write). */
 void chimera_vfs_gate_fh_dac(
+    struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *fh,
@@ -130,6 +160,7 @@ void chimera_vfs_gate_fh_dac(
 
 /* Authorize deleting `child_fh` from directory `parent_fh` (delete_allowed). */
 void chimera_vfs_gate_delete(
+    struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *parent_fh,

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -259,6 +259,55 @@ chimera_vfs_kv_route_fh(
 } /* chimera_vfs_kv_route_fh */
 
 /*
+ * Take a request off the thread's free list purely as storage for a gated
+ * operation's resume context (the `gate` arm of chimera_vfs_request).
+ *
+ * This deliberately bypasses chimera_vfs_request_alloc_common: a gate-scratch
+ * request is never dispatched, so it wants none of the per-operation
+ * accounting -- no opcode, no module or capability check, no trace span, no
+ * latency stopwatch, and no place on thread->active_requests (where it would
+ * show up as an operation in flight that no backend is working on).  It is
+ * bookkeeping-free storage that happens to be pooled, which is the whole
+ * point: a gated operation now allocates nothing.
+ *
+ * Alloc and free must run on the same thread, which they do: the free list is
+ * per-thread and unlocked, and a gate's completion is delivered on the thread
+ * that started it (chimera_vfs_process_completion drains onto the owning
+ * thread), exactly as chimera_vfs_request_free already relies on.
+ *
+ * Returns the scratch area itself; chimera_vfs_gate_scratch_free() recovers
+ * the request from it.
+ */
+static inline void *
+chimera_vfs_gate_scratch_alloc(struct chimera_vfs_thread *thread)
+{
+    struct chimera_vfs_request *request;
+
+    if (thread->free_requests) {
+        request = thread->free_requests;
+        LL_DELETE(thread->free_requests, request);
+    } else {
+        request              = calloc(1, sizeof(struct chimera_vfs_request));
+        request->thread      = thread;
+        request->plugin_data = malloc(CHIMERA_VFS_PLUGIN_DATA_SIZE);
+    }
+
+    return request->gate.data;
+} /* chimera_vfs_gate_scratch_alloc */
+
+static inline void
+chimera_vfs_gate_scratch_free(
+    struct chimera_vfs_thread *thread,
+    void                      *scratch)
+{
+    struct chimera_vfs_request *request;
+
+    request = container_of(scratch, struct chimera_vfs_request, gate.data);
+
+    LL_PREPEND(thread->free_requests, request);
+} /* chimera_vfs_gate_scratch_free */
+
+/*
  * Common request allocation helper with capability enforcement.
  * Returns ERR_PTR on failure:
  *   - CHIMERA_VFS_ESTALE if module is NULL

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -29,23 +29,14 @@
 /* ----------------------------------------------------------------------------
  * chimera_vfs_gate_fh: require a fixed mask on a single object.
  * ------------------------------------------------------------------------- */
-struct chimera_vfs_gate_fh_ctx {
-    struct chimera_vfs_thread      *thread;
-    const struct chimera_vfs_cred  *cred;
-    uint32_t                        required;
-    chimera_vfs_gate_callback_t     callback;
-    void                           *private_data;
-    struct chimera_vfs_open_handle *handle;
-};
-
 static void
 chimera_vfs_gate_fh_getattr(
     enum chimera_vfs_error    error_code,
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
-    struct chimera_vfs_gate_fh_ctx *ctx = private_data;
-    enum chimera_vfs_error          status;
+    struct chimera_vfs_gate_ctx *ctx = private_data;
+    enum chimera_vfs_error       status;
 
     if (error_code != CHIMERA_VFS_OK) {
         status = error_code;
@@ -65,7 +56,6 @@ chimera_vfs_gate_fh_getattr(
     chimera_vfs_release(ctx->thread, ctx->handle);
 
     ctx->callback(status, ctx->private_data);
-    free(ctx);
 } /* chimera_vfs_gate_fh_getattr */
 
 static void
@@ -74,11 +64,10 @@ chimera_vfs_gate_fh_open(
     struct chimera_vfs_open_handle *handle,
     void                           *private_data)
 {
-    struct chimera_vfs_gate_fh_ctx *ctx = private_data;
+    struct chimera_vfs_gate_ctx *ctx = private_data;
 
     if (error_code != CHIMERA_VFS_OK) {
         ctx->callback(error_code, ctx->private_data);
-        free(ctx);
         return;
     }
 
@@ -91,6 +80,7 @@ chimera_vfs_gate_fh_open(
 
 static void
 chimera_vfs_gate_fh_impl(
+    struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *fh,
@@ -100,14 +90,11 @@ chimera_vfs_gate_fh_impl(
     chimera_vfs_gate_callback_t    callback,
     void                          *private_data)
 {
-    struct chimera_vfs_gate_fh_ctx *ctx;
-
     if (!needed) {
         callback(CHIMERA_VFS_OK, private_data);
         return;
     }
 
-    ctx               = malloc(sizeof(*ctx));
     ctx->thread       = thread;
     ctx->cred         = cred;
     ctx->required     = required;
@@ -122,6 +109,7 @@ chimera_vfs_gate_fh_impl(
 
 SYMBOL_EXPORT void
 chimera_vfs_gate_fh(
+    struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *fh,
@@ -139,7 +127,7 @@ chimera_vfs_gate_fh(
         return;
     }
 
-    chimera_vfs_gate_fh_impl(thread, cred, fh, fhlen, required,
+    chimera_vfs_gate_fh_impl(ctx, thread, cred, fh, fhlen, required,
                              chimera_vfs_gate_needed(module->capabilities, cred),
                              callback, private_data);
 } /* chimera_vfs_gate_fh */
@@ -151,6 +139,7 @@ chimera_vfs_gate_fh(
  */
 SYMBOL_EXPORT void
 chimera_vfs_gate_fh_dac(
+    struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *fh,
@@ -168,7 +157,7 @@ chimera_vfs_gate_fh_dac(
         return;
     }
 
-    chimera_vfs_gate_fh_impl(thread, cred, fh, fhlen, required,
+    chimera_vfs_gate_fh_impl(ctx, thread, cred, fh, fhlen, required,
                              chimera_vfs_gate_needed_dac(module->capabilities, cred),
                              callback, private_data);
 } /* chimera_vfs_gate_fh_dac */
@@ -180,34 +169,20 @@ chimera_vfs_gate_fh_dac(
  * done with no child fetch (the common case).  Otherwise fetch the child too so
  * the per-object DELETE grant and the sticky-bit owner check can be evaluated.
  * ------------------------------------------------------------------------- */
-struct chimera_vfs_gate_delete_ctx {
-    struct chimera_vfs_thread      *thread;
-    const struct chimera_vfs_cred  *cred;
-    const void                     *child_fh;
-    int                             child_fhlen;
-    chimera_vfs_gate_callback_t     callback;
-    void                           *private_data;
-    struct chimera_vfs_open_handle *handle;     /* currently-open object */
-    int                             dc;         /* parent grants DELETE_CHILD */
-    int                             sticky;
-    uint64_t                        parent_uid;
-};
-
 static void
 chimera_vfs_gate_delete_child_getattr(
     enum chimera_vfs_error    error_code,
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
-    struct chimera_vfs_gate_delete_ctx *ctx = private_data;
-    enum chimera_vfs_error              status;
-    int                                 allow;
-    uint64_t                            child_uid;
+    struct chimera_vfs_gate_ctx *ctx = private_data;
+    enum chimera_vfs_error       status;
+    int                          allow;
+    uint64_t                     child_uid;
 
     if (error_code != CHIMERA_VFS_OK) {
         chimera_vfs_release(ctx->thread, ctx->handle);
         ctx->callback(error_code, ctx->private_data);
-        free(ctx);
         return;
     }
 
@@ -235,7 +210,6 @@ chimera_vfs_gate_delete_child_getattr(
 
     status = allow ? CHIMERA_VFS_OK : CHIMERA_VFS_EACCES;
     ctx->callback(status, ctx->private_data);
-    free(ctx);
 } /* chimera_vfs_gate_delete_child_getattr */
 
 static void
@@ -244,11 +218,10 @@ chimera_vfs_gate_delete_child_open(
     struct chimera_vfs_open_handle *handle,
     void                           *private_data)
 {
-    struct chimera_vfs_gate_delete_ctx *ctx = private_data;
+    struct chimera_vfs_gate_ctx *ctx = private_data;
 
     if (error_code != CHIMERA_VFS_OK) {
         ctx->callback(error_code, ctx->private_data);
-        free(ctx);
         return;
     }
 
@@ -265,13 +238,12 @@ chimera_vfs_gate_delete_parent_getattr(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
-    struct chimera_vfs_gate_delete_ctx *ctx = private_data;
-    uint32_t                            mode;
+    struct chimera_vfs_gate_ctx *ctx = private_data;
+    uint32_t                     mode;
 
     if (error_code != CHIMERA_VFS_OK) {
         chimera_vfs_release(ctx->thread, ctx->handle);
         ctx->callback(error_code, ctx->private_data);
-        free(ctx);
         return;
     }
 
@@ -289,7 +261,6 @@ chimera_vfs_gate_delete_parent_getattr(
      * without fetching the child at all. */
     if (ctx->dc && !ctx->sticky) {
         ctx->callback(CHIMERA_VFS_OK, ctx->private_data);
-        free(ctx);
         return;
     }
 
@@ -304,11 +275,10 @@ chimera_vfs_gate_delete_parent_open(
     struct chimera_vfs_open_handle *handle,
     void                           *private_data)
 {
-    struct chimera_vfs_gate_delete_ctx *ctx = private_data;
+    struct chimera_vfs_gate_ctx *ctx = private_data;
 
     if (error_code != CHIMERA_VFS_OK) {
         ctx->callback(error_code, ctx->private_data);
-        free(ctx);
         return;
     }
 
@@ -321,6 +291,7 @@ chimera_vfs_gate_delete_parent_open(
 
 SYMBOL_EXPORT void
 chimera_vfs_gate_delete(
+    struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,
     const void                    *parent_fh,
@@ -330,8 +301,7 @@ chimera_vfs_gate_delete(
     chimera_vfs_gate_callback_t    callback,
     void                          *private_data)
 {
-    struct chimera_vfs_module          *module;
-    struct chimera_vfs_gate_delete_ctx *ctx;
+    struct chimera_vfs_module *module;
 
     module = chimera_vfs_get_module(thread, parent_fh, parent_fhlen);
 
@@ -345,7 +315,6 @@ chimera_vfs_gate_delete(
         return;
     }
 
-    ctx               = malloc(sizeof(*ctx));
     ctx->thread       = thread;
     ctx->cred         = cred;
     ctx->child_fh     = child_fh;

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -180,6 +180,9 @@ struct chimera_vfs_link_at_gate {
     void                           *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_link_at_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "link_at gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_link_at_gate_complete(
     enum chimera_vfs_error status,
@@ -189,7 +192,7 @@ chimera_vfs_link_at_gate_complete(
 
     if (status != CHIMERA_VFS_OK) {
         gate->callback(status, NULL, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -201,7 +204,7 @@ chimera_vfs_link_at_gate_complete(
                                  gate->parent_lease_skip : NULL,
                                  gate->op_handle,
                                  gate->callback, gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_link_at_gate_complete */
 
 SYMBOL_EXPORT void
@@ -250,7 +253,7 @@ chimera_vfs_link_at(
      * destination directory and never checks its write permission for the caller
      * (pjd link/07).  SMB keeps its own model (see gate_needed_dac). */
     if (module && chimera_vfs_gate_needed_dac(module->capabilities, cred)) {
-        gate                 = malloc(sizeof(*gate));
+        gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;
         gate->cred           = cred;
         gate->fh             = fh;

--- a/src/vfs/vfs_proc_link_at.c
+++ b/src/vfs/vfs_proc_link_at.c
@@ -160,6 +160,7 @@ chimera_vfs_link_at_dispatch(
  * directory requires ADD_FILE on that directory.
  */
 struct chimera_vfs_link_at_gate {
+    struct chimera_vfs_gate_ctx     gate_ctx;
     struct chimera_vfs_thread      *thread;
     const struct chimera_vfs_cred  *cred;
     const void                     *fh;
@@ -272,7 +273,8 @@ chimera_vfs_link_at(
         gate->callback     = callback;
         gate->private_data = private_data;
 
-        chimera_vfs_gate_fh_dac(thread, cred, dir_fh, dir_fhlen,
+        chimera_vfs_gate_fh_dac(&gate->gate_ctx, thread, cred,
+                                dir_fh, dir_fhlen,
                                 CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
                                 chimera_vfs_link_at_gate_complete, gate);
         return;

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -181,6 +181,9 @@ struct chimera_vfs_lookup_at_gate {
     void                            *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_lookup_at_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "lookup_at gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_lookup_at_gate_complete(
     enum chimera_vfs_error status,
@@ -190,7 +193,7 @@ chimera_vfs_lookup_at_gate_complete(
 
     if (status != CHIMERA_VFS_OK) {
         gate->callback(status, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -198,7 +201,7 @@ chimera_vfs_lookup_at_gate_complete(
                                    gate->name, gate->namelen, gate->attr_mask,
                                    gate->dir_attr_mask, gate->callback,
                                    gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_lookup_at_gate_complete */
 
 SYMBOL_EXPORT void
@@ -221,7 +224,7 @@ chimera_vfs_lookup_at(
      * which bypasses the kernel's directory-search DAC, so the prefix would
      * otherwise never be checked.  SMB keeps its own model (see gate_needed_dac). */
     if (chimera_vfs_gate_needed_dac(handle->vfs_module->capabilities, cred)) {
-        gate                = malloc(sizeof(*gate));
+        gate                = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread        = thread;
         gate->cred          = cred;
         gate->handle        = handle;

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -169,6 +169,7 @@ chimera_vfs_lookup_at_dispatch(
  * name-cache fast path in the dispatch is only reached once search is granted.
  */
 struct chimera_vfs_lookup_at_gate {
+    struct chimera_vfs_gate_ctx      gate_ctx;
     struct chimera_vfs_thread       *thread;
     const struct chimera_vfs_cred   *cred;
     struct chimera_vfs_open_handle  *handle;
@@ -231,7 +232,8 @@ chimera_vfs_lookup_at(
         gate->callback      = callback;
         gate->private_data  = private_data;
 
-        chimera_vfs_gate_fh_dac(thread, cred, handle->fh, handle->fh_len,
+        chimera_vfs_gate_fh_dac(&gate->gate_ctx, thread, cred,
+                                handle->fh, handle->fh_len,
                                 CHIMERA_ACE_EXECUTE,
                                 chimera_vfs_lookup_at_gate_complete, gate);
         return;

--- a/src/vfs/vfs_proc_mkdir_at.c
+++ b/src/vfs/vfs_proc_mkdir_at.c
@@ -188,6 +188,9 @@ struct chimera_vfs_mkdir_at_gate {
     void                           *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_mkdir_at_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "mkdir_at gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_mkdir_at_gate_complete(
     enum chimera_vfs_error status,
@@ -197,7 +200,7 @@ chimera_vfs_mkdir_at_gate_complete(
 
     if (status != CHIMERA_VFS_OK) {
         gate->callback(status, NULL, NULL, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -206,7 +209,7 @@ chimera_vfs_mkdir_at_gate_complete(
                                   gate->attr_mask, gate->pre_attr_mask,
                                   gate->post_attr_mask, gate->callback,
                                   gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_mkdir_at_gate_complete */
 
 SYMBOL_EXPORT void
@@ -231,7 +234,7 @@ chimera_vfs_mkdir_at(
     }
 
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
-        gate                 = malloc(sizeof(*gate));
+        gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;
         gate->cred           = cred;
         gate->handle         = handle;

--- a/src/vfs/vfs_proc_mkdir_at.c
+++ b/src/vfs/vfs_proc_mkdir_at.c
@@ -174,6 +174,7 @@ chimera_vfs_mkdir_at_dispatch(
  * parent's attrs+ACL and authorizes before the real mkdir is dispatched.
  */
 struct chimera_vfs_mkdir_at_gate {
+    struct chimera_vfs_gate_ctx     gate_ctx;
     struct chimera_vfs_thread      *thread;
     const struct chimera_vfs_cred  *cred;
     struct chimera_vfs_open_handle *handle;
@@ -245,7 +246,8 @@ chimera_vfs_mkdir_at(
 
         /* Creating an entry in a directory requires both the right to add a
          * subdirectory (APPEND_DATA) and search permission (EXECUTE) on it. */
-        chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
+        chimera_vfs_gate_fh(&gate->gate_ctx, thread, cred,
+                            handle->fh, handle->fh_len,
                             CHIMERA_ACE_APPEND_DATA | CHIMERA_ACE_EXECUTE,
                             chimera_vfs_mkdir_at_gate_complete, gate);
         return;

--- a/src/vfs/vfs_proc_mknod_at.c
+++ b/src/vfs/vfs_proc_mknod_at.c
@@ -175,6 +175,9 @@ struct chimera_vfs_mknod_at_gate {
     void                           *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_mknod_at_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "mknod_at gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_mknod_at_gate_complete(
     enum chimera_vfs_error status,
@@ -184,7 +187,7 @@ chimera_vfs_mknod_at_gate_complete(
 
     if (status != CHIMERA_VFS_OK) {
         gate->callback(status, NULL, NULL, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -193,7 +196,7 @@ chimera_vfs_mknod_at_gate_complete(
                                   gate->attr_mask, gate->pre_attr_mask,
                                   gate->post_attr_mask, gate->callback,
                                   gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_mknod_at_gate_complete */
 
 SYMBOL_EXPORT void
@@ -218,7 +221,7 @@ chimera_vfs_mknod_at(
     }
 
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
-        gate                 = malloc(sizeof(*gate));
+        gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;
         gate->cred           = cred;
         gate->handle         = handle;

--- a/src/vfs/vfs_proc_mknod_at.c
+++ b/src/vfs/vfs_proc_mknod_at.c
@@ -161,6 +161,7 @@ chimera_vfs_mknod_at_dispatch(
  * requires ADD_FILE on the parent directory.
  */
 struct chimera_vfs_mknod_at_gate {
+    struct chimera_vfs_gate_ctx     gate_ctx;
     struct chimera_vfs_thread      *thread;
     const struct chimera_vfs_cred  *cred;
     struct chimera_vfs_open_handle *handle;
@@ -230,7 +231,8 @@ chimera_vfs_mknod_at(
         gate->callback       = callback;
         gate->private_data   = private_data;
 
-        chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
+        chimera_vfs_gate_fh(&gate->gate_ctx, thread, cred,
+                            handle->fh, handle->fh_len,
                             CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
                             chimera_vfs_mknod_at_gate_complete, gate);
         return;

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -276,6 +276,9 @@ struct chimera_vfs_read_gate {
     void                           *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_read_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "read gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_read_gate_complete(
     enum chimera_vfs_error    error_code,
@@ -286,7 +289,7 @@ chimera_vfs_read_gate_complete(
 
     if (error_code != CHIMERA_VFS_OK) {
         gate->callback(error_code, 0, 0, NULL, 0, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -296,7 +299,7 @@ chimera_vfs_read_gate_complete(
 
     if (!(gate->handle->granted_access & CHIMERA_ACE_READ_DATA)) {
         gate->callback(CHIMERA_VFS_EACCES, 0, 0, NULL, 0, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -307,7 +310,7 @@ chimera_vfs_read_gate_complete(
                               gate->has_io_owner ? &gate->io_owner : NULL,
                               gate->callback,
                               gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_read_gate_complete */
 
 /* Common path for chimera_vfs_read{,_owned,_into}: mediate the read through the
@@ -340,7 +343,7 @@ chimera_vfs_read_submit(
             }
         } else {
             /* First gated I/O on this handle: compute and cache the grant. */
-            gate = malloc(sizeof(*gate));
+            gate = chimera_vfs_gate_scratch_alloc(thread);
 
             gate->thread    = thread;
             gate->cred      = cred;

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -195,6 +195,7 @@ chimera_vfs_remove_at_dispatch(
  * parent alone.
  */
 struct chimera_vfs_remove_at_gate {
+    struct chimera_vfs_gate_ctx      gate_ctx;
     struct chimera_vfs_thread       *thread;
     const struct chimera_vfs_cred   *cred;
     struct chimera_vfs_open_handle  *handle;
@@ -250,7 +251,7 @@ chimera_vfs_remove_at_sticky_lookup(
     gate->child_fh_len      = attr->va_fh_len;
     gate->child_fh_resolved = 1;
 
-    chimera_vfs_gate_delete(gate->thread, gate->cred,
+    chimera_vfs_gate_delete(&gate->gate_ctx, gate->thread, gate->cred,
                             gate->handle->fh, gate->handle->fh_len,
                             gate->child_fh, gate->child_fh_len,
                             chimera_vfs_remove_at_gate_complete, gate);
@@ -348,7 +349,8 @@ chimera_vfs_remove_at_common(
         gate->private_data = private_data;
 
         if (child_fh && child_fh_len > 0) {
-            chimera_vfs_gate_delete(thread, cred, handle->fh, handle->fh_len,
+            chimera_vfs_gate_delete(&gate->gate_ctx, thread, cred,
+                                    handle->fh, handle->fh_len,
                                     child_fh, child_fh_len,
                                     chimera_vfs_remove_at_gate_complete, gate);
         } else {

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -223,6 +223,9 @@ struct chimera_vfs_remove_at_gate {
     uint8_t                          child_fh_resolved;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_remove_at_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "remove_at gate context outgrew the request gate scratch area");
+
 static void chimera_vfs_remove_at_gate_complete(
     enum chimera_vfs_error status,
     void                  *private_data);
@@ -242,7 +245,7 @@ chimera_vfs_remove_at_sticky_lookup(
     if (error_code != CHIMERA_VFS_OK) {
         /* Name absent/unreadable: surface the natural removal error (ENOENT). */
         gate->callback(error_code, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -266,7 +269,7 @@ chimera_vfs_remove_at_gate_complete(
 
     if (status != CHIMERA_VFS_OK) {
         gate->callback(status, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -287,7 +290,7 @@ chimera_vfs_remove_at_gate_complete(
                                    gate->parent_lease_skip : NULL,
                                    gate->callback,
                                    gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_remove_at_gate_complete */
 
 static void
@@ -326,7 +329,7 @@ chimera_vfs_remove_at_common(
     }
 
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
-        gate                    = malloc(sizeof(*gate));
+        gate                    = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread            = thread;
         gate->cred              = cred;
         gate->handle            = handle;
@@ -396,6 +399,9 @@ struct chimera_vfs_remove_recall_ctx {
     int                              child_fh_len;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_remove_recall_ctx) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "remove recall context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_remove_recall_lookup_complete(
     enum chimera_vfs_error    error_code,
@@ -421,7 +427,7 @@ chimera_vfs_remove_recall_lookup_complete(
                                  ctx->pre_attr_mask, ctx->post_attr_mask,
                                  ctx->parent_lease_skip, ctx->callback,
                                  ctx->private_data);
-    free(ctx);
+    chimera_vfs_gate_scratch_free(ctx->thread, ctx);
 } /* chimera_vfs_remove_recall_lookup_complete */
 
 /* Remove a name in a directory (unconditional by-name unlink).  child_fh, when
@@ -454,7 +460,7 @@ chimera_vfs_remove_at(
         !child_fh && namelen >= 1 && namelen < CHIMERA_VFS_NAME_MAX &&
         !(namelen == 1 && name[0] == '.') &&
         !(namelen == 2 && name[0] == '.' && name[1] == '.')) {
-        struct chimera_vfs_remove_recall_ctx *ctx = malloc(sizeof(*ctx));
+        struct chimera_vfs_remove_recall_ctx *ctx = chimera_vfs_gate_scratch_alloc(thread);
 
         ctx->thread            = thread;
         ctx->cred              = cred;

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -375,6 +375,7 @@ chimera_vfs_rename_at_dispatch(
  * distinguishing APPEND_DATA on the destination.
  */
 struct chimera_vfs_rename_at_gate {
+    struct chimera_vfs_gate_ctx      gate_ctx;
     struct chimera_vfs_thread       *thread;
     const struct chimera_vfs_cred   *cred;
     const void                      *fh;
@@ -469,7 +470,7 @@ chimera_vfs_rename_at_gate_dst_lookup(
         memcpy(gate->dst_target_fh, attr->va_fh, attr->va_fh_len);
         gate->dst_target_fh_len = attr->va_fh_len;
 
-        chimera_vfs_gate_delete(gate->thread, gate->cred,
+        chimera_vfs_gate_delete(&gate->gate_ctx, gate->thread, gate->cred,
                                 gate->new_fh, gate->new_fhlen,
                                 gate->dst_target_fh, gate->dst_target_fh_len,
                                 chimera_vfs_rename_at_gate_target, gate);
@@ -495,7 +496,7 @@ chimera_vfs_rename_at_gate_dst(
     }
 
     if (gate->target_fh && gate->target_fh_len > 0) {
-        chimera_vfs_gate_delete(gate->thread, gate->cred,
+        chimera_vfs_gate_delete(&gate->gate_ctx, gate->thread, gate->cred,
                                 gate->new_fh, gate->new_fhlen,
                                 gate->target_fh, gate->target_fh_len,
                                 chimera_vfs_rename_at_gate_target, gate);
@@ -525,7 +526,8 @@ chimera_vfs_rename_at_gate_src(
         return;
     }
 
-    chimera_vfs_gate_fh(gate->thread, gate->cred, gate->new_fh, gate->new_fhlen,
+    chimera_vfs_gate_fh(&gate->gate_ctx, gate->thread, gate->cred,
+                        gate->new_fh, gate->new_fhlen,
                         CHIMERA_ACE_WRITE_DATA,
                         chimera_vfs_rename_at_gate_dst, gate);
 } /* chimera_vfs_rename_at_gate_src */
@@ -550,7 +552,7 @@ chimera_vfs_rename_at_gate_lookup(
         memcpy(gate->src_child_fh, attr->va_fh, attr->va_fh_len);
         gate->src_child_fh_len = attr->va_fh_len;
 
-        chimera_vfs_gate_delete(gate->thread, gate->cred,
+        chimera_vfs_gate_delete(&gate->gate_ctx, gate->thread, gate->cred,
                                 gate->fh, gate->fhlen,
                                 gate->src_child_fh, gate->src_child_fh_len,
                                 chimera_vfs_rename_at_gate_src, gate);
@@ -559,7 +561,8 @@ chimera_vfs_rename_at_gate_lookup(
 
     /* No FH resolved: fall back to DELETE_CHILD on the source directory alone
      * (sticky owner check needs the object's attrs). */
-    chimera_vfs_gate_fh(gate->thread, gate->cred, gate->fh, gate->fhlen,
+    chimera_vfs_gate_fh(&gate->gate_ctx, gate->thread, gate->cred,
+                        gate->fh, gate->fhlen,
                         CHIMERA_ACE_DELETE_CHILD,
                         chimera_vfs_rename_at_gate_src, gate);
 } /* chimera_vfs_rename_at_gate_lookup */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -402,13 +402,16 @@ struct chimera_vfs_rename_at_gate {
     void                            *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_rename_at_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "rename_at gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_rename_at_gate_fail(
     struct chimera_vfs_rename_at_gate *gate,
     enum chimera_vfs_error             status)
 {
     gate->callback(status, NULL, NULL, NULL, NULL, gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_rename_at_gate_fail */
 
 static void
@@ -425,7 +428,7 @@ chimera_vfs_rename_at_gate_dispatch(struct chimera_vfs_rename_at_gate *gate)
                                    gate->parent_lease_skip : NULL,
                                    gate->op_handle,
                                    gate->callback, gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_rename_at_gate_dispatch */
 
 /* Step 3 complete: replaced-target delete authorized -> dispatch. */
@@ -620,7 +623,7 @@ chimera_vfs_rename_at(
     module = chimera_vfs_get_module(thread, fh, fhlen);
 
     if (module && chimera_vfs_gate_needed(module->capabilities, cred)) {
-        gate                 = malloc(sizeof(*gate));
+        gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;
         gate->cred           = cred;
         gate->fh             = fh;

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -301,6 +301,9 @@ struct chimera_vfs_setattr_gate {
     void                           *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_setattr_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "setattr gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_setattr_gate_complete(
     enum chimera_vfs_error    error_code,
@@ -312,7 +315,7 @@ chimera_vfs_setattr_gate_complete(
 
     if (error_code != CHIMERA_VFS_OK) {
         gate->callback(error_code, NULL, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -358,7 +361,7 @@ chimera_vfs_setattr_gate_complete(
     if (chimera_vfs_gate(attr, gate->cred, required & ~CHIMERA_ACE_WRITE_OWNER) != CHIMERA_VFS_OK) {
         gate->callback(chimera_vfs_setattr_denied_error(gate->set_attr),
                        NULL, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -390,7 +393,7 @@ chimera_vfs_setattr_gate_complete(
         if (has_write_owner) {
             if (chimera_vfs_setattr_write_owner_check(gate->cred, gate->set_attr, attr) != CHIMERA_VFS_OK) {
                 gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
-                free(gate);
+                chimera_vfs_gate_scratch_free(gate->thread, gate);
                 return;
             }
         } else {
@@ -403,7 +406,7 @@ chimera_vfs_setattr_gate_complete(
                 ((required & CHIMERA_ACE_WRITE_OWNER) && !is_owner && gate->cred->uid != 0 &&
                  chimera_vfs_gate(attr, gate->cred, CHIMERA_ACE_WRITE_OWNER) != CHIMERA_VFS_OK)) {
                 gate->callback(CHIMERA_VFS_EPERM, NULL, NULL, NULL, gate->private_data);
-                free(gate);
+                chimera_vfs_gate_scratch_free(gate->thread, gate);
                 return;
             }
         }
@@ -448,7 +451,7 @@ chimera_vfs_setattr_gate_complete(
                                  gate->set_attr, gate->pre_attr_mask,
                                  gate->post_attr_mask, gate->callback,
                                  gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_setattr_gate_complete */
 
 static void
@@ -494,7 +497,7 @@ chimera_vfs_setattr_common(
         }
 
         if (required) {
-            gate = malloc(sizeof(*gate));
+            gate = chimera_vfs_gate_scratch_alloc(thread);
 
             gate->thread         = thread;
             gate->cred           = cred;

--- a/src/vfs/vfs_proc_symlink_at.c
+++ b/src/vfs/vfs_proc_symlink_at.c
@@ -126,6 +126,9 @@ struct chimera_vfs_symlink_at_gate {
     void                             *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_symlink_at_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "symlink_at gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_symlink_at_gate_complete(
     enum chimera_vfs_error status,
@@ -135,7 +138,7 @@ chimera_vfs_symlink_at_gate_complete(
 
     if (status != CHIMERA_VFS_OK) {
         gate->callback(status, NULL, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -145,7 +148,7 @@ chimera_vfs_symlink_at_gate_complete(
                                     gate->attr_mask, gate->pre_attr_mask,
                                     gate->post_attr_mask, gate->callback,
                                     gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_symlink_at_gate_complete */
 
 SYMBOL_EXPORT void
@@ -172,7 +175,7 @@ chimera_vfs_symlink_at(
     }
 
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
-        gate                 = malloc(sizeof(*gate));
+        gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;
         gate->cred           = cred;
         gate->handle         = handle;

--- a/src/vfs/vfs_proc_symlink_at.c
+++ b/src/vfs/vfs_proc_symlink_at.c
@@ -110,6 +110,7 @@ chimera_vfs_symlink_at_dispatch(
  * parent directory.
  */
 struct chimera_vfs_symlink_at_gate {
+    struct chimera_vfs_gate_ctx       gate_ctx;
     struct chimera_vfs_thread        *thread;
     const struct chimera_vfs_cred    *cred;
     struct chimera_vfs_open_handle   *handle;
@@ -186,7 +187,8 @@ chimera_vfs_symlink_at(
         gate->callback       = callback;
         gate->private_data   = private_data;
 
-        chimera_vfs_gate_fh(thread, cred, handle->fh, handle->fh_len,
+        chimera_vfs_gate_fh(&gate->gate_ctx, thread, cred,
+                            handle->fh, handle->fh_len,
                             CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
                             chimera_vfs_symlink_at_gate_complete, gate);
         return;

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -112,6 +112,9 @@ struct chimera_vfs_write_gate {
     void                           *private_data;
 };
 
+_Static_assert(sizeof(struct chimera_vfs_write_gate) <= CHIMERA_VFS_GATE_SCRATCH_SIZE,
+               "write gate context outgrew the request gate scratch area");
+
 static void
 chimera_vfs_write_gate_complete(
     enum chimera_vfs_error    error_code,
@@ -122,7 +125,7 @@ chimera_vfs_write_gate_complete(
 
     if (error_code != CHIMERA_VFS_OK) {
         gate->callback(error_code, 0, 0, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -132,7 +135,7 @@ chimera_vfs_write_gate_complete(
 
     if (!(gate->handle->granted_access & CHIMERA_ACE_WRITE_DATA)) {
         gate->callback(CHIMERA_VFS_EACCES, 0, 0, NULL, NULL, gate->private_data);
-        free(gate);
+        chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
     }
 
@@ -142,7 +145,7 @@ chimera_vfs_write_gate_complete(
                                gate->iov, gate->niov,
                                gate->has_io_owner ? &gate->io_owner : NULL,
                                gate->callback, gate->private_data);
-    free(gate);
+    chimera_vfs_gate_scratch_free(gate->thread, gate);
 } /* chimera_vfs_write_gate_complete */
 
 SYMBOL_EXPORT void
@@ -170,7 +173,7 @@ chimera_vfs_write_owned(
                 return;
             }
         } else {
-            gate = malloc(sizeof(*gate));
+            gate = chimera_vfs_gate_scratch_alloc(thread);
 
             gate->thread         = thread;
             gate->cred           = cred;


### PR DESCRIPTION
Removes the per-operation heap allocations from the VFS access-gate path.  All
three commits are semantically neutral — no authorization behaviour changes.

**`vfs/linux,io_uring: NUL-terminate xattr names in request scratch`**
get/set/remove_xattr malloc'd a buffer per call purely to NUL-terminate a name,
then freed it a few lines later.  Every other name-taking entry point in these
backends already terminates into `request->plugin_data` via `TERM_STR`; use the
same idiom.  Six malloc/free pairs leave the per-op path.

**`vfs: let gated ops supply the gate helpers' context`**
A gated namespace operation allocated twice: once for the wrapper's own resume
context, and again inside `chimera_vfs_gate_fh`/`_dac`/`_delete` for the state
those helpers carry across their open → getattr → evaluate → release steps.
Hoisting the helper state into a caller-supplied `struct chimera_vfs_gate_ctx`
makes the second allocation disappear rather than move: every gated wrapper
already allocates a context to resume itself from, so the helper embeds one
there.  `rename_at` chains up to four gates and reuses a single embedded
context, which is safe because the helpers never run concurrently on one
context — each step is started from the previous step's completion.

**`vfs: park gated operations' resume state in a pooled request`**
The remaining allocation is the context a gated op resumes itself from.  That
cannot live in the gate's nested requests (they come and go underneath it) or in
the real operation's request (it does not exist yet) — but it can have a request
of its own.  A `gate` arm on the request union, taken straight off the thread's
free list, bypassing the dispatch accounting a never-dispatched request does not
want (no opcode, capability check, trace span, latency stopwatch, or place on
the active list).

The arm is free: the union is already 2032 bytes for its largest operation and
the biggest resume context is 184, so `sizeof(request)` is unchanged at 6584.
Each wrapper static-asserts its own context against
`CHIMERA_VFS_GATE_SCRATCH_SIZE` rather than moving ten struct definitions into
the header.  Alloc and free run on one thread — the free list is per-thread and
unlocked, and a gate's completion is delivered on the thread that started it
(`chimera_vfs_process_completion` drains onto the owning thread), the same
invariant `chimera_vfs_request_free` already depends on.

## Notes for review

- Pooling the gate contexts gives up ASan's use-after-free visibility on them —
  the tradeoff the request pool already makes for every other operation.
- Rebased on `aae6fae4`.  That commit added a fourth `chimera_vfs_gate_delete`
  call site in `rename_at` (destination-name resolution for the sticky check);
  it takes the new context argument, folded into commit 2.
- What still allocates per-op in the VFS core: `copy_range`'s context (amortised
  over a bulk data movement) and `chimera_vfs_open_follow_ctx`
  (`vfs_proc_open.c:240`, new in 93467500).  The latter is the same continuation
  pattern and would fit the pooled scratch; left for a follow-up rather than
  widening this PR.

## Dropped from this PR

An earlier revision also cached the directory-search grant on the open handle,
to spare `lookup_at`/`mkdir_at`/`mknod_at`/`symlink_at` the open + uncached
getattr + release that `chimera_vfs_gate_fh` performs per operation (the gate
asks for `CHIMERA_VFS_ATTR_ACL`, which is outside
`CHIMERA_VFS_ATTR_MASK_CACHEABLE`, so that getattr can never hit the attr
cache — and for lookup it is per path component).

That collided with `c91d4bef` ("vfs: bind I/O access rights at open"), which
landed concurrently and claims the same `handle->granted_access` with the
opposite lifetime: rights bound at open and *retained* across later mode
changes, where a gate cache must be *invalidated* by them.  Reconciling the two
needs the field split into open-bound rights and a separately-invalidated
search-grant cache, which is design work rather than a rebase, so it is deferred
to its own PR.  Filed as a follow-up; the work is preserved locally.

## Verification

Local box is a 6-CPU VM with a known flaky-abort cluster, so counts are noisy.

- Release, 2739 vfs+pjd+acl tests: 2 failures, both `diskfs_io_uring` rename,
  both passing on serial rerun.  `upstream/main` under the same conditions
  gives 3.
- `vfs/enforce_test`, `vfs/acl_test` and `pjd/granular` pass.
- `make syntax-check` and `make copyright-check` pass; `reuse-lint` passed in CI
  on the previous push and no files were added since.
