### PR TITLE
Fix three remotely reachable memory-safety bugs (SMB decompress, NFSv4.1 replay, NFSv3 LOOKUP)

### DIFF
--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -159,7 +159,10 @@ chimera_nfs4_compound_process(
         nfs4_release_write_args(thread, req->args_compound);
         rc = nfs4_send_cached_reply(thread, req);
         chimera_nfs_abort_if(rc, "Failed to send cached RPC2 reply");
-        req->replay_slot = NULL;
+        /* Release the slot the retransmit path claimed (IN_PROGRESS) back to
+        * CACHED now that the pinned buffer has been sent; this re-arms the
+        * slot for further retransmits and lets a waiting advance proceed. */
+        nfs4_replay_slot_replay_done(req);
         nfs_request_free(thread, req);
         return;
     }

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1645,15 +1645,34 @@ nfs4_replay_slot_acquire(
                     nfs4_replay_arm_capture(req);
                 }
             } else if (seqid == cseq) {
-                /* Retransmit. */
-                if (state == NFS4_SLOT_CACHED && slot->cached_buf) {
-                    req->replay_slot    = slot;
-                    req->replay_slot_id = slotid;
-                    req->replay_action  = NFS4_REPLAY_ACTION_FROM_CACHE;
-                    *out_is_replay      = true;
+                /* Retransmit.  A CACHED slot always has a live cached_buf
+                 * (finalize promotes to CACHED only when bytes were captured),
+                 * so claim it CACHED -> IN_PROGRESS with the *same* CAS the
+                 * advance path uses to win the right to free that buffer.
+                 * Winning here excludes a concurrent advance (seqid+1) on
+                 * another connection from freeing cached_buf out from under the
+                 * replay read in nfs4_send_cached_reply -- the use-after-free
+                 * the old lock-free reader path allowed.  The compound
+                 * dispatcher restores the slot to CACHED via
+                 * nfs4_replay_slot_replay_done once the bytes are on the wire.
+                 * Reading cached_buf only after the CAS also keeps that plain
+                 * field free of a concurrent free/read data race. */
+                if (state == NFS4_SLOT_CACHED) {
+                    if (!atomic_compare_exchange_weak_explicit(
+                            &slot->state_word, &cur,
+                            nfs4_slot_word(cseq, NFS4_SLOT_IN_PROGRESS),
+                            memory_order_acq_rel, memory_order_acquire)) {
+                        continue;  /* lost the race; re-read and re-evaluate */
+                    }
+                    req->replay_slot        = slot;
+                    req->replay_slot_id     = slotid;
+                    req->replay_action      = NFS4_REPLAY_ACTION_FROM_CACHE;
+                    *out_is_replay          = true;
+                    slot->in_progress_since = nfs4_slot_now();
+                    slot->last_stuck_report = 0;
                 } else {
-                    /* Original ran with cachethis=false (or was demoted
-                     * for size).  We cannot replay the bytes. */
+                    /* COMPLETED: original ran with cachethis=false (or was
+                     * demoted for size).  We cannot replay the bytes. */
                     status = NFS4ERR_RETRY_UNCACHED_REP;
                 }
             } else {
@@ -1763,6 +1782,31 @@ nfs4_replay_slot_finalize(struct nfs_request *req)
 
     req->replay_slot = NULL;
 } /* nfs4_replay_slot_finalize */
+
+void
+nfs4_replay_slot_replay_done(struct nfs_request *req)
+{
+    struct nfs4_replay_slot *slot = req->replay_slot;
+    uint64_t                 cur;
+
+    if (!slot) {
+        return;
+    }
+
+    /* Release a slot claimed by the retransmit path (nfs4_replay_slot_acquire
+     * moved it CACHED -> IN_PROGRESS to pin cached_buf across the replay send)
+     * back to CACHED, preserving its seqid and cached buffer and re-publishing
+     * them with a release store for the next reader.  The slot has been
+     * IN_PROGRESS and owned by this request for the whole replay, so no other
+     * thread has advanced the word -- a plain load of the seqid bits is safe. */
+    cur = atomic_load_explicit(&slot->state_word, memory_order_relaxed);
+    atomic_store_explicit(&slot->state_word,
+                          nfs4_slot_word((uint32_t) (cur >> NFS4_SLOT_SEQID_SHIFT),
+                                         NFS4_SLOT_CACHED),
+                          memory_order_release);
+
+    req->replay_slot = NULL;
+} /* nfs4_replay_slot_replay_done */
 
 /*
  * Record the delegation callback path for a client onto its unified state

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -52,7 +52,11 @@ enum nfs4_slot_state {
  * another connection/thread; it is arbitrated by the CAS in
  * nfs4_replay_slot_acquire.  cached_buf/cached_len are written by the (rare)
  * cachethis capture path on the owning thread and published via the release
- * store in nfs4_replay_slot_finalize.
+ * store in nfs4_replay_slot_finalize.  A retransmit that replays those bytes
+ * first claims the slot CACHED -> IN_PROGRESS with that same CAS (restored by
+ * nfs4_replay_slot_replay_done after the send): holding IN_PROGRESS excludes a
+ * concurrent advance (seqid+1) from freeing cached_buf mid-replay, so the
+ * buffer is only ever read or freed by the single thread that owns the slot.
  */
 struct nfs4_replay_slot {
     _Atomic uint64_t state_word;       /* (seqid << NFS4_SLOT_SEQID_SHIFT) | state */
@@ -538,6 +542,14 @@ nfsstat4 nfs4_replay_slot_acquire(
  * Phase 1 this advances IN_PROGRESS -> COMPLETED.  Phase 2 will optionally
  * capture the encoded reply bytes and transition to CACHED. */
 void nfs4_replay_slot_finalize(
+    struct nfs_request *req);
+
+/* Called by the compound dispatcher after a cached reply has been replayed for
+ * a retransmit.  Releases the slot the retransmit path claimed (CACHED ->
+ * IN_PROGRESS) back to CACHED, keeping its seqid and cached buffer so the
+ * buffer stays pinned for the whole replay and no concurrent advance can free
+ * it mid-send. */
+void nfs4_replay_slot_replay_done(
     struct nfs_request *req);
 
 /* Record the delegation callback path on a client's unified state record.

--- a/src/server/nfs/tests/test_replay_slot.c
+++ b/src/server/nfs/tests/test_replay_slot.c
@@ -321,6 +321,74 @@ test_advance_frees_cache(void)
     destroy_session_table(&table, session);
 } /* test_advance_frees_cache */
 
+/* Case 7b (regression): while a retransmit is replaying a CACHED slot, a
+ * concurrent advance (seqid+1) on another connection must not free the cached
+ * buffer out from under the replay read.  The retransmit path now claims the
+ * slot CACHED -> IN_PROGRESS; an advance that lands in that window is deferred
+ * instead of freeing, and the buffer survives until nfs4_replay_slot_replay_done
+ * restores the slot to CACHED. */
+static void
+test_retransmit_pins_cache_against_advance(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS, TEST_MAXRESP);
+    struct nfs_request       req_replay, req_adv;
+    bool                     is_replay;
+    nfsstat4                 status;
+    char                    *fake_reply;
+
+    /* Get slot 0 into CACHED with simulated captured bytes. */
+    reset_request(&req_replay);
+    req_replay.session = session;
+    status             = nfs4_replay_slot_acquire(session, 0, 1, true, &req_replay, &is_replay);
+    CHECK(status == NFS4_OK);
+    fake_reply = malloc(96);
+    memset(fake_reply, 'z', 96);
+    session->replay_slots[0].cached_buf = fake_reply;
+    session->replay_slots[0].cached_len = 96;
+    session->replay_bytes_in_use       += 96;
+    nfs4_replay_slot_finalize(&req_replay);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_CACHED);
+
+    /* Retransmit (same seqid) claims the slot for replay: IN_PROGRESS, with the
+     * buffer still present and pinned. */
+    reset_request(&req_replay);
+    req_replay.session = session;
+    status             = nfs4_replay_slot_acquire(session, 0, 1, true, &req_replay, &is_replay);
+    CHECK(status == NFS4_OK);
+    CHECK(is_replay);
+    CHECK(req_replay.replay_action == NFS4_REPLAY_ACTION_FROM_CACHE);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_IN_PROGRESS);
+    CHECK(session->replay_slots[0].cached_buf == fake_reply);
+
+    /* An advance arriving during the replay window must NOT free the buffer. */
+    reset_request(&req_adv);
+    req_adv.session = session;
+    status          = nfs4_replay_slot_acquire(session, 0, 2, false, &req_adv, &is_replay);
+    CHECK(status == NFS4ERR_SEQ_MISORDERED);
+    CHECK(session->replay_slots[0].cached_buf == fake_reply);   /* still alive */
+    CHECK(session->replay_bytes_in_use == 96);
+
+    /* Replay done: slot restored to CACHED with buffer and seqid intact. */
+    nfs4_replay_slot_replay_done(&req_replay);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_CACHED);
+    CHECK(nfs4_slot_seqid(&session->replay_slots[0]) == 1);
+    CHECK(session->replay_slots[0].cached_buf == fake_reply);
+
+    /* Now the advance succeeds and frees the buffer as usual. */
+    reset_request(&req_adv);
+    req_adv.session = session;
+    status          = nfs4_replay_slot_acquire(session, 0, 2, false, &req_adv, &is_replay);
+    CHECK(status == NFS4_OK);
+    CHECK(!is_replay);
+    CHECK(nfs4_slot_state(&session->replay_slots[0]) == NFS4_SLOT_IN_PROGRESS);
+    CHECK(session->replay_slots[0].cached_buf == NULL);
+    CHECK(session->replay_bytes_in_use == 0);
+    nfs4_replay_slot_finalize(&req_adv);
+
+    destroy_session_table(&table, session);
+} /* test_retransmit_pins_cache_against_advance */
+
 /* Case 8: misordered seqid on a completed slot. */
 static void
 test_misordered_after_completed(void)
