### PR TITLE
nfs: stop the DRCs replaying one client's reply to another

### DIFF
--- a/kvm/kvm_nfs40_drc_reboot_test_wrapper.sh
+++ b/kvm/kvm_nfs40_drc_reboot_test_wrapper.sh
@@ -209,8 +209,8 @@ if [ "${RC2:-1}" != "0" ]; then
     FAIL=1
 fi
 
-if grep -q "conn DRC (type 0x08): hydrated" "$CHIMERA_LOG"; then
-    RELOADED=$(grep -oP 'conn DRC \(type 0x08\): hydrated \K[0-9]+' "$CHIMERA_LOG" | tail -1)
+if grep -q "conn DRC (type 0x09): hydrated" "$CHIMERA_LOG"; then
+    RELOADED=$(grep -oP 'conn DRC \(type 0x09\): hydrated \K[0-9]+' "$CHIMERA_LOG" | tail -1)
     echo "=== chimera B hydrated ${RELOADED} NFSv4.0 reply record(s) for the returning client ==="
     if [ "${RELOADED:-0}" -lt 1 ]; then
         echo "FAIL: no NFSv4.0 reply records hydrated for the returning client"

--- a/scripts/nfs4_v40_drc_replay_test_wrapper.sh
+++ b/scripts/nfs4_v40_drc_replay_test_wrapper.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Usage: nfs4_v40_drc_replay_test_wrapper.sh <chimera_binary> <pynfs_dir> <test_script>
+#
+# Cross-client replay regression: stands up a chimera NFS server with the NFSv4.0
+# duplicate-request cache ENABLED (server.nfs4_drc) in a network namespace, then
+# drives the replay test against it.  The cache is opt-in, so a run without the
+# flag would prove nothing -- the code under test would not be installed.
+#
+# memfs only and no vfs section at all (memfs is a built-in module), so the
+# server is the only thing in the picture: no dlopened backend, no KV store.
+
+set -u
+
+# Save and clear LD_PRELOAD immediately to avoid ASAN interference with system
+# binaries (ip, sysctl, ...) which exit non-zero under ASAN.  Restored only for
+# the chimera daemon.
+SAVED_LD_PRELOAD="${LD_PRELOAD:-}"
+unset LD_PRELOAD
+
+CHIMERA_BINARY=$1; shift
+PYNFS_DIR=$1; shift
+TEST_SCRIPT=$1; shift
+
+NETNS_NAME="v40drc_$$_$(date +%s%N)"
+BUILD_DIR=$(dirname "$(dirname "$CHIMERA_BINARY")")
+SESSION_DIR=$(mktemp -d "${BUILD_DIR}/v40drc_session_XXXXXX")
+CONFIG_FILE="${SESSION_DIR}/chimera.json"
+CHIMERA_LOG="${SESSION_DIR}/chimera.log"
+PYCOMPAT_DIR="${SESSION_DIR}/pycompat"
+CHIMERA_PID=""
+
+TEST_TIMEOUT="${V40DRC_TIMEOUT:-120}"
+
+cleanup() {
+    if [ -n "$CHIMERA_PID" ]; then
+        kill "$CHIMERA_PID" 2>/dev/null || true
+        for i in $(seq 1 150); do
+            kill -0 "$CHIMERA_PID" 2>/dev/null || break
+            sleep 0.02
+        done
+        kill -9 "$CHIMERA_PID" 2>/dev/null || true
+        wait "$CHIMERA_PID" 2>/dev/null || true
+    fi
+    ip netns delete "${NETNS_NAME}" 2>/dev/null || true
+    rm -rf "$SESSION_DIR"
+}
+trap cleanup EXIT
+
+if [ ! -d "$PYNFS_DIR" ]; then
+    echo "pynfs not found at ${PYNFS_DIR}; skipping"
+    exit 77
+fi
+
+cat > "$CONFIG_FILE" << EOF
+{
+    "common": {
+        "rcu_reclaim_threads": 4
+    },
+    "server": {
+        "nfs_enabled": true,
+        "threads": 4,
+        "delegation_threads": 4,
+        "nfs4_drc": true,
+        "external_portmap": false
+    },
+    "mounts": {
+        "share": {
+            "module": "memfs",
+            "path": "/"
+        }
+    },
+    "exports": {
+        "/share": {
+            "path": "/share"
+        }
+    }
+}
+EOF
+
+ip netns add "${NETNS_NAME}"
+ip netns exec "${NETNS_NAME}" ip link set lo up
+
+ulimit -l unlimited
+
+if [ -n "${SAVED_LD_PRELOAD}" ]; then
+    ip netns exec "${NETNS_NAME}" env LD_PRELOAD="${SAVED_LD_PRELOAD}" \
+        "$CHIMERA_BINARY" -c "$CONFIG_FILE" > "$CHIMERA_LOG" 2>&1 &
+else
+    ip netns exec "${NETNS_NAME}" \
+        "$CHIMERA_BINARY" -c "$CONFIG_FILE" > "$CHIMERA_LOG" 2>&1 &
+fi
+CHIMERA_PID=$!
+
+READY=0
+for i in $(seq 1 500); do
+    if grep -q "Server is ready." "$CHIMERA_LOG" &&
+       ip netns exec "${NETNS_NAME}" bash -c "echo > /dev/tcp/127.0.0.1/2049" 2>/dev/null; then
+        READY=1
+        break
+    fi
+    if ! kill -0 "$CHIMERA_PID" 2>/dev/null; then
+        echo "chimera daemon exited prematurely"
+        cat "$CHIMERA_LOG"
+        exit 1
+    fi
+    sleep 0.02
+done
+
+if [ "$READY" != "1" ]; then
+    echo "chimera NFS port never became ready"
+    cat "$CHIMERA_LOG"
+    exit 1
+fi
+
+# Python 3.14 images ship xdrlib3, whose pack_string requires bytes; pynfs still
+# hands it str in places.  Same in-process shim the pynfs wrapper installs,
+# rather than modifying the external /opt/pynfs checkout.
+mkdir -p "${PYCOMPAT_DIR}"
+cat > "${PYCOMPAT_DIR}/sitecustomize.py" <<'EOF'
+try:
+    from xdrlib3 import Packer
+except ImportError:
+    Packer = None
+
+if Packer is not None:
+    _pack_string = Packer.pack_string
+
+    def _chimera_pack_string(self, s):
+        if isinstance(s, str):
+            s = s.encode()
+        return _pack_string(self, s)
+
+    Packer.pack_string = _chimera_pack_string
+EOF
+export PYTHONPATH="${PYCOMPAT_DIR}:${PYNFS_DIR}:${PYTHONPATH:-}"
+
+ip netns exec "${NETNS_NAME}" \
+    timeout "${TEST_TIMEOUT}" python3 "$TEST_SCRIPT" \
+        --host 127.0.0.1 --port 2049 --export share
+RC=$?
+
+if [ "$RC" = "124" ]; then
+    echo "=== test timed out after ${TEST_TIMEOUT}s ==="
+fi
+
+if [ "$RC" != "0" ]; then
+    echo "=== chimera log ==="
+    cat "$CHIMERA_LOG"
+fi
+
+exit $RC

--- a/scripts/pynfs_test_wrapper.sh
+++ b/scripts/pynfs_test_wrapper.sh
@@ -89,6 +89,17 @@ case " $FLAG_ARGS " in
         ;;
 esac
 
