### PR TITLE
smb/vfs: five conformance and access-control fixes from the PR #1511 review

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -240,9 +240,11 @@ chimera_server_config_init(void)
     config->smb2_max_async_credits = 512;
 
     /* FileFsSectorSizeInformation defaults: report 4KiB physical sectors and
-     * aligned + partition-aligned flags for modern storage. */
+     * aligned + partition-aligned flags for modern storage.  Per MS-FSCC
+     * 2.5.8 those two flags are bits 0 and 1; every higher bit is reserved. */
     config->smb_fs_physical_bytes_per_sector = 4096;
-    config->smb_fs_sector_size_flags         = 0x300;
+    config->smb_fs_sector_size_flags         = SMB2_SSINFO_FLAGS_ALIGNED_DEVICE |
+        SMB2_SSINFO_FLAGS_PARTITION_ALIGNED_ON_DEVICE;
 
     // SMB auth config defaults - local NTLM only
     config->smb_auth.winbind_enabled    = 0;

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -440,11 +440,19 @@ chimera_smb_compound_reply(struct chimera_smb_compound *compound)
      * whatever connection currently owns the recycled bind, corrupting its
      * stream from the first message (seen as a fresh smbtorture connection
      * failing NEGOTIATE with NT_STATUS_INVALID_NETWORK_RESPONSE).  The client
-     * this reply was for is gone; drop it and just release the compound. */
+     * this reply was for is gone; drop it and just release the compound.
+     *
+     * evpl_bind_is_closing() reports our OWN half-close (EVPL_BIND_FINISH)
+     * alongside the peer-initiated EVPL_BIND_PENDING_CLOSED / _CLOSED.  The
+     * unparseable-request path deliberately queues an error reply and only then
+     * calls evpl_finish -- a flush-then-close -- so treating FINISH as "drop it"
+     * would silently free exactly the reply that close was meant to deliver,
+     * leaving the client a bare FIN.  conn->finishing marks that case; the
+     * peer-initiated flags still drop. */
     if (unlikely(conn->generation != compound->conn_generation ||
                  conn->disconnecting ||
                  !conn->bind ||
-                 evpl_bind_is_closing(conn->bind))) {
+                 (evpl_bind_is_closing(conn->bind) && !conn->finishing))) {
         chimera_smb_compound_free(thread, compound);
         return;
     }
@@ -1995,6 +2003,12 @@ chimera_smb_server_handle_smb2(
             }
 
             if (thread->shared->config.soft_fail_bad_req == 0) {
+                /* Half-close: flush what is queued (including the error reply
+                 * completed just above, and any compound still parked on async
+                 * VFS work), then close.  Mark it so the reply-drop guard in
+                 * chimera_smb_compound_reply does not mistake this for a peer
+                 * teardown and free those replies unsent. */
+                conn->finishing = 1;
                 evpl_finish(evpl, conn->bind);
             }
 

--- a/src/server/smb/smb2.h
+++ b/src/server/smb/smb2.h
@@ -1159,6 +1159,13 @@ typedef uint8_t smb2_guid[SMB2_GUID_SIZE];
 #define SMB2_FILE_FS_OBJECTID_INFO_SIZE             64
 #define SMB2_FILE_FS_SECTOR_SIZE_INFO_SIZE          28
 