@@ -432,6 +500,7 @@ main(
     test_completed_retry_uncached();
     test_cached_retry_replay();
     test_advance_frees_cache();
+    test_retransmit_pins_cache_against_advance();
     test_misordered_after_completed();
     test_slots_independent();
     test_implicit_session_no_slots();

--- a/src/server/smb/smb_compress.c
+++ b/src/server/smb/smb_compress.c
@@ -134,7 +134,13 @@ chimera_smb_lz77_decompress(
 
         /* Match. */
         uint16_t mb;
-        int      length, offset;
+        int      offset;
+        /* The 32-bit length escape below is attacker-controlled and can reach
+         * ~4 GB.  Decode and bound-check it in 64-bit so neither the length
+         * fix-ups nor the `outpos + length` comparison can overflow a signed
+         * int (CWE-190): a wrapped-negative bound once let a ~2 GB match slip
+         * past the check and overrun `out`. */
+        int64_t  length;
 
         if (inpos + 2 > in_len) {
             return -1;
@@ -176,7 +182,7 @@ chimera_smb_lz77_decompress(
                         if (inpos + 4 > in_len) {
                             return -1;
                         }
-                        length = (int) rd32(in + inpos);
+                        length = (int64_t) rd32(in + inpos);
                         inpos += 4;
                     }
                     length -= (15 + 7);
@@ -187,7 +193,10 @@ chimera_smb_lz77_decompress(
         }
         length += SMB_LZ77_MIN_MATCH;
 
-        if (offset > outpos || outpos + length > out_len) {
+        /* `out_len - outpos` is the remaining output space (>= 1 here, since the
+         * loop runs only while outpos < out_len); comparing against it keeps both
+         * sides non-negative and avoids the signed overflow of outpos + length. */
+        if (offset > outpos || length > (int64_t) (out_len - outpos)) {
             return -1;
         }
         /* Overlapping copy: byte-by-byte (offset may be < length). */

--- a/src/server/smb/tests/smb_compress_test.c
+++ b/src/server/smb/tests/smb_compress_test.c
@@ -208,6 +208,38 @@ test_decode_short_match(void)
     }
 } /* test_decode_short_match */
 
+/* Regression: a match whose 32-bit length escape is near INT_MAX must be
+ * rejected, not wrapped past the bound check.  Wire layout: one literal (so
+ * outpos > 0 and offset 1 is valid), then a match token with length code 7
+ * (escape) and offset 1, a half-byte nibble of 15, an extended byte of 255, a
+ * 16-bit 0 (escape to 32-bit), and a 32-bit length of 0x7FFFFFFC (decoded
+ * length 0x7FFFFFFF).  With the old signed `outpos + length` test this wrapped
+ * negative and drove a ~2 GB overlapping copy off the 64-byte output; the codec
+ * must now return -1. */
+static void
+test_decode_length_overflow(void)
+{
+    uint8_t in[15];
+    uint8_t out[64];
+    int     dlen;
+
+    in[0]  = 0x00; in[1] = 0x00; in[2] = 0x00; in[3] = 0x40; /* literal, then match */
+    in[4]  = 'A';                                            /* literal */
+    in[5]  = 0x07; in[6] = 0x00;                             /* match: len-code 7, offset 1 */
+    in[7]  = 0x0F;                                           /* half-byte nibble = 15 */
+    in[8]  = 0xFF;                                           /* extended byte = 255 */
+    in[9]  = 0x00; in[10] = 0x00;                            /* 16-bit 0 => 32-bit escape */
+    in[11] = 0xFC; in[12] = 0xFF; in[13] = 0xFF; in[14] = 0x7F; /* 32-bit len 0x7FFFFFFC */
+
+    dlen = chimera_smb_lz77_decompress(in, sizeof(in), out, sizeof(out));
+    if (dlen == -1) {
+        TEST_PASS("decode: 32-bit length escape overflow rejected");
+    } else {
+        TEST_FAIL("decode: 32-bit length escape overflow rejected");
+        fprintf(stderr, "    expected -1, got %d\n", dlen);
+    }
+} /* test_decode_length_overflow */
+
 /* LZNT1 compress -> decompress round-trip over the same payload shapes. */
 static void
 roundtrip_lznt1(
@@ -469,6 +501,7 @@ main(
     fprintf(stderr, "=== SMB3 compression: Plain LZ77 decode vectors ===\n");
     test_decode_literals();
     test_decode_short_match();
+    test_decode_length_overflow();
 
     fprintf(stderr, "\nTotal: %d passed, %d failed\n", passed, failed);
     return failed == 0 ? 0 : 1;

--- a/src/vfs/tests/vfs_enforce_test.c
+++ b/src/vfs/tests/vfs_enforce_test.c
@@ -505,6 +505,20 @@ main(
         kid_fh_len = ctx.fh_len;
         TEST_PASS("lookup: non-owner denied, owner allowed (0700 dir)");
 
+        /* A component longer than {NAME_MAX} is rejected with ENAMETOOLONG
+         * before dispatch -- lookup_at was the sole _at proc missing this bound,
+         * letting an attacker-sized NFSv3 LOOKUP name overrun a passthrough
+         * backend's fixed request buffer. */
+        {
+            char longname[CHIMERA_VFS_NAME_MAX + 32];
+
+            memset(longname, 'a', sizeof(longname) - 1);
+            longname[sizeof(longname) - 1] = '\0';
+            assert(lookup_as(&ctx, &owner, dir_handle, longname) ==
+                   CHIMERA_VFS_ENAMETOOLONG);
+        }
+        TEST_PASS("lookup: over-long component rejected (ENAMETOOLONG)");
+
         assert(remove_as(&ctx, &other, dir_handle, "kid", kid_fh, kid_fh_len) ==
                CHIMERA_VFS_EACCES);
         assert(remove_as(&ctx, &owner, dir_handle, "kid", kid_fh, kid_fh_len) ==

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -214,6 +214,17 @@ chimera_vfs_lookup_at(
 {
     struct chimera_vfs_lookup_at_gate *gate;
 
+    /* A single component may not exceed {NAME_MAX}.  Every other _at proc
+     * (mkdir_at, remove_at, open_at, ...) rejects an over-long name here; lookup
+     * was the sole gap, letting an attacker-sized NFSv3 LOOKUP component (bounded
+     * only by the ~4 MB RPC limit) reach a passthrough backend that copies it
+     * into a fixed CHIMERA_VFS_PLUGIN_DATA_SIZE (8 KB) request buffer and overrun
+     * the heap.  Bound it before dispatch. */
+    if (namelen >= CHIMERA_VFS_NAME_MAX) {
+        callback(CHIMERA_VFS_ENAMETOOLONG, NULL, NULL, private_data);
+        return;
+    }
+
     /* Path-prefix search (EXECUTE) is enforced by the engine even for
      * DELEGATES_DAC (passthrough) backends when the caller is a POSIX (AUTH_UNIX)
      * client: they resolve each component by file handle (open_by_handle_at),


### PR DESCRIPTION
Three memory-safety fixes for remotely reachable bugs in the NFS and SMB
servers. Each fix is a self-contained commit with a regression test.

All three issues were identified by **François Renaud-Philippon**.

### 1. SMB LZ77 decompression — pre-auth heap overflow (`smb_compress.c`)

The Plain LZ77 decoder read the 32-bit length escape into a signed `int` and
checked `outpos + length > out_len` in signed arithmetic. An attacker-chosen
length near `INT_MAX` wraps that sum negative, so the bound passes and the
overlapping copy runs ~2 GB past the output buffer. It is reachable **pre-auth**
on TCP/445: a ~35-byte compression-transform message (`0xFC 'S' 'M' 'B'`) is
decompressed before any session or authentication check, so a single packet
crashes the daemon.

Fix: decode the length into `int64_t` and compare against the remaining output
space (`out_len - outpos`), keeping both sides non-negative so neither the
length fix-ups nor the bound check can overflow.

### 2. NFSv4.1 SEQUENCE slot replay — use-after-free (`nfs4_session.c`)

The replay-slot state machine let a retransmit (`seqid == cached`) read
`slot->cached_buf` and defer the reply send while, on another connection bound
to the same session, an advance (`seqid+1`) won the `CACHED -> IN_PROGRESS` CAS
and `free()`d that buffer. The lock-free reader path was never excluded from the
freeing writer: the two race on a plain pointer, crashing the daemon (SIGSEGV)
or replaying post-free heap bytes to the client.

Fix: the retransmit path now claims the slot with the same `CACHED ->
IN_PROGRESS` CAS the advance uses, so holding `IN_PROGRESS` excludes a
concurrent advance from freeing the buffer mid-replay. The compound dispatcher
restores the slot to `CACHED` (seqid and buffer intact) via the new
`nfs4_replay_slot_replay_done` once the bytes are on the wire.

### 3. NFSv3 LOOKUP — heap overflow via unchecked component length (`vfs_proc_lookup_at.c`)

`chimera_vfs_lookup_at` was the only `_at` proc missing the `{NAME_MAX}` bound
that every sibling (`mkdir_at`, `remove_at`, `open_at`, …) enforces. An NFSv3
LOOKUP name is bounded only by the ~4 MB RPC limit and reaches this proc
unchecked, so the `linux` / `io_uring` passthrough backends `TERM_STR`-copy it
into the fixed `CHIMERA_VFS_PLUGIN_DATA_SIZE` (8 KB) request buffer and overrun
the heap with fully attacker-controlled content. (NFSv4 already validates names;
memfs is comparison-only and unaffected.)

Fix: bound the component to `CHIMERA_VFS_NAME_MAX` before dispatch and return
`ENAMETOOLONG`, closing the gap for every caller at the VFS layer.

---

Reported-by: François Renaud-Philippon
