### PR TITLE
tests/quint: run the NFS3 model suite on diskfs and cairn

### DIFF
--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -81,6 +81,31 @@ set_tests_properties(chimera/server/nfs/mbt/batch_memfs PROPERTIES
     LABELS "nfs3_mbt;memfs"
     TIMEOUT 300)
 
+# The same NFS3 corpus replayed against the on-disk backends.  The corpus is
+# protocol-level (RFC 1813) and backend-agnostic, so a divergence here is a
+# genuine backend deviation from the model memfs already satisfies.  Each
+# replay process self-provisions its scratch (device image / rocksdb dir) under
+# its own mkdtemp session dir, so the batches still run fully parallel and clean
+# up with the temp dir.  Gated on the storage each backend needs: diskfs on
+# libaio (its device type), cairn on rocksdb.
+if(HAVE_LIBAIO)
+    add_test(NAME chimera/server/nfs/mbt/batch_diskfs
+        COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
+                --backend diskfs)
+    set_tests_properties(chimera/server/nfs/mbt/batch_diskfs PROPERTIES
+        LABELS "nfs3_mbt;diskfs"
+        TIMEOUT 300)
+endif()
+
+if(CAIRN_ENABLED)
+    add_test(NAME chimera/server/nfs/mbt/batch_cairn
+        COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
+                --backend cairn)
+    set_tests_properties(chimera/server/nfs/mbt/batch_cairn PROPERTIES
+        LABELS "nfs3_mbt;cairn"
+        TIMEOUT 300)
+endif()
+
 # SKIP_RETURN_CODE 77 still applies to NFS4: a trace whose capability profile
 # does not match the live server exits 77 individually; the batch reports SKIP
 # only if every trace skips, otherwise the runnable traces gate it.

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -25,6 +25,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <inttypes.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/stat.h>
 
 #include "server/server.h"
 #include "common/tcp_flavor.h"
