### PR TITLE
build: tri-state CUDA_SUPPORT flag, and make DISABLE_TESTS actually disable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,12 @@ option(CHIMERA_VFS_IO_URING "Enable chimera VFS io_uring backend" ${CHIMERA_LINU
 option(REQUIRE_NETNS_TESTS "Fail configure if network namespace tests cannot be enabled" OFF)
 option(EVPL_IOVEC_PROFILE "Enable libevpl retained-iovec stack profiling" OFF)
 
+# Build the product only: no test executables are compiled and no ctests are
+# registered, here or in the bundled libevpl (which reads the same variable).
+# Declared as a cache option so it shows up in ccmake/cmake-gui alongside the
+# rest; it has always been settable with -DDISABLE_TESTS=ON.
+option(DISABLE_TESTS "Do not build or register any tests" OFF)
+
 # CUDA / GPUDirect Storage support.
 #
 # The only CUDA-dependent part of the tree is src/cufile: a cuFile-compatible
@@ -403,7 +409,12 @@ set(KVM_TESTING "AUTO" CACHE STRING "KVM test suites: AUTO (enable iff available
 set_property(CACHE KVM_TESTING PROPERTY STRINGS AUTO ON OFF)
 string(TOUPPER "${KVM_TESTING}" KVM_TESTING)
 
-if(KVM_TESTING STREQUAL "OFF")
+if(DISABLE_TESTS)
+    # DISABLE_TESTS wins over an explicit KVM_TESTING=ON: the caller asked for
+    # no tests at all, which is not the "KVM is missing" failure ON guards
+    # against.
+    message(STATUS "KVM testing disabled (DISABLE_TESTS=ON)")
+elseif(KVM_TESTING STREQUAL "OFF")
     message(STATUS "KVM testing disabled (KVM_TESTING=OFF)")
 elseif(NOT CHIMERA_LINUX)
     # No /dev/kvm and no guest images for non-Linux hosts; leave ON fatal so a
@@ -567,7 +578,8 @@ endfunction()
 # so builds without the pynfs checkout (most non-devcontainer images) skip it.
 option(CHIMERA_ENABLE_PYNFS_TESTS "Register PyNFS test suite ctests" ON)
 find_package(Python3 COMPONENTS Interpreter QUIET)
-if(CHIMERA_ENABLE_PYNFS_TESTS
+if(NOT DISABLE_TESTS
+    AND CHIMERA_ENABLE_PYNFS_TESTS
     AND Python3_FOUND
     AND EXISTS "/opt/pynfs/nfs4.0/testserver.py")
     message(STATUS "PyNFS testing enabled")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,6 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-if (EXISTS "/usr/local/cuda")
-    set(CUDA_ENABLED true)
-    set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
-    set(CMAKE_CUDA_ARCHITECTURES 80)
-else()
-    set(CUDA_ENABLED false) 
-endif()
-
 if (EXISTS "/fio")
     set(FIO_ENABLED true)
 else()
@@ -24,11 +16,9 @@ else()
     set(ELBENCHO_ENABLED false)
 endif()
 
-if (CUDA_ENABLED)
-    project(chimera LANGUAGES C CUDA)
-else()
-    project(chimera LANGUAGES C)
-endif()
+# CUDA is enabled later with enable_language(), once the platform gate below
+# has run and the toolkit probe has decided whether there is one to enable.
+project(chimera LANGUAGES C)
 
 # Platform gate.  Chimera is developed on Linux and a good deal of the stack --
 # io_uring, the cairn/linux VFS backends' Linux-only syscalls, netns-isolated
@@ -101,6 +91,99 @@ option(CHIMERA_VFS_IO_URING "Enable chimera VFS io_uring backend" ${CHIMERA_LINU
 option(REQUIRE_NETNS_TESTS "Fail configure if network namespace tests cannot be enabled" OFF)
 option(EVPL_IOVEC_PROFILE "Enable libevpl retained-iovec stack profiling" OFF)
 
+# CUDA / GPUDirect Storage support.
+#
+# The only CUDA-dependent part of the tree is src/cufile: a cuFile-compatible
+# shim over the chimera client plus a .cu test that drives it.  Building it
+# needs a full toolkit -- nvcc for the device sources, and the CUDA runtime and
+# cuFile headers/libraries to link against -- so a host carrying just the
+# driver, or a partial toolkit, is not enough.
+#
+# CUDA_SUPPORT is tri-state, matching KVM_TESTING further down:
+#   AUTO (default) - enable iff a usable toolkit is present, else skip
+#   ON             - require CUDA; hard fail if the toolkit is incomplete
+#   OFF            - never build the CUDA bits
+#
+# This replaces a bare `if (EXISTS "/usr/local/cuda")`, which gave a host with
+# an incomplete toolkit a confusing failure partway through the build and gave
+# a host with a complete one no way to opt out.
+set(CUDA_SUPPORT "AUTO" CACHE STRING "CUDA support: AUTO (enable iff available), ON (require), or OFF")
+set_property(CACHE CUDA_SUPPORT PROPERTY STRINGS AUTO ON OFF)
+string(TOUPPER "${CUDA_SUPPORT}" CUDA_SUPPORT)
+
+set(CUDA_TOOLKIT_ROOT "/usr/local/cuda" CACHE PATH
+    "CUDA toolkit installation to build against")
+
+if(NOT CUDA_SUPPORT MATCHES "^(AUTO|ON|OFF)$")
+    message(FATAL_ERROR "CUDA_SUPPORT must be AUTO, ON or OFF (got \"${CUDA_SUPPORT}\").")
+endif()
+
+set(CUDA_ENABLED FALSE)
+
+if(CUDA_SUPPORT STREQUAL "OFF")
+    message(STATUS "CUDA disabled (CUDA_SUPPORT=OFF)")
+elseif(NOT CHIMERA_LINUX)
+    # cuFile/GPUDirect Storage is Linux-only, so there is no toolkit to look
+    # for here; leave ON fatal so a CI job that demands CUDA still fails loudly
+    # if it is pointed at the wrong host.
+    if(CUDA_SUPPORT STREQUAL "ON")
+        message(FATAL_ERROR "CUDA_SUPPORT=ON but the host is ${CMAKE_SYSTEM_NAME}, not Linux.")
+    endif()
+    message(STATUS "CUDA disabled (host is ${CMAKE_SYSTEM_NAME}, not Linux)")
+else()
+    # Probe exactly the pieces src/cufile consumes, collecting whatever is
+    # missing so the AUTO/ON message below can name it.  NO_DEFAULT_PATH keeps
+    # the probe honest: a stray nvcc on PATH must not make us build against a
+    # toolkit whose headers and libraries we then fail to find.
+    find_program(CUDA_NVCC_EXECUTABLE nvcc
+        HINTS ${CUDA_TOOLKIT_ROOT}/bin NO_DEFAULT_PATH)
+    find_path(CUDA_CUFILE_INCLUDE_DIR cufile.h
+        HINTS ${CUDA_TOOLKIT_ROOT}/include NO_DEFAULT_PATH)
+    find_library(CUDA_CUFILE_LIBRARY cufile
+        HINTS ${CUDA_TOOLKIT_ROOT}/lib64 ${CUDA_TOOLKIT_ROOT}/lib NO_DEFAULT_PATH)
+    find_library(CUDA_CUDART_LIBRARY cudart
+        HINTS ${CUDA_TOOLKIT_ROOT}/lib64 ${CUDA_TOOLKIT_ROOT}/lib NO_DEFAULT_PATH)
+
+    set(CUDA_AVAILABLE TRUE)
+    set(CUDA_UNAVAILABLE_REASON "")
+
+    if(NOT CUDA_NVCC_EXECUTABLE)
+        set(CUDA_AVAILABLE FALSE)
+        string(APPEND CUDA_UNAVAILABLE_REASON " nvcc not found;")
+    endif()
+
+    if(NOT CUDA_CUFILE_INCLUDE_DIR)
+        set(CUDA_AVAILABLE FALSE)
+        string(APPEND CUDA_UNAVAILABLE_REASON " cufile.h not found;")
+    endif()
+
+    if(NOT CUDA_CUFILE_LIBRARY)
+        set(CUDA_AVAILABLE FALSE)
+        string(APPEND CUDA_UNAVAILABLE_REASON " libcufile not found;")
+    endif()
+
+    if(NOT CUDA_CUDART_LIBRARY)
+        set(CUDA_AVAILABLE FALSE)
+        string(APPEND CUDA_UNAVAILABLE_REASON " libcudart not found;")
+    endif()
+
+    if(CUDA_AVAILABLE)
+        set(CUDA_ENABLED TRUE)
+        set(CMAKE_CUDA_COMPILER ${CUDA_NVCC_EXECUTABLE})
+        set(CMAKE_CUDA_ARCHITECTURES 80)
+        message(STATUS "CUDA enabled (${CUDA_TOOLKIT_ROOT})")
+    elseif(CUDA_SUPPORT STREQUAL "ON")
+        message(FATAL_ERROR
+            "CUDA_SUPPORT=ON but the CUDA toolkit at ${CUDA_TOOLKIT_ROOT} is "
+            "incomplete:${CUDA_UNAVAILABLE_REASON} Install the missing pieces, point "
+            "-DCUDA_TOOLKIT_ROOT at a complete toolkit, or re-run with "
+            "-DCUDA_SUPPORT=AUTO/OFF.")
+    else()
+        message(STATUS "CUDA disabled (CUDA_SUPPORT=AUTO;${CUDA_UNAVAILABLE_REASON}). "
+            "Pass -DCUDA_SUPPORT=ON to make missing prerequisites fatal.")
+    endif()
+endif()
+
 # Use ccache as the compiler launcher when it is installed.  The cache location
 # is left to ccache's own CCACHE_DIR env var (not hardcoded here): the
 # devcontainer points it at the persistent /build/ccache volume so all worktrees
@@ -116,6 +199,13 @@ if(CCACHE_PROGRAM)
     message(STATUS "ccache enabled (${CCACHE_PROGRAM})")
 else()
     message(STATUS "ccache not found; building without compiler cache")
+endif()
+
+# Turn CUDA on now that the toolkit has been probed and its compiler launcher
+# picked.  Deferred to here rather than named in project() so that AUTO can
+# decline gracefully instead of failing configure on a host with no toolkit.
+if(CUDA_ENABLED)
+    enable_language(CUDA)
 endif()
 
 set(CHIMERA_VERSION "0.1.0")
@@ -242,14 +332,6 @@ if(NOT CHIMERA_LINUX)
     # is worth doing on its own terms, not as a side effect of the macOS port.
     # (This does not weaken -Wdeprecated-declarations on Linux.)
     add_definitions(-Wno-deprecated-declarations)
-endif()
-
-if (CUDA_ENABLED)
-    message(STATUS "CUDA enabled")
-    #include_directories(${CUDA_INCLUDE_DIRS})
-    #link_directories(${CUDA_LIBRARIES})
-else()
-    message(STATUS "CUDA disabled")
 endif()
 
 if (FIO_ENABLED)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(chimera_common SHARED
 
 target_link_libraries(chimera_common ${CHIMERA_UNWIND_LIB} ${CHIMERA_DL_LIB} evpl jansson ${CHIMERA_OTEL_LIBS})
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()
 
 install(TARGETS chimera_common DESTINATION lib)

--- a/src/cufile/CMakeLists.txt
+++ b/src/cufile/CMakeLists.txt
@@ -15,4 +15,6 @@ target_link_libraries(chimera_cufile chimera_client chimera_common)
 
 install(TARGETS chimera_cufile DESTINATION lib)
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/cufile/CMakeLists.txt
+++ b/src/cufile/CMakeLists.txt
@@ -1,9 +1,13 @@
-# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
-include_directories(/usr/local/cuda/include)
-link_directories(/usr/local/cuda/lib64)
+# Header and library locations come from the toolkit probe in the top-level
+# CMakeLists (CUDA_TOOLKIT_ROOT), so this tree follows whichever install the
+# probe accepted rather than assuming /usr/local/cuda.
+include_directories(${CUDA_CUFILE_INCLUDE_DIR})
+get_filename_component(CUDA_LIBRARY_DIR ${CUDA_CUFILE_LIBRARY} DIRECTORY)
+link_directories(${CUDA_LIBRARY_DIR})
 
 add_library(chimera_cufile SHARED chimera_cufile.c)
 

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -15,4 +15,6 @@ configure_file(
 )
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/elbencho/CMakeLists.txt
+++ b/src/elbencho/CMakeLists.txt
@@ -12,4 +12,6 @@ install(TARGETS elbencho_chimera DESTINATION lib)
 
 set(ELBENCHO_PLUGIN_PATH ${CMAKE_CURRENT_BINARY_DIR}/libelbencho_chimera.so)
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/fio/CMakeLists.txt
+++ b/src/fio/CMakeLists.txt
@@ -12,4 +12,6 @@ install(TARGETS chimera_fio DESTINATION lib)
 set(PLUGIN_PATH ${CMAKE_CURRENT_BINARY_DIR}/libchimera_fio.so)
 
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/nfs_common/CMakeLists.txt
+++ b/src/nfs_common/CMakeLists.txt
@@ -109,4 +109,6 @@ install(TARGETS chimera_nfs_common DESTINATION lib)
 # Ensure xdrzcc is built before these libraries
 add_dependencies(chimera_nfs_common xdrzcc)
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -83,4 +83,6 @@ target_link_libraries(chimera_posix chimera_client evpl)
 
 install(TARGETS chimera_posix DESTINATION lib)
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -21,4 +21,6 @@ add_subdirectory(smb)
 
 add_subdirectory(rest)
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -107,4 +107,6 @@ if (CAIRN_ENABLED)
     target_link_libraries(chimera_vfs chimera_vfs_cairn)
 endif()
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -58,5 +58,7 @@ target_link_libraries(chimera_vfs_nfs chimera_nfs_common evpl evpl_rpc2)
 
 install(TARGETS chimera_vfs_nfs DESTINATION lib)
 
-add_subdirectory(tests)
+if (NOT DISABLE_TESTS)
+    add_subdirectory(tests)
+endif()
 


### PR DESCRIPTION
Two independent build-system fixes, one commit each.

## `build: make CUDA support a tri-state CUDA_SUPPORT flag (default AUTO)`

CUDA was gated on a bare `if (EXISTS "/usr/local/cuda")`. The only CUDA-dependent part of the tree is `src/cufile` — a cuFile-compatible shim over the chimera client, plus a `.cu` test — and building it needs a complete toolkit: `nvcc`, the CUDA runtime, and the cuFile headers/libraries. A host with the directory present but a partial toolkit (driver-only, or no GPUDirect Storage package) passed the check and then failed partway through the build; a host with a complete toolkit had no way to opt out.

Replaced with a tri-state `CUDA_SUPPORT` cache variable, mirroring the existing `KVM_TESTING` flag:

| value | behaviour |
|---|---|
| `AUTO` (default) | enable iff a usable toolkit is present, else skip |
| `ON` | require CUDA; hard fail if the toolkit is incomplete |
| `OFF` | never build the CUDA bits |

`AUTO` probes the four pieces `src/cufile` actually consumes — `nvcc`, `cufile.h`, `libcufile`, `libcudart` — under a new `CUDA_TOOLKIT_ROOT` (default `/usr/local/cuda`). The probe uses `NO_DEFAULT_PATH` so a stray `nvcc` on `PATH` cannot select a toolkit whose headers and libraries we then fail to find, and it accumulates every missing piece so the `AUTO`/`ON` messages name them:

```
-- CUDA disabled (CUDA_SUPPORT=AUTO; cufile.h not found;). Pass -DCUDA_SUPPORT=ON to make missing prerequisites fatal.
```

Non-Linux hosts short-circuit, since cuFile is Linux-only; as with `KVM_TESTING`, `ON` stays fatal there so a job that demands CUDA fails loudly when pointed at the wrong host.

One structural change worth calling out: `project()` is now unconditionally `LANGUAGES C`, with CUDA coming in via `enable_language(CUDA)` after the probe. Naming CUDA in `project()` would make configure fail outright on a host with no toolkit — exactly what `AUTO` must not do — and deferring it also puts the probe after the platform gate, so `CHIMERA_LINUX` is available to it. `src/cufile` now takes its include and library directories from the probe rather than hardcoding `/usr/local/cuda`.

## `build: honor DISABLE_TESTS in the trees that ignored it`

`DISABLE_TESTS` gates `enable_testing()`, so `ctest -N` on such a build already reported zero tests — but ten `add_subdirectory(tests)` calls never consulted the variable, so the binaries behind those registrations were still compiled and linked. A build asking for no tests paid for all of them: **2677 ninja targets instead of 1496**, the bulk of it `src/posix/tests`, which alone builds several hundred cthon, pjd and POSIX-call executables.

Gated the ten that were missing it (`common`, `cufile`, `daemon`, `elbencho`, `fio`, `nfs_common`, `posix`, `server`, `vfs`, `vfs/nfs`) the same way the six that already honored it are gated. Also skipped the `kvm` and `pynfs` trees, which exist only to register test suites — `DISABLE_TESTS` is checked ahead of `KVM_TESTING` so it wins over an explicit `KVM_TESTING=ON`, since a caller asking for no tests at all is not the "KVM prerequisites regressed" case that `ON` is there to catch.

`DISABLE_TESTS` is also now declared with `option()` alongside the other build flags. It has always been settable with `-DDISABLE_TESTS=ON`, but as a bare undeclared variable it did not show up in ccmake/cmake-gui.

A `-DDISABLE_TESTS=ON` build now produces the daemon and every shared library and no test executables at all. One leak remains: `ext/libevpl/ext/prometheus-c` builds its four test binaries unconditionally, but that lives in a separate repository.

## Notes for review

- No CI job sets `DISABLE_TESTS` or references CUDA, so neither change moves CI behaviour. On every current build host the CUDA probe reaches the same conclusion the old `EXISTS` check did.
- Default-configuration ninja target count is unchanged at 3669, and `ctest -N` still lists 8261 tests.
- The first commit configures cleanly on its own, so the branch is bisectable.