+# The NFSv4.0 duplicate-request cache is opt-in (server.nfs4_drc), like the
+# NFSv3 one.  pynfs's replay suite (st_replay.py, RPLY*) re-sends a compound at
+# the same xid on one connection and requires the original reply back, so the
+# 4.0 runs have to turn it on -- otherwise the suite is asserting behaviour the
+# server was configured not to provide.  4.1+ replay goes through the session
+# reply cache instead and needs nothing here.
+DRC_ENABLE="false"
+if [ "$NFS_MINOR_VERSION" = "0" ]; then
+    DRC_ENABLE="true"
+fi
+
 # Generate chimera config based on backend
 generate_config() {
     local mount_path="/"
@@ -155,6 +166,7 @@ generate_config() {
         "threads": 4,
         "delegation_threads": 4,
         "nfs4_delegations": $DELEG_ENABLE,
+        "nfs4_drc": $DRC_ENABLE,
         "nfs4_lease_time": $PYNFS_NFS4_LEASE_TIME,
         "nfs4_grace_time": $PYNFS_NFS4_GRACE_TIME,
         $vfs_section

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -400,10 +400,15 @@ nfs_server_init(
     if (chimera_server_config_get_nfs3_drc(config)) {
         nfs3_drc_install(shared);
     }
-    /* The NFSv4.0 reply cache is always installed (its in-memory cache fixes
-     * replay across a client's reconnect regardless of persistence); KV
-     * persistence is gated by nfs4_drc inside the install. */
-    nfs4_v40_drc_install(shared, chimera_server_config_get_nfs4_drc(config));
+    /* Same for the NFSv4.0 reply cache, gated on nfs4_drc.  It used to install
+     * unconditionally, with the flag gating only KV persistence, so a server
+     * that had opted out still carried the cache and everything that can be
+     * replayed from it.  A 4.0 client's exactly-once needs for the state ops are
+     * met by the RFC 7530 Section 9.1.7 per-owner replay cache either way; this
+     * cache covers the remaining non-idempotent ops and is opt-in. */
+    if (chimera_server_config_get_nfs4_drc(config)) {
+        nfs4_v40_drc_install(shared, 1);
+    }
     pthread_mutex_init(&shared->nfs4_pnfs_devcache.lock, NULL);
     shared->nfs4_pnfs_devcache.count = 0;
 
@@ -803,15 +808,40 @@ chimera_nfs_server_notify(
     char                              local_addr[80], remote_addr[80];
 
     switch (notify->notify_type) {
+        /* The connectionless DRCs key replies by source address, which alone
+         * cannot separate two clients on one host.  Register the connection so
+         * an entry only replays to the connection that produced it, or to anyone
+         * once that connection is gone.
+         *
+         * Both events register, because which one a connection reports depends
+         * on how it arrived: an inbound connection is announced with ACCEPTED
+         * from evpl_rpc2_accept, and the transport separately reports CONNECTED.
+         * Registration keeps the first generation it assigned, so seeing both is
+         * harmless; missing both would silently leave every entry ownerless and
+         * replayable by anyone, which is the bug this guards against.  No-ops
+         * when the DRC in question was not installed. */
+        case EVPL_RPC2_NOTIFY_ACCEPTED:
+            nfs3_drc_conn_open(&shared->nfs3_drc, conn);
+            nfs3_drc_conn_open(&shared->v40_drc, conn);
+            break;
         case EVPL_RPC2_NOTIFY_CONNECTED:
             evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
             evpl_rpc2_conn_get_remote_address(conn, remote_addr, sizeof(remote_addr));
             chimera_nfs_debug("Client connected from %s to %s", remote_addr, local_addr);
+
+            nfs3_drc_conn_open(&shared->nfs3_drc, conn);
+            nfs3_drc_conn_open(&shared->v40_drc, conn);
             break;
         case EVPL_RPC2_NOTIFY_DISCONNECTED:
             evpl_rpc2_conn_get_local_address(conn, local_addr, sizeof(local_addr));
             evpl_rpc2_conn_get_remote_address(conn, remote_addr, sizeof(remote_addr));
             chimera_nfs_debug("Client disconnected from %s to %s", remote_addr, local_addr);
+
+            /* Before the early-out below: the replies this connection captured
+             * become replayable by the client's next connection, which is the
+             * cross-reconnect retransmit the cache exists for. */
+            nfs3_drc_conn_close(&shared->nfs3_drc, conn);
+            nfs3_drc_conn_close(&shared->v40_drc, conn);
 
             priv = evpl_rpc2_conn_get_private_data(conn);
             if (!priv) {

--- a/src/server/nfs/nfs3_drc.c
+++ b/src/server/nfs/nfs3_drc.c
@@ -135,6 +135,134 @@ nfs3_drc_client_addr(
 } /* nfs3_drc_client_addr */
 
 /* ------------------------------------------------------------------ *
+*  live connection registry                                          *
+*                                                                    *
+*  {address, xid, checksum} cannot distinguish a retransmit from a    *
+*  different client's first-ever request when both come from one host.*
+*  Recording which connection captured a reply -- and whether that    *
+*  connection is still open -- supplies the missing bit: a concurrent *
+*  peer never replays another connection's reply, while a genuine     *
+*  reconnect (origin gone) still does.                               *
+* ------------------------------------------------------------------ */
+
+/* Caller holds drc->lock.  0 when conn is NULL or was never opened. */
+static uint64_t
+nfs3_drc_conn_gen_locked(
+    struct nfs3_drc *drc,
+    const void      *conn)
+{
+    struct nfs3_drc_conn *c;
+
+    if (!conn) {
+        return 0;
+    }
+    HASH_FIND_PTR(drc->live_conns, &conn, c);
+    return c ? c->gen : 0;
+} /* nfs3_drc_conn_gen_locked */
+
+/* Is a reply captured at `ts` still young enough to be answering a retransmit?
+ * CLOCK_MONOTONIC_COARSE never runs backwards within a boot, but guard the
+ * subtraction anyway so a future-stamped entry reads as fresh rather than
+ * wrapping around to expired. */
+static inline int
+nfs3_drc_entry_fresh(
+    uint64_t now,
+    uint64_t ts)
+{
+    return now < ts || now - ts <= NFS3_DRC_MAX_AGE_NS;
+} /* nfs3_drc_entry_fresh */
+
+/* Caller holds drc->lock.  May this entry be replayed to `conn`? */
+static int
+nfs3_drc_replayable_locked(
+    struct nfs3_drc             *drc,
+    const struct nfs3_drc_entry *e,
+    const void                  *conn)
+{
+    struct nfs3_drc_conn *origin;
+    const void           *origin_conn = e->origin_conn;
+
+    if (!e->origin_gen) {
+        return 1;  /* hydrated from the KV store: no live origin to protect */
+    }
+    if (origin_conn == conn) {
+        return 1;  /* the connection that captured it is asking again */
+    }
+
+    /* A different connection may replay only once the origin is gone -- either
+     * absent from the registry, or its pointer already recycled for a newer
+     * connection (a different generation). */
+    HASH_FIND_PTR(drc->live_conns, &origin_conn, origin);
+    return !origin || origin->gen != e->origin_gen;
+} /* nfs3_drc_replayable_locked */
+
+void
+nfs3_drc_conn_open(
+    struct nfs3_drc *drc,
+    const void      *conn)
+{
+    struct nfs3_drc_conn *c;
+
+    /* orig_dispatch is set only by install; an uninstalled cache tracks
+     * nothing so a disabled DRC costs nothing per connection. */
+    if (!drc->orig_dispatch || !conn) {
+        return;
+    }
+
+    c = malloc(sizeof(*c));
+    if (!c) {
+        return;  /* OOM: the conn reads as not-live, which only loosens replay */
+    }
+    c->conn = conn;
+
+    pthread_mutex_lock(&drc->lock);
+    /* Idempotent: a connection may be announced more than once (accepted, then
+     * connected).  Keep the generation already assigned rather than minting a
+     * new one, or a re-announcement mid-connection would orphan the entries it
+     * had already captured -- they would read as origin-gone and become
+     * replayable by any peer, which is exactly what must not happen.  A conn is
+     * always removed on disconnect, before the rpc2 layer frees it, so a
+     * genuinely recycled pointer never finds a stale record here. */
+    {
+        struct nfs3_drc_conn *old;
+
+        HASH_FIND_PTR(drc->live_conns, &conn, old);
+        if (old) {
+            pthread_mutex_unlock(&drc->lock);
+            free(c);
+            return;
+        }
+    }
+    c->gen = ++drc->next_conn_gen;  /* pre-increment: never hands out 0 */
+    HASH_ADD_PTR(drc->live_conns, conn, c);
+    pthread_mutex_unlock(&drc->lock);
+} /* nfs3_drc_conn_open */
+
+void
+nfs3_drc_conn_close(
+    struct nfs3_drc *drc,
+    const void      *conn)
+{
+    struct nfs3_drc_conn *c;
+
+    if (!drc->orig_dispatch || !conn) {
+        return;
+    }
+
+    pthread_mutex_lock(&drc->lock);
+    HASH_FIND_PTR(drc->live_conns, &conn, c);
+    if (c) {
+        HASH_DEL(drc->live_conns, c);
+    }
+    pthread_mutex_unlock(&drc->lock);
+
+    /* Entries this connection captured are deliberately left in place: with the
+     * origin gone they become replayable by the client's next connection, which
+     * is the cross-reconnect replay the cache exists for. */
+    free(c);
+} /* nfs3_drc_conn_close */
+
+/* ------------------------------------------------------------------ *
 *  reply value (de)serialization                                     *
 * ------------------------------------------------------------------ */
 
@@ -196,11 +324,13 @@ nfs3_drc_cache_insert_locked(
     const void                   *body,
     uint32_t                      body_len,
     uint64_t                      ts,
+    const void                   *origin_conn,
     struct nfs3_drc_keybuf       *evicted,
     int                           max_evicted)
 {
     struct nfs3_drc_entry *e;
-    int                    nev = 0;
+    uint64_t               origin_gen = nfs3_drc_conn_gen_locked(drc, origin_conn);
+    int                    nev        = 0;
 
     HASH_FIND(hh, drc->table, key, sizeof(*key), e);
     if (e) {
@@ -215,9 +345,11 @@ nfs3_drc_cache_insert_locked(
             return 0;
         }
         memcpy(e->buf, body, body_len);
-        e->len      = body_len;
-        e->ts       = ts;
-        drc->bytes += body_len;
+        e->len         = body_len;
+        e->ts          = ts;
+        e->origin_conn = origin_conn;
+        e->origin_gen  = origin_gen;
+        drc->bytes    += body_len;
         return 0;
     }
 
@@ -245,8 +377,10 @@ nfs3_drc_cache_insert_locked(
         return nev;
     }
     memcpy(e->buf, body, body_len);
-    e->len = body_len;
-    e->ts  = ts;
+    e->len         = body_len;
+    e->ts          = ts;
+    e->origin_conn = origin_conn;
+    e->origin_gen  = origin_gen;
     HASH_ADD(hh, drc->table, key, sizeof(e->key), e);
     drc->bytes += body_len;
 
@@ -259,10 +393,12 @@ nfs3_drc_cache_insert(
     const struct nfs3_drc_keybuf *key,
     const void                   *body,
     uint32_t                      body_len,
-    uint64_t                      ts)
+    uint64_t                      ts,
+    const void                   *origin_conn)
 {
     pthread_mutex_lock(&drc->lock);
-    nfs3_drc_cache_insert_locked(drc, key, body, body_len, ts, NULL, 0);
+    nfs3_drc_cache_insert_locked(drc, key, body, body_len, ts, origin_conn,
+                                 NULL, 0);
     pthread_mutex_unlock(&drc->lock);
 } /* nfs3_drc_cache_insert */
 
@@ -270,16 +406,23 @@ int
 nfs3_drc_cache_lookup(
     struct nfs3_drc              *drc,
     const struct nfs3_drc_keybuf *key,
+    const void                   *conn,
     uint8_t                     **out_buf,
     uint32_t                     *out_len)
 {
     struct nfs3_drc_entry *e;
+    uint64_t               now = nfs_lease_now_ns();
     uint8_t               *buf = NULL;
     uint32_t               len = 0;
 
     pthread_mutex_lock(&drc->lock);
     HASH_FIND(hh, drc->table, key, sizeof(*key), e);
-    if (e) {
+    /* An entry only answers when it is this connection's to replay (or its
+     * origin is gone) and is recent enough that it can still plausibly be
+     * answering a retransmit rather than a fresh request. */
+    if (e &&
+        nfs3_drc_replayable_locked(drc, e, conn) &&
+        nfs3_drc_entry_fresh(now, e->ts)) {
         len = e->len;
         buf = malloc(len);
         if (buf) {
@@ -368,6 +511,7 @@ struct nfs3_drc_capture_ctx {
     struct chimera_server_nfs_thread *thread;
     struct nfs3_drc                  *drc;
     struct nfs3_drc_keybuf            key;
+    const void                       *conn;   /* connection being replied to */
 };
 
 static void
@@ -403,7 +547,7 @@ nfs3_drc_capture_reply(
 
     pthread_mutex_lock(&drc->lock);
     nev = nfs3_drc_cache_insert_locked(drc, &ctx->key, buf, total_length, ts,
-                                       evicted, NFS3_DRC_EVICT_MAX);
+                                       ctx->conn, evicted, NFS3_DRC_EVICT_MAX);
     pthread_mutex_unlock(&drc->lock);
 
     if (!drc->persistence_disabled) {
@@ -497,7 +641,7 @@ nfs3_drc_lookup_or_forward(
     uint8_t                     *cached;
     uint32_t                     cached_len;
 
-    if (nfs3_drc_cache_lookup(drc, key, &cached, &cached_len)) {
+    if (nfs3_drc_cache_lookup(drc, key, conn, &cached, &cached_len)) {
         int rc = nfs_drc_send_cached_reply(thread, encoding, cached, cached_len);
 
         free(cached);
@@ -513,6 +657,7 @@ nfs3_drc_lookup_or_forward(
         cctx->thread                    = thread;
         cctx->drc                       = drc;
         cctx->key                       = *key;
+        cctx->conn                      = conn;
         encoding->reply_capture_cb      = nfs3_drc_capture_reply;
         encoding->reply_capture_private = cctx;
     }
@@ -582,7 +727,25 @@ nfs3_drc_hydrate_scan_cb(
     if (nfs3_drc_value_parse(value, value_len, &ts, &body, &body_len) != 0) {
         return 0;  /* skip a corrupt value */
     }
-    nfs3_drc_cache_insert(drc, &kb, body, body_len, ts);
+
+    /* Stamp the hydrated entry with this instance's clock rather than the
+     * persisted one: the record's ts came from a different boot (or a different
+     * node), where CLOCK_MONOTONIC_COARSE counted from a different origin, so it
+     * cannot be compared against ours.  The client has only just reconnected, so
+     * dating the entry from now is both meaningful and what keeps the record
+     * usable -- the point of persisting it.
+     *
+     * The band is claimed by the connection whose request triggered the
+     * hydrate.  Leaving it ownerless instead would hand every record to any
+     * connection from the address, which is precisely the cross-client replay
+     * the origin guard exists to stop -- reintroduced on the persistent path,
+     * where the records are by construction the non-idempotent ones.  The
+     * connection that triggers the hydrate is the returning client (its request
+     * is the one the band may have to answer), and once it closes the records
+     * fall back to being replayable by any of that client's later connections,
+     * exactly as captured entries do. */
+    nfs3_drc_cache_insert(drc, &kb, body, body_len, nfs_lease_now_ns(),
+                          hc->conn);
     hc->loaded++;
     return 0;
 } /* nfs3_drc_hydrate_scan_cb */
@@ -734,6 +897,8 @@ nfs3_drc_init(
     pthread_mutex_init(&drc->lock, NULL);
     drc->table                = NULL;
     drc->hydrated             = NULL;
+    drc->live_conns           = NULL;
+    drc->next_conn_gen        = 0;
     drc->bytes                = 0;
     drc->kv_type              = kv_type;
     drc->persistence_disabled = 0;
@@ -749,6 +914,7 @@ nfs3_drc_destroy(struct nfs3_drc *drc)
 #ifndef __clang_analyzer__
     struct nfs3_drc_entry *e, *tmp;
     struct nfs3_drc_hydra *h, *htmp;
+    struct nfs3_drc_conn  *c, *ctmp;
 
     HASH_ITER(hh, drc->table, e, tmp)
     {
@@ -760,6 +926,11 @@ nfs3_drc_destroy(struct nfs3_drc *drc)
     {
         HASH_DELETE(hh, drc->hydrated, h);
         free(h);
+    }
+    HASH_ITER(hh, drc->live_conns, c, ctmp)
+    {
+        HASH_DELETE(hh, drc->live_conns, c);
+        free(c);
     }
 #endif /* ifndef __clang_analyzer__ */
     pthread_mutex_destroy(&drc->lock);

--- a/src/server/nfs/nfs3_drc.h
+++ b/src/server/nfs/nfs3_drc.h
@@ -34,6 +34,21 @@ struct evpl_rpc2_cred;
  * Only non-idempotent procedures are cached (CREATE/MKDIR/REMOVE/RENAME/...);
  * re-executing an idempotent op is harmless, so those bypass the cache.
  *
+ * Two further conditions gate a replay, because {address, xid, checksum} alone
+ * cannot tell a retransmit from a different client's first-ever request when
+ * both come from one host:
+ *
+ *   - Connection origin.  An entry records the connection whose reply it
+ *     captured.  It replays to that connection, or -- once that connection is
+ *     gone -- to any connection from the same address.  A second, concurrently
+ *     live connection never replays another's reply, so a real mutation can no
+ *     longer be acknowledged and discarded.  Records loaded from the KV store
+ *     have no live origin and stay replayable, which is what keeps a client's
+ *     reply band useful after it reconnects to another instance.
+ *   - Age.  A retransmit follows its call by seconds; an entry older than
+ *     NFS3_DRC_MAX_AGE_NS is treated as a miss rather than answering a fresh
+ *     request with an arbitrarily old reply.
+ *
  * The cache is installed as a wrapper around the generated NFS_V3 call
  * dispatcher (see nfs3_drc_install): on a hit it replays the cached reply and
  * skips execution; on a miss it arms the rpc2 reply-capture hook and forwards
@@ -50,6 +65,13 @@ struct evpl_rpc2_cred;
 #define NFS3_DRC_MAX_REPLY_SIZE (64u * 1024u)
 #define NFS3_DRC_MAX_BYTES      (4u * 1024u * 1024u)
 
+/* How long a captured reply stays eligible for replay.  A retransmit follows
+ * its original call within the client's RPC timeout (seconds), so 120s leaves
+ * generous headroom while bounding how stale a replayed reply can be.  Entries
+ * are still inserted regardless of age -- only lookups are gated -- so a band
+ * hydrated from the KV store after a restart is unaffected. */
+#define NFS3_DRC_MAX_AGE_NS     (120ULL * 1000000000ULL)
+
 /* Fixed-layout identity used as the uthash key.  memset to zero before filling
  * so the trailing pad and any unused addr bytes hash deterministically. */
 struct nfs3_drc_keybuf {
@@ -65,8 +87,33 @@ struct nfs3_drc_entry {
     struct nfs3_drc_keybuf key;
     uint8_t               *buf;     /* cached procedure-result body */
     uint32_t               len;
-    uint64_t               ts;      /* capture time (monotonic ticks), diag */
+    uint64_t               ts;      /* capture time (monotonic ns) */
+    /* Connection this reply was captured on, and the generation that connection
+     * held at the time (see nfs3_drc_conn).  origin_gen 0 means "no live origin"
+     * and replays to anyone.
+     *
+     * Deliberately payload rather than part of the hash key.  Keying on the
+     * connection would give each one its own entry, but a reconnecting client
+     * would then miss its own record entirely -- and answering a retransmit that
+     * arrives on a new connection is the whole point of an address-keyed cache.
+     * The cost is that two live connections at one address issuing byte-
+     * identical requests at the same xid share one entry, so the later capture
+     * takes ownership and the earlier connection loses its replay protection.
+     * That direction is safe: it degrades to re-executing a retransmit, never to
+     * answering one connection with another's reply. */
+    const void            *origin_conn;
+    uint64_t               origin_gen;
     UT_hash_handle         hh;
+};
+
+/* One connection currently open on this server.  The generation disambiguates a
+ * recycled pointer: a new connection landing on a freed conn's address gets a
+ * fresh generation, so an entry naming the old {conn, gen} still reads as
+ * origin-gone rather than as this connection's own reply. */
+struct nfs3_drc_conn {
+    const void    *conn;
+    uint64_t       gen;
+    UT_hash_handle hh;
 };
 
 /* One per client address this instance has hydrated from the KV store (loaded
@@ -87,6 +134,8 @@ struct nfs3_drc {
     pthread_mutex_t        lock;
     struct nfs3_drc_entry *table;            /* uthash, FIFO eviction order */
     struct nfs3_drc_hydra *hydrated;         /* uthash: addrs hydrated from KV  */
+    struct nfs3_drc_conn  *live_conns;       /* uthash: connections now open    */
+    uint64_t               next_conn_gen;    /* monotonic; never hands out 0    */
     uint64_t               bytes;
     uint8_t                kv_type;          /* CHIMERA_KV_TYPE_NFS{3,4_V40}_REPLY */
     int                    persistence_disabled;
@@ -119,6 +168,20 @@ nfs3_drc_init(
 void
 nfs3_drc_destroy(
     struct nfs3_drc *drc);
+
+/* Connection lifecycle, driven from the NFS server's rpc2 notify callback.  Both
+ * are no-ops on a DRC that was never installed, so a disabled cache costs
+ * nothing per connection.  A conn the DRC never saw opened reads as "not live",
+ * which is the safe direction: entries it captured stay replayable. */
+void
+nfs3_drc_conn_open(
+    struct nfs3_drc *drc,
+    const void      *conn);
+
+void
+nfs3_drc_conn_close(
+    struct nfs3_drc *drc,
+    const void      *conn);
 
 /* ----------------------------------------------------------------------- *
 *  Shared connectionless-DRC core, used by the NFSv3 and NFSv4.0 adapters. *
@@ -191,19 +254,25 @@ nfs3_drc_value_parse(
     const uint8_t **out_body,
     uint32_t       *out_body_len);
 
-/* In-memory cache primitives (lock taken internally). */
+/* In-memory cache primitives (lock taken internally).  origin_conn is the
+ * connection whose reply this is; pass NULL for a record loaded from the KV
+ * store, which has no live origin and stays replayable by any connection. */
 void
 nfs3_drc_cache_insert(
     struct nfs3_drc              *drc,
     const struct nfs3_drc_keybuf *key,
     const void                   *body,
     uint32_t                      body_len,
-    uint64_t                      ts);
+    uint64_t                      ts,
+    const void                   *origin_conn);
 
-/* Returns 1 and fills out_buf (malloc'd, caller frees) + out_len on a hit. */
+/* Returns 1 and fills out_buf (malloc'd, caller frees) + out_len on a hit.
+ * `conn` is the connection asking; an entry captured on a different, still-live
+ * connection, or one older than NFS3_DRC_MAX_AGE_NS, reads as a miss. */
 int
 nfs3_drc_cache_lookup(
     struct nfs3_drc              *drc,
     const struct nfs3_drc_keybuf *key,
+    const void                   *conn,
     uint8_t                     **out_buf,
     uint32_t                     *out_len);

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -14,6 +14,7 @@
 #include "nfs4_op_matrix.h"
 #include "nfs4_rofs.h"
 #include "nfs_drc_reply.h"
+#include "nfs4_v40_drc.h"
 
 static int
 nfs4_send_cached_reply(
@@ -565,7 +566,28 @@ chimera_nfs4_compound(
     req->lock_4_0_lock_owner         = NULL;
 
     /* NFSv4.0 duplicate-request caching is handled before the compound is
-     * decoded, by the dispatcher wrapper in nfs4_v40_drc.c. */
+     * decoded, by the dispatcher wrapper in nfs4_v40_drc.c.  That wrapper cannot
+     * see the operations -- they are still XDR at that point -- so it arms the
+     * reply capture for every 4.0 COMPOUND and we cancel it here, now that the
+     * argarray is decoded, unless the compound actually carries something that
+     * must not be re-executed.
+     *
+     * Cancelling means the reply is never cached, which is also what stops it
+     * ever being replayed: the cache key covers a checksum of the request, so a
+     * read-only COMPOUND can only ever match another read-only COMPOUND's entry,
+     * and those no longer exist.  Without this, a byte-identical LOOKUP or
+     * READDIR from any client at the same address and xid was answered with an
+     * arbitrarily old reply.
+     *
+     * The capture context lives in the encoding's dbuf, so dropping the pointers
+     * is the whole cancellation.  4.1+ arms its own capture from
+     * nfs4_replay_slot_acquire, which runs later, in the SEQUENCE handler. */
+    if (args->minorversion == 0 &&
+        req->encoding->reply_capture_cb &&
+        !nfs4_v40_drc_compound_cacheable(args)) {
+        req->encoding->reply_capture_cb      = NULL;
+        req->encoding->reply_capture_private = NULL;
+    }
 
     /* Chimera implements NFS v4.0, v4.1 and v4.2 (minorversions 0–2).
      * Reject unknown minor versions with NFS4ERR_MINOR_VERS_MISMATCH per

--- a/src/server/nfs/nfs4_v40_drc.c
+++ b/src/server/nfs/nfs4_v40_drc.c
@@ -32,15 +32,22 @@ v40_be32(const uint8_t *p)
  * compound header is virtually always within the first iovec on TCP; if the tag
  * runs past it, we cannot tell -- return false and let the request pass through
  * uncached (safe: a missed cache, never a wrong reply).
+ *
+ * tag_len is attacker-controlled, so the offset arithmetic is done in 64 bits.
+ * In 32-bit arithmetic `4 + tag_len + pad` wraps for tag_len near UINT32_MAX --
+ * 0xFFFFFFF5 through 0xFFFFFFF8 land on off == 0xFFFFFFFC, whose `off + 4` wraps
+ * to 0 and sails through a 32-bit bounds check, reading ~4GB past the buffer.
+ * Widening makes the comparison exact and the guard unconditional.
  */
-static bool
-v40_peek_minorversion(
+bool
+nfs4_v40_peek_minorversion(
     const xdr_iovec *iov,
     int              niov,
     uint32_t        *out_mv)
 {
     const uint8_t *p;
-    uint32_t       len, tag_len, off;
+    uint32_t       len, tag_len;
+    uint64_t       off;
 
     if (niov < 1) {
         return false;
@@ -51,13 +58,68 @@ v40_peek_minorversion(
         return false;
     }
     tag_len = v40_be32(p);
-    off     = 4 + tag_len + ((4 - (tag_len & 3)) & 3); /* tag padded to 4 */
-    if (off + 4 > len) {
+    off     = 4ull + tag_len + ((4u - (tag_len & 3u)) & 3u); /* tag padded to 4 */
+    if (off + 4ull > (uint64_t) len) {
         return false;  /* tag spans beyond the first iovec */
     }
     *out_mv = v40_be32(p + off);
     return true;
-} /* v40_peek_minorversion */
+} /* nfs4_v40_peek_minorversion */
+
+/*
+ * Which minorversion-0 operations must not be re-executed on a retransmit.
+ *
+ * The NFSv3 path answers the same question per procedure in
+ * nfs3_drc_proc_cacheable(); a COMPOUND has to be judged by the operations it
+ * carries, so this is its equivalent.  Deliberate exclusions:
+ *
+ *   - Idempotent ops (LOOKUP, READDIR, GETATTR, READ, ACCESS, COMMIT, ...) are
+ *     safe to re-execute, so they never justify an entry.  WRITE is excluded for
+ *     the same reason and to match the v3 list: replaying the same bytes at the
+ *     same offset is harmless.
+ *   - The seqid-sequenced state operations (OPEN, CLOSE, LOCK, LOCKU,
+ *     OPEN_CONFIRM, OPEN_DOWNGRADE) have their own, better replay cache: RFC 7530
+ *     Section 9.1.7 keeps the last response per state-owner, which chimera
+ *     implements (struct nfs4_replay_cache).  The RFC calls that "a more reliable
+ *     cache of duplicate non-idempotent requests than that of the traditional
+ *     cache", so covering them here as well would add nothing and only widen the
+ *     window in which a reply can be replayed.
+ *
+ * This is not NFS4_OP_FLAG_MUTATES from nfs4_op_matrix.h: that flag answers a
+ * different question (does the op need a writable export) and includes WRITE.
+ */
+static bool
+nfs4_v40_op_cacheable(const struct nfs_argop4 *argop)
+{
+    switch (argop->argop) {
+        case OP_CREATE:
+        case OP_REMOVE:
+        case OP_RENAME:
+        case OP_LINK:
+        case OP_SETATTR:
+        case OP_SETCLIENTID:
+        case OP_SETCLIENTID_CONFIRM:
+            return true;
+        case OP_OPENATTR:
+            /* Only creates the named-attribute directory when asked to. */
+            return argop->opopenattr.createdir != 0;
+        default:
+            return false;
+    } /* switch */
+} /* nfs4_v40_op_cacheable */
+
+bool
+nfs4_v40_drc_compound_cacheable(const struct COMPOUND4args *args)
+{
+    uint32_t i;
+
+    for (i = 0; i < args->num_argarray; i++) {
+        if (nfs4_v40_op_cacheable(&args->argarray[i])) {
+            return true;
+        }
+    }
+    return false;
+} /* nfs4_v40_drc_compound_cacheable */
 
 static int
 nfs4_v40_drc_dispatch(
@@ -81,11 +143,19 @@ nfs4_v40_drc_dispatch(
      * 4.1+ COMPOUNDs (the session reply cache covers those) pass through.  The
      * cached reply is the TCP on-wire form, so RDMA framing would not match. */
     if (conn->rdma || proc != NFS4_PROC_COMPOUND ||
-        !v40_peek_minorversion(iov, niov, &mv) || mv != 0) {
+        !nfs4_v40_peek_minorversion(iov, niov, &mv) || mv != 0) {
         return drc->orig_dispatch(evpl, conn, encoding, proc, program_data,
                                   cred, iov, niov, length, private_data);
     }
 
+    /* The lookup below runs for every 4.0 COMPOUND, read-only ones included,
+     * because the operations are not known until the arguments are decoded.
+     * That is safe: only a COMPOUND carrying a non-idempotent operation is ever
+     * inserted (chimera_nfs4_compound cancels the capture otherwise, keyed on
+     * nfs4_v40_drc_compound_cacheable), and the key covers a checksum of the
+     * whole request, so a read-only COMPOUND's bytes cannot match a cached
+     * mutating one's.  A read-only request therefore always misses and executes
+     * for real. */
     memset(&key, 0, sizeof(key));
     key.addr_len = nfs3_drc_client_addr(conn, key.addr);
     key.proc     = NFS4_PROC_COMPOUND;   /* constant for 4.0; cksum disambiguates */
@@ -105,8 +175,8 @@ nfs4_v40_drc_install(
     const char      *kvname = (shared->vfs && shared->vfs->kv_module) ?
         shared->vfs->kv_module->name : "";
 
-    /* In-memory cache is always on; persist only when nfs4_drc is enabled AND
-     * the backend is persistent (mirrors the 4.1 reply cache). */
+    /* The caller has already checked server.nfs4_drc; persist to the KV store
+     * only when the backend can actually outlive the process. */
     drc->persistence_disabled = !persist || (strcmp(kvname, "memkv") == 0);
 
     drc->orig_dispatch                     = shared->nfs_v4.rpc2.recv_call_dispatch;

--- a/src/server/nfs/nfs4_v40_drc.h
+++ b/src/server/nfs/nfs4_v40_drc.h
@@ -4,7 +4,14 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
+/* nfs3_xdr.h defines xdr_iovec (used by the minorversion peek below). */
+#include "nfs3_xdr.h"
+
 struct chimera_server_nfs_shared;
+struct COMPOUND4args;
 
 /*
  * NFSv4.0 duplicate-request cache.
@@ -17,11 +24,36 @@ struct chimera_server_nfs_shared;
  * after it reconnects to a different node.  4.1+ COMPOUNDs (handled by the
  * session reply cache) and NULL pass straight through.
  *
- * The in-memory cache is always on (it also fixes replay across a client's own
- * reconnect to the same node); persistence to the KV store is gated by
- * server.nfs4_drc + a persistent kv_module, matching the 4.1 reply cache.
+ * Installed only when server.nfs4_drc is set, exactly as the NFSv3 DRC is gated
+ * on server.nfs3_drc; persistence to the KV store additionally requires a
+ * persistent kv_module.
  */
 void
 nfs4_v40_drc_install(
     struct chimera_server_nfs_shared *shared,
     int                               persist);
+
+/*
+ * Is this COMPOUND worth caching -- does it carry an operation that must not be
+ * re-executed on a retransmit?  Read-only compounds are not cached, so they can
+ * never be answered from the cache either; see the comment on the definition.
+ *
+ * Called after the arguments are decoded, from chimera_nfs4_compound.
+ */
+bool
+nfs4_v40_drc_compound_cacheable(
+    const struct COMPOUND4args *args);
+
+/*
+ * Read the COMPOUND4args minorversion straight off the wire, before the request
+ * is decoded.  False when it cannot be determined from the first iovec, which
+ * the caller must treat as "do not cache" rather than as minorversion 0.
+ *
+ * Exposed for unit tests (test_nfs_persist): tag_len is attacker-controlled and
+ * the offset arithmetic has to stay overflow-free.
+ */
+bool
+nfs4_v40_peek_minorversion(
+    const xdr_iovec *iov,
+    int              niov,
+    uint32_t        *out_mv);

--- a/src/server/nfs/nfs_kv_keys.h
+++ b/src/server/nfs/nfs_kv_keys.h
@@ -66,8 +66,15 @@ enum chimera_kv_record_type {
     CHIMERA_KV_TYPE_NFS3_REPLY     = 0x05, /* NFSv3 DRC reply entry (by client)  */
     CHIMERA_KV_TYPE_NSM_STATE      = 0x06, /* singleton NSM/statd state number   */
     CHIMERA_KV_TYPE_NSM_MONITOR    = 0x07, /* per-host NSM monitor (nfs_nsm)     */
-    CHIMERA_KV_TYPE_NFS4_V40_REPLY = 0x08, /* NFSv4.0 DRC reply entry (by client)*/
-    /* 0x09 .. 0xFE reserved for future global record types */
+    /* 0x08 was the first NFSv4.0 DRC band.  It was written by builds that
+     * cached every minorversion-0 COMPOUND, read-only ones included, so its
+     * records are not safe to hydrate: replaying one answers a fresh LOOKUP or
+     * READDIR with a stale reply.  There is no way to tell those records from
+     * the non-idempotent ones after the fact, so the band was abandoned rather
+     * than filtered.  Records left in 0x08 by an older build are simply never
+     * scanned; they age out with the store.  Do not reuse this value. */
+    CHIMERA_KV_TYPE_NFS4_V40_REPLY = 0x09, /* NFSv4.0 DRC reply entry (by client)*/
+    /* 0x0A .. 0xFE reserved for future global record types */
 };
 
 /* Longest normalized client address string an NFSv3 DRC key embeds (IPv6

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(test_nfs_persist
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_recovery.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_drc.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs3_drc.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_v40_drc.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs_drc_reply.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_callback.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_cb.c)
@@ -163,6 +164,28 @@ target_include_directories(test_open_owner_lifetime PRIVATE
     ${NFS_COMMON_INCLUDE_DIR})
 add_test(NAME chimera/server/nfs/open_owner_lifetime
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_open_owner_lifetime)
+
+# End-to-end regression: two connections from one address presenting
+# byte-identical NFSv4.0 COMPOUNDs at the same xid must not be served each
+# other's replies -- neither a stale directory listing nor, worse, an
+# acknowledged-but-never-executed CREATE.  Runs against a real daemon with
+# server.nfs4_drc enabled (the cache is opt-in, so a default config would leave
+# the code under test uninstalled), and also asserts the cache still replays a
+# genuine same-connection retransmit.
+#
+# Needs pynfs for its NFSv4.0 client, and a network namespace to own port 2049;
+# the wrapper exits 77 (skip) if pynfs is missing at run time.
+if(CHIMERA_NETNS_TESTING AND EXISTS "/opt/pynfs/nfs4.0/nfs4lib.py")
+    add_test(NAME chimera/server/nfs/v40_drc_replay
+        COMMAND bash ${CMAKE_SOURCE_DIR}/scripts/nfs4_v40_drc_replay_test_wrapper.sh
+                ${CMAKE_BINARY_DIR}/src/daemon/chimera
+                /opt/pynfs
+                ${CMAKE_CURRENT_SOURCE_DIR}/nfs4_v40_drc_replay.py)
+    set_tests_properties(chimera/server/nfs/v40_drc_replay PROPERTIES
+        SKIP_RETURN_CODE 77
+        TIMEOUT 180
+        ENVIRONMENT "PYTHONUNBUFFERED=1")
+endif()
 
 # Tag every test registered above with the 'nfs' label so these NFS server unit
 # tests can be run independently via `ctest -L nfs`.

--- a/src/server/nfs/tests/nfs4_v40_drc_replay.py
+++ b/src/server/nfs/tests/nfs4_v40_drc_replay.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+"""
+Regression test: the NFSv4.0 duplicate-request cache must not answer one
+client's request with another's reply.
+
+The v4.0 DRC keys a cached COMPOUND by {client address with the port stripped,
+xid, checksum of the request}.  Nothing in that key separates two connections
+from one host, and every fresh pynfs NFS4Client restarts its xid at 0 (rpc.py,
+RPCClient.__init__), so byte-identical compounds from different clients used to
+collide.  Two things went wrong:
+
+  * a read-only COMPOUND (PUTFH+READDIR, PUTROOTFH+LOOKUP) was cached, so a
+    fresh client was served an arbitrarily old directory listing; and
+  * a CREATE from a second, concurrently live connection was answered NFS4_OK
+    straight from the cache without ever executing -- a silently dropped
+    mutation.
+
+Four checks, run against a daemon with server.nfs4_drc enabled so the cache is
+actually installed:
+
+  1. read-only replay : fresh connections issuing byte-identical READDIRs must
+                        each see the current directory, not the first one's.
+  2. control          : the same loop with the request bytes made unique, so
+                        the DRC key cannot match.  Proves the harness itself is
+                        sound -- if this fails, the server's view is the
+                        problem, not the cache.
+  3. silent data loss : a byte-identical CREATE from a second live connection
+                        must really create.
+  4. real retransmit  : the cache must still do its job -- re-sending one
+                        connection's own CREATE at the same xid replays
+                        NFS4_OK instead of failing NFS4ERR_EXIST.
+
+Every request the test cares about carries an explicit tag and an explicitly
+forced xid, so byte-identity between two clients is asserted by construction
+rather than left to pynfs's tag heuristics.
+
+Trap worth knowing before editing this: READDIR request bytes do not vary with
+directory contents, so a fixed maxcount repeats across *runs* as well as within
+one, and a leftover entry from the previous run can poison a later one.  Hence
+the per-run tag on every created name and the per-run maxcount base -- without
+them the test ends up testing the cache against itself.
+
+Needs pynfs and root (the AUTH_SYS cred is uid 0 against a root-owned export
+root).  Driven by scripts/nfs4_v40_drc_replay_test_wrapper.sh.
+"""
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, "/opt/pynfs/nfs4.0")
+sys.path.insert(1, "/opt/pynfs/nfs4.0/lib")
+
+import nfs4lib                                          # noqa: E402
+from nfs4lib import op4                                 # noqa: E402
+from xdrdef.nfs4_const import *                         # noqa: E402
+from xdrdef.nfs4_type import createtype4                # noqa: E402
+import rpc.rpc as rpc                                   # noqa: E402
+
+nfs4lib.SHOW_TRAFFIC = False
+
+ATTRS = nfs4lib.list2bitmap([FATTR4_TYPE, FATTR4_FILEID])
+
+# xid every "colliding" request is forced onto.  Fixed and shared, so two
+# clients present identical xids by construction.
+COLLIDE_XID = 4242
+
+COUNTER = 0
+
+
+def client(args):
+    """A brand-new connection, which is the point: on the wire it is
+    indistinguishable from the previous one apart from its source port, and the
+    DRC key does not carry the port."""
+    global COUNTER
+    COUNTER += 1
+    sec = rpc.SecAuthSys(0, b"chimdrc", 0, 0, [])
+    c = nfs4lib.NFS4Client(("drc%d" % COUNTER).encode(), args.host, args.port,
+                           homedir=[args.export.encode()], sec_list=[sec])
+    c.null()
+    return c
+
+
+def compound_at(c, ops, tag, xid=None):
+    """Issue a COMPOUND, optionally forcing the RPC xid.  get_new_xid()
+    pre-increments, so seed one below the value we want."""
+    if xid is not None:
+        c.xid = xid - 1
+    return c.compound(ops, tag=tag)
+
+
+def readdir(c, fh, maxcount, tag, xid=None):
+    """Raw paged READDIR so the request bytes are exactly under our control."""
+    names, cookie, verf = [], 0, b"\0" * 8
+    for _ in range(8):
+        res = compound_at(c,
+                          [op4.putfh(fh),
+                           op4.readdir(cookie, verf, maxcount // 2, maxcount,
+                                       ATTRS)],
+                          tag,
+                          # Only the first page needs the forced xid: it is the
+                          # one that must collide with the other client's.
+                          xid if cookie == 0 else None)
+        if res.status != NFS4_OK:
+            return "status=%d" % res.status
+        rd = res.resarray[-1].opreaddir.resok4
+        e = rd.reply.entries
+        while e:
+            names.append(e[0].name.decode())
+            cookie = e[0].cookie
+            e = e[0].nextentry
+        verf = rd.cookieverf
+        if rd.reply.eof:
+            break
+    return sorted(names)
+
+
+def create_ops(args, name):
+    return ([op4.putrootfh(), op4.lookup(args.export.encode())] +
+            [op4.create(createtype4(NF4DIR), name, {FATTR4_MODE: 0o755})])
+
+
+def lookup(c, args, name):
+    return c.compound([op4.putrootfh(), op4.lookup(args.export.encode()),
+                       op4.lookup(name)], tag=b"verify").status
+
+
+def remove(c, args, name):
+    return c.compound([op4.putrootfh(), op4.lookup(args.export.encode()),
+                       op4.remove(name)], tag=b"cleanup").status
+
+
+def test_readonly_replay(args, writer, tag):
+    """Fresh connections issuing byte-identical READDIRs must not be served the
+    first one's listing."""
+    print("\n[1] read-only replay: byte-identical READDIR, fresh connections")
+    root = [args.export.encode()]
+    bad = 0
+    for i in range(5):
+        name = ("%s-r%d" % (tag, i)).encode()
+        writer.create_obj(root + [name])
+        cur = readdir(writer, writer.do_getfh(root), 4096, b"writer")
+        b = client(args)
+        # Same bytes and same xid every iteration -- exactly what used to
+        # collide in the DRC.
+        got = readdir(b, b.do_getfh(root), 4096, b"reader", COLLIDE_XID)
+        ok = got == cur
+        bad += not ok
+        print("    iter %d  writer=%-24s fresh=%-24s match=%s"
+              % (i, cur, got, ok))
+        remove(writer, args, name)
+    print("    -> disagreements: %d/5 (expected 0)" % bad)
+    return bad == 0
+
+
+def test_control(args, writer, tag, mc_base):
+    """The same loop with unique request bytes: the DRC key cannot match, so a
+    failure here means the server's view is wrong, not the cache."""
+    print("\n[2] control: unique maxcount per READDIR (DRC key cannot match)")
+    root = [args.export.encode()]
+    bad = 0
+    for i in range(5):
+        name = ("%s-c%d" % (tag, i)).encode()
+        writer.create_obj(root + [name])
+        cur = readdir(writer, writer.do_getfh(root), mc_base + 900 + i * 41,
+                      b"writer")
+        b = client(args)
+        # Unique per iteration AND per run, so neither this loop nor a previous
+        # run of it can supply a matching cache entry.
+        got = readdir(b, b.do_getfh(root), mc_base + i * 37, b"reader")
+        ok = got == cur
+        bad += not ok
+        print("    iter %d  writer=%-24s fresh=%-24s match=%s"
+              % (i, cur, got, ok))
+        remove(writer, args, name)
+    print("    -> disagreements: %d/5 (expected 0)" % bad)
+    return bad == 0
+
+
+def test_data_loss(args, verifier, tag):
+    """A byte-identical CREATE from a second live connection must execute, not
+    be answered from the first connection's cache entry."""
+    print("\n[3] silent data loss: byte-identical CREATE, second connection")
+    name = ("%s-victim" % tag).encode()
+    ops = create_ops(args, name)
+
+    remove(verifier, args, name)
+    print("    start:            exists=%s"
+          % (lookup(verifier, args, name) == NFS4_OK))
+
+    c1 = client(args)
+    st1 = compound_at(c1, ops, b"victim", COLLIDE_XID).status
+    e1 = lookup(verifier, args, name) == NFS4_OK
+    print("    client1 CREATE -> %d  exists=%s" % (st1, e1))
+
+    remove(verifier, args, name)
+    print("    after delete:     exists=%s"
+          % (lookup(verifier, args, name) == NFS4_OK))
+
+    # Brand-new connection, byte-identical request, identical xid.  c1 is still
+    # open, so its cache entry must stay its own.
+    c2 = client(args)
+    st2 = compound_at(c2, ops, b"victim", COLLIDE_XID).status
+    e2 = lookup(verifier, args, name) == NFS4_OK
+    print("    client2 CREATE -> %d  exists=%s" % (st2, e2))
+    remove(verifier, args, name)
+
+    ok = (st1 == NFS4_OK and e1 and st2 == NFS4_OK and e2)
+    if not ok and st2 == NFS4_OK and not e2:
+        print("    -> FAIL: CREATE returned NFS4_OK but nothing was created")
+    else:
+        print("    -> %s" % ("ok: the second CREATE really executed" if ok
+                             else "FAIL: unexpected statuses"))
+    return ok
+
+
+def test_real_retransmit(args, verifier, tag):
+    """The cache must still replay a genuine retransmit: the SAME connection
+    re-presenting its own request at the same xid gets the original reply, not
+    NFS4ERR_EXIST from a second execution."""
+    print("\n[4] real retransmit: same connection, same xid, replayed")
+    name = ("%s-rexmit" % tag).encode()
+    ops = create_ops(args, name)
+
+    remove(verifier, args, name)
+    c = client(args)
+    first = compound_at(c, ops, b"rexmit", COLLIDE_XID + 1).status
+    second = compound_at(c, ops, b"rexmit", COLLIDE_XID + 1).status
+    print("    first=%d  retransmit=%d (want %d/%d, not %d)"
+          % (first, second, NFS4_OK, NFS4_OK, NFS4ERR_EXIST))
+    remove(verifier, args, name)
+
+    ok = (first == NFS4_OK and second == NFS4_OK)
+    print("    -> %s" % ("ok: the retransmit replayed" if ok else
+                         "FAIL: the retransmit re-executed"))
+    return ok
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="NFSv4.0 DRC cross-client replay regression test")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=2049)
+    p.add_argument("--export", default="share",
+                   help="export name without the leading slash")
+    args = p.parse_args()
+
+    # Unique per run so the WRITER's own requests can never collide with a
+    # previous run's cache entries -- only the reader's deliberately-identical
+    # ones do.
+    tag = "t%d" % (os.getpid() % 100000)
+    print("NFSv4.0 DRC replay test against %s:%d /%s   (run tag %s)"
+          % (args.host, args.port, args.export, tag))
+
+    # Long-lived and always advancing its xid from a high base, so the ground
+    # truth these tests compare against can never itself be a replay.
+    writer = client(args)
+    writer.xid = 100000 + (os.getpid() % 1000) * 100
+    verifier = client(args)
+    verifier.xid = 500000 + (os.getpid() % 1000) * 100
+
+    # Unique per run: a fixed maxcount would collide with the previous run's
+    # control requests, since READDIR bytes do not vary with directory contents.
+    mc_base = 5000 + (int(time.time()) % 811) * 3
+
+    results = [
+        ("read-only replay", test_readonly_replay(args, writer, tag)),
+        ("control", test_control(args, writer, tag, mc_base)),
+        ("no silent data loss", test_data_loss(args, verifier, tag)),
+        ("retransmit still replays", test_real_retransmit(args, verifier, tag)),
+    ]
+
+    print("\n=== verdict ===")
+    for name, ok in results:
+        print("  %-26s : %s" % (name, "PASS" if ok else "FAIL"))
+    passed = all(ok for _, ok in results)
+    print("  overall %s" % ("PASS" if passed else "FAIL"))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/server/nfs/tests/test_nfs_persist.c
+++ b/src/server/nfs/tests/test_nfs_persist.c
@@ -25,6 +25,8 @@
 #include "nfs4_recovery.h"
 #include "nfs4_drc.h"
 #include "nfs3_drc.h"
+#include "nfs4_v40_drc.h"
+#include "nfs4_lease.h"
 #include "nfs4_state.h"
 #include "nfs_kv_keys.h"
 
@@ -459,22 +461,25 @@ test_nfs3_cache_lookup(void)
     nfs3_drc_init(&drc,CHIMERA_KV_TYPE_NFS3_REPLY);
 
     /* Miss on an empty cache. */
-    CHECK(nfs3_drc_cache_lookup(&drc,&k1,&out,&out_len) == 0);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k1,NULL,&out,&out_len) == 0);
 
-    nfs3_drc_cache_insert(&drc,&k1,reply,sizeof(reply),1);
+    /* NULL origin = no owning connection (the hydrate path), so any connection
+     * may replay it.  Entries are age-gated, so stamp them with the same clock
+     * the lookup compares against. */
+    nfs3_drc_cache_insert(&drc,&k1,reply,sizeof(reply),nfs_lease_now_ns(),NULL);
 
     /* Hit returns the exact bytes. */
-    CHECK(nfs3_drc_cache_lookup(&drc,&k1,&out,&out_len) == 1);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k1,NULL,&out,&out_len) == 1);
     CHECK(out_len == sizeof(reply));
     CHECK(memcmp(out,reply,sizeof(reply)) == 0);
     free(out);
 
     /* A different xid (same client/proc) is a distinct identity -> miss. */
-    CHECK(nfs3_drc_cache_lookup(&drc,&k2,&out,&out_len) == 0);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k2,NULL,&out,&out_len) == 0);
 
     /* Re-insert under the same key replaces last-writer-wins. */
-    nfs3_drc_cache_insert(&drc,&k1,"NEW",3,2);
-    CHECK(nfs3_drc_cache_lookup(&drc,&k1,&out,&out_len) == 1);
+    nfs3_drc_cache_insert(&drc,&k1,"NEW",3,nfs_lease_now_ns(),NULL);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k1,NULL,&out,&out_len) == 1);
     CHECK(out_len == 3 && memcmp(out,"NEW",3) == 0);
     free(out);
 
@@ -541,7 +546,11 @@ test_nfs3_cross_reboot(void)
     k_after.cksum    = nfs_kv_le64(kvkey + p);
 
     CHECK(nfs3_drc_value_parse(kvval,kvval_len,&ts,&body,&body_len) == 0);
-    nfs3_drc_cache_insert(&drc,&k_after,body,body_len,ts);
+    /* The hydrate path re-stamps with the local clock rather than the persisted
+     * ts: that value was taken from another boot's CLOCK_MONOTONIC_COARSE and
+     * cannot be compared against this one's.  Mirror that here, or the age gate
+     * would (correctly) reject the record. */
+    nfs3_drc_cache_insert(&drc,&k_after,body,body_len,nfs_lease_now_ns(),NULL);
 
     /* --- retransmit after reboot: the client re-presents an identical call.
      * The independently-recomputed key must hit and return the cached reply. */
@@ -550,7 +559,7 @@ test_nfs3_cross_reboot(void)
     uint8_t               *out;
     uint32_t               out_len;
 
-    CHECK(nfs3_drc_cache_lookup(&drc,&k_retransmit,&out,&out_len) == 1);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k_retransmit,NULL,&out,&out_len) == 1);
     CHECK(out_len == sizeof(reply));
     CHECK(memcmp(out,reply,sizeof(reply)) == 0);
     free(out);
@@ -559,11 +568,282 @@ test_nfs3_cross_reboot(void)
      * the stale entry -- the checksum disambiguates it. */
     struct nfs3_drc_keybuf k_other = nfs3_make_key(addr,proc,xid,
                                                    "different-args",14);
-    CHECK(nfs3_drc_cache_lookup(&drc,&k_other,&out,&out_len) == 0);
+    CHECK(nfs3_drc_cache_lookup(&drc,&k_other,NULL,&out,&out_len) == 0);
 
     nfs3_drc_destroy(&drc);
     printf("ok: nfs3_cross_reboot\n");
 } /* test_nfs3_cross_reboot */
+
+/* ------------------------------------------------------------------ *
+*  Replay is scoped to the originating connection and to an age       *
+*  bound, so one host's clients cannot answer each other's requests.  *
+* ------------------------------------------------------------------ */
+
+/* nfs3_drc_conn_open/_close track connections only on an installed cache (a
+ * disabled DRC should cost nothing per connection), and orig_dispatch is what
+ * marks it installed.  A stub is enough -- these tests never dispatch. */
+static int
+drc_stub_dispatch(
+    struct evpl              *evpl,
+    struct evpl_rpc2_conn    *conn,
+    struct evpl_rpc2_encoding*encoding,
+    uint32_t                  proc,
+    void                     *program_data,
+    struct evpl_rpc2_cred    *cred,
+    xdr_iovec                *iov,
+    int                       niov,
+    int                       length,
+    void                     *private_data)
+{
+    (void) evpl; (void) conn; (void) encoding; (void) proc;
+    (void) program_data; (void) cred; (void) iov; (void) niov;
+    (void) length; (void) private_data;
+    return 0;
+} /* drc_stub_dispatch */
+
+static void
+test_nfs3_drc_conn_origin(void)
+{
+    struct nfs3_drc        drc;
+    /* Stand-ins for two connections from ONE address -- the shape the key
+     * cannot tell apart on its own. */
+    int                    conn_a,conn_b;
+    struct nfs3_drc_keybuf key = nfs3_make_key("10.0.0.7",8 /* CREATE */,2,
+                                               "identical-create-args",21);
+    const uint8_t          reply[] = "CREATE3res NFS3_OK";
+    uint8_t               *out;
+    uint32_t               out_len;
+
+    nfs3_drc_init(&drc,CHIMERA_KV_TYPE_NFS3_REPLY);
+    drc.orig_dispatch = drc_stub_dispatch;
+
+    nfs3_drc_conn_open(&drc,&conn_a);
+    nfs3_drc_conn_open(&drc,&conn_b);
+    /* A connection can be announced twice (accepted, then connected); the second
+     * registration must not re-generation it out from under its own entries. */
+    nfs3_drc_conn_open(&drc,&conn_a);
+
+    nfs3_drc_cache_insert(&drc,&key,reply,sizeof(reply),nfs_lease_now_ns(),
+                          &conn_a);
+
+    /* The connection that produced the reply replays it: a genuine retransmit. */
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,&conn_a,&out,&out_len) == 1);
+    free(out);
+
+    /* A second, concurrently live connection presenting byte-identical args at
+     * the same xid must NOT be answered from the cache -- that is a different
+     * client's first-ever request, and replaying it would acknowledge a mutation
+     * that never executed. */
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,&conn_b,&out,&out_len) == 0);
+
+    /* Once the originating connection is gone, the entry is up for grabs again:
+     * this is the reconnect-and-retransmit case the cache exists for. */
+    nfs3_drc_conn_close(&drc,&conn_a);
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,&conn_b,&out,&out_len) == 1);
+    CHECK(out_len == sizeof(reply));
+    CHECK(memcmp(out,reply,sizeof(reply)) == 0);
+    free(out);
+
+    /* A connection reusing conn_a's address is a NEW connection, not the origin:
+     * the generation differs, so it takes the origin-is-gone path rather than
+     * being mistaken for the entry's owner. */
+    nfs3_drc_conn_open(&drc,&conn_a);
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,&conn_a,&out,&out_len) == 1);
+    free(out);
+
+    nfs3_drc_destroy(&drc);
+    printf("ok: nfs3_drc_conn_origin\n");
+} /* test_nfs3_drc_conn_origin */
+
+static void
+test_nfs3_drc_entry_age(void)
+{
+    struct nfs3_drc        drc;
+    struct nfs3_drc_keybuf key = nfs3_make_key("10.0.0.8",12 /* REMOVE */,5,
+                                               "remove-args",11);
+    const uint8_t          reply[] = "REMOVE3res NFS3_OK";
+    uint64_t               now     = nfs_lease_now_ns();
+    uint8_t               *out;
+    uint32_t               out_len;
+
+    nfs3_drc_init(&drc,CHIMERA_KV_TYPE_NFS3_REPLY);
+
+    /* Just inside the window: still a plausible retransmit. */
+    nfs3_drc_cache_insert(&drc,&key,reply,sizeof(reply),
+                          now - (NFS3_DRC_MAX_AGE_NS - 1000000000ULL),NULL);
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,NULL,&out,&out_len) == 1);
+    free(out);
+
+    /* Past it: a fresh request must never be answered with a reply this old. */
+    nfs3_drc_cache_insert(&drc,&key,reply,sizeof(reply),
+                          now - (NFS3_DRC_MAX_AGE_NS + 1000000000ULL),NULL);
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,NULL,&out,&out_len) == 0);
+
+    nfs3_drc_destroy(&drc);
+    printf("ok: nfs3_drc_entry_age\n");
+} /* test_nfs3_drc_entry_age */
+
+/* The minorversion peek runs on undecoded wire bytes, so tag_len is whatever
+ * the client sent.  In 32-bit arithmetic `4 + tag_len + pad` wraps: tag_len
+ * 0xFFFFFFF5..0xFFFFFFF8 all land on off == 0xFFFFFFFC, whose `off + 4` wraps
+ * to 0 and passes a 32-bit bounds check, reading ~4GB past the buffer.  Every
+ * such tag must be refused instead. */
+static void
+test_nfs4_v40_peek_minorversion(void)
+{
+    uint8_t   buf[32];
+    xdr_iovec iov;
+    uint32_t  mv;
+
+    memset(buf,0,sizeof(buf));
+    xdr_iovec_set_data(&iov,buf);
+    xdr_iovec_set_len(&iov,sizeof(buf));
+
+    /* Well-formed: empty tag, then minorversion 0. */
+    buf[3] = 0;                       /* tag_len = 0 */
+    buf[7] = 0;                       /* minorversion = 0 */
+    CHECK(nfs4_v40_peek_minorversion(&iov,1,&mv) == true);
+    CHECK(mv == 0);
+
+    /* Well-formed: 4-byte tag, then minorversion 1. */
+    buf[3]  = 4;                      /* tag_len = 4 */
+    buf[11] = 1;                      /* minorversion at offset 8 */
+    CHECK(nfs4_v40_peek_minorversion(&iov,1,&mv) == true);
+    CHECK(mv == 1);
+
+    /* A tag that runs past the iovec is refused, not guessed at. */
+    buf[2] = 0xFF; buf[3] = 0xFF;     /* tag_len = 65535 */
+    CHECK(nfs4_v40_peek_minorversion(&iov,1,&mv) == false);
+
+    /* The wrap-critical band: every one of these used to pass the guard and
+     * read from p + 0xFFFFFFFC. */
+    for (uint32_t t = 0xFFFFFFF0u; t != 0; t++) {
+        buf[0] = (uint8_t) (t >> 24);
+        buf[1] = (uint8_t) (t >> 16);
+        buf[2] = (uint8_t) (t >> 8);
+        buf[3] = (uint8_t) t;
+        CHECK(nfs4_v40_peek_minorversion(&iov,1,&mv) == false);
+    }
+
+    /* A short iovec cannot even hold the tag length. */
+    xdr_iovec_set_len(&iov,3);
+    CHECK(nfs4_v40_peek_minorversion(&iov,1,&mv) == false);
+    CHECK(nfs4_v40_peek_minorversion(&iov,0,&mv) == false);
+
+    printf("ok: nfs4_v40_peek_minorversion\n");
+} /* test_nfs4_v40_peek_minorversion */
+
+/* A band loaded from the KV store is claimed by the connection whose request
+ * triggered the load.  Leaving it ownerless would let any connection from the
+ * address replay records that are, by construction, the non-idempotent ones. */
+static void
+test_nfs3_drc_hydrated_band_origin(void)
+{
+    struct nfs3_drc        drc;
+    int                    conn_a,conn_b;
+    struct nfs3_drc_keybuf key = nfs3_make_key("10.0.0.9",8 /* CREATE */,3,
+                                               "create-args",11);
+    const uint8_t          reply[] = "CREATE3res NFS3_OK";
+    uint8_t               *out;
+    uint32_t               out_len;
+
+    nfs3_drc_init(&drc,CHIMERA_KV_TYPE_NFS4_V40_REPLY);
+    drc.orig_dispatch = drc_stub_dispatch;
+
+    nfs3_drc_conn_open(&drc,&conn_a);
+    nfs3_drc_conn_open(&drc,&conn_b);
+
+    /* What nfs3_drc_hydrate_scan_cb does: insert under the triggering conn. */
+    nfs3_drc_cache_insert(&drc,&key,reply,sizeof(reply),nfs_lease_now_ns(),
+                          &conn_a);
+
+    /* The returning client replays its own band... */
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,&conn_a,&out,&out_len) == 1);
+    free(out);
+
+    /* ...and a concurrent peer at the same address does not. */
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,&conn_b,&out,&out_len) == 0);
+
+    /* Once the hydrating connection is gone the band is up for grabs again,
+     * matching how captured entries behave. */
+    nfs3_drc_conn_close(&drc,&conn_a);
+    CHECK(nfs3_drc_cache_lookup(&drc,&key,&conn_b,&out,&out_len) == 1);
+    free(out);
+
+    nfs3_drc_destroy(&drc);
+    printf("ok: nfs3_drc_hydrated_band_origin\n");
+} /* test_nfs3_drc_hydrated_band_origin */
+
+/* Only a COMPOUND carrying an operation that must not be re-executed earns a
+ * cache entry.  Read-only compounds are what made the defect visible: a
+ * byte-identical LOOKUP or READDIR from any client at the same address and xid
+ * was served an arbitrarily old reply. */
+static void
+test_nfs4_v40_compound_cacheable(void)
+{
+    struct nfs_argop4    ops[3];
+    struct COMPOUND4args args = { .argarray = ops };
+
+    memset(ops,0,sizeof(ops));
+
+    /* PUTROOTFH + LOOKUP: idempotent, must not be cached. */
+    args.num_argarray = 2;
+    ops[0].argop      = OP_PUTROOTFH;
+    ops[1].argop      = OP_LOOKUP;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+
+    /* PUTFH + READDIR: the frozen-listing symptom. */
+    ops[0].argop = OP_PUTFH;
+    ops[1].argop = OP_READDIR;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+
+    ops[1].argop = OP_GETATTR;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+
+    /* WRITE re-executes harmlessly, as on the v3 path. */
+    ops[1].argop = OP_WRITE;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+
+    /* State ops carry their own RFC 7530 9.1.7 per-owner replay cache. */
+    ops[1].argop = OP_OPEN;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+    ops[1].argop = OP_CLOSE;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+
+    /* The ops a retransmit must not re-run. */
+    ops[1].argop = OP_CREATE;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+    ops[1].argop = OP_REMOVE;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+    ops[1].argop = OP_RENAME;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+    ops[1].argop = OP_LINK;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+    ops[1].argop = OP_SETATTR;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+    ops[1].argop = OP_SETCLIENTID;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+
+    /* OPENATTR only mutates when it is asked to create the attribute dir. */
+    ops[1].argop                = OP_OPENATTR;
+    ops[1].opopenattr.createdir = 0;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+    ops[1].opopenattr.createdir = 1;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+
+    /* One cacheable op anywhere in the compound is enough. */
+    args.num_argarray = 3;
+    ops[0].argop      = OP_PUTFH;
+    ops[1].argop      = OP_GETATTR;
+    ops[2].argop      = OP_REMOVE;
+    CHECK(nfs4_v40_drc_compound_cacheable(&args));
+
+    /* An empty compound has nothing to protect. */
+    args.num_argarray = 0;
+    CHECK(!nfs4_v40_drc_compound_cacheable(&args));
+
+    printf("ok: nfs4_v40_compound_cacheable\n");
+} /* test_nfs4_v40_compound_cacheable */
 
 /* ------------------------------------------------------------------ *
 *  Multi-node namespacing (N instances over one shared backing store) *
@@ -664,6 +944,11 @@ main(void)
     test_nfs3_value_roundtrip();
     test_nfs3_cache_lookup();
     test_nfs3_cross_reboot();
+    test_nfs3_drc_conn_origin();
+    test_nfs3_drc_entry_age();
+    test_nfs3_drc_hydrated_band_origin();
+    test_nfs4_v40_compound_cacheable();
+    test_nfs4_v40_peek_minorversion();
 
     test_node_scoped_identifiers();
     test_two_node_key_isolation();


### PR DESCRIPTION
The NFSv4.0 duplicate-request cache caches every minorversion-0 COMPOUND,
read-only ones included, and keys it by `{client address with the ephemeral
port stripped, xid, request checksum}`. Nothing in that key separates two
connections from one host, so a byte-identical COMPOUND at the same xid is
answered from the cache no matter who sent it. Two consequences:

- a read-only COMPOUND (`PUTROOTFH+LOOKUP`, `PUTFH+READDIR`) is served an
  arbitrarily old reply, and
- a `CREATE` from a second, concurrently live connection is answered `NFS4_OK`
  from the cache without ever executing, so a real mutation is acknowledged and
  discarded.

Any client that restarts its xid at a fixed value collides with its own earlier
runs and with sibling clients on the same host; a fresh pynfs `NFS4Client`
starts at 0, which is how this surfaced.

This is a regression. The v4.0 reply cache added in cd259a97 keyed on the
connection (`entry->conn == conn && entry->xid == xid`), so neither symptom was
reachable. 601a8d03 replaced it with an instance of the NFSv3 connectionless
DRC, keyed "like NFSv3 by {client,xid,proc,cksum}" — dropping the connection
from the key is the defect. That change had a real goal (a client's reply band
following it to another instance on failover), so the fix below keeps the
address-keyed band rather than simply reinstating a per-connection cache.

## Changes

- **Install the v4.0 cache only when `server.nfs4_drc` is set**, as the NFSv3
  DRC already is with `server.nfs3_drc`. It previously installed
  unconditionally with the flag gating only KV persistence, so a server that
  had opted out still carried the cache.

- **Cache a 4.0 COMPOUND only when it carries an operation that must not be
  re-executed.** The operations are still XDR at dispatch, so the filter gates
  the insert rather than the lookup: `chimera_nfs4_compound` cancels the armed
  reply capture unless the compound is cacheable. Never inserted is also never
  matched, because the key covers a checksum of the request. WRITE is excluded,
  as on the v3 path, and so are the seqid-sequenced state operations — RFC 7530
  §9.1.7 gives those a per-owner reply cache, which the RFC calls the more
  reliable of the two.

- **Record which connection a cached reply was captured on.** An entry replays
  to that connection, or to any connection once that one is gone. A band loaded
  from the KV store is claimed by the connection whose request triggered the
  load, so the persistent path gets the same protection as the captured one.

- **Bound entry age at 120s.** Entries previously lived until FIFO eviction at
  the 4MB cap, so a reply could be replayed arbitrarily long after capture.

- **Move the NFSv4.0 reply band from KV record type `0x08` to `0x09`.** Records
  in `0x08` were written by builds that cached read-only compounds too, and
  nothing in a record distinguishes the two, so the band is abandoned rather
  than hydrated into a cache that would replay stale LOOKUP and READDIR replies
  after an upgrade.

- **Compute the minorversion peek offset in 64 bits.** `tag_len` is read
  straight off the wire before the request is decoded, and in 32-bit arithmetic
  `4 + tag_len + pad` wraps: `tag_len` `0xFFFFFFF5`–`0xFFFFFFF8` all land on
  `off == 0xFFFFFFFC`, whose `off + 4` wraps to 0 and passes the bounds check,
  reading roughly 4GB past the buffer. A crafted COMPOUND tag could therefore
  crash the server.

The connection-origin guard and the age bound live in the shared core, so the
NFSv3 cache gets them too — it has the same key and the same exposure.

## Notes for review

- The connection origin is deliberately entry *payload* rather than part of the
  hash key. Keying on it would give each connection its own entry, but a
  reconnecting client would then miss its own record entirely, and answering a
  retransmit that arrives on a new connection is the whole point of an
  address-keyed cache. The cost is that two live connections at one address
  issuing byte-identical requests at the same xid share one entry, so the later
  capture takes ownership. That direction is safe: it degrades to re-executing
  a retransmit, never to answering one connection with another's reply.

- pynfs RPLY14 replays a CREATE at the same xid and requires the cached reply,
  so the 4.0 runs of the pynfs wrapper now enable `nfs4_drc`; 4.1+ replay goes
  through the session reply cache and is unaffected.

- `kvm_nfs40_drc_reboot_test_wrapper.sh`'s hydration assertion moves with the
  band to type `0x09`. The KVM legs have not been run against this branch — the
  container used here does not register them — so they are worth a run before
  merge, as they are the only coverage for the band change.
