### PR TITLE
vfs: fix the RPL cache's forward hash bucket collapse

### DIFF
--- a/src/vfs/tests/vfs_notify_test.c
+++ b/src/vfs/tests/vfs_notify_test.c
@@ -496,6 +496,89 @@ test_rpl_cache_cross_shard_invalidate(void)
 } /* test_rpl_cache_cross_shard_invalidate */
 
 /* ------------------------------------------------------------------ */
+/* Test 10b: the forward index uses every slot, not one slot per shard */
+/* ------------------------------------------------------------------ */
+/*
+ * The shard index takes the low `num_shards_bits` of the child-FH hash.  If
+ * the slot index is masked off the same low bits, it becomes a pure function
+ * of the shard: every child in a shard lands in that shard's single slot and
+ * the forward index degenerates from 64x16x4 = 4096 entries to 64x4 = 256.
+ *
+ * Insert more distinct children than the degenerate capacity and count how
+ * many survive.  Collapsed, at most 256 of the 1024 can be resident.  Healthy,
+ * 1024 keys spread over 1024 four-way slots lose only the handful that pile
+ * more than four deep on one slot (Poisson(1) tail, ~5 entries), so the count
+ * lands just under 1024.  The 900 threshold sits far from both.
+ */
+#define RPL_CAPACITY_KEYS 1024
+#define RPL_COLLAPSED_CAP 256   /* num_shards * entries_per_slot */
+
+static void
+test_rpl_cache_slot_distribution(void)
+{
+    struct chimera_vfs_rpl_cache *cache;
+    struct chimera_vfs_thread     thread = { 0 }; /* zeroed magazines */
+    uint8_t                       child_fh[CHIMERA_VFS_FH_SIZE];
+    uint8_t                       parent_fh[CHIMERA_VFS_FH_SIZE];
+    char                          name[32];
+    uint8_t                       r_pfh[CHIMERA_VFS_FH_SIZE];
+    uint16_t                      r_pfh_len   = 0;
+    char                          r_name[256] = { 0 };
+    uint16_t                      r_name_len  = 0;
+    int                           name_len;
+    int                           i, hits = 0;
+
+    fprintf(stderr, "\ntest_rpl_cache_slot_distribution\n");
+
+    /* 64 shards, 16 slots, 4 entries per slot, 30s ttl — the same geometry
+     * vfs_notify_init() uses. */
+    cache = chimera_vfs_rpl_cache_create(6, 4, 2, 30);
+
+    make_fh(parent_fh, 0xFE);
+
+    for (i = 0; i < RPL_CAPACITY_KEYS; i++) {
+        memset(child_fh, 0, sizeof(child_fh));
+        child_fh[0] = 0xAA; /* fake magic, as make_fh() uses */
+        child_fh[1] = (uint8_t) i;
+        child_fh[2] = (uint8_t) (i >> 8);
+
+        name_len = snprintf(name, sizeof(name), "f%d", i);
+
+        chimera_vfs_rpl_cache_insert(&thread, cache,
+                                     chimera_vfs_hash(child_fh, sizeof(child_fh)),
+                                     child_fh, sizeof(child_fh),
+                                     parent_fh, sizeof(parent_fh),
+                                     chimera_vfs_hash(parent_fh, sizeof(parent_fh)),
+                                     chimera_vfs_hash(name, name_len),
+                                     name, name_len);
+    }
+
+    for (i = 0; i < RPL_CAPACITY_KEYS; i++) {
+        memset(child_fh, 0, sizeof(child_fh));
+        child_fh[0] = 0xAA;
+        child_fh[1] = (uint8_t) i;
+        child_fh[2] = (uint8_t) (i >> 8);
+
+        if (chimera_vfs_rpl_cache_lookup(cache,
+                                         chimera_vfs_hash(child_fh, sizeof(child_fh)),
+                                         child_fh, sizeof(child_fh),
+                                         r_pfh, &r_pfh_len,
+                                         r_name, &r_name_len) == 0) {
+            hits++;
+        }
+    }
+
+    fprintf(stderr, "  %d/%d entries resident (collapsed ceiling is %d)\n",
+            hits, RPL_CAPACITY_KEYS, RPL_COLLAPSED_CAP);
+
+    CHECK(hits > RPL_COLLAPSED_CAP,
+          "forward index holds more than one slot per shard");
+    CHECK(hits >= 900, "forward index retains nearly all 1024 keys");
+
+    chimera_vfs_rpl_cache_destroy(cache);
+} /* test_rpl_cache_slot_distribution */
+
+/* ------------------------------------------------------------------ */
 /* Test 11: oversized name_len is clamped, ring entry does not overflow */
 /* ------------------------------------------------------------------ */
 static void