@@ -114,11 +117,15 @@ struct mbt_env_opts {
     int         disable_caches;   /* VFS attr+name caches: exact attr
                                    * comparison cannot tolerate staleness */
     const char *memfs_config;     /* module config JSON, e.g. block_size */
+    const char *module;           /* VFS backend: NULL/"memfs", "diskfs",
+                                   * "cairn".  diskfs/cairn self-provision
+                                   * scratch under the env's session_dir. */
 };
 
 struct mbt_env {
     struct chimera_server     *server;
     struct prometheus_metrics *metrics;
+    const char                *module;   /* backend for mkfs/mount/rmfs */
 
     struct evpl               *evpl;
     struct evpl_rpc2_thread   *rpc2_thread;
@@ -211,6 +218,8 @@ mbt_env_open_opts(
     chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
     chimera_server_config_set_nfs_enabled(config, 1);
 
+    env->module = (opts && opts->module) ? opts->module : "memfs";
+
     if (opts) {
         if (opts->nfs4_delegations) {
             chimera_server_config_set_nfs4_delegations(config, 1);
@@ -219,10 +228,46 @@ mbt_env_open_opts(
             chimera_server_config_set_attr_cache_enabled(config, 0);
             chimera_server_config_set_name_cache_enabled(config, 0);
         }
-        if (opts->memfs_config) {
-            chimera_server_config_add_module(config, "memfs", NULL,
-                                             opts->memfs_config);
+    }
+
+    /* Backend module registration.  memfs is a default module (only its
+     * optional block_size config is applied); diskfs and cairn are not
+     * default-registered and need a config pointing at scratch storage, which
+     * we self-provision under the per-process session_dir so every replay
+     * process is isolated and is cleaned up with its temp dir. */
+    if (strcmp(env->module, "diskfs") == 0) {
+        char img[300], cfg[512];
+        int  fd;
+
+        snprintf(img, sizeof(img), "%s/device-0.img", env->session_dir);
+        fd = open(img, O_CREAT | O_TRUNC | O_RDWR, 0644);
+        if (fd < 0 || ftruncate(fd, 1024LL * 1024 * 1024) != 0) {
+            fprintf(stderr, "diskfs device image %s: %s\n", img,
+                    strerror(errno));
+            exit(1);
         }
+        close(fd);
+        /* 1 GiB sparse device + a 64 MiB intent log, matching the posix
+         * driver's diskfs profile. */
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"unsafe_async\":true,"
+                 "\"intent_log_size\":67108864,"
+                 "\"devices\":[{\"type\":\"libaio\",\"size\":1,\"path\":\"%s\"}]}",
+                 img);
+        chimera_server_config_add_module(config, "diskfs", NULL, cfg);
+    } else if (strcmp(env->module, "cairn") == 0) {
+        char dir[300], cfg[512];
+
+        snprintf(dir, sizeof(dir), "%s/cairn", env->session_dir);
+        if (mkdir(dir, 0755) != 0 && errno != EEXIST) {
+            fprintf(stderr, "cairn dir %s: %s\n", dir, strerror(errno));
+            exit(1);
+        }
+        snprintf(cfg, sizeof(cfg), "{\"initialize\":true,\"path\":\"%s\"}", dir);
+        chimera_server_config_add_module(config, "cairn", NULL, cfg);
+    } else if (opts && opts->memfs_config) {
+        chimera_server_config_add_module(config, "memfs", NULL,
+                                         opts->memfs_config);
     }
 
     env->server = chimera_server_init(config, env->metrics);
@@ -278,21 +323,22 @@ mbt_env_open_opts(
     env->data_buf = malloc(MBT_MAX_DATA);
 } /* mbt_env_open_opts */
 
-/* Per-trace filesystem: create a fresh named memfs (unique fsname => distinct
- * fsid => distinct FH mount-id, so stale attr/name/open-cache entries from an
- * earlier trace can never be hit), mount it at "share", and export it.  Runs
- * on the already-started server -- the trade that lets one process amortize
- * server/client init across every trace of a batch. */
+/* Per-trace filesystem: create a fresh named filesystem (unique fsname =>
+ * distinct fsid => distinct FH mount-id, so stale attr/name/open-cache entries
+ * from an earlier trace can never be hit), mount it at "share", and export it.
+ * Runs on the already-started server -- the trade that lets one process
+ * amortize server/client init across every trace of a batch. */
 static inline void
 mbt_env_fs_setup(
     struct mbt_env *env,
     const char     *fsname)
 {
-    if (chimera_server_mkfs(env->server, "memfs", fsname, NULL) != 0) {
-        fprintf(stderr, "failed to create memfs filesystem %s\n", fsname);
+    if (chimera_server_mkfs(env->server, env->module, fsname, NULL) != 0) {
+        fprintf(stderr, "failed to create %s filesystem %s\n", env->module,
+                fsname);
         exit(1);
     }
-    chimera_server_mount(env->server, "share", "memfs", fsname, NULL);
+    chimera_server_mount(env->server, "share", env->module, fsname, NULL);
     if (chimera_server_create_export(env->server, "/share", "/share", 0,
                                      NULL) != 0) {
         fprintf(stderr, "failed to create /share export\n");
@@ -317,7 +363,7 @@ mbt_env_fs_teardown(
      * async close thread, so the fs can stay busy for a short window; retry
      * until it drains rather than leaking the filesystem (which would slow a
      * long corpus quadratically).  5s ceiling, matching the SMB harness. */
-    while (chimera_server_rmfs(env->server, "memfs", fsname) != 0) {
+    while (chimera_server_rmfs(env->server, env->module, fsname) != 0) {
         if (++tries >= 5000) {
             fprintf(stderr, "warning: rmfs %s still failed after %d retries\n",
                     fsname, tries);

--- a/src/server/nfs/tests/quint/nfs3_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_replay.c
@@ -53,8 +53,6 @@
 #define MBT_FSINFO_PROPERTIES  0x1b
 #define MBT_PATHCONF_LINKMAX   0xffffffffU
 #define MBT_PATHCONF_NAME_MAX  255
-#define MBT_FSSTAT_BYTES       UINT64_C(107374182400)
-#define MBT_FSSTAT_FILES       UINT64_C(1048576)
 
 struct mism {
     int  n;
@@ -1018,17 +1016,25 @@ op_fsstat(
         expected != NFS3_OK) {
         return;
     }
-    if (res->tbytes != MBT_FSSTAT_BYTES || res->fbytes != MBT_FSSTAT_BYTES ||
-        res->abytes != MBT_FSSTAT_BYTES) {
-        mism_add(m, "fsstat bytes: expected %" PRIu64 ", got "
-                 "t=%" PRIu64 " f=%" PRIu64 " a=%" PRIu64,
-                 MBT_FSSTAT_BYTES, res->tbytes, res->fbytes, res->abytes);
+    /* The model explicitly does not model space-used (nfs3.qnt: "space-used
+     * are not modeled"), and RFC 1813 leaves the FSSTAT totals
+     * implementation-defined -- different backends legitimately report
+     * different capacities (memfs/cairn a fixed synthetic size, diskfs its
+     * real device geometry, and free/avail shift as data is written).  Assert
+     * only the ordering invariant the protocol guarantees, not a size. */
+    if (res->tbytes == 0 || res->fbytes > res->tbytes ||
+        res->abytes > res->fbytes) {
+        mism_add(m, "fsstat bytes invariant (avail<=free<=total, total>0) "
+                 "violated: t=%" PRIu64 " f=%" PRIu64 " a=%" PRIu64,
+                 res->tbytes, res->fbytes, res->abytes);
     }
-    if (res->tfiles != MBT_FSSTAT_FILES || res->ffiles != MBT_FSSTAT_FILES ||
-        res->afiles != MBT_FSSTAT_FILES) {
-        mism_add(m, "fsstat files: expected %" PRIu64 ", got "
+    /* Likewise the file-slot counts are implementation-defined and unmodeled;
+     * RFC 1813 even lets a server report 0 for "unknown", so assert only the
+     * ordering (no total>0 requirement, unlike bytes). */
+    if (res->ffiles > res->tfiles || res->afiles > res->ffiles) {
+        mism_add(m, "fsstat files invariant (avail<=free<=total) violated: "
                  "t=%" PRIu64 " f=%" PRIu64 " a=%" PRIu64,
-                 MBT_FSSTAT_FILES, res->tfiles, res->ffiles, res->afiles);
+                 res->tfiles, res->ffiles, res->afiles);
     }
     if (res->invarsec != 0) {
         mism_add(m, "invarsec: expected 0, got %u", res->invarsec);
@@ -1615,6 +1621,8 @@ main(
           'n'                                                                                                                                                                   },
         { "verbose",            no_argument,                    0,
           'v'                                                                                                                                                                                                },
+        { "backend",            required_argument,              0,
+          'B'                                                                           },
         { 0,                    0,                              0,                             0 },
     };
     char               **traces;
@@ -1623,6 +1631,7 @@ main(
     double               max_attr_skip_rate = 0.1;
     int                  dry_run            = 0;
     int                  verbose            = 0;
+    const char          *backend            = "memfs";
     int                  failures           = 0;
     int                  c;
     int                  i;
@@ -1633,7 +1642,7 @@ main(
      * error, and skips them here (the 't'/'D'/'X' cases). */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:b:r:nv", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:b:r:nvB:", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -1652,10 +1661,14 @@ main(
             case 'v':
                 verbose = 1;
                 break;
+            case 'B':
+                backend = optarg;
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
                         "[--block-size N] [--max-attr-skip-rate F] "
+                        "[--backend memfs|diskfs|cairn] "
                         "[--dry-run] [--verbose]\n", argv[0]);
                 mbt_free_traces(traces, ntraces);
                 return 2;
@@ -1674,7 +1687,8 @@ main(
      * isolation.  A single-fs backend (linux/io_uring) would instead clear the
      * backing directory between traces. */
     if (!dry_run) {
-        mbt_env_open_opts(&env, NULL);
+        struct mbt_env_opts opts = { .module = backend };
+        mbt_env_open_opts(&env, &opts);
     }
 
     for (i = 0; i < ntraces; i++) {


### PR DESCRIPTION
The NFS3 model-based test corpus is protocol-level (RFC 1813) and
backend-agnostic: the same traces that drive the memfs backend describe NFS3
semantics any conformant backend must satisfy. This replays the full corpus
against the two on-disk backends, diskfs and cairn, to confirm they implement
the same behavior.

### Changes

- A `--backend memfs|diskfs|cairn` selector on the NFS3 replayer. diskfs and
  cairn are not default-registered modules, so the harness registers them with
  a scratch config self-provisioned under the per-process session dir (a 1 GiB
  sparse libaio device for diskfs, a rocksdb dir for cairn); every replay
  process is isolated and cleaned up with its temp dir, so the batches stay
  fully parallel.
- Two gated ctests, `batch_diskfs` (`HAVE_LIBAIO`) and `batch_cairn`
  (`CAIRN_ENABLED`), replaying the full corpus.
- FSSTAT is now checked against the RFC-1813 ordering invariants
  (`avail <= free <= total`, `total > 0` for bytes) rather than memfs's
  synthetic byte/file constants. The model explicitly does not model
  space-used, and a real device-backed backend legitimately reports different
  totals, so pinning the memfs constant was a harness over-assertion that only
  memfs and cairn happened to satisfy.

Both backends replay the full corpus with zero divergences. linux/io_uring
passthrough backends are intentionally left out of this change.
