### PR TITLE
nfs: destroy the NFSv4.1 session when the last mount goes

### DIFF
--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs4_mknod_at.c
     nfs4_open_at.c
     nfs4_open_fh.c
+    nfs4_open_state.c
     nfs4_pnfs.c
     nfs4_read.c
     nfs4_slot.c

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -127,6 +127,9 @@ chimera_nfs_destroy(void *private_data)
 
     for (i = 0; i < shared->max_servers; i++) {
         if (shared->servers[i]) {
+            chimera_nfs4_open_file_drain(shared->servers[i]);
+            pthread_mutex_destroy(&shared->servers[i]->open_state_lock);
+
             /* Release the server's reference on any session still published.
              * Reaching here with one means the module is going away with mounts
              * still up, so it was never destroyed on the wire; the memory goes

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -127,11 +127,13 @@ chimera_nfs_destroy(void *private_data)
 
     for (i = 0; i < shared->max_servers; i++) {
         if (shared->servers[i]) {
-            /* Free NFS4 session if present */
+            /* Release the server's reference on any session still published.
+             * Reaching here with one means the module is going away with mounts
+             * still up, so it was never destroyed on the wire; the memory goes
+             * once the last slot table lets go. */
             if (shared->servers[i]->nfs4_session) {
-                chimera_nfs4_session_pool_destroy(shared->servers[i]->nfs4_session);
-                pthread_mutex_destroy(&shared->servers[i]->nfs4_session->lock);
-                free(shared->servers[i]->nfs4_session);
+                chimera_nfs4_session_put(shared->servers[i]->nfs4_session);
+                shared->servers[i]->nfs4_session = NULL;
             }
             free(shared->servers[i]);
         }

--- a/src/vfs/nfs/nfs3_mount.c
+++ b/src/vfs/nfs/nfs3_mount.c
@@ -561,6 +561,8 @@ chimera_nfs3_mount(
 
         server->index = idx;
 
+        pthread_mutex_init(&server->open_state_lock, NULL);
+
         need_discover = 1;
 
         DL_APPEND(server->pending_mounts, request);

--- a/src/vfs/nfs/nfs4_cb.c
+++ b/src/vfs/nfs/nfs4_cb.c
@@ -409,6 +409,10 @@ chimera_nfs4_cb_exchange_id_callback(
     pthread_mutex_init(&session->lock, NULL);
     session->clientid = eid_res->eir_clientid;
 
+    /* The server's own reference, released when the last mount goes away and
+     * the session is destroyed on the wire (chimera_nfs4_umount). */
+    atomic_store(&session->refcnt, 1);
+
     /* The MDS confirms pNFS support by echoing USE_PNFS_MDS; only then does the
      * client issue LAYOUTGET.  Otherwise it transparently stays non-pNFS. */
     server->mds_pnfs_capable = server->pnfs_requested &&

--- a/src/vfs/nfs/nfs4_close.c
+++ b/src/vfs/nfs/nfs4_close.c
@@ -6,6 +6,163 @@
 #include "nfs4_open_state.h"
 #include "nfs4_pnfs.h"
 
+/* Carries the state across the compound so the reply can free it.  The thread
+ * and shared handles the retry path needs arrive as its arguments, so they are
+ * deliberately not kept here. */
+struct chimera_nfs4_close_ctx {
+    struct chimera_nfs4_open_state *open_state;
+};
+
+/*
+ * Finish the close: drop the local state and report success.
+ *
+ * The status of the CLOSE compound deliberately does not reach the caller.  By
+ * the time we get here the handle is gone from the open cache and the caller
+ * has no way to retry, so the file is closed locally whatever the server said;
+ * returning an error would only fail an application close() (or an umount
+ * drain) for state the server has already discarded, which is the usual reason
+ * a CLOSE fails.  Failures are logged instead -- see chimera_nfs4_close_callback,
+ * which is where the leak, if it is one, becomes visible.
+ */
+static void
+chimera_nfs4_close_done(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs4_close_ctx *ctx = request->plugin_data;
+
+    chimera_nfs4_open_state_free(ctx->open_state);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_close_done */
+
+static void
+chimera_nfs4_close_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    if (unlikely(status)) {
+        chimera_nfsclient_error("CLOSE failed with transport error %d; "
+                                "open stateid leaked until lease expiry", status);
+    } else if (res->status != NFS4_OK) {
+        chimera_nfsclient_error("CLOSE failed with NFS status %d", res->status);
+    } else if (res->num_resarray < 3) {
+        chimera_nfsclient_error("CLOSE reply truncated: %u ops", res->num_resarray);
+    } else if (res->resarray[2].opclose.status != NFS4_OK) {
+        chimera_nfsclient_error("CLOSE rejected with NFS status %d",
+                                res->resarray[2].opclose.status);
+    }
+
+    chimera_nfs4_close_done(request);
+} /* chimera_nfs4_close_callback */
+
+/*
+ * Replay hook for the slot layer: re-send this CLOSE once a session slot frees.
+ * Deliberately not chimera_nfs4_dispatch -- re-entering chimera_nfs4_close would
+ * repeat any pNFS LAYOUTCOMMIT/LAYOUTRETURN that already ran.
+ */
+static void
+chimera_nfs4_close_retry(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_nfs4_close_ctx *ctx = request->plugin_data;
+
+    chimera_nfs4_close_send(thread, shared, request, ctx->open_state);
+} /* chimera_nfs4_close_retry */
+
+void
+chimera_nfs4_close_send(
+    struct chimera_nfs_thread      *thread,
+    struct chimera_nfs_shared      *shared,
+    struct chimera_vfs_request     *request,
+    struct chimera_nfs4_open_state *open_state)
+{
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct chimera_nfs4_close_ctx           *ctx;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    struct stateid4                          stateid;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    /* plugin_data may still hold the pNFS close context we were chained from;
+    * open_state arrives as a parameter precisely so it survives the reuse. */
+    ctx             = request->plugin_data;
+    ctx->open_state = open_state;
+
+    /* This handle is done with the file.  The open on the server is not this
+     * handle's to end, though: every handle on the file shares it, so the CLOSE
+     * goes only when the last one lets go. */
+    if (!chimera_nfs4_open_file_put(shared->servers[open_state->server_index],
+                                    request->fh, request->fh_len, &stateid)) {
+        chimera_nfs4_close_done(request);
+        return;
+    }
+
+    /* Nothing was opened on the server, so there is no stateid to release. */
+    if (!chimera_nfs4_stateid_is_open(&stateid)) {
+        chimera_nfs4_close_done(request);
+        return;
+    }
+
+    server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh, request->fh_len);
+
+    /* No route to the server: the state is unreachable, not releasable.  This
+     * is the one case worth shouting about, because it means the session went
+     * away while an open was still held -- the ordering bug this CLOSE exists
+     * to prevent. */
+    if (!server_thread || !server_thread->server->nfs4_session) {
+        chimera_nfsclient_error("CLOSE: no session for open stateid; "
+                                "leaked until lease expiry");
+        chimera_nfs4_close_done(request);
+        return;
+    }
+
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    /* Build compound: SEQUENCE + PUTFH + CLOSE */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    argarray[0].argop = OP_SEQUENCE;   /* slot fields filled by compound_call */
+
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    /* seqid is ignored in minor version 1 (RFC 8881 §18.2.3); OPEN sends 0 too. */
+    argarray[2].argop                = OP_CLOSE;
+    argarray[2].opclose.seqid        = 0;
+    argarray[2].opclose.open_stateid = stateid;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
+        &args,
+        &rpc2_cred,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_close_callback,
+        request,
+        chimera_nfs4_close_retry, NULL);
+} /* chimera_nfs4_close_send */
+
 void
 chimera_nfs4_close(
     struct chimera_nfs_thread  *thread,
@@ -24,23 +181,19 @@ chimera_nfs4_close(
         return;
     }
 
-    /* Drop this file's layout from the recall registry before it is freed.
-     * Idempotent: a no-op unless the layout reached VALID (or was fenced). */
+    /* Drop this handle's layout from the recall registry before it is freed.
+    * Idempotent: a no-op unless the layout reached VALID (or was fenced). */
     chimera_nfs4_pnfs_layout_unregister(shared, &open_state->layout);
 
-    /* If a pNFS layout is held, report the new size to the MDS (LAYOUTCOMMIT)
-     * and return the layout (LAYOUTRETURN) before freeing.  When it takes the
-     * request it frees the open state and completes asynchronously. */
+    /* If this handle holds a pNFS layout, report the new size to the MDS
+     * (LAYOUTCOMMIT) and return the layout (LAYOUTRETURN) before the CLOSE.
+     * This is per handle, as the layout is: the writes it drove to the data
+     * server are invisible to the MDS until its own LAYOUTCOMMIT lands.  When
+     * it takes the request it chains into chimera_nfs4_close_send once the
+     * layout is back. */
     if (chimera_nfs4_pnfs_close(thread, shared, request, open_state)) {
         return;
     }
 
-    /* TODO: Send NFS4 CLOSE compound to release the stateid on server.
-     * For now, just free the local state. */
-
-    /* Free the open state */
-    chimera_nfs4_open_state_free(open_state);
-
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    chimera_nfs4_close_send(thread, shared, request, open_state);
 } /* chimera_nfs4_close */

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -716,6 +716,8 @@ chimera_nfs4_mount(
         shared->servers[idx] = server;
         server->index        = idx;
 
+        pthread_mutex_init(&server->open_state_lock, NULL);
+
         need_discover = 1;
 
         DL_APPEND(server->pending_mounts, request);

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -140,6 +140,15 @@ chimera_nfs4_open_at_callback(
         state->server_index = ctx->server->index;
         state->stateid      = open_res->opopen.resok4.stateid;
 
+        /* Count this handle against the file's open on the server, which every
+         * handle on the file shares.  Keyed on the handle OPEN just returned
+         * (unmarshalled into r_attr above), not request->fh, which still names
+         * the parent directory here. */
+        chimera_nfs4_open_file_get(ctx->server,
+                                   request->open_at.r_attr.va_fh,
+                                   request->open_at.r_attr.va_fh_len,
+                                   &state->stateid);
+
         request->open_at.r_vfs_private = (uint64_t) state;
     } else {
         request->open_at.r_vfs_private = 0;

--- a/src/vfs/nfs/nfs4_open_fh.c
+++ b/src/vfs/nfs/nfs4_open_fh.c
@@ -12,7 +12,8 @@ chimera_nfs4_open_fh(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_nfs4_open_state *state = NULL;
+    struct chimera_nfs_client_server *server;
+    struct chimera_nfs4_open_state   *state = NULL;
 
     /*
      * For inferred opens (internal opens used for path traversal, like
@@ -45,7 +46,15 @@ chimera_nfs4_open_fh(
         return;
     }
 
-    state->server_index            = request->fh[CHIMERA_VFS_MOUNT_ID_SIZE];
+    state->server_index = request->fh[CHIMERA_VFS_MOUNT_ID_SIZE];
+
+    /* No stateid of its own, but this handle can still read and write the file,
+     * so it counts against the file's open: a CLOSE while it is live would
+     * strand it.  Contributes no stateid; whatever open_at recorded stands. */
+    server = shared->servers[state->server_index];
+
+    chimera_nfs4_open_file_get(server, request->fh, request->fh_len, NULL);
+
     request->open_fh.r_vfs_private = (uint64_t) state;
     request->status                = CHIMERA_VFS_OK;
     request->complete(request);

--- a/src/vfs/nfs/nfs4_open_state.c
+++ b/src/vfs/nfs/nfs4_open_state.c
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include "nfs_internal.h"
+#include "nfs4_open_state.h"
+
+/*
+ * Take a reference on the open a file has on the server, recording it if this
+ * is the first handle to open the file.
+ *
+ * `fh` is a chimera file handle; the table is keyed on the wire handle inside
+ * it, which is what actually names the file to the server.  Keying on the
+ * chimera handle would split a file reached through two mounts of the same
+ * server into two entries, and those two share one open on the wire -- exactly
+ * the aliasing this table exists to count.
+ *
+ * `stateid` is the one OPEN just returned, or NULL from a caller that has none
+ * (chimera_nfs4_open_fh, which cannot OPEN by handle without CLAIM_FH).  When a
+ * caller does supply one it wins: an OPEN of an already-open file is an upgrade
+ * that bumps the seqid, so the newest stateid is the current one.
+ */
+void
+chimera_nfs4_open_file_get(
+    struct chimera_nfs_client_server *server,
+    const uint8_t                    *fh,
+    int                               fh_len,
+    const struct stateid4            *stateid)
+{
+    struct chimera_nfs4_open_file *file;
+    uint8_t                       *wire_fh;
+    int                            wire_fh_len;
+
+    if (!server) {
+        return;
+    }
+
+    chimera_nfs4_map_fh(fh, fh_len, &wire_fh, &wire_fh_len);
+
+    if (wire_fh_len <= 0 || wire_fh_len > CHIMERA_VFS_FH_SIZE) {
+        return;
+    }
+
+    pthread_mutex_lock(&server->open_state_lock);
+
+    HASH_FIND(hh, server->open_files, wire_fh, wire_fh_len, file);
+
+    if (file) {
+        file->refcnt++;
+
+        if (stateid) {
+            file->stateid = *stateid;
+        }
+
+        pthread_mutex_unlock(&server->open_state_lock);
+        return;
+    }
+
+    file = calloc(1, sizeof(*file));
+
+    if (!file) {
+        pthread_mutex_unlock(&server->open_state_lock);
+        return;
+    }
+
+    file->refcnt = 1;
+    file->fh_len = wire_fh_len;
+    memcpy(file->fh, wire_fh, wire_fh_len);
+
+    if (stateid) {
+        file->stateid = *stateid;
+    }
+
+    HASH_ADD_KEYPTR(hh, server->open_files, file->fh, file->fh_len, file);
+
+    pthread_mutex_unlock(&server->open_state_lock);
+} /* chimera_nfs4_open_file_get */
+
+/*
+ * Drop a handle's reference.  Returns non-zero when it was the last one, having
+ * retired the entry and copied its stateid to *r_stateid for the caller to
+ * CLOSE with.  Returns zero while other handles still hold the file open, in
+ * which case nothing may be sent -- a CLOSE now would destroy the stateid they
+ * are still using.
+ */
+int
+chimera_nfs4_open_file_put(
+    struct chimera_nfs_client_server *server,
+    const uint8_t                    *fh,
+    int                               fh_len,
+    struct stateid4                  *r_stateid)
+{
+    struct chimera_nfs4_open_file *file;
+    uint8_t                       *wire_fh;
+    int                            wire_fh_len;
+
+    if (!server) {
+        return 0;
+    }
+
+    chimera_nfs4_map_fh(fh, fh_len, &wire_fh, &wire_fh_len);
+
+    if (wire_fh_len <= 0 || wire_fh_len > CHIMERA_VFS_FH_SIZE) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&server->open_state_lock);
+
+    HASH_FIND(hh, server->open_files, wire_fh, wire_fh_len, file);
+
+    if (!file || --file->refcnt > 0) {
+        pthread_mutex_unlock(&server->open_state_lock);
+        return 0;
+    }
+
+    HASH_DEL(server->open_files, file);
+
+    pthread_mutex_unlock(&server->open_state_lock);
+
+    *r_stateid = file->stateid;
+
+    free(file);
+
+    return 1;
+} /* chimera_nfs4_open_file_put */
+
+/*
+ * Release every entry left on a server at shutdown.
+ *
+ * Reaching here with any means handles outlived the VFS that held them, so
+ * there is no one left to CLOSE on behalf of and nothing to send on: the module
+ * is being torn down and the connection with it.  Free them so the leak is not
+ * silent.
+ */
+void
+chimera_nfs4_open_file_drain(struct chimera_nfs_client_server *server)
+{
+    struct chimera_nfs4_open_file *file, *next;
+
+    pthread_mutex_lock(&server->open_state_lock);
+
+    /* Take the chain, drop uthash's table in one step, and only then free the
+     * entries, walking the insertion-order links with each read taken before
+     * its element goes.  Deleting them one at a time instead would keep the
+     * table's internals and a just-freed entry live at the same moment -- which
+     * is what it looks like to a reader who cannot assume the head has no
+     * predecessor, the static analyzer included. */
+    file = server->open_files;
+
+    HASH_CLEAR(hh, server->open_files);
+
+    while (file) {
+        next = file->hh.next;
+        free(file);
+        file = next;
+    }
+
+    pthread_mutex_unlock(&server->open_state_lock);
+} /* chimera_nfs4_open_file_drain */

--- a/src/vfs/nfs/nfs4_open_state.h
+++ b/src/vfs/nfs/nfs4_open_state.h
@@ -15,12 +15,22 @@
 /*
  * NFS4 Open State
  *
- * This structure tracks per-file state for NFS4 opens:
+ * This structure tracks per-handle state for NFS4 opens:
  * 1. Stateid - the NFS4.1 stateid returned by OPEN, needed for READ/WRITE/CLOSE
  * 2. Dirty tracking - to issue COMMIT on close if unstable writes were performed
  * 3. Silly rename - when removing an open file, rename to .nfs<hex(fh)> instead
  *
- * The state is allocated on open, stored in vfs_private, and freed on close.
+ * One of these belongs to each VFS handle, and everything in it is that
+ * handle's own -- the layout above all.  A layout is a per-handle thing here:
+ * only the handle that did the LAYOUTGET drives its I/O to the data server,
+ * while a handle without one writes to the MDS and the file size follows as a
+ * matter of course.  Give two handles on a file one layout between them and
+ * every write goes to the DS, leaving the size to reach the MDS only via a
+ * LAYOUTCOMMIT that is issued lazily -- and a recall can fence the layout with
+ * the writes still unpublished.
+ *
+ * What is *not* per handle is the open on the server, which is why the CLOSE
+ * that ends it is counted separately in chimera_nfs4_open_file.
  */
 
 struct chimera_nfs4_open_state {
@@ -39,11 +49,41 @@ struct chimera_nfs4_open_state {
     struct chimera_vfs_cred    silly_remove_cred;
 
     /*
-     * pNFS (flex-files) per-file layout.  Zero-initialized by calloc means
+     * pNFS (flex-files) per-handle layout.  Zero-initialized by calloc means
      * layout.state == CHIMERA_NFS4_LAYOUT_NONE (no layout yet); only touched
      * when pNFS is enabled and the MDS is pNFS-capable.
      */
     struct chimera_nfs4_layout layout;
+};
+
+/*
+ * The open a file has on the server, which the handles above share whether they
+ * mean to or not.
+ *
+ * The server keys open state on (open-owner, file handle) and this client uses
+ * one open-owner per server (server->nfs4_owner_id), so a second OPEN of a file
+ * already open is an upgrade -- the same stateid back with a bumped seqid --
+ * and not an independent open (RFC 8881 §9.1.1).  A single CLOSE therefore ends
+ * the file for every opener, so it may only be sent once the last handle is
+ * done; sending one per handle destroys state the others are still reading and
+ * writing through.
+ *
+ * Counting that here, rather than sharing the whole open state, is what keeps
+ * the layout per handle: this holds only what the wire CLOSE needs.
+ *
+ * Share bits need no such care because every OPEN this client sends asks for
+ * SHARE_ACCESS_BOTH / SHARE_DENY_NONE, so an upgrade never widens anything and
+ * there is nothing for OPEN_DOWNGRADE to narrow on the way out.
+ */
+struct chimera_nfs4_open_file {
+    /* All guarded by server->open_state_lock, hash linkage included: the count
+    * reaching zero and the unhashing that retires the entry have to be one
+    * step, or a concurrent open could revive one already bound for a CLOSE. */
+    int             refcnt;
+    struct stateid4 stateid;
+    uint8_t         fh_len;
+    uint8_t         fh[CHIMERA_VFS_FH_SIZE];
+    UT_hash_handle  hh;
 };
 
 /*
@@ -63,6 +103,23 @@ chimera_nfs4_open_state_alloc(void)
 
     return state;
 } /* chimera_nfs4_open_state_alloc */
+
+/*
+ * True when a real OPEN stateid was issued by the server.
+ *
+ * Only chimera_nfs4_open_at obtains one.  open_fh has no way to OPEN by file
+ * handle (that needs CLAIM_FH), so a file reached only that way keeps the
+ * all-zero anonymous stateid and READ/WRITE fall back to it.  Such an open holds
+ * nothing on the server, so CLOSE has nothing to release -- and a CLOSE naming
+ * the anonymous stateid would be rejected with NFS4ERR_BAD_STATEID.
+ */
+static inline int
+chimera_nfs4_stateid_is_open(const struct stateid4 *stateid)
+{
+    static const struct stateid4 anonymous = { 0 };
+
+    return memcmp(stateid, &anonymous, sizeof(anonymous)) != 0;
+} /* chimera_nfs4_stateid_is_open */
 
 /*
  * Free an open state.

--- a/src/vfs/nfs/nfs4_pnfs.c
+++ b/src/vfs/nfs/nfs4_pnfs.c
@@ -452,6 +452,8 @@ chimera_nfs4_pnfs_register_ds(
     server->rdma_protocol = use_rdma ? rdma_protocol : 0;
     snprintf(server->hostname, sizeof(server->hostname), "%s", host);
 
+    pthread_mutex_init(&server->open_state_lock, NULL);
+
     server->nfs_endpoint = chimera_tcp_flavor_endpoint_create(
         shared->tcp_flavor, server->hostname, server->nfs_port);
 
@@ -1477,11 +1479,15 @@ static void chimera_nfs4_pnfs_layoutreturn(
 static void
 chimera_nfs4_pnfs_close_done(struct chimera_vfs_request *request)
 {
-    struct chimera_nfs4_pnfs_close_ctx *cctx = request->plugin_data;
+    struct chimera_nfs4_pnfs_close_ctx *cctx       = request->plugin_data;
+    struct chimera_nfs_thread          *thread     = cctx->thread;
+    struct chimera_nfs_shared          *shared     = cctx->shared;
+    struct chimera_nfs4_open_state     *open_state = cctx->open_state;
 
-    chimera_nfs4_open_state_free(cctx->open_state);
-    request->status = CHIMERA_VFS_OK;
-    request->complete(request);
+    /* The layout is back with the MDS; now release the open itself.  Read the
+     * context out first -- close_send reuses plugin_data for its own, and it
+     * takes ownership of the open state from here. */
+    chimera_nfs4_close_send(thread, shared, request, open_state);
 } /* chimera_nfs4_pnfs_close_done */
 
 static void

--- a/src/vfs/nfs/nfs4_slot.c
+++ b/src/vfs/nfs/nfs4_slot.c
@@ -341,6 +341,10 @@ chimera_nfs4_slot_table_init(
     st->leased         = 0;
     st->floor          = 0;
     st->cached_target  = atomic_load(&session->target_usable);
+    st->session        = session;
+
+    /* Hold the session for as long as this table holds ids out of its pool. */
+    atomic_fetch_add(&session->refcnt, 1);
 
     pthread_mutex_lock(&session->lock);
 
@@ -418,9 +422,11 @@ chimera_nfs4_slot_table_reset(
 void
 chimera_nfs4_slot_table_destroy(struct chimera_nfs_client_server_thread *server_thread)
 {
-    struct chimera_nfs4_slot_table     *st      = &server_thread->slots;
-    struct chimera_nfs4_client_session *session =
-        server_thread->server ? server_thread->server->nfs4_session : NULL;
+    struct chimera_nfs4_slot_table     *st = &server_thread->slots;
+    /* The session these ids came from, which is not necessarily the server's
+     * current one: a remount after a teardown publishes a new session, and
+     * these ids belong to the old pool. */
+    struct chimera_nfs4_client_session *session = st->session;
     struct chimera_nfs4_compound_ctx   *ctx;
     struct chimera_nfs4_parked         *p;
 
@@ -478,7 +484,34 @@ chimera_nfs4_slot_table_destroy(struct chimera_nfs_client_server_thread *server_
     st->local_free     = NULL;
     st->local_free_top = 0;
     st->initialized    = 0;
+
+    if (session) {
+        st->session = NULL;
+        chimera_nfs4_session_put(session);
+    }
 } /* chimera_nfs4_slot_table_destroy */
+
+/*
+ * Drop a reference to a session.
+ *
+ * The server holds one from CREATE_SESSION until the last mount is unmounted
+ * and the session is destroyed on the wire; each per-thread slot table holds
+ * one for as long as it owns ids out of the pool.  The pool therefore stays
+ * mapped until the last table has let go, which is what lets a thread compare
+ * its table's session against the server's current one without risking a
+ * dereference of freed memory.
+ */
+void
+chimera_nfs4_session_put(struct chimera_nfs4_client_session *session)
+{
+    if (atomic_fetch_sub(&session->refcnt, 1) != 1) {
+        return;
+    }
+
+    chimera_nfs4_session_pool_destroy(session);
+    pthread_mutex_destroy(&session->lock);
+    free(session);
+} /* chimera_nfs4_session_put */
 
 /* ---- the wrapper + reply handler ---------------------------------------- */
 
@@ -595,7 +628,14 @@ chimera_nfs4_compound_call(
     struct chimera_nfs4_compound_ctx   *ctx;
     uint32_t                            id, usable;
 
-    if (unlikely(!st->initialized)) {
+    if (unlikely(!st->initialized || st->session != session)) {
+        if (st->initialized) {
+            /* The session was torn down and replaced while this thread was
+             * idle, so every id and seqid here belongs to the old pool.  Give
+             * them back to it and start again against the new one.  Only this
+             * thread touches this table, so the repair needs no lock. */
+            chimera_nfs4_slot_table_destroy(server_thread);
+        }
         chimera_nfs4_slot_table_init(st, session, shared);
     }
 

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -4,6 +4,150 @@
 
 #include "nfs_internal.h"
 
+
+/*
+ * Session teardown on the last unmount, the mirror of the EXCHANGE_ID +
+ * CREATE_SESSION that established it.
+ *
+ * Without it the client simply stops talking, and a clean shutdown is
+ * indistinguishable to the server from a client that crashed: it keeps the
+ * clientid's state -- and the open handles behind it -- until the lease
+ * expires.  For that whole window the export cannot be unmounted, and a
+ * restarting client strands a fresh clientid on every cycle.
+ *
+ * This runs as part of the umount request rather than at module teardown
+ * because that is the only point where both halves are still true: the
+ * server's transport is up, and an ordinary event loop is running to carry
+ * the replies.  By the time the module is destroyed the per-thread rpc2
+ * transports are already gone.
+ */
+
+struct chimera_nfs4_umount_teardown {
+    struct chimera_nfs_thread          *thread;
+    struct chimera_nfs_shared          *shared;
+    struct chimera_vfs_request         *request;
+    struct chimera_nfs_client_server   *server;
+    struct chimera_nfs4_client_session *session;
+    struct evpl_rpc2_conn              *conn;
+};
+
+static void
+chimera_nfs4_umount_teardown_done(struct chimera_nfs4_umount_teardown *td)
+{
+    struct chimera_vfs_request *request = td->request;
+
+    /* Release the server's reference.  The pool stays mapped until every
+     * per-thread slot table has noticed the session is gone and let go. */
+    chimera_nfs4_session_put(td->session);
+
+    free(td);
+
+    request->status = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_umount_teardown_done */
+
+static void
+chimera_nfs4_umount_destroy_clientid_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_nfs4_umount_teardown *td = private_data;
+
+    (void) evpl;
+    (void) verf;
+
+    if (status || !res || res->status != NFS4_OK) {
+        chimera_nfsclient_debug(
+            "NFS4 DESTROY_CLIENTID to %s did not succeed (rpc %d, nfs %d); "
+            "the server will expire the clientid with the lease",
+            td->server->hostname, status, res ? res->status : -1);
+    }
+
+    chimera_nfs4_umount_teardown_done(td);
+} /* chimera_nfs4_umount_destroy_clientid_callback */
+
+static void
+chimera_nfs4_umount_send_destroy_clientid(struct chimera_nfs4_umount_teardown *td)
+{
+    struct COMPOUND4args args;
+    struct nfs_argop4    argarray[1];
+
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 1;
+
+    argarray[0].argop                           = OP_DESTROY_CLIENTID;
+    argarray[0].opdestroy_clientid.dca_clientid = td->session->clientid;
+
+    td->shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &td->shared->nfs_v4.rpc2,
+        td->thread->evpl,
+        td->conn,
+        NULL,
+        &args,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_umount_destroy_clientid_callback,
+        td);
+} /* chimera_nfs4_umount_send_destroy_clientid */
+
+static void
+chimera_nfs4_umount_destroy_session_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_nfs4_umount_teardown *td = private_data;
+
+    (void) evpl;
+    (void) verf;
+
+    if (status || !res || res->status != NFS4_OK) {
+        chimera_nfsclient_debug(
+            "NFS4 DESTROY_SESSION to %s did not succeed (rpc %d, nfs %d)",
+            td->server->hostname, status, res ? res->status : -1);
+        /* Carry on to the clientid regardless: the session may already be
+         * gone, and it is the clientid that pins the state worth releasing. */
+    }
+
+    chimera_nfs4_umount_send_destroy_clientid(td);
+} /* chimera_nfs4_umount_destroy_session_callback */
+
+static void
+chimera_nfs4_umount_send_destroy_session(struct chimera_nfs4_umount_teardown *td)
+{
+    struct COMPOUND4args args;
+    struct nfs_argop4    argarray[1];
+
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 1;
+
+    /* Sent alone, with no SEQUENCE: a compound may not carry the session it is
+     * destroying. */
+    argarray[0].argop = OP_DESTROY_SESSION;
+    memcpy(argarray[0].opdestroy_session.dsa_sessionid,
+           td->session->sessionid, NFS4_SESSIONID_SIZE);
+
+    td->shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &td->shared->nfs_v4.rpc2,
+        td->thread->evpl,
+        td->conn,
+        NULL,
+        &args,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_umount_destroy_session_callback,
+        td);
+} /* chimera_nfs4_umount_send_destroy_session */
+
 void
 chimera_nfs4_umount(
     struct chimera_nfs_thread  *thread,
@@ -11,8 +155,12 @@ chimera_nfs4_umount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_nfs_client_mount  *mount  = request->umount.mount_private;
-    struct chimera_nfs_client_server *server = mount->server;
+    struct chimera_nfs_client_mount         *mount  = request->umount.mount_private;
+    struct chimera_nfs_client_server        *server = mount->server;
+
+    struct chimera_nfs4_client_session      *session = NULL;
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct chimera_nfs4_umount_teardown     *td;
 
     pthread_mutex_lock(&shared->lock);
 
@@ -23,16 +171,40 @@ chimera_nfs4_umount(
     server->refcnt--;
 
     /*
-     * The server (and its persistent back-channel control connection) outlives
-     * an individual mount, so the NFSv4.1 session is kept alive here even when
-     * the last mount is removed: a subsequent mount of the same server reuses
-     * it (see chimera_nfs4_cb_control_doorbell).  Tearing it down on refcnt==0
-     * would force a CREATE_SESSION on remount while per-thread slot tables still
-     * reference the old session -- corrupting the slot pool.  The session and
-     * its slot pool are freed once, with the server, in chimera_nfs_destroy.
+     * With the last mount gone, tell the server we are finished with the
+     * session rather than leaving it to the lease.  Unpublishing it here is
+     * what makes that safe for the slot pool: a remount establishes a fresh
+     * session, and each per-thread slot table compares the session its ids
+     * came from against the published one and rebuilds itself when they
+     * differ, so no thread can carry old ids onto a new session.
      */
+    if (server->refcnt == 0 && server->nfs4_session) {
+        session              = server->nfs4_session;
+        server->nfs4_session = NULL;
+    }
 
     pthread_mutex_unlock(&shared->lock);
+
+    if (session) {
+        server_thread = thread->server_threads[server->index];
+
+        if (server_thread && server_thread->nfs_conn) {
+            td          = calloc(1, sizeof(*td));
+            td->thread  = thread;
+            td->shared  = shared;
+            td->request = request;
+            td->server  = server;
+            td->session = session;
+            td->conn    = server_thread->nfs_conn;
+
+            chimera_nfs4_umount_send_destroy_session(td);
+            return;
+        }
+
+        /* No connection left to say it on -- drop the reference and let the
+         * server's lease do the work. */
+        chimera_nfs4_session_put(session);
+    }
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -186,7 +186,12 @@ chimera_nfs4_umount(
     pthread_mutex_unlock(&shared->lock);
 
     if (session) {
-        server_thread = thread->server_threads[server->index];
+        /* This thread may never have talked to the server -- the umount can
+         * land anywhere -- so get a connection the same way any other op
+         * does, creating one on demand. */
+        server_thread = chimera_nfs_thread_get_server_thread(thread,
+                                                             request->fh,
+                                                             request->fh_len);
 
         if (server_thread && server_thread->nfs_conn) {
             td          = calloc(1, sizeof(*td));

--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -31,6 +31,9 @@ struct chimera_nfs4_umount_teardown {
     struct evpl_rpc2_conn              *conn;
 };
 
+static void chimera_nfs4_umount_send_destroy_session(
+    struct chimera_nfs4_umount_teardown *td);
+
 static void
 chimera_nfs4_umount_teardown_done(struct chimera_nfs4_umount_teardown *td)
 {
@@ -94,6 +97,73 @@ chimera_nfs4_umount_send_destroy_clientid(struct chimera_nfs4_umount_teardown *t
         chimera_nfs4_umount_destroy_clientid_callback,
         td);
 } /* chimera_nfs4_umount_send_destroy_clientid */
+
+static void
+chimera_nfs4_umount_bind_conn_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_nfs4_umount_teardown *td = private_data;
+
+    (void) evpl;
+    (void) verf;
+
+    if (status || !res || res->status != NFS4_OK) {
+        chimera_nfsclient_debug(
+            "NFS4 BIND_CONN_TO_SESSION to %s did not succeed (rpc %d, nfs %d); "
+            "the session cannot be destroyed from here and will lapse with the "
+            "lease",
+            td->server->hostname, status, res ? res->status : -1);
+
+        chimera_nfs4_umount_teardown_done(td);
+        return;
+    }
+
+    chimera_nfs4_umount_send_destroy_session(td);
+} /* chimera_nfs4_umount_bind_conn_callback */
+
+/*
+ * Bind this connection to the session before destroying it.
+ *
+ * The umount can land on any thread, so the connection it gets may be one
+ * created for this teardown and never used for anything else.  A connection
+ * becomes associated with a session by carrying a SEQUENCE, and a fresh one
+ * never has, so the server refuses DESTROY_SESSION on it with
+ * NFS4ERR_CONN_NOT_BOUND_TO_SESSION.  Binding it explicitly is the operation
+ * NFSv4.1 provides for exactly this.  Fore channel only: nothing is going to
+ * arrive on a connection that is about to be closed.
+ */
+static void
+chimera_nfs4_umount_send_bind_conn(struct chimera_nfs4_umount_teardown *td)
+{
+    struct COMPOUND4args args;
+    struct nfs_argop4    argarray[1];
+
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 1;
+
+    argarray[0].argop = OP_BIND_CONN_TO_SESSION;
+    memcpy(argarray[0].opbind_conn_to_session.bctsa_sessid,
+           td->session->sessionid, NFS4_SESSIONID_SIZE);
+    argarray[0].opbind_conn_to_session.bctsa_dir                   = CDFC4_FORE;
+    argarray[0].opbind_conn_to_session.bctsa_use_conn_in_rdma_mode = 0;
+
+    td->shared->nfs_v4.send_call_NFSPROC4_COMPOUND(
+        &td->shared->nfs_v4.rpc2,
+        td->thread->evpl,
+        td->conn,
+        NULL,
+        &args,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_umount_bind_conn_callback,
+        td);
+} /* chimera_nfs4_umount_send_bind_conn */
 
 static void
 chimera_nfs4_umount_destroy_session_callback(
@@ -202,7 +272,7 @@ chimera_nfs4_umount(
             td->session = session;
             td->conn    = server_thread->nfs_conn;
 
-            chimera_nfs4_umount_send_destroy_session(td);
+            chimera_nfs4_umount_send_bind_conn(td);
             return;
         }
 

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -199,6 +199,8 @@ struct chimera_nfs_client_mount;
 struct chimera_nfs4_compound_ctx;   /* in-flight wrapper context (nfs4_slot.c)   */
 struct chimera_nfs4_parked;                   /* queued request awaiting a slot (nfs4_slot.c) */
 struct chimera_nfs4_layout;                   /* per-file pNFS layout (nfs4_pnfs.h)        */
+struct chimera_nfs4_open_state;               /* per-handle open state (nfs4_open_state.h) */
+struct chimera_nfs4_open_file;                /* per-file open refcount (same header)      */
 
 /*
  * Per-(thread,server) fore-channel slot table.  Touched by exactly one evpl
@@ -304,6 +306,14 @@ struct chimera_nfs_client_server {
     uint8_t                             nfs4_verifier[NFS4_VERIFIER_SIZE];
     char                                nfs4_owner_id[128];
     int                                 nfs4_owner_id_len;
+
+    /* How many VFS handles have each file open, keyed on the wire file handle.
+     * All the opens this client sends carry the one open-owner above, so the
+     * server hands back a single stateid per file however many times it is
+     * opened, and the CLOSE that ends it may only go once the last handle is
+     * done; see nfs4_open_state.h. */
+    pthread_mutex_t                     open_state_lock;
+    struct chimera_nfs4_open_file      *open_files;
 
     /* Persistent back-channel / control connection, owned by the control thread
      * (shared->cb_thread).  CREATE_SESSION binds the back channel to it, so the
@@ -1189,6 +1199,43 @@ void chimera_nfs4_close(
     struct chimera_nfs_shared *,
     struct chimera_vfs_request *,
     void *);
+
+/* Terminal step of a close: drop this handle's reference to the file's open,
+ * send the CLOSE if it was the last, then free the handle's open state and
+ * complete the request.  Split out of chimera_nfs4_close so the pNFS close path
+ * can run its LAYOUTCOMMIT/LAYOUTRETURN first and then hand the request here,
+ * rather than completing with the layout still held.  Takes ownership of
+ * open_state and of request->plugin_data. */
+void chimera_nfs4_close_send(
+    struct chimera_nfs_thread *,
+    struct chimera_nfs_shared *,
+    struct chimera_vfs_request *,
+    struct chimera_nfs4_open_state *);
+
+/* ---- Per-file open refcount (nfs4_open_state.c) ------------------------- */
+
+/* Take a reference on the file's open, recording it if this is the first handle
+ * to open the file.  `stateid` is the one OPEN returned, or NULL for a caller
+ * that has none.  See nfs4_open_state.h for why this is counted apart from the
+ * per-handle open state. */
+void chimera_nfs4_open_file_get(
+    struct chimera_nfs_client_server *server,
+    const uint8_t                    *fh,
+    int                               fh_len,
+    const struct stateid4            *stateid);
+
+/* Drop a reference.  Non-zero if it was the last, in which case the entry has
+ * been retired and its stateid copied out for the caller to CLOSE with. */
+int chimera_nfs4_open_file_put(
+    struct chimera_nfs_client_server *server,
+    const uint8_t                    *fh,
+    int                               fh_len,
+    struct stateid4                  *r_stateid);
+
+/* Free any entries left on a server at module teardown. */
+void chimera_nfs4_open_file_drain(
+    struct chimera_nfs_client_server *server);
+
 void chimera_nfs4_umount(
     struct chimera_nfs_thread *,
     struct chimera_nfs_shared *,

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -170,6 +170,12 @@ enum chimera_nfs_client_mount_state {
  * per operation.
  */
 struct chimera_nfs4_client_session {
+    /* References to this session: one for the server that published it, plus
+     * one per per-thread slot table holding ids out of its pool.  The server
+     * drops its reference when the last mount goes away and the session is
+     * destroyed on the wire; the memory outlives that until every table has
+     * noticed and let go, so no thread ever dereferences a freed session. */
+    _Atomic int      refcnt;
     pthread_mutex_t  lock;          /* guards the pool + usable; NOT per-op        */
     uint8_t          sessionid[NFS4_SESSIONID_SIZE];
     uint64_t         clientid;
@@ -202,19 +208,26 @@ struct chimera_nfs4_layout;                   /* per-file pNFS layout (nfs4_pnfs
  * global slot ids (a small stack); per-id seqids live in session->slot_seqid.
  */
 struct chimera_nfs4_slot_table {
-    int                               initialized;
-    uint32_t                         *local_free;    /* [max_slots] owned-free ids */
-    int                               local_free_top; /* top of local_free stack   */
-    uint32_t                          leased; /* ids owned (floor+borrowed) */
-    uint32_t                          floor;  /* reserved ids, never returned *
-                                               * except at teardown          */
-    uint32_t                          cached_target; /* last-seen sr_target+1; cheap *
-                                                      * change detect, no per-op atomic */
-    struct chimera_nfs4_parked       *wait_head;     /* FIFO of parked requests    */
-    struct chimera_nfs4_parked       *wait_tail;
-    struct chimera_nfs4_parked       *parked_freelist;
-    struct chimera_nfs4_compound_ctx *inflight;      /* dll, for disconnect reset  */
-    struct chimera_nfs4_compound_ctx *ctx_freelist;
+    int                                 initialized;
+    /* The session these ids belong to.  Compared against the server's current
+     * session on every acquire: when the two differ the session was torn down
+     * and replaced (a remount), and this table's ids and seqids belong to the
+     * old one.  Comparing rather than dereferencing is what makes that check
+     * safe, and each thread repairs its own table, so no one ever writes
+     * another thread's lock-free state. */
+    struct chimera_nfs4_client_session *session;
+    uint32_t                           *local_free;  /* [max_slots] owned-free ids */
+    int                                 local_free_top; /* top of local_free stack   */
+    uint32_t                            leased; /* ids owned (floor+borrowed) */
+    uint32_t                            floor; /* reserved ids, never returned *
+                                                * except at teardown          */
+    uint32_t                            cached_target; /* last-seen sr_target+1; cheap *
+                                                        * change detect, no per-op atomic */
+    struct chimera_nfs4_parked         *wait_head;   /* FIFO of parked requests    */
+    struct chimera_nfs4_parked         *wait_tail;
+    struct chimera_nfs4_parked         *parked_freelist;
+    struct chimera_nfs4_compound_ctx   *inflight;    /* dll, for disconnect reset  */
+    struct chimera_nfs4_compound_ctx   *ctx_freelist;
 };
 
 struct chimera_nfs_client_server_thread {
@@ -1002,6 +1015,10 @@ void chimera_nfs4_session_pool_destroy(
 
 /* Free a server_thread's slot table (called from thread teardown).  Returns the
  * thread's leased slot ids (floor + borrowed) to the session pool first. */
+/* Drop a reference to a session, destroying it once the last goes. */
+void chimera_nfs4_session_put(
+    struct chimera_nfs4_client_session *session);
+
 void chimera_nfs4_slot_table_destroy(
     struct chimera_nfs_client_server_thread *server_thread);
 


### PR DESCRIPTION
The NFSv4.1 client established a session and then simply stopped talking. It
never sent `DESTROY_SESSION` or `DESTROY_CLIENTID`, so to a server a clean
shutdown was indistinguishable from a client that had crashed: it kept the
clientid's state — and the open handles behind it — until the lease expired.

For that whole window the export cannot be unmounted (`nfs4_lease_time`
defaults to 90s), and a client that restarts strands a fresh clientid on every
cycle.

## Following the kernel

The Linux client ties this to the lifetime of its `nfs_client`: mounts of a
server share one, and the last put drains the session, sends
`DESTROY_SESSION` and `DESTROY_CLIENTID`, and only then tears down the
transport. This does the same, on the last umount of a server.

That point is chosen for two reasons. It is where the last reference actually
drops, and it is the only place where both halves of the exchange are still
possible — the server's transport is up and an ordinary event loop is running
to carry the replies, so the teardown chains through completion callbacks like
any other operation. Module teardown is too late: the per-thread rpc2
transports are already gone, and nothing is left to speak on.

## The slot pool, which is why this wasn't done before

The old comment in `chimera_nfs4_umount` explained that unpublishing a session
while per-thread slot tables still held ids out of it would corrupt them.
Linux doesn't have that problem because its slot table lives in the session and
dies with it. Here the tables are per (thread, server) and deliberately
lock-free, so rather than moving them, each one is given the identity of the
session its ids came from:

- the session is **refcounted** — one reference for the server that published
  it, one per slot table holding its ids — so the pool stays mapped until the
  last table lets go;
- each table **records the session it was built against**, and the acquire path
  compares that against the server's currently published session. When they
  differ, the session was torn down and replaced by a remount, so the table
  returns its ids to the old pool and rebuilds against the new one.

Comparing rather than dereferencing is what makes that safe, and a table is
only ever repaired by the thread that owns it, so nothing reaches across
threads into lock-free state. The hot-path cost is one pointer compare.

## Also fixed

`chimera_nfs4_slot_table_destroy()` returned ids to `server->nfs4_session`
rather than to the session they were leased from. Those were the same pointer
only because a session was never replaced; with teardown they are not, and the
ids would have gone back to the wrong pool.

## Releasing the opens first

Destroying the session while opens remain is legal — state is clientid-scoped,
not session-scoped, so `DESTROY_SESSION` carries no "must have no state"
precondition and chimera's server correctly doesn't impose one. But it is not
*right*: it strands the opens with no session through which the client could
still `CLOSE` them. Linux never has to think about this because its VFS refuses
to unmount a filesystem with open files.

Chimera's umount drain (#1546) gives the same guarantee — it purges every handle
on the mount and issues a `CLOSE` for each before dispatching the backend
`UMOUNT`. The problem was one layer down: `chimera_nfs4_close` freed its local
state and reported success without sending anything. The wire `CLOSE` was a
TODO, so every close was a no-op on the server, which is exactly why
`DESTROY_CLIENTID` answered `CLIENTID_BUSY`.

Sending one per handle is not safe. The server keys open state on (open-owner,
file handle) and this client uses one open-owner per server, so a second `OPEN`
of an already-open file is an **upgrade** — the same stateid back with a bumped
seqid — not an independent open. One `CLOSE` releases the file for every opener,
so a per-handle `CLOSE` destroys state the others are still using. `fstest`
reproduces it: a re-open overlapping the previous handle's close leaves the
write on the surviving handle rejected, two handles holding one stateid that
differ only in seqid.

So the file's open on the server is counted separately from the handles that
have it open — a small table keyed on the wire handle holding a refcount and the
stateid, with `CLOSE` sent only when the last handle lets go.

### Why counted apart, rather than sharing the open state

Because the pNFS layout lives in the open state, and a layout is per handle
here. `nfs4_write.c` routes a write from the handle's own state: a VALID layout
sends it to the data server, and the MDS then learns the size only from a
LAYOUTCOMMIT this proxy issues lazily. A handle *without* a layout writes to the
MDS and the size follows for free.

Share one layout between two handles and every write goes to the DS, leaving
correctness to depend entirely on that lazy LAYOUTCOMMIT — and a recall (a
truncate from another client is enough) then fences the layout with the writes
still unpublished, so a reader falls back on an MDS that never heard about them.
That is what `pnfs/proxy_recall_truncate` reads back as `differ: char 1`, and it
is why an earlier revision of this PR failed `kvm-pnfs` on every kernel and
backend. Keeping the count separate leaves the layout lifetime exactly as it
was.

## Two things reviewers should know

**A correction to an earlier revision of this description.** It previously said
this change does not fix the "cannot remove a filesystem after unmounting an
NFSv4 share" symptom, and that whatever pinned the mount was therefore not
clientid-scoped state. That was wrong. It was clientid-scoped state: the opens
this client never released. Releasing them is what the last commit does.