+/* FileFsSectorSizeInformation Flags (MS-FSCC 2.5.8) */
+#define SMB2_SSINFO_FLAGS_ALIGNED_DEVICE            0x00000001
+#define SMB2_SSINFO_FLAGS_PARTITION_ALIGNED_ON_DEVICE \
+        0x00000002
+#define SMB2_SSINFO_FLAGS_NO_SEEK_PENALTY           0x00000004
+#define SMB2_SSINFO_FLAGS_TRIM_ENABLED              0x00000008
+
 /* FileFsAttributeInformation FileSystemAttributes flags */
 #define SMB2_FS_ATTR_CASE_SENSITIVE_SEARCH          0x00000001
 #define SMB2_FS_ATTR_CASE_PRESERVED_NAMES           0x00000002

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1240,6 +1240,15 @@ struct chimera_smb_conn {
      * is gone, it will yield -- retry briefly" from "a genuinely-live durable
      * holder -- real SHARING_VIOLATION".  Cleared on reuse in conn_alloc. */
     uint8_t                            disconnecting;
+    /* Set when the SERVER half-closes this connection itself (evpl_finish on
+     * the unparseable-request path).  That is a flush-then-close: replies
+     * already in flight must still reach the client.  evpl_bind_is_closing()
+     * cannot distinguish our own half-close from a peer FIN -- it reports
+     * EVPL_BIND_FINISH, EVPL_BIND_PENDING_CLOSED and EVPL_BIND_CLOSED alike --
+     * so the reply-drop guard consults this to keep the peer-initiated cases
+     * dropping while letting our own graceful close flush.  Cleared on reuse in
+     * conn_alloc. */
+    uint8_t                            finishing;
     /* Count of compounds in flight on THIS connection (guarded by the owning
     * thread's lease_break_lock).  A dir-lease break whose holder connection is
     * mid-compound is a self-break: the same connection's reply must precede the
@@ -2406,6 +2415,7 @@ chimera_smb_conn_alloc(struct chimera_server_smb_thread *thread)
         LL_DELETE(thread->free_conns, conn);
         conn->lease_break_tearing_down = 0;
         conn->disconnecting            = 0;
+        conn->finishing                = 0;
         conn->in_compound              = 0;
     } else {
         conn = calloc(1, sizeof(*conn));

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -632,6 +632,20 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                     case SMB2_FILE_ATTRIBUTE_TAG_INFO:
                         request->query_info.output_length = SMB2_FILE_ATTRIBUTE_TAG_INFO_SIZE;
                         break;
+                    case SMB2_FILE_ALL_INFO:
+                        /* Windows queries FileAllInformation on a pipe FID, and
+                         * this branch's comment above already counts it among
+                         * the classes it serves -- but the case was missing, so
+                         * it fell through to INVALID_INFO_CLASS.  Size it the
+                         * same way the VFS path does: the fixed 100 bytes plus
+                         * the share-relative name as UTF-16LE.  A pipe open
+                         * carries the pipe name in full_path (set by
+                         * chimera_smb_create_gen_open_file), so the reply names
+                         * the pipe, as Windows reports it. */
+                        request->query_info.output_length = SMB2_FILE_ALL_INFO_FIXED_SIZE +
+                            (request->query_info.open_file->full_path_len
+                             ? request->query_info.open_file->full_path_len * 2 : 2);
+                        break;
                     default:
                         /* Info classes we don't synthesize for pipes: fail
                          * cleanly rather than falling through to the VFS path. */

--- a/src/server/smb/smb_proc_query_info.c
+++ b/src/server/smb/smb_proc_query_info.c
@@ -72,6 +72,34 @@ chimera_smb_query_info_getattr_callback(
     }
 } /* chimera_smb_query_info_getattr_callback */
 
+/*
+ * MS-SMB2 3.3.5.20 OutputBufferLength validation, shared by the synthetic
+ * named-pipe branch and the regular VFS path.
+ *
+ * min_length is the info level's fixed minimum; levels that did not set one
+ * inherit their own output_length.  A buffer below that minimum is
+ * INFO_LENGTH_MISMATCH; a buffer that merely cannot hold the whole reply gets
+ * the reply truncated and BUFFER_OVERFLOW.
+ */
+static inline unsigned int
+chimera_smb_query_info_check_length(struct chimera_smb_request *request)
+{
+    if (request->query_info.min_length == 0) {
+        request->query_info.min_length = request->query_info.output_length;
+    }
+
+    if (request->query_info.max_response_size < request->query_info.min_length) {
+        return SMB2_STATUS_INFO_LENGTH_MISMATCH;
+    }
+
+    if (request->query_info.max_response_size < request->query_info.output_length) {
+        request->query_info.output_length = request->query_info.max_response_size;
+        return SMB2_STATUS_BUFFER_OVERFLOW;
+    }
+
+    return SMB2_STATUS_SUCCESS;
+} /* chimera_smb_query_info_check_length */
+
 /* Walk the packed VFS list_streams records and either measure (cursor == NULL)
  * or emit MS-FSCC 2.4.43 FILE_STREAM_INFORMATION entries.  Each entry is
  *   NextEntryOffset(4) StreamNameLength(4) StreamSize(8) StreamAllocationSize(8)
@@ -597,6 +625,11 @@ chimera_smb_query_info(struct chimera_smb_request *request)
     if (request->query_info.open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_PIPE) {
         struct chimera_vfs_attrs pipe_attrs;
 
+        /* Requests are recycled, so seed min_length here rather than relying on
+         * the regular path's initialization further down -- the fixed-size
+         * levels below inherit output_length from it, ALL_INFO overrides it. */
+        request->query_info.min_length = 0;
+
         memset(&pipe_attrs, 0, sizeof(pipe_attrs));
         pipe_attrs.va_mode  = S_IFREG | 0666;
         pipe_attrs.va_nlink = 1;
