### PR TITLE
nfs4client: take the reply's session from the slot table, not the server

### DIFF
--- a/src/vfs/nfs/nfs4_slot.c
+++ b/src/vfs/nfs/nfs4_slot.c
@@ -515,6 +515,17 @@ chimera_nfs4_session_put(struct chimera_nfs4_client_session *session)
 
 /* ---- the wrapper + reply handler ---------------------------------------- */
 
+/*
+ * The session this reply accounts against is the one the slot table borrowed
+ * its ids from (st->session) -- NOT whatever the server publishes now.
+ * chimera_nfs4_umount unpublishes server->nfs4_session the moment the last
+ * mount goes away, and a remount publishes a different one, either of which
+ * can land while this call is in flight.  The table's own reference is what
+ * keeps the borrowed-from session mapped until every reply has been accounted
+ * for, so reading it from the table is both crash-free and correct; reading
+ * the server's pointer here raced an unmount into a NULL dereference and a
+ * remount into advancing a seqid / returning an id on the wrong pool.
+ */
 static void
 chimera_nfs4_compound_call_cb(
     struct evpl                 *evpl,
@@ -526,7 +537,7 @@ chimera_nfs4_compound_call_cb(
     struct chimera_nfs4_compound_ctx        *ctx           = private_data;
     struct chimera_nfs_client_server_thread *server_thread = ctx->server_thread;
     struct chimera_nfs4_slot_table          *st            = &server_thread->slots;
-    struct chimera_nfs4_client_session      *session       = server_thread->server->nfs4_session;
+    struct chimera_nfs4_client_session      *session       = st->session;
     struct chimera_nfs4_parked              *p;
 
     void                                     (*real_cb)(


### PR DESCRIPTION
The NFSv4 client's COMPOUND reply handler took its session from the wrong place, so a reply that landed after an unmount dereferenced NULL.

## The bug

`chimera_nfs4_compound_call_cb` read

```c
struct chimera_nfs4_client_session *session = server_thread->server->nfs4_session;
```

— the session the server *currently publishes*. But `chimera_nfs4_umount` deliberately unpublishes it (`server->nfs4_session = NULL`) as soon as the last mount goes away, and its comment spells out why that is safe: each per-thread slot table holds its **own** reference to the session its ids came from, so the pool stays mapped until every table has let go. The send path honors that contract (it compares `st->session` against the published pointer and rebuilds the table when they differ); the reply path did not, and re-read the server's pointer instead.

So for any COMPOUND still in flight when the last mount goes away, the reply handler dereferences NULL at

```c
session->slot_seqid[ctx->slot_id] = ctx->seqid + 1;
```

The remount case is quieter but worse: if a new session has been published by the time the reply lands, the handler advances a sequence id and returns a slot id **on the new session's pool**, using an id borrowed from the old one.

## Fix

Take the session from `st->session` — the table's own refcounted pointer to the session the id was borrowed from. One line, plus a comment recording the invariant.

## Evidence

ASan, from CI (`Test rocky10 amd64 Debug`, and repeatedly across the matrix):

```
==...==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000060
==...==The signal is caused by a READ memory access.
    #0 chimera_nfs4_compound_call_cb src/vfs/nfs/nfs4_slot.c:548
    #1 reply_dispatch_NFS_V4 nfs4_xdr.c:48803
    #2 evpl_rpc2_client_handle_reply ext/libevpl/src/rpc2/rpc2.c:2160
```

The faulting address identifies the null pointer exactly, and does so twice over. `offsetof(struct chimera_nfs4_client_session, slot_seqid)` is **0x58** on x86_64 (40-byte `pthread_mutex_t`) and **0x60** on aarch64 (48-byte) — and CI faults at 0x58 on the amd64 runners and 0x60 on the arm64 ones. Two ABIs, two addresses, each matching its own `offsetof`: `session` was NULL.

That the reports are null-page SEGVs and *not* heap-use-after-frees is itself the proof of *which* pointer went stale: the slot table and its session were alive and referenced — only the server's published pointer had been cleared.

The immediately preceding log lines show the race directly: `DESTROY_CLIENTID`, `Umount ... status 0 (OK)`, client disconnect — then the reply arrives.

## Impact

This is the dominant residual flake in the CI matrix: one to three failures per full run, always on NFSv4 tests that mount and unmount, always after the test body has passed. Observed as `chimera/posix/pjd/unlink/00/nfs4_memfs`, `cthon_basic_{1,7,7b}_nfs4_*`, `cthon_special_stat2_nfs4_diskfs_aio`, `nametest_nfs4_linux`, `dirstress_nfs4_{io_uring,diskfs_aio}` — across every backend, which is what you would expect from a bug in the client's session bookkeeping rather than in any one VFS module.

Pre-existing; unrelated to the claim core that just landed (it merely made the flake visible by making everything else stop failing).

## Adjacent hazards, deliberately not fixed here

- `chimera_nfs4_slot_table_destroy` frees in-flight contexts, so a reply arriving after a table re-key or thread teardown is a use-after-free on the context itself. Not reachable in the traces above (ASan would have reported the UAF first), and fixing it means draining rather than freeing — its own change.
- The **send** path (`chimera_nfs4_compound_call`) reads the same published pointer, and for an op issued after the unpublish would reach `chimera_nfs4_slot_table_init` with a NULL session and fault in `calloc(session->max_slots, ...)` — a distinct signature, at offset 0x50 and in `slot_table_init` rather than the reply callback. It does not appear in any CI log I searched, so it is latent rather than active; fixing it also means deciding how a post-unmount send should fail, since `chimera_nfs4_compound_call` has no error return today. `chimera_nfs4_pnfs_layoutcommit` / `layoutreturn` read the pointer the same way, where `chimera_nfs4_close` guards.

Worth knowing for flake triage, and unrelated to either: when `chimera_client_init` fails *after* the in-process NFS server has started, `posix_test_init` calls `exit()` and tearing down the live server faults at address **0xb8**. In CI that also presents as `***Exception: SegFault` seconds into an nfs4 test, but it is distinguishable by address and is always preceded by `Failed to load client config`.


## On validation

I could not reproduce this on demand. A dedicated attempt in the CI devcontainer — the hot nfs4 test set on loop, a purpose-built harness unmounting under twelve threads of concurrent I/O (25 runs), and a forced 5 ms window opened immediately before the session read (10 runs) — produced no crash, and an instrumented build that logs whenever `server->nfs4_session != st->session` at reply time saw **zero divergences in 282 mount/unmount cycles**, including 49 with slot starvation forced.

That negative result is informative rather than discouraging, because it explains the rarity. `chimera_vfs_umount` purges the open caches and waits for `pending_closes == 0 && referenced == 0` before it ever dispatches the module unmount, so over the in-process transport the drain normally leaves nothing in flight by the time the pointer is cleared. Hitting the window needs a COMPOUND the drain does not account for — a request re-dispatched from the parked-slot drain at the tail of this very callback (which runs *after* `real_cb`, i.e. after the caller may have completed the unmount), a pNFS follow-on `LAYOUTCOMMIT`→`LAYOUTRETURN`, or simply a real transport whose reply latency exceeds the drain. That is consistent with a handful of failures per full CI matrix and none in a targeted loop.

The correctness argument does not depend on the reproduction. `st->session` is set in `slot_table_init` under the reference it takes; only `slot_table_destroy` clears it, and that drains and frees every in-flight context first; the disconnect path (`slot_table_reset`) deliberately leaves it intact. So whenever this callback runs with a live context, `st->session` is exactly the session that context's slot id and sequence id came from. The published pointer has no such guarantee — which is what the crashes show.
