### PR TITLE
vfs: umount waits for the mount's handles to be gone

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,7 @@ the canonical place to set them.
 | `preallocate_threads` | int | libevpl default | Threads used to preallocate slabs in parallel. |
 | `rdmacm_tos` | int | `0` | RoCEv2 traffic class stamped on every RDMA QP. ToS = DSCP x 4 (e.g. `104` for DSCP 26) so the fabric's lossless/PFC class carries Chimera traffic. |
 | `metrics_file` | string | - | On shutdown, write a final Prometheus scrape to this file (so short runs keep their metrics). |
+| `umount_timeout_ms` | int | `1000` | How long an unmount waits for the mount's open handles to be closed and released before giving up and returning `EBUSY`. Raise it for backends whose closes are slow; it exists so that unmounting a genuinely busy mount fails rather than hanging. |
 
 ---
 

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -33,6 +33,7 @@ chimera_client_config_init(void)
     config->async_delegation_threads = 8;
     config->cache_ttl                = 60;
     config->attr_cache_enabled       = 1;
+    config->umount_timeout_ms        = CHIMERA_COMMON_UMOUNT_TIMEOUT_MS_DEFAULT;
     config->name_cache_enabled       = 1;
     config->rcu_reclaim_threads      = 4; /* 4 = cap RCU reclaim workers to avoid thread exhaustion on many-core hosts */
     config->max_fds                  = 1024;
