### PR TITLE
diskfs: fault inodes through the block cache, not the device

### DIFF
--- a/src/vfs/diskfs/diskfs_block.c
+++ b/src/vfs/diskfs/diskfs_block.c
@@ -232,15 +232,6 @@ diskfs_bt_op_pin(
     struct diskfs_block_shard *shard,
     struct diskfs_block       *blk);
 
-static struct diskfs_block *
-diskfs_block_claim_async(
-    struct diskfs_thread *thread,
-    uint32_t device_id,
-    uint64_t device_offset,
-    int is_new,
-    void ( *resume )(struct diskfs_thread *, void *),
-    void *arg);
-
 static void
 diskfs_pin_cont_resume(
     struct diskfs_thread *thread,
@@ -1500,7 +1491,7 @@ diskfs_bt_block_get(
  * the async evpl_block path.  The caller's continuation re-invokes this once
  * the block has loaded, when it returns the now-resident block inline.
  */
-static struct diskfs_block *
+struct diskfs_block *
 diskfs_block_claim_async(
     struct diskfs_thread *thread,
     uint32_t device_id,

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -1990,7 +1990,6 @@ struct diskfs_inode_load_ctx {
     enum diskfs_inode_lock_mode mode;
     diskfs_inode_cb_t           cb;
     void                       *private_data;
-    struct evpl_iovec           iov;
     /* Record-load chain state (valid once the inode is published). */
     struct diskfs_inode        *inode;
     int                         acl_len;
@@ -2285,6 +2284,20 @@ diskfs_block_claim(
     uint32_t              device_id,
     uint64_t              device_offset,
     int                   is_new);
+
+/* As diskfs_block_claim (returns the block pinned; is_new starts from a zeroed
+ * buffer) but never reads or waits synchronously: on a miss, an in-flight read,
+ * or pin-cap backpressure it parks resume(thread, arg) -- dispatched back on the
+ * claiming thread -- and returns NULL.  The resume re-invokes the claim, which
+ * then returns the resident block inline. */
+struct diskfs_block *
+diskfs_block_claim_async(
+    struct diskfs_thread *thread,
+    uint32_t device_id,
+    uint64_t device_offset,
+    int is_new,
+    void ( *resume )(struct diskfs_thread *, void *),
+    void *arg);
 
 void
 diskfs_block_buf_release(

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -93,10 +93,9 @@ diskfs_inode_load_recs(
     struct diskfs_inode_load_ctx *lc);
 
 static void
-diskfs_inode_load_complete(
-    struct evpl *evpl,
-    int          status,
-    void        *private_data);
+diskfs_inode_load_resume(
+    struct diskfs_thread *thread,
+    void                 *arg);
 
 static void
 diskfs_dirent_release(
@@ -811,23 +810,58 @@ diskfs_inode_load_recs(struct diskfs_inode_load_ctx *lc)
 } /* diskfs_inode_load_recs */
 
 
+/*
+ * Fault an inode's home block THROUGH the block cache -- never the device
+ * directly -- and materialize the inode from it.
+ *
+ * The cache is the coherence point for metadata: a dinode's latest bytes live
+ * as a dirty block (pinned until pushed home) from the commit that logged them
+ * until the push thread writes them out, and only then does the device catch
+ * up.  A direct device read in that window returns the previous life of the
+ * block: an inode re-faulted while its last change (or its retirement
+ * tombstone) is still un-pushed materializes from stale bytes.  In the drain
+ * path that is not just stale data -- a straggling lookup of a retired inode
+ * could see the pre-retire dinode, believe the file live, and free its blocks
+ * a second time.  Reading through the cache makes the fault see whatever is
+ * true right now -- the tombstone, a live dinode, or a reallocated block's
+ * fresh contents, which the inum/gen check below rejects.
+ *
+ * This also replaces the old scheme of seeding the cache from the disk image
+ * (claim is_new + memcpy + mark CLEAN), which could clobber a newer dirty
+ * block with stale bytes -- the same incoherence from the write side.
+ */
 static void
-diskfs_inode_load_complete(
-    struct evpl *evpl,
-    int          status,
-    void        *private_data)
+diskfs_inode_load_resume(
+    struct diskfs_thread *thread,
+    void                 *arg)
 {
-    struct diskfs_inode_load_ctx *lc     = private_data;
-    struct diskfs_thread         *thread = lc->thread;
-    struct diskfs_shared         *shared = thread->shared;
-    struct diskfs_dinode         *di     = (struct diskfs_dinode *) lc->iov.data;
+    struct diskfs_inode_load_ctx *lc     = arg;
+    struct diskfs_thread         *self   = lc->thread;
+    struct diskfs_shared         *shared = self->shared;
     struct diskfs_inode_shard    *shard  = diskfs_inode_shard(shared, lc->inum);
+    struct diskfs_block          *blk;
+    struct diskfs_dinode         *di;
     struct diskfs_inode          *inode;
+    uint32_t                      dev;
+    uint64_t                      off;
 
-    if (status != 0 || di->inum != lc->inum || di->gen != lc->gen ||
-        di->nlink == 0) {
-        /* No such inode on disk (or stale generation). */
-        evpl_iovec_release(thread->evpl, &lc->iov);
+    (void) thread;
+
+    off = sm_inum_to_device_offset(shared->space_map, lc->inum, &dev);
+
+    blk = diskfs_block_claim_async(self, dev, off, 0,
+                                   diskfs_inode_load_resume, lc);
+
+    if (!blk) {
+        return;     /* parked (read in flight or pin cap); re-runs when ready */
+    }
+
+    di = (struct diskfs_dinode *) blk->iov.data;
+
+    if (di->inum != lc->inum || di->gen != lc->gen || di->nlink == 0) {
+        /* No such inode (stale generation, tombstone, or the block has been
+         * reallocated to something else entirely). */
+        diskfs_block_unpin(self, blk, DISKFS_BLOCK_CLEAN);
         lc->cb(NULL, CHIMERA_VFS_ENOENT, lc->private_data);
         free(lc);
         return;
@@ -867,43 +901,28 @@ diskfs_inode_load_complete(
         inode->writer = 1;
         rb_tree_insert(&shard->inodes, inum, inode);
         shard->ninodes++;
-        diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_LOAD);
+        diskfs_metric_inode_cache(self, DISKFS_METRIC_INODE_CACHE_LOAD);
     } else {
         /* Lost a concurrent fault race: the winner published the inode (and
          * does/did its own record loads).  Just re-drive the acquire. */
         pthread_mutex_unlock(&shard->lock);
-        evpl_iovec_release(thread->evpl, &lc->iov);
-        diskfs_inode_acquire(thread, lc->txn, lc->inum, lc->gen, lc->mode,
+        diskfs_block_unpin(self, blk, DISKFS_BLOCK_CLEAN);
+        diskfs_inode_acquire(self, lc->txn, lc->inum, lc->gen, lc->mode,
                              lc->cb, lc->private_data);
         free(lc);
         return;
     }
     pthread_mutex_unlock(&shard->lock);
 
-    /* Seed the inode's home block (dinode + embedded b+tree root) into the
-     * block cache from the disk image, so the b+tree traversal and inode-block
-     * pin find the real contents instead of a zero-created block.  No writer
-     * can be modifying it yet -- we hold the inode exclusively.  Claim is_new
-     * (no disk read): we already hold the freshly-read image in lc->iov and
-     * overwrite the whole block below, so reading it back would be redundant
-     * -- and a synchronous read here cannot reach a VFIO device anyway. */
-    {
-        uint32_t             dev;
-        uint64_t             off = sm_inum_to_device_offset(shared->space_map,
-                                                            lc->inum, &dev);
-        struct diskfs_block *blk = diskfs_block_claim(thread, dev, off, 1);
-
-        memcpy(blk->iov.data, lc->iov.data, DISKFS_BLOCK_SIZE);
-        diskfs_block_unpin(thread, blk, DISKFS_BLOCK_CLEAN);
-    }
-
-    evpl_iovec_release(thread->evpl, &lc->iov);
+    /* The fields are copied out; the record loads below re-claim the block
+     * from the cache themselves (resident, since we just loaded it). */
+    diskfs_block_unpin(self, blk, DISKFS_BLOCK_CLEAN);
 
     /* Load the ACL/pNFS record mirrors, then release the hold and re-drive
      * the acquire to grant the lock as usual. */
     lc->inode = inode;
     diskfs_inode_load_recs(lc);
-} /* diskfs_inode_load_complete */
+} /* diskfs_inode_load_resume */
 
 
 void
@@ -917,10 +936,7 @@ diskfs_inode_load(
     void                       *private_data)
 {
     struct diskfs_inode_load_ctx *lc = malloc(sizeof(*lc));
-    uint32_t                      dev;
-    uint64_t                      off;
 
-    off              = sm_inum_to_device_offset(thread->shared->space_map, inum, &dev);
     lc->thread       = thread;
     lc->txn          = txn;
     lc->inum         = inum;
@@ -929,13 +945,7 @@ diskfs_inode_load(
     lc->cb           = cb;
     lc->private_data = private_data;
 
-    evpl_iovec_alloc(thread->evpl, DISKFS_BLOCK_SIZE, DISKFS_BLOCK_SIZE, 1, 0, &lc->iov);
-    diskfs_metric_block_io(thread, DISKFS_METRIC_IO_READ,
-                           DISKFS_METRIC_IO_INODE, DISKFS_BLOCK_SIZE);
-    diskfs_metric_block_io_device(thread, dev, DISKFS_METRIC_IO_READ,
-                                  DISKFS_METRIC_IO_INODE, DISKFS_BLOCK_SIZE);
-    evpl_block_read(thread->evpl, thread->queue[dev], &lc->iov, 1, off,
-                    diskfs_inode_load_complete, lc);
+    diskfs_inode_load_resume(thread, lc);
 } /* diskfs_inode_load */
 
 

--- a/src/vfs/diskfs/diskfs_reclaim.c
+++ b/src/vfs/diskfs/diskfs_reclaim.c
@@ -258,8 +258,12 @@ diskfs_drain_final_cb(
     /* The retire txn is durable and its locks are released; drop the dead
      * struct from the cache so it neither accumulates nor lingers to collide
      * with a reallocation of the inum.  Straggling lookups by the old (or
-     * any) generation fault from disk and get ENOENT from the tombstone /
-     * inum check there. */
+     * any) generation fault through the block cache -- where the tombstone
+     * just logged is still current however far behind the device is -- and
+     * get ENOENT from the tombstone / inum check there.  (A straggler that
+     * re-faulted while the tombstone was un-pushed used to read the device
+     * directly, see the pre-retire dinode, and could re-orphan the inode,
+     * double-freeing its blocks.) */
     pthread_mutex_lock(&shard->lock);
     rb_tree_query_exact(&shard->inodes, d->inum, inum, inode);
     if (inode && inode->nlink == 0 && inode->refcnt == 0 &&


### PR DESCRIPTION
The inode-cache miss path read the inode's home block with a direct device read, then seeded the block cache from that image (claim `is_new` + memcpy + mark CLEAN). Both halves are incoherent with the write side.

## The invariant, and the one hole in it

A dinode's latest bytes live in the block cache as a dirty block — pinned from the commit that logged them until the push thread writes them home — so the device is allowed to be arbitrarily far behind. The rest of the metadata path already honors that:

- a **new** inode allocates its home block with no read at all;
- a **dirty** inode cannot leave the inode cache before its dinode is serialized into the pinned home block at commit;
- every b+tree read faults **through the block cache**.

The inode fault was the one direct-device reader. In the window between commit and push-home it returned the block's previous life, and the seeding then wrote those stale bytes *over* whatever the cache held — so a newer dirty block could be destroyed and marked clean.

With this change the chain closes: an inode is pinned in the inode cache until it reaches the block cache, pinned in the block cache until it reaches the device, and no reader can observe anything older.

## How it bites

The reclaim path makes the window concrete. The drain retires an inode by logging a tombstone dinode and freeing its home block; until the tombstone is pushed home, the device still holds the pre-retire image. A straggling lookup that faulted in that window materialized a live-looking inode — nlink intact, generation matching — and a drain acting on it freed the inode's blocks a second time: `space_map` fatal `"double-free or overlap"`.

On main that straggle is rare and the symptom is quieter (stale metadata served from the re-fault). #1527's recursive RMFS tree burn-down makes it routine — a hard link's second dirent arrives after the file's own drain retired it — and its diskfs link tests fail on every merge-queue platform without this fix (`Test devcontainer/*` and all distro Test jobs, 4 identical `double-free or overlap` failures each).

## The fix

Fault through the block cache with the same async claim the b+tree uses (`diskfs_block_claim_async`, previously static, now exported): resident dirty truth, an in-flight read, pin-cap backpressure, and the device read are all the cache's business, and the dinode is parsed out of the pinned block. The seeding disappears — the cache already holds what was read — and with it the clobber. The existing inum/generation/nlink check then sees whatever is actually current: a tombstone, a live dinode, or a reallocated block's unrelated bytes, all of which resolve correctly.

The `diskfs_drain_final_cb` comment that asserted the old behavior was safe ("straggling lookups... fault from disk and get ENOENT from the tombstone") assumed the tombstone had reached the disk; it is corrected to describe the coherent path.

## Testing

- This branch: full Debug build; client + diskfs suites pass; scan-build clean (Debug and Release, no bugs found).
- On the #1527 branch, where the trigger is routine: the reproduction (`test_link -b diskfs_aio`) failed ~10% per run at baseline (3/30) and is 0/50 with this fix; a ~2600-test battery across cairn/diskfs/client/REST at `-j 4` shows **zero** double-frees (previously 4 identical fatals), with residual failures being known resource-pressure flakes of this environment (`io_uring ENOMEM` under load, and clusters that also fail on backends this change does not touch).

Two attempted fixes that did *not* work are worth recording for review context: deduplicating drain submission per-inode (the flag dies with the struct the drain frees) and a pool-level in-flight registry (the duplicate arrives after the drain completes). Both attacked the duplicate submit; the actual defect was that the second fault *believed the device over the cache*. Fixing the read makes the drain's existing hard-link guard (`nlink == 0` → drop the dirent) work as written, with no dedup needed.
