### PR TITLE
nfs4: three RFC conformance fixes in SEEK, DESTROY_CLIENTID and the data-path type gate

### DIFF
--- a/src/server/nfs/nfs4_proc_commit.c
+++ b/src/server/nfs/nfs4_proc_commit.c
@@ -83,7 +83,7 @@ chimera_nfs4_commit_getattr_complete(
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
         !S_ISREG(attr->va_mode)) {
-        res->status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
+        res->status = chimera_nfs4_data_nonreg_status(attr->va_mode);
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
         chimera_nfs4_compound_complete(req, res->status);
         return;

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -43,7 +43,7 @@ chimera_nfs4_lockt_probe(
      * type is NFS4ERR_INVAL. */
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) && !S_ISREG(attr->va_mode)) {
         chimera_vfs_release(req->thread->vfs_thread, handle);
-        res->status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
+        res->status = chimera_nfs4_data_nonreg_status(attr->va_mode);
         chimera_nfs4_compound_complete(req, res->status);
         return;
     }

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -129,7 +129,7 @@ chimera_nfs4_read_typecheck_complete(
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
         !S_ISREG(attr->va_mode)) {
-        res->status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
+        res->status = chimera_nfs4_data_nonreg_status(attr->va_mode);
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
         req->handle = NULL;
         chimera_nfs4_compound_complete(req, res->status);

--- a/src/server/nfs/nfs4_proc_seek.c
+++ b/src/server/nfs/nfs4_proc_seek.c
@@ -5,6 +5,7 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_state.h"
+#include "nfs4_session.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
 
@@ -105,6 +106,23 @@ chimera_nfs4_seek(
     if (nfs4_stateid_is_special(&args->sa_stateid)) {
         if (req->fhlen == 0) {
             res->sa_status = NFS4ERR_NOFILEHANDLE;
+            chimera_nfs4_compound_complete(req, res->sa_status);
+            return;
+        }
+
+        /* A special-stateid read op must still honor share-reservation
+         * deny-READ modes held by any owner of any client (RFC 8881
+         * §9.7): SEEK reports the file's data/hole structure, so a
+         * conflicting deny-READ open makes it NFS4ERR_LOCKED, exactly as
+         * READ (and as DEALLOCATE does for deny-WRITE).  Without this the
+         * offset check below runs first and reports NFS4ERR_NXIO for a
+         * file the caller was never entitled to inspect. */
+        nfsstat4 dstatus = nfs4_clients_check_io_denied(
+            &thread->shared->nfs4_shared_clients,
+            req->fh, req->fhlen, OPEN4_SHARE_ACCESS_READ);
+
+        if (dstatus != NFS4_OK) {
+            res->sa_status = dstatus;
             chimera_nfs4_compound_complete(req, res->sa_status);
             return;
         }

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -149,7 +149,7 @@ chimera_nfs4_write_typecheck_complete(
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
         !S_ISREG(attr->va_mode)) {
-        res->status = S_ISDIR(attr->va_mode) ? NFS4ERR_ISDIR : NFS4ERR_INVAL;
+        res->status = chimera_nfs4_data_nonreg_status(attr->va_mode);
         evpl_iovecs_release(req->thread->evpl, args->data.iov, args->data.niov);
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
         req->handle = NULL;

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -531,6 +531,22 @@ nfs4_client_has_state(const struct nfs4_client *c)
             c->unified->lock_owners_by_str != NULL);
 } /* nfs4_client_has_state */
 
+/* Does the client hold any *leased* state?  DESTROY_CLIENTID (RFC 8881
+ * §18.50.3) must refuse while any opens, locks, delegations or layouts remain,
+ * which is a wider set than nfs4_client_has_state() tests -- that one serves
+ * the SETCLIENTID CLID_INUSE rule (RFC 7530 §16.33.5) and deliberately looks
+ * only at open/lock owners, which is the right test there.
+ *
+ * The owner hashes are not usable as the leased-state test: an owner record
+ * outlives its last CLOSE/LOCKU (it caches the 4.0 seqid and replay slot), so
+ * testing them reports BUSY for a client that has already released everything.
+ * nfs_client_has_leased_state walks down to the actual state containers. */
+static int
+nfs4_client_has_leased_state(const struct nfs4_client *c)
+{
+    return c->unified && nfs_client_has_leased_state(c->unified);
+} /* nfs4_client_has_leased_state */
+
 void
 nfs4_client_setclientid(
     struct nfs4_client_table           *table,
@@ -894,6 +910,18 @@ nfs4_client_destroy_clientid(
     /* RFC 8881 §18.50.3: a client that still owns sessions cannot be
      * destroyed -- the client must DESTROY_SESSION them first. */
     if (nfs4_client_has_session_locked(table, client_id)) {
+        pthread_mutex_unlock(&table->nfs4_ct_lock);
+        return NFS4ERR_CLIENTID_BUSY;
+    }
+
+    /* Sessions are only half the rule: §18.50.3 makes CLIENTID_BUSY a MUST
+     * while opens, locks, delegations, layouts and/or wants remain on the
+     * clientid's unexpired lease, not merely while sessions do.  Destroying
+     * the record here would tear that leased state down underneath its
+     * holder, which is exactly what the error exists to prevent -- a client
+     * that DESTROY_SESSIONs and then DESTROY_CLIENTIDs must be refused while
+     * it still holds opens. */
+    if (nfs4_client_has_leased_state(c)) {
         pthread_mutex_unlock(&table->nfs4_ct_lock);
         return NFS4ERR_CLIENTID_BUSY;
     }

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -427,9 +427,12 @@ nfs4_client_reclaim_complete(
     struct nfs4_client_table *table,
     uint64_t                  client_id);
 
-/* DESTROY_CLIENTID (RFC 8881 §18.50): returns NFS4ERR_STALE_CLIENTID if no
- * such client, NFS4ERR_CLIENTID_BUSY if it still owns sessions, else removes
- * the record (tearing down its unified state hierarchy) and returns NFS4_OK. */
+/*
+ * DESTROY_CLIENTID (RFC 8881 §18.50): returns NFS4ERR_STALE_CLIENTID if no
+ * such client, NFS4ERR_CLIENTID_BUSY if it still owns sessions or any leased
+ * state (opens, locks, delegations, layouts) per §18.50.3, else removes the
+ * record (tearing down its unified state hierarchy) and returns NFS4_OK.
+ */
 nfsstat4
 nfs4_client_destroy_clientid(
     struct nfs4_client_table  *table,

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -1201,6 +1201,59 @@ nfs_client_has_open_state_for_fh(
     return found;
 } /* nfs_client_has_open_state_for_fh */
 
+/* Does this client hold any leased state at all -- opens, locks, delegations
+ * or layouts?  DESTROY_CLIENTID (RFC 8881 §18.50.3) must answer
+ * NFS4ERR_CLIENTID_BUSY while any of it remains.
+ *
+ * The owner hashes are deliberately NOT the test: an open/lock owner record
+ * outlives its last CLOSE/LOCKU (it caches the 4.0 seqid and replay slot), so
+ * a non-empty owner hash does not mean the client still holds state.  Walk
+ * down to the per-owner state containers instead.
+ *
+ * Lock order is client->lock then owner->lock, matching
+ * nfs_client_has_open_state_for_fh; callers may hold nfs4_ct_lock, as
+ * nfs4_clients_check_io_denied already does. */
+bool
+nfs_client_has_leased_state(struct nfs_client *client)
+{
+    struct nfs_open_owner *oo, *oo_tmp;
+    struct nfs_lock_owner *lo, *lo_tmp;
+    bool                   found;
+
+    pthread_mutex_lock(&client->lock);
+
+    found = (client->delegations != NULL) || (client->layouts_by_fh != NULL);
+
+    if (!found) {
+        HASH_ITER(hh, client->open_owners_by_str, oo, oo_tmp)
+        {
+            pthread_mutex_lock(&oo->lock);
+            found = (oo->states_by_fh != NULL);
+            pthread_mutex_unlock(&oo->lock);
+
+            if (found) {
+                break;
+            }
+        }
+    }
+
+    if (!found) {
+        HASH_ITER(hh, client->lock_owners_by_str, lo, lo_tmp)
+        {
+            pthread_mutex_lock(&lo->lock);
+            found = (lo->states != NULL);
+            pthread_mutex_unlock(&lo->lock);
+
+            if (found) {
+                break;
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&client->lock);
+    return found;
+} /* nfs_client_has_leased_state */
+
 nfsstat4
 nfs_open_state_check_io_denied(
     struct nfs_open_state *requesting_state,

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -909,6 +909,14 @@ nfs_client_has_open_state_for_fh(
     const uint8_t     *fh,
     uint16_t           fh_len);
 
+/* True if `client` holds any leased state -- opens, locks, delegations or
+ * layouts.  DESTROY_CLIENTID must return NFS4ERR_CLIENTID_BUSY while it does
+ * (RFC 8881 §18.50.3).  Note this looks past the open/lock-owner hashes to the
+ * state they contain: an owner record outlives its last CLOSE. */
+SYMBOL_EXPORT bool
+nfs_client_has_leased_state(
+    struct nfs_client *client);
+
 /* One bit identifying a (share_access, share_deny) OPEN event for
  * nfs_open_state.share_combos.  access and deny are each 2-bit masks. */
 static inline uint16_t

--- a/src/server/nfs/nfs4_status.h
+++ b/src/server/nfs/nfs4_status.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/stat.h>
+
 #include "nfs_internal.h"
 #include "vfs/vfs_error.h"
 
@@ -72,3 +74,28 @@ chimera_nfs4_errno_to_nfsstat4(enum chimera_vfs_error err)
             return NFS4ERR_SERVERFAULT;
     } /* switch */
 } /* chimera_nfs4_errno_to_nfsstat4 */
+
+/*
+ * Status for a data-path op -- READ, WRITE, COMMIT, LOCKT, SETATTR(size) and
+ * the RFC 7862 sparse ops -- whose current filehandle is not a regular file.
+ *
+ * A directory is NFS4ERR_ISDIR and a symbolic link is NFS4ERR_SYMLINK; every
+ * other non-regular type is NFS4ERR_INVAL.  This is deliberately NOT
+ * chimera_nfs4_open_nonreg_status(): OPEN reports NFS4ERR_WRONG_TYPE for
+ * fifos, sockets and devices under 4.1+, but the data-path ops must keep
+ * answering INVAL for those -- pynfs RD7b/RD7c (st_read.testBlock/testChar)
+ * assert INVAL exactly.  Splitting out the symlink arm is safe because
+ * RFC 7530 Table 7 lists both SYMLINK and INVAL for a symlink cfh and pynfs
+ * RD7a accepts either.
+ */
+static inline nfsstat4
+chimera_nfs4_data_nonreg_status(mode_t mode)
+{
+    if (S_ISDIR(mode)) {
+        return NFS4ERR_ISDIR;
+    }
+    if (S_ISLNK(mode)) {
+        return NFS4ERR_SYMLINK;
+    }
+    return NFS4ERR_INVAL;
+} /* chimera_nfs4_data_nonreg_status */


### PR DESCRIPTION
Three conformance bugs in the NFSv4 server, each with an RFC citation and no
behaviour change beyond the error code returned.

**SEEK ignored share reservations on the special-stateid path.** RFC 8881 §9.7
makes a special-stateid read honour a conflicting deny-READ open, and
`nfs4_proc_deallocate.c` already does exactly that for deny-WRITE, but
`nfs4_proc_seek.c` went straight from the filehandle check to the offset check.
The visible effect was `NFS4ERR_NXIO` — "past end of file" — for a file the
caller was never entitled to inspect, where `NFS4ERR_LOCKED` is the answer.

**DESTROY_CLIENTID refused only while the client still owned sessions.**
RFC 8881 §18.50.3 makes `NFS4ERR_CLIENTID_BUSY` a MUST while *any* leased state
remains — opens, locks, delegations or layouts — and this repo's own R-SESS-48
note records the full rule. A client that issued DESTROY_SESSION and then
DESTROY_CLIENTID while still holding opens was destroyed anyway, tearing that
state down underneath its holder.

The new test deliberately looks past the open/lock-owner hashes to the state
they contain: an owner record outlives its last CLOSE (it caches the 4.0 seqid
and replay slot), so testing the hashes reports BUSY for a client that has
released everything. `nfs4_client_has_state()` is left alone — it serves the
SETCLIENTID `CLID_INUSE` rule (RFC 7530 §16.33.5), where owner-level
granularity is the correct test.

**READ/WRITE/COMMIT/LOCKT collapsed every non-regular filehandle to INVAL.**
RFC 7530 Table 7 lists `NFS4ERR_SYMLINK` alongside INVAL for a symlink cfh, and
the OPEN path has done the per-type split since
`chimera_nfs4_open_nonreg_status` — the data-path ops never learned it.

The new helper is deliberately *not* that function: OPEN answers
`NFS4ERR_WRONG_TYPE` for fifos, sockets and devices under 4.1+, but the data
path must keep answering INVAL for those, because pynfs RD7b and RD7c
(`st_read.testBlock` / `testChar`) assert INVAL exactly. Only the symlink arm is
safe to split out, since pynfs RD7a accepts either answer. SETATTR(size) and the
sparse ops are untouched: their type error comes from the VFS errno mapping
rather than an explicit gate.

pynfs 4.0/4.1/4.2 on memfs stays at 254/254.