@@ -215,6 +216,8 @@ chimera_client_init(
      * open outbound connections with the same transport. */
     chimera_vfs_set_tcp_flavor(client->vfs, config->tcp_flavor);
 
+    chimera_vfs_set_umount_timeout(client->vfs, config->umount_timeout_ms);
+
     /* Initialize the root file handle after VFS is initialized */
     chimera_vfs_get_root_fh(client->root_fh, &client->root_fh_len);
 
@@ -355,6 +358,10 @@ chimera_client_init_json(
     /* The VFS attribute cache (common.attr_cache) is a VFS-level facility shared
      * with the server; on by default. */
     config->attr_cache_enabled = chimera_common_attr_cache_enabled(root);
+
+    /* Bound on umount's wait for a mount's handles (common.umount_timeout_ms);
+     * shared with the server. */
+    config->umount_timeout_ms = chimera_common_umount_timeout_ms(root);
 
     /* The VFS name (lookup) cache (common.name_cache) is likewise shared with
      * the server; on by default. */

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -430,6 +430,7 @@ struct chimera_client_config {
     int                           async_delegation_threads;
     int                           cache_ttl;
     int                           attr_cache_enabled;
+    int                           umount_timeout_ms;
     int                           name_cache_enabled;
     int                           rcu_reclaim_threads;
     int                           max_fds;

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+/* Default for common.umount_timeout_ms (see below). */
+#define CHIMERA_COMMON_UMOUNT_TIMEOUT_MS_DEFAULT 1000
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <strings.h>
@@ -342,6 +345,39 @@ chimera_common_attr_cache_enabled(json_t *root)
 
     return 1;
 } /* chimera_common_attr_cache_enabled */
+
+/*
+ * How long umount waits for a mount's open handles to be dropped before
+ * giving up with EBUSY, from the shared "common" section's
+ * "umount_timeout_ms" key.  Milliseconds; 0 means do not wait at all.
+ *
+ * The wait covers the sub-millisecond tail of ordinary activity -- a path
+ * walk's reference on the mount root outlives the operation that took it --
+ * so the default is generous against that and still far short of anything a
+ * person would read as a hang.  A client genuinely holding a file open is
+ * meant to hit the timeout and get EBUSY, not wedge the umount forever.
+ */
+static inline int
+chimera_common_umount_timeout_ms(json_t *root)
+{
+    json_t *common, *val;
+
+    if (!root) {
+        return CHIMERA_COMMON_UMOUNT_TIMEOUT_MS_DEFAULT;
+    }
+
+    common = json_object_get(root, "common");
+    if (!json_is_object(common)) {
+        return CHIMERA_COMMON_UMOUNT_TIMEOUT_MS_DEFAULT;
+    }
+
+    val = json_object_get(common, "umount_timeout_ms");
+    if (json_is_integer(val) && json_integer_value(val) >= 0) {
+        return (int) json_integer_value(val);
+    }
+
+    return CHIMERA_COMMON_UMOUNT_TIMEOUT_MS_DEFAULT;
+} /* chimera_common_umount_timeout_ms */
 
 /*
  * Whether the VFS name (lookup) cache is enabled, from the shared "common"

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -493,6 +493,11 @@ main(
     chimera_server_config_set_name_cache_enabled(server_config,
                                                  chimera_common_name_cache_enabled(config));
 
+    /* How long umount waits for a mount's handles to drain before reporting
+     * EBUSY (common.umount_timeout_ms); shared with the client. */
+    chimera_server_config_set_umount_timeout(server_config,
+                                             chimera_common_umount_timeout_ms(config));
+
     json_value = json_object_get(server_params, "smb_persistent_handles");
     if (json_is_boolean(json_value)) {
         chimera_server_config_set_smb_persistent_handles(server_config, json_is_true(json_value));

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -185,6 +185,7 @@ chimera_posix_errno_from_status(enum chimera_vfs_error status)
         case CHIMERA_VFS_EAGAIN:       return EAGAIN;
         case CHIMERA_VFS_EACCES:       return EACCES;
         case CHIMERA_VFS_EFAULT:       return EFAULT;
+        case CHIMERA_VFS_EBUSY:        return EBUSY;
         case CHIMERA_VFS_EEXIST:       return EEXIST;
         case CHIMERA_VFS_EXDEV:        return EXDEV;
         case CHIMERA_VFS_ENOTDIR:      return ENOTDIR;

--- a/src/server/rest/rest_mounts.c
+++ b/src/server/rest/rest_mounts.c
@@ -302,6 +302,9 @@ mount_delete_complete(
     if (status == CHIMERA_VFS_ENOENT) {
         chimera_rest_send_error(ctx->evpl, ctx->request, 404, "Not Found",
                                 "Mount does not exist");
+    } else if (status == CHIMERA_VFS_EBUSY) {
+        chimera_rest_send_error(ctx->evpl, ctx->request, 409, "Conflict",
+                                "Mount still has open handles");
     } else if (status != CHIMERA_VFS_OK) {
         chimera_rest_send_error(ctx->evpl, ctx->request, 500,
                                 "Internal Server Error",

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -30,6 +30,7 @@
 #include "common/macros.h"
 #include "common/chimera_tracing.h"
 #include "server/server.h"
+#include "common/common_config.h"
 #include "smb/smb2.h"
 #include "rest/rest.h"
 
@@ -73,6 +74,7 @@ struct chimera_server_config {
     int                                   async_delegation_threads;
     int                                   cache_ttl;
     int                                   attr_cache_enabled;
+    int                                   umount_timeout_ms;
     int                                   name_cache_enabled;
     int                                   rcu_reclaim_threads;
     int                                   nfs4_session_slots;
@@ -328,6 +330,7 @@ chimera_server_config_init(void)
 
     /* The VFS attribute cache is on by default (common.attr_cache). */
     config->attr_cache_enabled = 1;
+    config->umount_timeout_ms  = CHIMERA_COMMON_UMOUNT_TIMEOUT_MS_DEFAULT;
 
     /* The VFS name (lookup) cache is on by default (common.name_cache). */
     config->name_cache_enabled = 1;
@@ -715,6 +718,14 @@ chimera_server_config_get_cache_ttl(const struct chimera_server_config *config)
 {
     return config->cache_ttl;
 } /* chimera_server_config_get_cache_ttl */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_umount_timeout(
+    struct chimera_server_config *config,
+    int                           timeout_ms)
+{
+    config->umount_timeout_ms = timeout_ms;
+} /* chimera_server_config_set_umount_timeout */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_attr_cache_enabled(
@@ -2560,6 +2571,8 @@ chimera_server_init(
      * remove/rename paths know to resolve a by-name victim's FH and recall a
      * cross-protocol holder before the namespace change (see
      * chimera_vfs_remove_at).  When none are enabled the lookup is skipped. */
+    chimera_vfs_set_umount_timeout(server->vfs, config->umount_timeout_ms);
+
     chimera_vfs_set_caching_enabled(server->vfs,
                                     config->nfs4_delegations ||
                                     config->smb_leases ||

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -219,6 +219,13 @@ chimera_server_config_set_rcu_reclaim_threads(
     struct chimera_server_config *config,
     int                           threads);
 
+/* Bound on how long umount waits for a mount's open handles to be dropped
+ * before reporting EBUSY (milliseconds). */
+void
+chimera_server_config_set_umount_timeout(
+    struct chimera_server_config *config,
+    int                           timeout_ms);
+
 void
 chimera_server_config_set_attr_cache_enabled(
     struct chimera_server_config *config,

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -14,6 +14,7 @@
 #include <utlist.h>
 
 #include "common/platform.h"
+#include "common/common_config.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_internal.h"
 #include "vfs/vfs_open_cache.h"
@@ -527,6 +528,11 @@ chimera_vfs_init(
 
     vfs = calloc(1, sizeof(*vfs));
 
+    /* Sane default for a VFS brought up without a server or client config
+     * behind it (in-process module tests); chimera_vfs_set_umount_timeout
+     * overrides it from common.umount_timeout_ms. */
+    vfs->umount_timeout_us = (uint64_t) CHIMERA_COMMON_UMOUNT_TIMEOUT_MS_DEFAULT * 1000;
+
     /* Synthesize machine name for identification */
     chimera_vfs_synthesize_machine_name(vfs);
 
@@ -687,6 +693,14 @@ chimera_vfs_set_tcp_flavor(
 {
     vfs->tcp_flavor = flavor;
 } /* chimera_vfs_set_tcp_flavor */
+
+SYMBOL_EXPORT void
+chimera_vfs_set_umount_timeout(
+    struct chimera_vfs *vfs,
+    int                 timeout_ms)
+{
+    vfs->umount_timeout_us = (uint64_t) timeout_ms * 1000;
+} /* chimera_vfs_set_umount_timeout */
 
 SYMBOL_EXPORT void
 chimera_vfs_set_caching_enabled(

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -747,6 +747,14 @@ struct chimera_vfs_request {
         struct {
             struct chimera_vfs_mount *mount;
             void                     *mount_private;
+            /* Handle closes still outstanding before the backend UMOUNT may
+             * be dispatched.  Carries a self-reference while a sweep is
+             * issuing them, so a close completing inline cannot finish the
+             * umount mid-sweep. */
+            int                       pending_closes;
+            /* Poll state while waiting for handles still referenced by
+             * someone else to be dropped (chimera_vfs_umount_wait). */
+            void                     *wait;
         } umount;
 
         struct {
@@ -1530,6 +1538,11 @@ struct chimera_vfs_mount {
     uint32_t                       pathlen;
     int                            root_fh_len;
     void                          *mount_private;
+    /* Set once umount has committed to tearing this mount down.  From that
+    * point chimera_vfs_get_module refuses to route new work here, so the
+    * set of handles referencing the mount can only shrink -- without it,
+    * umount could drain the cache and have a fresh open land behind it. */
+    int                            unmounting;
     struct chimera_vfs_mount_attrs attrs;
     struct chimera_vfs_mount      *prev;
     struct chimera_vfs_mount      *next;
@@ -1605,6 +1618,10 @@ struct chimera_vfs {
      * name another protocol caches recalls that holder first.  When clear
      * (single-protocol deployments) the extra lookup is skipped. */
     int                                   caching_enabled;
+    /* How long umount waits for a mount's handles to be dropped before
+     * reporting EBUSY (microseconds).  0 waits only as long as the closes it
+     * issues itself take. */
+    uint64_t                              umount_timeout_us;
     int                                   machine_name_len;
     char                                  machine_name[256];
 };
@@ -1678,6 +1695,14 @@ chimera_vfs_set_tcp_flavor(
  * delegations / SMB2 leases / SMB oplocks enabled).  When set, the VFS
  * remove/rename paths resolve a by-name victim to its FH so a caching holder
  * is recalled before the namespace change; when clear the lookup is skipped. */
+/* Bound on how long umount waits for a mount's open handles to be dropped
+ * before giving up with EBUSY, in milliseconds.  Without a bound a client
+ * holding a file open would wedge the umount indefinitely. */
+void
+chimera_vfs_set_umount_timeout(
+    struct chimera_vfs *vfs,
+    int                 timeout_ms);
+
 void
 chimera_vfs_set_caching_enabled(
     struct chimera_vfs *vfs,

--- a/src/vfs/vfs_error.h
+++ b/src/vfs/vfs_error.h
@@ -14,6 +14,7 @@ enum chimera_vfs_error {
     CHIMERA_VFS_EAGAIN       = 11,     /* Try again */
     CHIMERA_VFS_EACCES       = 13,     /* Permission denied */
     CHIMERA_VFS_EFAULT       = 14,         /* Bad address */
+    CHIMERA_VFS_EBUSY        = 16,     /* Device or resource busy */
     CHIMERA_VFS_EEXIST       = 17,     /* File exists */
     CHIMERA_VFS_EXDEV        = 18,     /* Cross-device link */
     CHIMERA_VFS_ENOTDIR      = 20,     /* Not a directory */

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -198,7 +198,10 @@ chimera_vfs_get_module(
 
     mount = chimera_vfs_mount_table_lookup(vfs->mount_table, fh);
 
-    module = mount ? mount->module : NULL;
+    /* A mount being torn down routes nothing new: umount has already
+     * established that no handle references it and is closing the cached
+     * ones, so admitting another op here would resurrect it. */
+    module = (mount && !mount->unmounting) ? mount->module : NULL;
 
     urcu_qsbr_read_unlock();
 

--- a/src/vfs/vfs_mount_table.h
+++ b/src/vfs/vfs_mount_table.h
@@ -345,6 +345,40 @@ chimera_vfs_mount_table_find_by_path(
 } /* chimera_vfs_mount_table_find_by_path */
 
 /*
+ * Find a mount by exact path match, leaving it in the table.
+ *
+ * umount needs the mount before it is unlinked: its cached handles are closed
+ * while it is still routable, so those closes resolve the mount exactly as any
+ * other op would.  Returns NULL if no mount has that path.
+ */
+static inline struct chimera_vfs_mount *
+chimera_vfs_mount_table_find_exact(
+    struct chimera_vfs_mount_table *table,
+    const char                     *path,
+    int                             pathlen)
+{
+    struct chimera_vfs_mount_table_entry *entry;
+    struct chimera_vfs_mount             *found = NULL;
+    uint32_t                              i;
+
+    pthread_mutex_lock(&table->lock);
+
+    for (i = 0; i < table->num_buckets && !found; i++) {
+        for (entry = table->buckets[i]; entry; entry = entry->next) {
+            if (entry->mount->pathlen == (uint32_t) pathlen &&
+                memcmp(entry->mount->path, path, pathlen) == 0) {
+                found = entry->mount;
+                break;
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&table->lock);
+
+    return found;
+} /* chimera_vfs_mount_table_find_exact */
+
+/*
  * Find and remove a mount by exact path match.
  * Returns the mount pointer if found and removed, NULL if not found.
  * The returned mount pointer is owned by the caller who must free it.

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -820,37 +820,68 @@ chimera_vfs_open_cache_defer_close(
 } /* vfs_open_cache_defer_close */
 
 /*
- * Count handles in the cache that belong to the given mount.
- * mount_id is the first 16 bytes of the file handle.
- * Returns count of handles with opencnt > 0 (actively referenced).
+ * Take this mount's unreferenced handles out of the cache ahead of a umount,
+ * and report how many are still referenced.
+ *
+ * Unreferenced handles are removed and returned via r_purged for the caller
+ * to dispose of: one that holds a backend open needs a close first, one that
+ * does not can simply be freed.  Either way it is gone by the time the caller
+ * is done with the list.
+ *
+ * Referenced handles are counted, not touched -- their holder is still using
+ * them.  umount waits for that count to reach zero, so every handle on the
+ * mount is genuinely gone (and every close that had to run has run) before
+ * the mount goes away.
+ *
+ * The count is transiently non-zero after ordinary activity: a path walk's
+ * reference on the mount root outlives the operation that took it by about a
+ * millisecond.  That is precisely why umount waits on it rather than failing
+ * the moment it sees one.
  */
 static inline uint64_t
-chimera_vfs_open_cache_count_by_mount(
-    struct vfs_open_cache *cache,
-    const uint8_t         *mount_id)
+chimera_vfs_open_cache_purge_by_mount(
+    struct vfs_open_cache           *cache,
+    const uint8_t                   *mount_id,
+    struct chimera_vfs_open_handle **r_purged)
 {
     struct vfs_open_cache_shard    *shard;
-    struct chimera_vfs_open_handle *handle;
-    uint64_t                        count = 0;
+    struct chimera_vfs_open_handle *handle, *next;
+    uint64_t                        referenced = 0;
 
     for (unsigned int i = 0; i < cache->num_shards; i++) {
         shard = &cache->shards[i];
 
         pthread_mutex_lock(&shard->lock);
 
-        for (handle = shard->handles; handle; handle = handle->bucket_next) {
-            if (memcmp(handle->fh, mount_id, CHIMERA_VFS_MOUNT_ID_SIZE) == 0) {
-                if (handle->opencnt > 0) {
-                    count++;
-                }
+        handle = shard->handles;
+
+        while (handle) {
+            next = handle->bucket_next;
+
+            if (memcmp(handle->fh, mount_id, CHIMERA_VFS_MOUNT_ID_SIZE) != 0) {
+                handle = next;
+                continue;
             }
+
+            if (handle->opencnt) {
+                referenced++;
+            } else {
+                /* Unreferenced handles sit on pending_close awaiting the idle
+                 * sweep; umount cannot wait out that timer. */
+                DL_DELETE(shard->pending_close, handle);
+                chimera_vfs_open_cache_shard_remove(shard, handle);
+                shard->open_handles--;
+                LL_PREPEND(*r_purged, handle);
+            }
+
+            handle = next;
         }
 
         pthread_mutex_unlock(&shard->lock);
     }
 
-    return count;
-} /* chimera_vfs_open_cache_count_by_mount */
+    return referenced;
+} /* chimera_vfs_open_cache_purge_by_mount */
 
 /*
  * Mark all handles belonging to the given mount for immediate close.

--- a/src/vfs/vfs_proc_umount.c
+++ b/src/vfs/vfs_proc_umount.c
@@ -6,7 +6,10 @@
 #include <string.h>
 #include "vfs_procs.h"
 #include "vfs_internal.h"
+#include "evpl/evpl_timer.h"
 #include "vfs_mount_table.h"
+#include "vfs_open_cache.h"
+#include "vfs_state.h"
 #include "common/macros.h"
 
 
@@ -30,6 +33,206 @@ chimera_vfs_umount_complete(struct chimera_vfs_request *request)
 } /* chimera_vfs_umount */
 
 
+/*
+ * How often umount re-checks for handles it does not own to be dropped.  The
+ * wait exists for the millisecond-scale tail of ordinary activity -- a path
+ * walk's reference on the mount root outlives its operation -- not for a
+ * client that is genuinely holding a file open, which is why it gives up
+ * after common.umount_timeout_ms rather than waiting forever.
+ */
+#define CHIMERA_VFS_UMOUNT_POLL_US 1000
+
+struct chimera_vfs_umount_wait {
+    struct evpl_timer           timer;
+    struct chimera_vfs_request *request;
+    uint64_t                    waited_us;
+};
+
+static void chimera_vfs_umount_progress(
+    struct chimera_vfs_request *request);
+
+/*
+ * Every handle on this mount is gone and every close they needed has run;
+ * unlink it and hand the backend its UMOUNT.
+ */
+static void
+chimera_vfs_umount_dispatch(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_thread *thread = request->thread;
+    struct chimera_vfs        *vfs    = thread->vfs;
+    struct chimera_vfs_mount  *mount  = request->umount.mount;
+
+    chimera_vfs_mount_table_remove_by_path(vfs->mount_table, mount->path,
+                                           mount->pathlen);
+
+    chimera_vfs_dispatch(request);
+} /* chimera_vfs_umount_dispatch */
+
+/* Give up: hand the mount back and report it busy. */
+static void
+chimera_vfs_umount_abandon(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_thread    *thread   = request->thread;
+    chimera_vfs_umount_callback_t callback = request->proto_callback;
+    void                         *arg      = request->proto_private_data;
+
+    request->umount.mount->unmounting = 0;
+
+    chimera_vfs_request_free(thread, request);
+
+    callback(thread, CHIMERA_VFS_EBUSY, arg);
+} /* chimera_vfs_umount_abandon */
+
+static void
+chimera_vfs_umount_wait_timer(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct chimera_vfs_umount_wait *wait =
+        container_of(timer, struct chimera_vfs_umount_wait, timer);
+
+    wait->waited_us += CHIMERA_VFS_UMOUNT_POLL_US;
+
+    chimera_vfs_umount_progress(wait->request);
+} /* chimera_vfs_umount_wait_timer */
+
+static void
+chimera_vfs_umount_wait_stop(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_umount_wait *wait = request->umount.wait;
+
+    if (wait) {
+        evpl_remove_timer(request->thread->evpl, &wait->timer);
+        free(wait);
+        request->umount.wait = NULL;
+    }
+} /* chimera_vfs_umount_wait_stop */
+
+static void
+chimera_vfs_umount_close_callback(
+    enum chimera_vfs_error status,
+    void                  *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    if (--request->umount.pending_closes == 0) {
+        chimera_vfs_umount_progress(request);
+    }
+} /* chimera_vfs_umount_close_callback */
+
+/*
+ * Sweep one cache: dispose of the handles nobody is using and report how many
+ * someone still is.
+ *
+ * The mount is deliberately still in the table while this runs, so the closes
+ * issued here resolve it exactly as any other op would -- which is what lets a
+ * backend treat "the mount my close names is still live" as an invariant
+ * rather than a hope.
+ */
+static uint64_t
+chimera_vfs_umount_sweep_cache(
+    struct chimera_vfs_request *request,
+    struct vfs_open_cache      *cache)
+{
+    struct chimera_vfs_thread      *thread = request->thread;
+    struct chimera_vfs_mount       *mount  = request->umount.mount;
+    struct chimera_vfs_open_handle *purged  = NULL, *handle;
+    uint64_t                        referenced;
+
+    referenced = chimera_vfs_open_cache_purge_by_mount(cache, mount->root_fh,
+                                                       &purged);
+
+    while (purged) {
+        handle = purged;
+        LL_DELETE(purged, handle);
+
+        /* A handle with no backend open has nothing to close; dropping it
+         * here is the whole of its teardown. */
+        if (chimera_vfs_open_handle_needs_backend_close(handle)) {
+            request->umount.pending_closes++;
+
+            chimera_vfs_close(thread,
+                              handle->vfs_module,
+                              handle->fh,
+                              handle->fh_len,
+                              handle->vfs_private,
+                              handle->fh_hash,
+                              chimera_vfs_umount_close_callback,
+                              request);
+        }
+
+        /* purge_by_mount took the handle out of the cache but left the struct
+         * to us, as defer_close does for the close thread. */
+        chimera_vfs_file_state_release(handle->file_state);
+
+        free(handle);
+    }
+
+    return referenced;
+} /* chimera_vfs_umount_sweep_cache */
+
+/*
+ * Drive the umount forward: sweep both caches, and finish once nothing on the
+ * mount remains.  Re-entered from a close completion or the poll timer, so it
+ * is written to be safe to call repeatedly.
+ */
+static void
+chimera_vfs_umount_progress(struct chimera_vfs_request *request)
+{
+    struct chimera_vfs_thread      *thread = request->thread;
+    struct chimera_vfs             *vfs    = thread->vfs;
+    struct chimera_vfs_umount_wait *wait;
+    uint64_t                        referenced;
+
+    /* Held across the sweeps so a close completing inline cannot finish the
+     * umount while handles are still being issued. */
+    request->umount.pending_closes++;
+
+    referenced  = chimera_vfs_umount_sweep_cache(request, vfs->vfs_open_file_cache);
+    referenced += chimera_vfs_umount_sweep_cache(request, vfs->vfs_open_path_cache);
+
+    request->umount.pending_closes--;
+
+    if (request->umount.pending_closes) {
+        /* Closes still in flight; their completion re-enters here, so no
+         * timer is armed against them.  The timeout below bounds the wait on
+         * references we do not own, which is the case that arises in normal
+         * operation.  It deliberately does not bound this one: a close that
+         * never completes is a backend that still owns this request, and
+         * giving up on it would free memory the backend is about to touch.
+         * chimera_vfs_close always runs its callback, including inline when
+         * it cannot allocate, so the only way to stay here is that bug. */
+        return;
+    }
+
+    if (referenced == 0) {
+        chimera_vfs_umount_wait_stop(request);
+        chimera_vfs_umount_dispatch(request);
+        return;
+    }
+
+    /* Someone else still holds a handle.  Wait for them to drop it. */
+    wait = request->umount.wait;
+
+    if (!wait) {
+        wait                 = calloc(1, sizeof(*wait));
+        wait->request        = request;
+        request->umount.wait = wait;
+    } else if (wait->waited_us >= vfs->umount_timeout_us) {
+        chimera_vfs_umount_wait_stop(request);
+        chimera_vfs_umount_abandon(request);
+        return;
+    }
+
+    /* One-shot rather than periodic: evpl takes a one-shot out of the timer
+     * set before running its callback, so the callback below is free to end
+     * the wait and release this struct.  A periodic timer is re-armed after
+     * the callback returns, which would be a use-after-free. */
+    evpl_add_oneshot_timer(thread->evpl, &wait->timer,
+                           chimera_vfs_umount_wait_timer,
+                           CHIMERA_VFS_UMOUNT_POLL_US);
+} /* chimera_vfs_umount_progress */
+
 SYMBOL_EXPORT void
 chimera_vfs_umount(
     struct chimera_vfs_thread     *thread,
@@ -47,21 +250,33 @@ chimera_vfs_umount(
         path++;
     }
 
-    mount = chimera_vfs_mount_table_remove_by_path(vfs->mount_table, path, strlen(path));
+    mount = chimera_vfs_mount_table_find_exact(vfs->mount_table, path, strlen(path));
 
     if (!mount) {
         callback(thread, CHIMERA_VFS_ENOENT, private_data);
         return;
     }
 
-    /* For umount operations, the mount was already removed from the table,
-     * so chimera_vfs_get_module returns NULL. Use alloc_with_module. */
+    if (mount->unmounting) {
+        callback(thread, CHIMERA_VFS_EBUSY, private_data);
+        return;
+    }
+
+    /* Claim the mount before counting, so the count can only fall afterwards.
+     * Counting first would let an open land in between and leave a handle
+     * referencing a mount that is already on its way out. */
+    mount->unmounting = 1;
+
+    /* The mount stays in the table until the drain below finishes.
+     * chimera_vfs_get_module now refuses it, so nothing new routes here, but
+     * the umount and its closes carry their module explicitly and proceed. */
     request = chimera_vfs_request_alloc_with_module(thread, cred,
                                                     mount->root_fh, mount->root_fh_len,
                                                     chimera_vfs_hash(mount->root_fh, mount->root_fh_len),
                                                     mount->module);
 
     if (CHIMERA_VFS_IS_ERR(request)) {
+        mount->unmounting = 0;
         callback(thread, CHIMERA_VFS_PTR_ERR(request), private_data);
         return;
     }
@@ -73,6 +288,9 @@ chimera_vfs_umount(
     request->proto_callback       = callback;
     request->proto_private_data   = private_data;
 
-    chimera_vfs_dispatch(request);
+    request->umount.pending_closes = 0;
+    request->umount.wait           = NULL;
+
+    chimera_vfs_umount_progress(request);
 
 } /* chimera_vfs_umount */


### PR DESCRIPTION
`umount` unlinked the mount from the mount table first and left whatever the
open cache still held for it in place, to be closed later by the idle sweep.
Those closes then ran against a mount that no longer existed. That is the root
of a whole class of awkwardness for backends: a close could name a mount the
backend had already torn down, so it could never treat the mount identified by
a close as something it was still able to look up.

This makes umount hold the mount until nothing references it.

## What it does

`umount` claims the mount by setting `mount->unmounting` rather than removing
it. `chimera_vfs_get_module` honours that flag, so no new operation routes to a
mount that is on its way out, while the mount itself stays addressable for the
handles still being torn down.

It then sweeps both open caches for handles belonging to the mount:

- handles nobody is using are disposed of immediately — closed first if they
  hold a backend open, simply freed if they do not (`NO_BACKEND_OPEN`);
- handles someone else still holds are waited on.

Only once no handle on the mount remains does umount unlink it from the table
and dispatch the backend `UMOUNT`.

## Why it has to wait rather than report EBUSY

The first version returned `EBUSY` the moment it found a handle it could not
dispose of. That flakes, and not for callers doing anything wrong: a path
walk's reference on the mount root outlives the operation that took it by about
a millisecond, so a caller that has genuinely closed everything still trips a
same-instant check. It failed 7 runs in 25 of one posix test, and separately on
a real path-cache reference released ~1ms after the operation that took it.

`umount` is already asynchronous, so instead it re-checks on a timer and only
reports `EBUSY` once the references outlast `common.umount_timeout_ms`
(default 1000). The bound is configurable because the right value is a property
of the deployment — a backend with slow closes wants longer — and because
having a bound at all is what keeps umount from hanging forever on a mount that
really is busy, the way it classically does on unix.

The timer is re-armed one-shot rather than periodic: evpl removes a one-shot
from the timer set before running its callback, so the callback is free to end
the wait and release its state. A periodic timer is re-armed *after* the
callback returns, which makes freeing it in the callback a use-after-free.

## Also here

`CHIMERA_VFS_EBUSY`, plus the two places that have to understand it: the POSIX
errno mapping, which otherwise falls through to `EIO` and reports a busy mount
as an I/O error, and the REST mount-delete handler, which now answers 409
rather than 500.

## Verification

- **The give-up path was forced deterministically** — a fault-injected
  reference plus a zero timeout, so that every umount took it rather than
  waiting on a race to produce one. 10/10 returned `EBUSY` through to
  "Device or resource busy", with no ASan or LSan findings: the undispatched
  request and the wait state are both released correctly. Left to chance this
  path fired in 1 run of 12 and then 0 of 15, so it would otherwise have
  shipped essentially untested — and it is where the periodic-timer
  use-after-free described above lived.
- The flakes that motivated the wait are gone: chown/memfs 0/40 and
  rename/diskfs_aio 0/25, run while the box was heavily loaded, which widens
  the transient-reference window rather than hiding it. The same tests failed
  7-in-25 and 1-in-15 before.
- posix sweep across five backend/protocol combinations (memfs, cairn,
  diskfs_aio, nfs3_memfs, nfs4_memfs): 258 passed, 22 failed. **Every one of
  the 22 fails identically on clean `upstream/main`** — verified by building
  the baseline in a separate worktree, including a byte-identical assertion
  diff for `exdev`. They are unsupported-feature gaps (`lockf`/`fcntl` need
  `CHIMERA_VFS_OP_LOCK`, which memfs does not implement) and export/pseudo-root
  cases unrelated to this change.
- `posix_test_fcntl` and `posix_test_dirstress` are excluded from that sweep:
  the first fails on the missing LOCK opcode, the second hangs in its workload
  immediately after MOUNT and never reaches umount. Both confirmed unrelated.
- REST `mounts`/`exports` tests pass; VFS ctest suite passes but for the known
  container-only `zerorange_diskfs_io_uring` SEGV.
- `make syntax-check`, `reuse-lint`, Release build, and scan-build clean in
  both ClangDebug and ClangRelease.

## Follow-on

This is the groundwork for the MkFs/RmFs series (#1527): once a cached open
handle cannot outlive its mount, that branch can drop its fs RCU map, the
per-backend `open_count` guards, and the CLOSE special-casing in the three
backend dispatches, and identify the filesystem from `mount->mount_private`
instead.
