### PR TITLE
smb: fix SIGSEGV on QUERY_DIRECTORY against a named-pipe FID

### DIFF
--- a/src/server/smb/smb_proc_query_directory.c
+++ b/src/server/smb/smb_proc_query_directory.c
@@ -378,6 +378,21 @@ chimera_smb_query_directory(struct chimera_smb_request *request)
         return;
     }
 
+    /* Named-pipe FIDs on IPC$ (srvsvc / lsarpc / samr / wkssvc) carry
+     * open_file->handle == NULL -- see chimera_smb_create_gen_open_file_pipe.
+     * The dup_handle below dereferences that handle unconditionally and would
+     * crash the server on a QUERY_DIRECTORY against a pipe FID, the same crash
+     * class already closed on QUERY_INFO and SET_INFO.
+     *
+     * A pipe is not a DirectoryFile, so MS-FSA 2.1.5.5.3 fails the enumeration
+     * with STATUS_INVALID_PARAMETER.  Check before the position resets below so
+     * a rejected query leaves the open's enumeration state untouched. */
+    if (unlikely(request->query_directory.open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_PIPE)) {
+        chimera_smb_open_file_release(request, request->query_directory.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
     if (request->query_directory.flags & SMB2_RESTART_SCANS) {
         request->query_directory.open_file->position = 0;
     }


### PR DESCRIPTION
`e7cf5a38` closed this crash on QUERY_INFO and SET_INFO but not on QUERY_DIRECTORY, which the same series rewrote.

Named-pipe FIDs on IPC$ (srvsvc / lsarpc / samr / wkssvc) carry `open_file->handle == NULL` — `chimera_smb_create_gen_open_file_pipe` passes no handle. `chimera_smb_query_directory` dereferences that handle unconditionally when it takes the extra readdir reference (`smb_proc_query_directory.c:464`):

```c
if (request->query_directory.open_file->handle->cache_id != CHIMERA_VFS_OPEN_ID_SYNTHETIC) {
```

Nothing upstream of that gates the verb. `chimera_smb_compound_advance` routes `SMB2_QUERY_DIRECTORY` straight to the handler with no share-type check, and the handler validates only the information class and the FileId. A client that opens `srvsvc` on IPC$ and sends QUERY_DIRECTORY on that FID takes the server down with a NULL dereference — a tree connect to IPC$ is enough, and IPC$ is reachable on any session.

### Fix

Reject the verb on a pipe FID. A named pipe is not a DirectoryFile, so MS-FSA 2.1.5.5.3 fails the enumeration with `STATUS_INVALID_PARAMETER` — the same section this file already cites for the tiny-buffer `INFO_LENGTH_MISMATCH` case.

The check sits immediately after the FileId resolve, ahead of the RESTART_SCANS / REOPEN / INDEX_SPECIFIED position resets, so a rejected query leaves the open's enumeration state untouched. It releases the resolve reference on the way out, like the other early returns in this function.

Regular-file FIDs are unaffected — they carry a real handle, so the existing backend ENOTDIR path still applies.

### Verification

Debug build clean; `ctest -R smb` 25/25 pass; `make syntax-check` clean.

No unit test, matching `e7cf5a38` (the sibling QUERY_INFO/SET_INFO pipe fix), which shipped source-only. The SMB unit tests here are parse-path and mock-structure tests with no live server, so exercising this verb would mean standing up a tree, compound, and session-handle table; the real coverage is smbtorture/WPTS in CI.