@@ -645,6 +678,10 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                         request->query_info.output_length = SMB2_FILE_ALL_INFO_FIXED_SIZE +
                             (request->query_info.open_file->full_path_len
                              ? request->query_info.open_file->full_path_len * 2 : 2);
+                        /* Variable-length level: the fixed portion ends after
+                         * the FileNameLength field, so that -- not the whole
+                         * reply -- is the buffer minimum. */
+                        request->query_info.min_length = SMB2_FILE_ALL_INFO_FIXED_SIZE + 4;
                         break;
                     default:
                         /* Info classes we don't synthesize for pipes: fail
@@ -660,6 +697,19 @@ chimera_smb_query_info(struct chimera_smb_request *request)
                 chimera_smb_complete_request(request, SMB2_STATUS_INVALID_DEVICE_REQUEST);
                 return;
         } /* switch */
+
+        /* The pipe branch answers without touching the VFS, so it has to run
+         * the same OutputBufferLength validation the regular path runs below.
+         * Without it a QUERY_INFO on a pipe FID with OutputBufferLength=2
+         * returned STATUS_SUCCESS carrying a full fixed-size payload, which
+         * MS-SMB2 3.3.5.20.1 requires to be INFO_LENGTH_MISMATCH. */
+        status = chimera_smb_query_info_check_length(request);
+
+        if (status != SMB2_STATUS_SUCCESS) {
+            chimera_smb_open_file_release(request, request->query_info.open_file);
+            chimera_smb_complete_request(request, status);
+            return;
+        }
 
         chimera_smb_query_info_getattr_callback(CHIMERA_VFS_OK, &pipe_attrs, request);
         return;
