### PR TITLE
Fix two single-packet pre-auth DoS bugs in the SMB receive path (short NBSS frame, SMB1 NEGOTIATE bcc)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -2114,7 +2114,16 @@ chimera_smb_server_handle_smb1(
 
     request = chimera_smb_request_alloc(thread);
 
-    evpl_iovec_cursor_copy(&request_cursor, &request->smb1_hdr, sizeof(request->smb1_hdr));
+    /* Every field below is parsed from an untrusted, attacker-framed message;
+     * the unchecked cursor readers abort() the whole shared process on a short
+     * read, so use the checked variants and reject a malformed frame cleanly. */
+    if (evpl_iovec_cursor_try_copy(&request_cursor, &request->smb1_hdr,
+                                   sizeof(request->smb1_hdr))) {
+        chimera_smb_error("Received truncated SMB1 header; closing connection");
+        chimera_smb_request_free(thread, request);
+        evpl_close(evpl, conn->bind);
+        return;
+    }
 
     if (request->smb1_hdr.command != SMB1_NEGOTIATE) {
         chimera_smb_error("Received SMB1 message with invalid command");
@@ -2123,13 +2132,32 @@ chimera_smb_server_handle_smb1(
         return;
     } /* switch */
 
-    evpl_iovec_cursor_get_uint8(&request_cursor, &wct);
+    if (evpl_iovec_cursor_try_get_uint8(&request_cursor, &wct)) {
+        chimera_smb_error("Received truncated SMB1 NEGOTIATE (word count); closing connection");
+        chimera_smb_request_free(thread, request);
+        evpl_close(evpl, conn->bind);
+        return;
+    }
     evpl_iovec_cursor_reset_consumed(&request_cursor);
-    evpl_iovec_cursor_get_uint16(&request_cursor, &bcc);
+    if (evpl_iovec_cursor_try_get_uint16(&request_cursor, &bcc)) {
+        chimera_smb_error("Received truncated SMB1 NEGOTIATE (byte count); closing connection");
+        chimera_smb_request_free(thread, request);
+        evpl_close(evpl, conn->bind);
+        return;
+    }
 
     dialects = alloca(bcc + 1);
 
-    evpl_iovec_cursor_copy(&request_cursor, dialects, bcc);
+    /* bcc is a client-declared byte count.  The unchecked copy that used to live
+     * here aborted the whole shared process when the frame carried fewer bytes
+     * than declared; fence the copy to what the frame actually holds. */
+    if (evpl_iovec_cursor_try_copy(&request_cursor, dialects, bcc)) {
+        chimera_smb_error("SMB1 NEGOTIATE byte count %u exceeds frame; closing connection",
+                          (unsigned int) bcc);
+        chimera_smb_request_free(thread, request);
+        evpl_close(evpl, conn->bind);
+        return;
+    }
 
     dialects[bcc] = 0;
 

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -2479,6 +2479,19 @@ chimera_smb_server_handle_tcp(
     struct netbios_header    netbios_hdr;
     uint32_t                 smb_hdr;
 
+    /* The segment layer delivers exactly 4 (the NBSS header) + the NBSS-declared
+     * length, enforcing no minimum, but the protocol-id peek below reads a
+     * 4-byte SMB id unconditionally.  A frame declaring 0..3 payload bytes would
+     * leave that read short and abort the whole (shared) process -- a single
+     * pre-auth packet DoS.  Drop any frame too short to contain both the NBSS
+     * header and the protocol id. */
+    if (length < (int) (sizeof(netbios_hdr) + sizeof(smb_hdr))) {
+        chimera_smb_error("Received short SMB frame (%d bytes); closing connection",
+                          length);
+        evpl_close(evpl, conn->bind);
+        return;
+    }
+
     evpl_iovec_cursor_init(&request_cursor, iov, niov);
     evpl_iovec_cursor_copy(&request_cursor, &netbios_hdr, sizeof(netbios_hdr));
 

--- a/src/server/smb/tests/smb_harden_test.c
+++ b/src/server/smb/tests/smb_harden_test.c
@@ -146,6 +146,38 @@ test_unbounded_default(void)
 } /* test_unbounded_default */
 
 /* ------------------------------------------------------------------ *
+*  Pre-dispatch frame bounds (chimera_smb_server_handle_tcp)         *
+* ------------------------------------------------------------------ */
+
+/* Regression: a frame carrying only the 4-byte NBSS header (NBSS-declared
+ * length 0) leaves no bytes for the 4-byte SMB protocol id the TCP handler
+ * peeks before dispatch.  The unchecked peek used to abort the whole process
+ * on such a short frame -- a single 4-byte pre-auth packet.  Reproduce the
+ * exact read sequence and confirm the shortfall is reported, not aborted. */
+static void
+test_short_nbss_frame_protocol_id(void)
+{
+    uint8_t                  frame[4] = { 0 }; /* NBSS header only, no payload */
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+    struct netbios_header    nb;
+    uint32_t                 proto;
+
+    cursor_over(&cur, &iov, frame, sizeof(frame));
+
+    /* The handler now drops frames shorter than NBSS header + protocol id. */
+    CHECK((int) sizeof(frame) < (int) (sizeof(nb) + sizeof(proto)),
+          "short frame is below the NBSS header + protocol id minimum");
+
+    /* And the underlying peek, if reached, reports the shortfall rather than
+     * aborting: consume the 4-byte NBSS header, then a checked protocol-id
+     * read must fail cleanly. */
+    evpl_iovec_cursor_copy(&cur, &nb, sizeof(nb));
+    CHECK(evpl_iovec_cursor_try_get_uint32(&cur, &proto) == -1,
+          "short NBSS frame: protocol-id peek rejected (no abort)");
+} /* test_short_nbss_frame_protocol_id */
+
+/* ------------------------------------------------------------------ *
 *  smb_cursor_seek_to                                                *
 * ------------------------------------------------------------------ */
 
@@ -292,6 +324,9 @@ main(
     test_try_copy_past_end_rejected();
     test_limit_fences_reads();
     test_unbounded_default();
+
+    fprintf(stderr, "=== SMB parse hardening: pre-dispatch frame bounds ===\n");
+    test_short_nbss_frame_protocol_id();
 
     fprintf(stderr, "=== SMB parse hardening: smb_cursor_seek_to ===\n");
     test_seek_to();

--- a/src/server/smb/tests/smb_harden_test.c
+++ b/src/server/smb/tests/smb_harden_test.c
@@ -177,6 +177,37 @@ test_short_nbss_frame_protocol_id(void)
           "short NBSS frame: protocol-id peek rejected (no abort)");
 } /* test_short_nbss_frame_protocol_id */
 
+/* Regression: the SMB1 NEGOTIATE byte count (bcc) is client-declared and was
+ * used as both an alloca size and an unchecked copy length for the dialect
+ * buffer, so declaring more bytes than the frame carries aborted the whole
+ * shared process.  Reproduce the parse layout -- NBSS header (4) + SMB1 header
+ * (32) + word count (1) + byte count (2) -- with a bcc that overruns the frame
+ * and confirm the checked dialect copy rejects it instead of aborting. */
+static void
+test_smb1_negotiate_bad_bcc(void)
+{
+    uint8_t                  frame[41] = { 0 }; /* header fields + 2 dialect bytes */
+    struct evpl_iovec        iov;
+    struct evpl_iovec_cursor cur;
+    uint8_t                  wct;
+    uint16_t                 bcc;
+    uint8_t                  dialects[16];
+
+    put_le16(frame, 37, 200); /* bcc: far more than the 2 bytes the frame holds */
+
+    cursor_over(&cur, &iov, frame, sizeof(frame));
+
+    /* NBSS header + SMB1 header, then the word count and byte count. */
+    CHECK(evpl_iovec_cursor_try_skip(&cur, 4 + 32) == 0, "skip NBSS + SMB1 header");
+    CHECK(evpl_iovec_cursor_try_get_uint8(&cur, &wct) == 0, "read word count");
+    evpl_iovec_cursor_reset_consumed(&cur);
+    CHECK(evpl_iovec_cursor_try_get_uint16(&cur, &bcc) == 0, "read byte count");
+    CHECK(bcc == 200, "byte count decoded");
+
+    CHECK(evpl_iovec_cursor_try_copy(&cur, dialects, bcc) == -1,
+          "SMB1 NEGOTIATE oversized byte count: dialect copy rejected (no abort)");
+} /* test_smb1_negotiate_bad_bcc */
+
 /* ------------------------------------------------------------------ *
 *  smb_cursor_seek_to                                                *
 * ------------------------------------------------------------------ */
@@ -327,6 +358,7 @@ main(
 
     fprintf(stderr, "=== SMB parse hardening: pre-dispatch frame bounds ===\n");
     test_short_nbss_frame_protocol_id();
+    test_smb1_negotiate_bad_bcc();
 
     fprintf(stderr, "=== SMB parse hardening: smb_cursor_seek_to ===\n");
     test_seek_to();


### PR DESCRIPTION
Two more single-packet, pre-authentication denial-of-service fixes in the SMB
receive path. Each is a self-contained commit with a hardening regression test.
Because NFS, SMB, S3 and REST share one process, either crash takes the whole
daemon down (and refuses subsequent connections).

Both issues were identified by **François Renaud-Philippon**.

### 1. NetBIOS short frame — pre-auth abort on a 4-byte packet (`smb.c`)

The segment layer delivers a message of exactly 4 (the NBSS header) + the
NBSS-declared length and enforces no minimum, but `chimera_smb_server_handle_tcp`
peeked a 4-byte SMB protocol id before checking the frame was long enough to
contain it. A frame declaring 0..3 payload bytes left the peek short, and the
unchecked cursor reader `abort()`s the whole process. A single 4-byte packet
(`00 00 00 00`) to TCP/445 kills the daemon.

Fix: reject any frame shorter than the NBSS header plus the protocol id before
the peek.

### 2. SMB1 NEGOTIATE byte count — pre-auth abort via declared-vs-actual length (`smb.c`)

`chimera_smb_server_handle_smb1` used the client-declared byte count (bcc) as
both the `alloca` size and the unchecked copy length for the dialect buffer, so
declaring more bytes than the frame carries aborted the process. The sibling
fixed-header reads (SMB1 header, word count, byte count) had the same unchecked
pattern and aborted on any short frame.

Fix: parse the SMB1 NEGOTIATE fixed fields with the bounds-checked cursor
readers (`try_copy` / `try_get_uint8` / `try_get_uint16`) that this codebase
already provides for untrusted input, rejecting a malformed or truncated frame
cleanly instead of aborting.

Reported-by: François Renaud-Philippon