@@ -1077,6 +1160,7 @@ main(
     test_callback_fires();
     test_watch_update_filter();
     test_rpl_cache_cross_shard_invalidate();
+    test_rpl_cache_slot_distribution();
     test_oversize_name_clamp();
     test_watch_tree_transition_clears_ring();
     test_watch_tree_transition_tree_to_nontree();

--- a/src/vfs/vfs_rpl_cache.h
+++ b/src/vfs/vfs_rpl_cache.h
@@ -136,6 +136,35 @@ chimera_vfs_rpl_cache_destroy(struct chimera_vfs_rpl_cache *cache)
 } /* chimera_vfs_rpl_cache_destroy */
 
 /*
+ * Base index of the forward-index slot a child-FH hash maps to.
+ *
+ * The shard index consumes the low `num_shards_bits` of the hash, so the slot
+ * index must come from the bits *above* those.  Masking the low bits again
+ * would make the slot a pure function of the shard -- `num_slots_bits <=
+ * num_shards_bits` in every configuration the tree builds (vfs_notify.c uses
+ * 6 and 4), so every child landing in a given shard would also land in that
+ * shard's single slot, collapsing the 16x4 forward index to one 4-entry
+ * direct-mapped bucket per shard and cutting usable capacity from 4096
+ * entries to 256.  The attr and name caches carried the same bug.
+ *
+ * Every forward-index site -- lookup, insert, and the forward removal inside
+ * invalidate -- must derive the slot through this helper; a site computing it
+ * differently would strand entries the others can no longer find or evict.
+ *
+ * The reverse index needs no such shift: its shard comes from the entry's
+ * fwd_key and its slot from the independent rev_key, so the two bit windows
+ * are already uncorrelated.
+ */
+static inline uint64_t
+chimera_vfs_rpl_cache_fwd_slot(
+    const struct chimera_vfs_rpl_cache *cache,
+    uint64_t                            fwd_key)
+{
+    return ((fwd_key >> cache->num_shards_bits) & cache->num_slots_mask) <<
+           cache->num_entries_bits;
+} /* chimera_vfs_rpl_cache_fwd_slot */
+
+/*
  * Forward lookup: child_fh -> (parent_fh, name)
  * Returns 0 on hit, -1 on miss.
  */
@@ -158,7 +187,7 @@ chimera_vfs_rpl_cache_lookup(
 
     shard = &cache->shards[key & cache->num_shards_mask];
 
-    slot     = &shard->fwd_entries[(key & cache->num_slots_mask) << cache->num_entries_bits];
+    slot     = &shard->fwd_entries[chimera_vfs_rpl_cache_fwd_slot(cache, key)];
     slot_end = slot + cache->num_entries;
 
     urcu_qsbr_read_lock();
@@ -308,7 +337,7 @@ chimera_vfs_rpl_cache_insert(
     urcu_qsbr_read_lock();
     pthread_mutex_lock(&shard->entry_lock);
 
-    slot     = &shard->fwd_entries[(fwd_key & cache->num_slots_mask) << cache->num_entries_bits];
+    slot     = &shard->fwd_entries[chimera_vfs_rpl_cache_fwd_slot(cache, fwd_key)];
     slot_end = slot + cache->num_entries;
 
     slot_best  = slot;
@@ -424,7 +453,7 @@ chimera_vfs_rpl_cache_invalidate(
                     struct chimera_vfs_rpl_cache_entry **fwd_slot, **fwd_end;
 
                     fwd_slot = &shard->fwd_entries[
-                        (entry->fwd_key & cache->num_slots_mask) << cache->num_entries_bits];
+                        chimera_vfs_rpl_cache_fwd_slot(cache, entry->fwd_key)];
                     fwd_end = fwd_slot + cache->num_entries;
 
                     while (fwd_slot < fwd_end) {


### PR DESCRIPTION
The shard/slot bit-window overlap that was fixed in the attr and name caches is still present in the RPL cache (`src/vfs/vfs_rpl_cache.h`).

Its forward index picks the shard with the low `num_shards_bits` of the child-FH hash and the slot with the low `num_slots_bits`. `chimera_vfs_notify_init()` configures 6 and 4, so the slot mask is a strict subset of the shard mask and the slot index becomes a pure function of the shard — every child landing in a given shard also lands in that shard's single slot. The 64 × 16 × 4 forward index degenerates to one 4-entry direct-mapped bucket per shard: **256 usable entries out of 4096**, with 15 of every 16 slots permanently empty.

The reverse index is not affected — its shard comes from `fwd_key` and its slot from the independent `rev_key` — but every entry lives in both indexes, so a forward eviction takes the reverse entry with it.

### Why it matters beyond miss latency

The RPL cache backs SMB2 CHANGE_NOTIFY subtree resolution. A forward miss makes `chimera_vfs_notify_resolve` issue an async `getparent` per path component per event, each holding one of the `CHIMERA_VFS_NOTIFY_MAX_PENDING` (256) resolver slots. When those run out, every subtree watch on the mount is overflowed and the SMB layer reports `STATUS_NOTIFY_ENUM_DIR` — the client throws away precise change records and rescans the directory. A watched tree with more than a couple hundred hot directories sits on that path continuously.

### The fix

Derive the forward slot from the bits *above* the shard window so the two are disjoint, matching the attr/name fix.

All three forward-index sites go through one helper. Two are obvious (lookup, insert); the third is the forward removal buried inside `chimera_vfs_rpl_cache_invalidate`. That one is the trap: a site left on the old formula would drop an entry from the reverse index while leaving it in the forward index, serving a stale parent/name for the full 30s TTL — wrong paths reported after a rename, which is worse than the throughput bug being fixed.

### Regression test

`test_rpl_cache_slot_distribution` inserts 1024 distinct children into a cache with the production geometry and counts how many stay resident:

- collapsed: **exactly 256** — the 64 × 4 ceiling, confirming the mechanism
- fixed: **1022** (the two losses are the Poisson tail of keys stacking more than four deep on one slot)

### Scope

I swept the rest of the tree for the same class of defect. This was the last one. Every other hashed structure is either single-level (`vfs_open_cache`, `vfs_notify` buckets, `vfs_mount_table`, `vfs_user_cache`, diskfs inode/kv shards, the uthash users) or already uses disjoint windows — `vfs_state.c` takes the shard from `fh_hash >> 32` and the slot from the low bits, and the diskfs block cache takes the shard from `hash & 0xFF` and the bucket from `(hash >> 8) & 0x3FF`.