@@ -852,15 +902,7 @@ chimera_smb_query_info(struct chimera_smb_request *request)
     /* Buffer-length validation (MS-SMB2 3.3.5.20).  Only for levels we accept;
      * NOT_IMPLEMENTED levels keep their status. */
     if (status == SMB2_STATUS_SUCCESS) {
-        if (request->query_info.min_length == 0) {
-            request->query_info.min_length = request->query_info.output_length;
-        }
-        if (request->query_info.max_response_size < request->query_info.min_length) {
-            status = SMB2_STATUS_INFO_LENGTH_MISMATCH;
-        } else if (request->query_info.max_response_size < request->query_info.output_length) {
-            status                            = SMB2_STATUS_BUFFER_OVERFLOW;
-            request->query_info.output_length = request->query_info.max_response_size;
-        }
+        status = chimera_smb_query_info_check_length(request);
     }
 
     if (status != SMB2_STATUS_SUCCESS) {

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -325,15 +325,30 @@ chimera_vfs_setattr_gate_complete(
      * permission.  For a setattr that changes only timestamps, the owner is
      * therefore unconditionally authorized.
      *
-     * The exempt set includes BTIME and DOS_ATTRIBUTES: the SMB
+     * The exempt set includes BTIME and CTIME: the SMB
      * SetInfo(FileBasicInformation) path always carries all four timestamps
-     * plus DOS attributes (the extras typically as TIME_OMIT / no-op
-     * sentinels), so an owner's plain `touch` arrives with BTIME and
-     * DOS_ATTRIBUTES in set_mask.  Excluding them made the exemption miss,
-     * leaving required=WRITE_ATTRIBUTES -- a right the mode-only owner is not
-     * granted (mode_access_check withholds it, Windows-style) -- so the
-     * owner's own touch was denied (STATUS_INTERNAL_ERROR over SMB).  NFS
-     * never sets BTIME on a touch, which is why it was unaffected. */
+     * (the untouched ones as TIME_OMIT sentinels), so an owner's plain `touch`
+     * arrives with BTIME and CTIME in set_mask.  Excluding them made the
+     * exemption miss, leaving required=WRITE_ATTRIBUTES -- a right the
+     * mode-only owner is not granted (mode_access_check withholds it,
+     * Windows-style) -- so the owner's own touch was denied
+     * (STATUS_INTERNAL_ERROR over SMB).  NFS never sets BTIME on a touch,
+     * which is why it was unaffected.
+     *
+     * DOS_ATTRIBUTES is exempt only when it is genuinely a no-op.  Unlike the
+     * timestamps it is not always present: MS-FSCC 2.4.7 gives FileAttributes
+     * == 0 the meaning "no change" and chimera_smb_unmarshal_basic_info sets
+     * the bit only for a non-zero value, so its presence signals either a real
+     * attribute change or a client restating the attributes it already sees.
+     * Exempting it unconditionally let the first case ride in on the timestamp
+     * exemption: an owner's `attrib +h` matched "only timestamps" and skipped
+     * the ACL gate, succeeding past an explicit Deny FILE_WRITE_ATTRIBUTES ACE.
+     * Compare against the current value instead -- a restate stays a sentinel,
+     * a real change faces the gate.  Backends store exactly the settable bits
+     * the SMB layer masked on the way in (SPARSE and friends are added by the
+     * SMB marshaller, not persisted), so the comparison is exact; a backend
+     * that does not report DOS attributes at all leaves the bit unexempt,
+     * which errs toward gating. */
     {
         uint64_t       m     = gate->set_attr->va_set_mask;
         int            owner = (gate->cred->uid == 0) ||
@@ -343,9 +358,14 @@ chimera_vfs_setattr_gate_complete(
         const uint64_t time_trigger = CHIMERA_VFS_ATTR_ATIME |
             CHIMERA_VFS_ATTR_MTIME |
             CHIMERA_VFS_ATTR_BTIME;
-        const uint64_t owner_exempt = time_trigger |
-            CHIMERA_VFS_ATTR_CTIME |
-            CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        uint64_t       owner_exempt = time_trigger |
+            CHIMERA_VFS_ATTR_CTIME;
+
+        if ((m & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) &&
+            (attr->va_set_mask & CHIMERA_VFS_ATTR_DOS_ATTRIBUTES) &&
+            attr->va_dos_attributes == gate->set_attr->va_dos_attributes) {
+            owner_exempt |= CHIMERA_VFS_ATTR_DOS_ATTRIBUTES;
+        }
 
         /* Owner setting only timestamps (+ benign SMB sentinels): skip ACL. */
         if (owner && (m & time_trigger) && !(m & ~owner_exempt)) {


### PR DESCRIPTION
Five independent fixes, one commit each, from the outstanding findings of the PR #1511 review. Each was re-verified against current `main` before being written — several other findings from that review are already fixed upstream and are not included.

---

### `vfs: gate real DOS attribute changes in the owner timestamp exemption`

**Access-control fix.** The owner's POSIX right to touch timestamps is implemented by zeroing `required` when the setattr mask holds nothing but timestamps. `b84a9ee3` added `DOS_ATTRIBUTES` to the exempt set, treating it as another always-present SMB sentinel.

It is not always present. MS-FSCC 2.4.7 gives `FileAttributes == 0` the meaning "no change", and `chimera_smb_unmarshal_basic_info` sets the mask bit only for a non-zero value — while the four timestamp bits are set unconditionally. So the bit's presence means either a real attribute change or a client restating what it already sees, and exempting it unconditionally let the first case through: an owner's `attrib +h` arrives as timestamp sentinels plus a genuine `DOS_ATTRIBUTES` change, matches the "only timestamps" test, and skips the ACL gate — succeeding past an explicit Deny FILE_WRITE_ATTRIBUTES ACE that should have been STATUS_ACCESS_DENIED.

Exempt the bit only when it is genuinely a no-op, comparing against the current value the gate has already fetched. A restate stays a sentinel (so the `touch` case `b84a9ee3` fixed keeps working, including for clients that echo back attributes); a real change falls through to `chimera_vfs_setattr_required`, which already maps it to `CHIMERA_ACE_WRITE_ATTRIBUTES`.

The comparison is exact rather than masked: backends persist and report exactly the settable bits the SMB layer masks on the way in, and the reportable extras (SPARSE) are added by the SMB marshaller rather than stored. A backend that does not report DOS attributes leaves the bit unexempt, erring toward gating.

### `smb: let the server's own graceful close flush its replies`

`c09804d8` widened the stale-connection reply guard to close "a window where a late VFS completion could try to send a reply into a bind mid-teardown". One of its predicates is broader than that intent: `evpl_bind_is_closing()` reports `EVPL_BIND_FINISH` — set by our *own* `evpl_finish()` half-close — alongside the peer-initiated `PENDING_CLOSED` and `CLOSED`.

The unparseable-request path is a flush-then-close: it completes an error reply and only then calls `evpl_finish`. With FINISH counted as "going away", any reply not already on the wire — the error reply itself when its compound still has requests parked on async VFS work, or a sibling compound in flight — is freed instead of flushed, and the client gets a bare FIN where the protocol promised a response.

libevpl exposes only the combined predicate, so rather than reach into the submodule this marks the server-initiated case on the connection (`conn->finishing`, cleared on reuse in `chimera_smb_conn_alloc` alongside the other per-connection flags) and exempts only that. The peer-initiated flags still drop, so the recycled-bind corruption from `c831169a` and the window `c09804d8` added stay covered.

### `smb: validate OutputBufferLength on a named-pipe QUERY_INFO`

The synthetic pipe branch answers without touching the VFS and completed the request *before* the MS-SMB2 3.3.5.20 length check the regular path runs. QUERY_INFO on a pipe FID with `OutputBufferLength=2` returned STATUS_SUCCESS carrying a full fixed-size payload where 3.3.5.20.1 requires INFO_LENGTH_MISMATCH.

Lifts the existing check into `chimera_smb_query_info_check_length` and calls it from both paths. The regular path keeps byte-identical behaviour — same three tests, same order, same BUFFER_OVERFLOW truncation. The pipe branch seeds `min_length` itself rather than inheriting the regular path's initialization further down, since requests are recycled and a stale value would otherwise decide the comparison.

### `smb: serve FILE_ALL_INFO on a named-pipe FID`

The pipe branch handles BASIC, STANDARD, INTERNAL, EA, NETWORK_OPEN and ATTRIBUTE_TAG, and its own comment lists FileAllInformation among the classes Windows queries on pipes — but the case was missing, so it fell to the default arm and returned INVALID_INFO_CLASS. The branch even notes that "FileInternalInformation (and FileAllInformation) marshal IndexNumber directly from va_ino", so this reads as an oversight.

Sized the way the VFS path sizes it. Pipe opens go through `chimera_smb_create_gen_open_file` like any other open, so `full_path` already holds the pipe name. No completion-path change needed — the getattr callback already marshals ALL_INFO and the reply emitter already appends the name.

### `smb: report the documented SectorSize flags, not reserved bits`

`FileFsSectorSizeInformation` defaulted Flags to `0x300` with the comment "aligned + partition aligned". Per MS-FSCC 2.5.8 those are `SSINFO_FLAGS_ALIGNED_DEVICE` (0x1) and `SSINFO_FLAGS_PARTITION_ALIGNED_ON_DEVICE` (0x2); `0x300` sets neither and lights two reserved bits. Applications that check ALIGNED_DEVICE before 4K-atomic I/O read "not aligned" and fall back, defeating the 4KiB physical sector size the same default block advertises. Gives the flags names from the spec; the value stays configurable.

---

## Verification

Debug build clean; `uncrustify --check` clean on all six changed files.

- `ctest -L "vfs|smb|client"` — **247/248**. The one failure, `chimera/vfs/zerorange_diskfs_io_uring`, fails identically on an unmodified control worktree, so it is pre-existing in this environment rather than caused by these changes.
- Setattr-path POSIX tests (chmod / fchmod / fchmodat / chown / fchown / lchown / fchownat / utime / truncate / ftruncate on memfs and linux) — **18/18**.
- pjd conformance for chmod / chown / truncate / utimensat on memfs and linux — **72/72**.

The full 4781-test POSIX matrix could not be run locally: the container's 4 GB `/build/test` scratch tmpfs is exhausted partway through, and once it fills, ASan cannot map its shadow and the remainder of the suite collapses with DEADLYSIGNAL. That collapse reproduces identically on an unmodified tree, so it is a harness/environment limit, not a signal about these changes — but it does mean CI is the first place the full matrix runs.

No new tests. The two pipe-branch fixes are in the same class as `e7cf5a38` (the QUERY_INFO/SET_INFO pipe-FID crash fix), which shipped source-only; the SMB unit tests here are parse-path and mock-structure tests with no live server, so exercising these verbs would mean standing up a tree, compound and session-handle table. Real coverage is smbtorture/WPTS in CI.