### PR TITLE
smb2/quint: drive caching, durable handles and exactly-once replay (+ a share-lifetime use-after-free)

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -2937,6 +2937,10 @@ chimera_smb_add_share(
     share->continuous_availability = shared->config.persistent_handles &&
         continuous_availability;
 
+    /* One reference for the shares list itself; each TREE_CONNECT adds its
+     * own (see chimera_smb_share_release). */
+    share->refcnt = 1;
+
     pthread_mutex_lock(&shared->shares_lock);
     LL_PREPEND(shared->shares, share);
     pthread_mutex_unlock(&shared->shares_lock);
@@ -3027,14 +3031,23 @@ chimera_smb_remove_share(
     LL_FOREACH(shared->shares, share)
     {
         if (strcmp(share->name, name) == 0) {
+            /* Unlink first, so no further TREE_CONNECT can find it, then drop
+             * the list reference OUTSIDE the lock.  The share is only actually
+             * freed once the last tree connected to it has gone away: a
+             * connection teardown runs asynchronously and its open files
+             * release their sharemode reservations through &share->sharemode
+             * on the way out, so freeing here regardless was a
+             * heap-use-after-free. */
             LL_DELETE(shared->shares, share);
-            chimera_smb_sharemode_destroy(&share->sharemode);
-            free(share);
             found = 1;
             break;
         }
     }
     pthread_mutex_unlock(&shared->shares_lock);
+
+    if (found) {
+        chimera_smb_share_release(share);
+    }
 
     return found ? 0 : -1;
 } /* chimera_smb_remove_share */

--- a/src/server/smb/smb_attr.h
+++ b/src/server/smb/smb_attr.h
@@ -298,6 +298,19 @@ chimera_smb_marshal_standard_info(
 
     /* Only include standard attributes */
     chimera_smb_marshal_standard_attrs(attr, smb_attr);
+
+    /* FileStandardInformation's Directory byte (MS-FSCC 2.4.41) is derived
+     * from smb_attributes, which marshal_standard_attrs does not set and
+     * SMB_ATTR_MASK_STANDARD does not require -- so the append-time assert
+     * could not catch it and a STANDALONE FileStandardInformation query
+     * reported whatever the reused request memory happened to hold in that
+     * field (FileAllInformation was correct, because it marshals every
+     * attribute).  Fill the attribute word the same way FileBasicInformation
+     * does and then drop the timestamp mask bits this class does not carry,
+     * exactly as marshal_attribute_tag_info does. */
+    chimera_smb_marshal_basic_attrs(attr, smb_attr);
+    smb_attr->smb_attr_mask &= ~(SMB_ATTR_CRTTIME | SMB_ATTR_ATIME |
+                                 SMB_ATTR_MTIME | SMB_ATTR_CTIME);
 } /* chimera_smb_marshal_standard_info */
 
 /* Marshal for FileInternalInformation (0x06) */

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -268,6 +268,15 @@ struct netbios_header {
 } __attribute__((packed));
 
 struct chimera_smb_share {
+    /* References keeping this share alive: one for its place on
+     * shared->shares (dropped by chimera_smb_remove_share) plus one per tree
+     * connected to it.  A tree outlives the share's removal -- the connection
+     * teardown that frees it runs asynchronously, and its open files release
+     * their sharemode reservations from &share->sharemode as they go -- so the
+     * share must not be freed while any tree still points at it.  Freeing it
+     * regardless was a heap-use-after-free in
+     * chimera_smb_sharemode_release(). */
+    int                                refcnt;
     char                               name[81];
     char                               path[CHIMERA_VFS_PATH_MAX];
     /* Access-based directory enumeration: hide directory entries the caller
@@ -297,6 +306,23 @@ struct chimera_smb_share {
      * records at first use (best-effort, idempotent recovery). */
     bool                               durable_recovered;
 };
+
+/* Drop one share reference; the last one out destroys the sharemode table and
+ * frees the share.  Safe to call with no lock held: the share is already
+ * unlinked from shared->shares before its list reference is dropped, so no new
+ * tree can find it, and every remaining reference is a tree's. */
+static inline void
+chimera_smb_share_release(struct chimera_smb_share *share)
+{
+    if (!share) {
+        return;
+    }
+
+    if (__atomic_sub_fetch(&share->refcnt, 1, __ATOMIC_ACQ_REL) == 0) {
+        chimera_smb_sharemode_destroy(&share->sharemode);
+        free(share);
+    }
+} /* chimera_smb_share_release */
 
 struct chimera_smb_conn;
 
@@ -2843,6 +2869,16 @@ chimera_smb_tree_free(
         pcreate->create.pending_linked = 0;
     }
     pthread_mutex_unlock(&tree->pending_creates_lock);
+
+    /* Every open on this tree has now released its sharemode reservation, so
+     * the tree is done with the share: drop the reference taken at
+     * TREE_CONNECT.  This may be the last one (the share was removed while the
+     * connection was still tearing down), in which case the sharemode table is
+     * destroyed here rather than under the client's feet. */
+    if (tree->share) {
+        chimera_smb_share_release(tree->share);
+        tree->share = NULL;
+    }
 
     pthread_mutex_lock(&shared->trees_lock);
 

--- a/src/server/smb/smb_proc_tree_connect.c
+++ b/src/server/smb/smb_proc_tree_connect.c
@@ -47,6 +47,13 @@ chimera_smb_tree_connect(struct chimera_smb_request *request)
             }
         }
 
+        /* Take the tree's reference while still holding shares_lock, so it
+         * cannot race chimera_smb_remove_share unlinking and releasing the
+         * share between the lookup and the store into tree->share. */
+        if (share) {
+            __atomic_fetch_add(&share->refcnt, 1, __ATOMIC_RELAXED);
+        }
+
         pthread_mutex_unlock(&shared->shares_lock);
 
         if (!share) {

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -45,11 +45,41 @@ set_tests_properties(chimera/server/smb/mbt/oplock_probe_memfs PROPERTIES
     LABELS "smb_mbt;memfs"
     TIMEOUT 90)
 
+# Durable/persistent-handle ground-truth probe: pins the durable grant matrix,
+# the granted Timeout policy, park/reclaim across a transport drop, the reclaim
+# denial matrix, v1 (DHnQ/DHnC) handling, expiry, replay eligibility,
+# FSCTL_LMR_REQUEST_RESILIENCY and persistent handles on a CA share.
+add_executable(smb2_durable_probe smb2_durable_probe.c)
+target_include_directories(smb2_durable_probe PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(smb2_durable_probe chimera_server chimera_metrics)
+
+add_test(NAME chimera/server/smb/mbt/durable_probe_memfs
+    COMMAND $<TARGET_FILE:smb2_durable_probe>)
+set_tests_properties(chimera/server/smb/mbt/durable_probe_memfs PROPERTIES
+    LABELS "smb_mbt;memfs"
+    TIMEOUT 120)
+
+# Replay / ChannelSequence ground-truth probe: pins the exactly-once layer --
+# the command-sequence window, what makes a CREATE replayable, the four
+# create_guid classification outcomes, and the ChannelSequence accept/reject
+# window at every checked operation.  Every exactly-once claim is asserted on
+# the EFFECT (file content, size, open count), never on the status alone.
+add_executable(smb2_replay_probe smb2_replay_probe.c)
+target_include_directories(smb2_replay_probe PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(smb2_replay_probe chimera_server chimera_metrics)
+
+add_test(NAME chimera/server/smb/mbt/replay_probe_memfs
+    COMMAND $<TARGET_FILE:smb2_replay_probe>)
+set_tests_properties(chimera/server/smb/mbt/replay_probe_memfs PROPERTIES
+    LABELS "smb_mbt;memfs"
+    TIMEOUT 120)
+
 # ---------------------------------------------------------------------------
 # Trace replay (ROADMAP-SMB.md Increment 3).  A single smb2_mbt_replay process
-# opens the server + client evpl once (capability profile taken from the first
-# trace -- every trace in a batch shares it, since a profile is fixed per
-# generation instance) and replays every trace in the corpus, standing up a
+# opens the server + client evpl once per CAPABILITY PROFILE (the corpus spans
+# several generation instances -- smb2Base has leases off, smb2Durable has
+# durable on -- so the replayer groups adjacent traces by profile and restarts
+# the server when it changes) and replays every trace in the corpus, standing up a
 # fresh uniquely-named memfs per trace AND opening fresh connections/sessions
 # per trace (smb2_conn_reset drops the prior trace's sessions/opens), so neither
 # the filesystem nor the SMB session/tree/handle state leaks across traces.

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -95,6 +95,10 @@ endif()
 
 add_test(NAME chimera/server/smb/mbt/batch_memfs
     COMMAND $<TARGET_FILE:smb2_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/smb2)
+# 40 traces at depth 500 against an ASAN build, each standing up and tearing
+# down its own filesystem: measured at 55-105 s on a loaded container, so 120 s
+# was close enough to the ceiling to flake.  This is a batch of 40 tests in one
+# ctest, not a single case.
 set_tests_properties(chimera/server/smb/mbt/batch_memfs PROPERTIES
     LABELS "smb_mbt;memfs"
-    TIMEOUT 120)
+    TIMEOUT 600)

--- a/src/server/smb/tests/quint/smb2_durable_probe.c
+++ b/src/server/smb/tests/quint/smb2_durable_probe.c
@@ -1,0 +1,1579 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * SMB2 durable / persistent / resilient handle ground-truth probe -- the
+ * durable twin of smb2_oplock_probe.c (ROADMAP-SMB.md Increment 1, extended
+ * to the durable-handle families).  It drives the real chimera SMB server
+ * over the in-process transport through the whole disconnect-survival
+ * lifecycle -- request, grant, park, reclaim, expire, yield -- and pins
+ * chimera's behavior BEFORE the generative model bakes any expectation.
+ *
+ * Conformance discipline (DEVIATIONS-SMB.md "Conformance discipline"): every
+ * EXPECT() asserts an MS-SMB2 / MS-FSA-required outcome and cites the clause.
+ * Where the spec leaves the server a choice -- WHETHER to grant durability at
+ * all, and what Timeout to grant (MS-SMB2 3.3.5.9.10: "the server MAY") --
+ * the value is recorded with NOTE() and, where the model must predict the
+ * exact reply, pinned as policy with an EXPECT that says so.  A chimera
+ * divergence from a mandate is a DEVIATIONS-SMB.md entry, never a weakened
+ * assertion.
+ *
+ * Sections:
+ *   D1  grant matrix    -- WHICH caching states make a durable request
+ *                          grantable (v1 DHnQ and v2 DH2Q), across no-oplock /
+ *                          LEVEL_II / EXCLUSIVE / BATCH and R / RH / RWH leases
+ *   D2  timeout         -- what Timeout a DH2Q grant reports for a requested
+ *                          0 / in-range / over-maximum value
+ *   D3  park + reclaim  -- a transport drop parks a leased durable open; a
+ *                          DH2C on a fresh connection of the same client
+ *                          reclaims the SAME open, with its data and its lease
+ *   D4  reclaim denial  -- every way a reconnect can fail to name the handle:
+ *                          wrong CreateGuid / no lease context / wrong lease
+ *                          key / wrong name / unknown id / wrong ClientGuid /
+ *                          illegal context combinations / persistent-on-durable
+ *   D5  v1 reconnect    -- DHnQ grant under a BATCH oplock, DHnC reclaim
+ *   D6  non-durable     -- an open with no durable request does NOT survive
+ *                          its connection
+ *   D7  parked yield    -- a conflicting open against a parked DURABLE-only
+ *                          holder: who wins, and can the loser still reclaim
+ *   D8  expiry          -- the disconnect-survival deadline is enforced: a
+ *                          reclaim after the granted Timeout has provably
+ *                          elapsed is refused
+ *   D9  replay          -- SMB2_FLAGS_REPLAY_OPERATION + the same DH2Q
+ *                          CreateGuid: the eligibility window, and the
+ *                          duplicate-open collision
+ *   D10 resiliency      -- FSCTL_LMR_REQUEST_RESILIENCY: the timeout policy,
+ *                          the malformed-buffer rejection, and whether a
+ *                          resilient (but not durable) open survives a drop
+ *   D11 persistent      -- a continuously-available share (its own server
+ *                          instance): SMB2_DHANDLE_FLAG_PERSISTENT, the
+ *                          persistent reclaim, and what a parked PERSISTENT
+ *                          holder does to a conflicting opener
+ *
+ * Each connection gets its own ClientGuid unless it is deliberately reopened
+ * as the same client (smb2_conn_reopen inherits guid_tag) -- chimera derives
+ * both the lease owner's client key and the durable reclaim's identity check
+ * from the ClientGuid, so a shared guid would silently disable the
+ * cross-client arbitration this probe is measuring.
+ */
+
+#include "smb2_mbt_common.h"
+
+static int nfail = 0;
+static int ndev  = 0;
+
+/* A spec-mandated assertion.  Fails the probe (and CI) on a violation. */
+#define EXPECT(ok, ...)                              \
+        do {                                         \
+            if (ok) { printf("ok   - "); }           \
+            else { printf("FAIL - "); nfail++; }  \
+            printf(__VA_ARGS__);                     \
+            printf("\n");                            \
+        } while (0)
+
+/* A ground-truth observation (server discretion / recorded behavior), not
+ * pass/fail. */
+#define NOTE(...)                                    \
+        do { printf("note - "); printf(__VA_ARGS__); printf("\n"); } while (0)
+
+/* A recorded, spec-cited DEVIATION: chimera contradicts a mandate.  Loud and
+ * counted, but does NOT fail CI -- it pins a known, documented
+ * non-conformance so the probe stays a regression anchor.  Every use has a
+ * DEVIATIONS-SMB.md entry. */
+#define DEVIATION(id, ...)                                       \
+        do {                                                     \
+            printf("DEVIATION %s - ", id); ndev++;               \
+            printf(__VA_ARGS__);                                 \
+            printf("\n");                                        \
+        } while (0)
+
+/* ---- small helpers ------------------------------------------------------ */
+
+static void
+fill_guid(
+    uint8_t guid[16],
+    int     tag)
+{
+    memset(guid, 0, 16);
+    guid[0]  = (uint8_t) tag;
+    guid[1]  = 0xD0;
+    guid[2]  = 0x0D;
+    guid[15] = (uint8_t) ~tag;
+} /* fill_guid */
+
+/* An RqLs lease request with a distinct key per (file, tag). */
+static void
+mk_lease(
+    struct smb2_oplock_req *r,
+    int                     key_tag,
+    uint32_t                state)
+{
+    memset(r, 0, sizeof(*r));
+    r->is_lease     = 1;
+    r->lease_key[0] = (uint8_t) key_tag;
+    r->lease_key[1] = 0x5E;
+    r->lease_state  = state;
+    r->lease_epoch  = 1;
+} /* mk_lease */
+
+static void
+mk_oplock(
+    struct smb2_oplock_req *r,
+    uint8_t                 level)
+{
+    memset(r, 0, sizeof(*r));
+    r->level = level;
+} /* mk_oplock */
+
+static const char *
+lease_str(uint32_t s)
+{
+    static char bufs[4][8];
+    static int  which = 0;
+    char       *buf   = bufs[which++ & 3];
+    int         n     = 0;
+
+    if (s & SMB2_LEASE_READ) {
+        buf[n++] = 'R';
+    }
+    if (s & SMB2_LEASE_HANDLE) {
+        buf[n++] = 'H';
+    }
+    if (s & SMB2_LEASE_WRITE) {
+        buf[n++] = 'W';
+    }
+    if (n == 0) {
+        buf[n++] = '-';
+    }
+    buf[n] = '\0';
+    return buf;
+} /* lease_str */
+
+/* Block until the server has finished PARKING the durable handle `file_id`.
+ *
+ * This is a real barrier, not a sleep, and the suite needs one: a
+ * client-initiated disconnect returns as soon as the DISCONNECTED notification
+ * reaches the CLIENT bind, but the server's teardown -- which is what parks the
+ * open (chimera_smb_durable_conn_disconnecting) -- runs on the dropped
+ * connection's own server thread, and smb2_quiesce() cannot order against a
+ * thread that has no connection left to echo on.  Any third party that acts on
+ * the parked handle before that teardown lands is racing it: measured, this
+ * turned D11 into a 1-in-N flake where the conflicting opener arrived first and
+ * took a file the parked persistent holder should have kept.
+ *
+ * The barrier is a DH2C reconnect carrying a deliberately WRONG CreateGuid.
+ * chimera_smb_durable_claim answers a not-yet-parked entry with *r_retry, and
+ * chimera_smb_durable_reconnect then retries on a timer until the entry parks
+ * -- so the reply cannot come back before the park has happened.  Once parked,
+ * the CreateGuid mismatch answers OBJECT_NAME_NOT_FOUND and the entry is left
+ * exactly as it was: a refused reconnect consumes nothing (D4j).
+ */
+static void
+wait_parked(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16])
+{
+    struct smb2_durable_req dur;
+    struct smb2_create_out  r;
+    uint32_t                st;
+
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, file_id, 16);
+    memset(dur.create_guid, 0xFE, 16);   /* cannot match any real create */
+    st = smb2_create_dur(c, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "park barrier: a wrong-CreateGuid DH2C is refused (0x%08x)", st);
+} /* wait_parked */
+
+/* ------------------------------------------------------------------------
+ * D1 -- under WHICH caching state is a durable handle actually granted?
+ *
+ * MS-SMB2 3.3.5.9.6 (DHnQ, durable v1) and 3.3.5.9.10 (DH2Q, durable v2) both
+ * gate the grant on the open ending up with a BATCH oplock or a lease carrying
+ * SMB2_LEASE_HANDLE_CACHING: without one of those the server MUST NOT grant a
+ * durable open (a disconnected handle with no handle-caching guarantee would
+ * hold the file against openers that were never told).  Whether it grants at
+ * all when the precondition IS met is the server's choice -- recorded as
+ * policy, and asserted so the model can predict the reply exactly.
+ *
+ * Presence of the response context IS the grant signal: chimera emits DHnQ /
+ * DH2Q only when it granted (build_dhnq_response / build_dh2q_response return
+ * -1 otherwise), and the DHnQ response body is 8 zero bytes.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d1(
+    struct smb2_env  *env,
+    struct smb2_conn *a)
+{
+    struct {
+        const char *label;
+        int         is_lease;
+        uint8_t     level;
+        uint32_t    lease_state;
+        int         v2;         /* 1 = DH2Q, 0 = DHnQ */
+        int         exp_grant;
+        const char *why;
+    } rows[] = {
+        { "no oplock          + DHnQ", 0, SMB2_OPLOCK_LEVEL_NONE,      0,                                         0,
+          0,
+          "no caching at all" },
+        { "no oplock          + DH2Q", 0, SMB2_OPLOCK_LEVEL_NONE,      0,                                         1,
+          0,
+          "no caching at all" },
+        { "LEVEL_II           + DHnQ", 0, SMB2_OPLOCK_LEVEL_II,        0,                                         0,
+          0,
+          "a read cache carries no handle guarantee" },
+        { "LEVEL_II           + DH2Q", 0, SMB2_OPLOCK_LEVEL_II,        0,                                         1,
+          0,
+          "a read cache carries no handle guarantee" },
+        { "EXCLUSIVE          + DHnQ", 0, SMB2_OPLOCK_LEVEL_EXCLUSIVE, 0,                                         0,
+          0,
+          "EXCLUSIVE caches data, not the handle" },
+        { "EXCLUSIVE          + DH2Q", 0, SMB2_OPLOCK_LEVEL_EXCLUSIVE, 0,                                         1,
+          0,
+          "EXCLUSIVE caches data, not the handle" },
+        { "BATCH              + DHnQ", 0, SMB2_OPLOCK_LEVEL_BATCH,     0,                                         0,
+          1,
+          "BATCH is the v1 precondition" },
+        { "BATCH              + DH2Q", 0, SMB2_OPLOCK_LEVEL_BATCH,     0,                                         1,
+          1,
+          "BATCH is the v2 precondition" },
+        { "lease R            + DH2Q", 1, 0,                           SMB2_LEASE_READ,                           1,
+          0,
+          "no HANDLE caching bit" },
+        { "lease RH           + DH2Q", 1, 0,
+          SMB2_LEASE_READ | SMB2_LEASE_HANDLE, 1, 1,
+          "HANDLE caching is the lease precondition" },
+        { "lease RWH          + DH2Q", 1, 0,                           SMB2_LEASE_RWH,                            1,
+          1,
+          "HANDLE caching is the lease precondition" },
+        { "lease RWH          + DHnQ", 1, 0,                           SMB2_LEASE_RWH,                            0,
+          1,
+          "v1 accepts a HANDLE-caching lease too" },
+        { "lease R            + DHnQ", 1, 0,                           SMB2_LEASE_READ,                           0,
+          0,
+          "no HANDLE caching bit" },
+    };
+    int n = (int) (sizeof(rows) / sizeof(rows[0]));
+
+    printf("\n# D1 durable grant matrix (MS-SMB2 3.3.5.9.6 / 3.3.5.9.10)\n");
+
+    for (int i = 0; i < n; i++) {
+        char                    name[32];
+        struct smb2_oplock_req  oreq;
+        struct smb2_durable_req dur;
+        struct smb2_create_out  o;
+        uint32_t                st;
+        int                     got;
+
+        /* One file per row, and one lease key per file: a lease key binds to
+         * exactly one file per client (MS-SMB2 3.3.5.9.8, C-10), so reusing a
+         * key across rows would answer INVALID_PARAMETER instead of measuring
+         * the durable grant. */
+        snprintf(name, sizeof(name), "d1_%d", i);
+        if (rows[i].is_lease) {
+            mk_lease(&oreq, 0x10 + i, rows[i].lease_state);
+        } else {
+            mk_oplock(&oreq, rows[i].level);
+        }
+
+        memset(&dur, 0, sizeof(dur));
+        if (rows[i].v2) {
+            dur.dh2q = 1;
+            fill_guid(dur.create_guid, 0x10 + i);
+        } else {
+            dur.dhnq = 1;
+        }
+
+        st = smb2_create_dur(a, name, FILE_OPEN_IF, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD,
+                             rows[i].level == SMB2_OPLOCK_LEVEL_NONE &&
+                             !rows[i].is_lease ? NULL : &oreq, &dur, &o);
+        EXPECT(st == ST_SUCCESS, "D1[%2d] %s: CREATE -> 0x%08x", i,
+               rows[i].label, st);
+        if (st != ST_SUCCESS) {
+            continue;
+        }
+
+        got = rows[i].v2 ? o.has_dh2q : o.has_dhnq;
+        NOTE("D1[%2d] %s: granted caching opl 0x%02x lease %s -> durable %s",
+             i, rows[i].label, o.oplock,
+             o.has_lease ? lease_str(o.lease_state) : "-",
+             got ? "GRANTED" : "refused");
+
+        if (rows[i].exp_grant) {
+            /* Policy (MS-SMB2 3.3.5.9.10 "the server MAY"): chimera grants
+             * whenever the precondition holds.  Pinned so the model can
+             * predict the exact reply. */
+            EXPECT(got, "D1[%2d] %s: durable GRANTED (policy: %s)", i,
+                   rows[i].label, rows[i].why);
+        } else {
+            /* Mandate: no batch oplock and no HANDLE-caching lease means no
+             * durable open (MS-SMB2 3.3.5.9.6 / 3.3.5.9.10). */
+            EXPECT(!got, "D1[%2d] %s: durable REFUSED (%s)", i, rows[i].label,
+                   rows[i].why);
+        }
+        smb2_close(a, o.file_id);
+    }
+    smb2_quiesce(env);
+} /* sec_d1 */
+
+/* ------------------------------------------------------------------------
+ * D2 -- the granted Timeout.
+ *
+ * MS-SMB2 2.2.14.2.12: the DH2Q response carries the Timeout the server
+ * granted, which need not be the one asked for.  chimera's policy
+ * (smb_proc_create.c chimera_smb_create_grant_durable): 0 selects the default
+ * (CHIMERA_SMB_DURABLE_TIMEOUT_DEFAULT_MS), an in-range value is honored, and
+ * an over-maximum value is CLAMPED to CHIMERA_SMB_DURABLE_TIMEOUT_MAX_MS
+ * rather than refused.  Discretion, pinned because the model predicts the
+ * reply.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d2(
+    struct smb2_env  *env,
+    struct smb2_conn *a)
+{
+    /* *INDENT-OFF* */ /* uncrustify oscillates on aligned struct-init tables */
+    struct {
+        const char *label;
+        uint32_t    ask;
+        uint32_t    exp;
+    } rows[] = {
+        { "Timeout 0 -> server default",      0,      SMB2C_DURABLE_TIMEOUT_DEFAULT_MS },
+        { "Timeout 5000 -> honored",          5000,   5000                             },
+        { "Timeout 400000 -> clamped to max", 400000, SMB2C_DURABLE_TIMEOUT_MAX_MS     },
+    };
+    /* *INDENT-ON* */
+    int n = (int) (sizeof(rows) / sizeof(rows[0]));
+
+    printf("\n# D2 granted durable Timeout (MS-SMB2 2.2.14.2.12)\n");
+
+    for (int i = 0; i < n; i++) {
+        char                    name[32];
+        struct smb2_oplock_req  oreq;
+        struct smb2_durable_req dur;
+        struct smb2_create_out  o;
+        uint32_t                st;
+
+        snprintf(name, sizeof(name), "d2_%d", i);
+        mk_oplock(&oreq, SMB2_OPLOCK_LEVEL_BATCH);
+        memset(&dur, 0, sizeof(dur));
+        dur.dh2q       = 1;
+        dur.timeout_ms = rows[i].ask;
+        fill_guid(dur.create_guid, 0x30 + i);
+
+        st = smb2_create_dur(a, name, FILE_OPEN_IF, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD, &oreq, &dur, &o);
+        EXPECT(st == ST_SUCCESS && o.has_dh2q,
+               "D2[%d] %s: CREATE -> 0x%08x dh2q %d", i, rows[i].label, st,
+               o.has_dh2q);
+        if (st != ST_SUCCESS || !o.has_dh2q) {
+            continue;
+        }
+        NOTE("D2[%d] asked %u ms -> granted %u ms, flags 0x%08x", i,
+             rows[i].ask, o.dh2q_timeout, o.dh2q_flags);
+        EXPECT(o.dh2q_timeout == rows[i].exp,
+               "D2[%d] %s: granted %u (policy %u)", i, rows[i].label,
+               o.dh2q_timeout, rows[i].exp);
+        /* No CA share here, so nothing may come back persistent. */
+        EXPECT((o.dh2q_flags & SMB2_DHANDLE_FLAG_PERSISTENT) == 0,
+               "D2[%d] not persistent on a non-CA share (MS-SMB2 3.3.5.9.10)",
+               i);
+        smb2_close(a, o.file_id);
+    }
+    smb2_quiesce(env);
+} /* sec_d2 */
+
+/* ------------------------------------------------------------------------
+ * D3 -- park on disconnect, reclaim on reconnect.
+ *
+ * MS-SMB2 3.3.7.1: when a connection drops, an open whose IsDurable is TRUE is
+ * NOT closed -- it is preserved until its durable timeout expires.  3.3.5.9.12:
+ * a CREATE carrying DH2C on a new connection reclaims it, and the reply is an
+ * OPEN of the same file (CreateAction = OPENED) with the same FileId.  The
+ * reclaim reply carries the lease context but no DH2Q (nothing new is being
+ * granted).
+ *
+ * Proving it is the SAME open, not a fresh one that happens to name the same
+ * path, needs three independent facts: the FileId is byte-identical, data
+ * written before the drop reads back, and the lease survives at its epoch.
+ * ------------------------------------------------------------------------ */
+static struct smb2_conn *
+sec_d3(
+    struct smb2_env  *env,
+    struct smb2_conn *a)
+{
+    struct smb2_oplock_req  lreq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, rec;
+    struct smb2_conn       *b;
+    uint8_t                 buf[32];
+    uint32_t                st, n;
+
+    printf("\n# D3 park on disconnect, DH2C reclaim (MS-SMB2 3.3.7.1,"
+           " 3.3.5.9.12)\n");
+
+    mk_lease(&lreq, 0x41, SMB2_LEASE_RWH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x41);
+
+    st = smb2_create_dur(a, "d3", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q && o.has_lease,
+           "D3 durable leased open: st 0x%08x dh2q %d lease %s", st,
+           o.has_dh2q, o.has_lease ? lease_str(o.lease_state) : "-");
+    if (st != ST_SUCCESS || !o.has_dh2q) {
+        return NULL;
+    }
+
+    st = smb2_write(a, o.file_id, 0, "DURABLE-PAYLOAD", 15, &n);
+    EXPECT(st == ST_SUCCESS && n == 15, "D3 write through the durable handle");
+
+    /* The transport drop.  smb2_conn_disconnect returns only once the
+     * DISCONNECTED notification has actually been delivered, so "the
+     * connection is gone" is an event, not a timeout. */
+    smb2_conn_disconnect(a);
+    EXPECT(a->disconnected && a->closed_by_client,
+           "D3 the client-initiated drop was delivered");
+
+    b = smb2_conn_reopen(env, a);
+    EXPECT(b->guid_tag == a->guid_tag,
+           "D3 the reconnect presents the SAME ClientGuid");
+    smb2_quiesce(env);
+
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x41);
+    /* An empty Name is the ordinary v2 reconnect form; the surviving open
+     * holds a lease, so the same lease key must be presented (3.3.5.9.7). */
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &lreq, &dur, &rec);
+    EXPECT(st == ST_SUCCESS, "D3 DH2C reclaim -> 0x%08x", st);
+    if (st != ST_SUCCESS) {
+        return b;
+    }
+    EXPECT(rec.action == FILE_ACT_OPENED,
+           "D3 the reclaim reports CreateAction = OPENED (%u)", rec.action);
+    EXPECT(memcmp(rec.file_id, o.file_id, 16) == 0,
+           "D3 the reclaimed handle carries the ORIGINAL FileId");
+    EXPECT(rec.has_lease && rec.lease_state == o.lease_state,
+           "D3 the lease survives the drop: %s (was %s)",
+           rec.has_lease ? lease_str(rec.lease_state) : "-",
+           lease_str(o.lease_state));
+    EXPECT(rec.lease_epoch == o.lease_epoch,
+           "D3 the lease epoch is unchanged across the reclaim (%u vs %u)",
+           rec.lease_epoch, o.lease_epoch);
+    /* MS-SMB2 3.3.5.9.12: a reconnect grants nothing new, so no DH2Q. */
+    EXPECT(!rec.has_dh2q,
+           "D3 the reclaim reply carries NO DH2Q response context");
+
+    memset(buf, 0, sizeof(buf));
+    st = smb2_read(b, rec.file_id, 0, 15, buf, &n);
+    EXPECT(st == ST_SUCCESS && n == 15 &&
+           memcmp(buf, "DURABLE-PAYLOAD", 15) == 0,
+           "D3 data written before the drop reads back through the reclaim"
+           " (st 0x%08x n %u '%.*s')", st, n, (int) n, buf);
+
+    /* D3b -- a reclaimed handle is durable AGAIN.  MS-SMB2 3.3.5.9.12 re-homes
+     * the surviving open rather than creating a new one, so its IsDurable and
+     * its identity are unchanged and a SECOND drop must park it again.  The
+     * model has to know this: a trace may disconnect the same handle twice, and
+     * a model that forgot the durability on the first reclaim would predict the
+     * handle dying on the second drop. */
+    {
+        struct smb2_conn      *c2;
+        struct smb2_create_out rec2;
+
+        smb2_conn_disconnect(b);
+        c2 = smb2_conn_reopen(env, b);
+        smb2_quiesce(env);
+        memset(&dur, 0, sizeof(dur));
+        dur.dh2c = 1;
+        memcpy(dur.file_id, o.file_id, 16);
+        fill_guid(dur.create_guid, 0x41);
+        st = smb2_create_dur(c2, "", FILE_OPEN, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD, &lreq, &dur, &rec2);
+        EXPECT(st == ST_SUCCESS &&
+               memcmp(rec2.file_id, o.file_id, 16) == 0,
+               "D3b a reclaimed handle parks and reclaims a SECOND time"
+               " (0x%08x)", st);
+        b = c2;
+    }
+
+    return b;
+} /* sec_d3 */
+
+/* ------------------------------------------------------------------------
+ * D4 -- every way a reconnect can fail.
+ *
+ * MS-SMB2 3.3.5.9.7 / 3.3.5.9.12 enumerate the checks a reclaim must pass.
+ * Each row below parks a handle, presents ONE malformed reconnect, and
+ * asserts the mandated status -- the handle must survive a refused reclaim,
+ * which the final correct reclaim proves.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d4(
+    struct smb2_env  *env,
+    struct smb2_conn *seed)
+{
+    struct smb2_oplock_req  lreq, wrongkey;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    struct smb2_conn       *b, *stranger;
+    uint32_t                st;
+
+    printf("\n# D4 reclaim denial matrix (MS-SMB2 3.3.5.9.7 / 3.3.5.9.12)\n");
+
+    mk_lease(&lreq, 0x51, SMB2_LEASE_RWH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x51);
+    st = smb2_create_dur(seed, "d4", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q, "D4 durable leased open");
+    if (st != ST_SUCCESS || !o.has_dh2q) {
+        return;
+    }
+    smb2_conn_disconnect(seed);
+    b = smb2_conn_reopen(env, seed);
+    smb2_quiesce(env);
+
+    /* (a) wrong CreateGuid: the v2 identity is (persistent id, CreateGuid). */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x99);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &lreq, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "D4a wrong CreateGuid -> OBJECT_NAME_NOT_FOUND (0x%08x)", st);
+
+    /* (b) the surviving open holds a lease and the reconnect omits RqLs. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x51);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "D4b leased handle, reconnect without a lease context ->"
+           " OBJECT_NAME_NOT_FOUND (0x%08x)", st);
+
+    /* (c) lease context present but naming a different lease key. */
+    mk_lease(&wrongkey, 0x52, SMB2_LEASE_RWH);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &wrongkey, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "D4c wrong lease key -> OBJECT_NAME_NOT_FOUND (0x%08x)", st);
+
+    /* (d) a leased reconnect naming a DIFFERENT, non-empty file name. */
+    st = smb2_create_dur(b, "d4_other", FILE_OPEN, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &r);
+    EXPECT(st == ST_INVALID_PARAMETER,
+           "D4d leased reconnect naming another file -> INVALID_PARAMETER"
+           " (0x%08x)", st);
+
+    /* (e) DH2C combined with DH2Q: 3.3.5.9.12 forbids the combination. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    dur.dh2q = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x51);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &lreq, &dur, &r);
+    EXPECT(st == ST_INVALID_PARAMETER,
+           "D4e DH2C + DH2Q -> INVALID_PARAMETER (0x%08x)", st);
+
+    /* (f) DH2C combined with DHnC: two reconnect contexts at once. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    dur.dhnc = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x51);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &lreq, &dur, &r);
+    EXPECT(st == ST_INVALID_PARAMETER,
+           "D4f DH2C + DHnC -> INVALID_PARAMETER (0x%08x)", st);
+
+    /* (g) reconnect asking for PERSISTENT against a non-persistent open. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c            = 1;
+    dur.reconnect_flags = SMB2_DHANDLE_FLAG_PERSISTENT;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x51);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &lreq, &dur, &r);
+    EXPECT(st == ST_INVALID_PARAMETER,
+           "D4g DH2C with FLAG_PERSISTENT against a durable-only open ->"
+           " INVALID_PARAMETER (0x%08x)", st);
+
+    /* (h) an id that names nothing. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memset(dur.file_id, 0xEE, 16);
+    fill_guid(dur.create_guid, 0x51);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &lreq, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "D4h unknown persistent id -> OBJECT_NAME_NOT_FOUND (0x%08x)", st);
+
+    /* (i) a DIFFERENT client (fresh ClientGuid) reclaiming a LEASED handle.
+     * 3.3.5.9.7 binds the ClientGuid check to leased opens. */
+    stranger = smb2_conn_reopen_raw(env, NULL);
+    smb2_handshake(stranger);
+    EXPECT(stranger->guid_tag != b->guid_tag,
+           "D4i the stranger presents a different ClientGuid");
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x51);
+    st = smb2_create_dur(stranger, "", FILE_OPEN, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "D4i cross-client reclaim of a leased handle ->"
+           " OBJECT_NAME_NOT_FOUND (0x%08x)", st);
+
+    /* (j) after all of that the handle must still be reclaimable: a refused
+     * reconnect must not consume it. */
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         &lreq, &dur, &r);
+    EXPECT(st == ST_SUCCESS &&
+           memcmp(r.file_id, o.file_id, 16) == 0,
+           "D4j the handle survived nine refused reconnects and reclaims"
+           " (0x%08x)", st);
+
+    /* (k) a reconnect naming a handle that is now LIVE again.  A live handle
+     * is never stolen -- but the refusal is not immediate: chimera cannot tell
+     * this case apart from a reclaim that raced its own disconnect, so it
+     * announces an ASYNC INTERIM and retries on a timer until its budget
+     * lapses (chimera_smb_durable_reconnect_retry_cb, ~3 s).  Both halves are
+     * asserted: the status AND the interim.  This is the one probe row that
+     * deliberately costs seconds, and it is why the generated corpus excludes
+     * the shape (smb2.qnt's unknownFids). */
+    if (st == ST_SUCCESS) {
+        int i0 = b->ninterim;
+
+        st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                             &lreq, &dur, &r);
+        EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+               "D4k a reconnect naming a LIVE handle is refused, never stolen"
+               " (0x%08x)", st);
+        EXPECT(b->ninterim > i0,
+               "D4k ... and the refusal is announced with an async interim"
+               " first (%d)", b->ninterim - i0);
+        smb2_close(b, r.file_id);
+    }
+    smb2_quiesce(env);
+} /* sec_d4 */
+
+/* ------------------------------------------------------------------------
+ * D5 -- durable v1: DHnQ grant under a BATCH oplock, DHnC reclaim.
+ *
+ * MS-SMB2 3.3.5.9.7: a v1 reconnect is keyed on the persistent id alone -- it
+ * carries no CreateGuid, and a non-leased handle ignores the name entirely.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d5(struct smb2_env *env)
+{
+    struct smb2_oplock_req  breq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    struct smb2_conn       *a, *b;
+    uint8_t                 buf[32];
+    uint32_t                st, n;
+
+    printf("\n# D5 durable v1 DHnQ / DHnC (MS-SMB2 3.3.5.9.6, 3.3.5.9.7)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    mk_oplock(&breq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dhnq = 1;
+    st       = smb2_create_dur(a, "d5", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                               FILE_SHARE_RWD, &breq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dhnq,
+           "D5 BATCH + DHnQ grants durable v1 (st 0x%08x dhnq %d opl 0x%02x)",
+           st, o.has_dhnq, o.oplock);
+    if (st != ST_SUCCESS || !o.has_dhnq) {
+        return;
+    }
+    st = smb2_write(a, o.file_id, 0, "V1-PAYLOAD", 10, &n);
+    EXPECT(st == ST_SUCCESS, "D5 write through the v1 durable handle");
+
+    smb2_conn_disconnect(a);
+    b = smb2_conn_reopen(env, a);
+    smb2_quiesce(env);
+
+    memset(&dur, 0, sizeof(dur));
+    dur.dhnc = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    EXPECT(st == ST_SUCCESS, "D5 DHnC reclaim -> 0x%08x", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+    EXPECT(memcmp(r.file_id, o.file_id, 16) == 0,
+           "D5 the v1 reclaim carries the ORIGINAL FileId");
+    EXPECT(r.action == FILE_ACT_OPENED, "D5 CreateAction = OPENED (%u)", r.action);
+    memset(buf, 0, sizeof(buf));
+    st = smb2_read(b, r.file_id, 0, 10, buf, &n);
+    EXPECT(st == ST_SUCCESS && n == 10 && memcmp(buf, "V1-PAYLOAD", 10) == 0,
+           "D5 pre-drop data reads back through the v1 reclaim");
+
+    /* D5b -- does a v1-reclaimed handle park AGAIN?  D3b answered yes for a v2
+     * (DH2C) reclaim; the model needs the v1 answer too, and a generated trace
+     * disagreed with the model here, which is why this is measured rather than
+     * assumed. */
+    {
+        struct smb2_conn      *c2;
+        struct smb2_create_out r2;
+
+        smb2_conn_disconnect(b);
+        c2 = smb2_conn_reopen(env, b);
+        smb2_quiesce(env);
+        memset(&dur, 0, sizeof(dur));
+        dur.dhnc = 1;
+        memcpy(dur.file_id, o.file_id, 16);
+        st = smb2_create_dur(c2, "", FILE_OPEN, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD, NULL, &dur, &r2);
+        NOTE("D5b second DHnC reclaim after a second drop -> 0x%08x", st);
+        EXPECT(st == ST_SUCCESS &&
+               memcmp(r2.file_id, o.file_id, 16) == 0,
+               "D5b a v1-reclaimed handle parks and reclaims a SECOND time"
+               " (0x%08x)", st);
+        if (st == ST_SUCCESS) {
+            b = c2;
+            r = r2;
+        } else {
+            smb2_quiesce(env);
+            return;
+        }
+    }
+
+    /* D5c -- DHnC + DHnQ on one CREATE is explicitly legal, unlike DH2C +
+     * anything (3.3.5.9.7 vs 3.3.5.9.12).  What the reply then carries is the
+     * question the model has to answer: is the v1 REQUEST ignored outright, or
+     * does the reconnect report a durable grant back? */
+    {
+        struct smb2_conn      *c3;
+        struct smb2_create_out r3;
+
+        smb2_conn_disconnect(b);
+        c3 = smb2_conn_reopen(env, b);
+        smb2_quiesce(env);
+        memset(&dur, 0, sizeof(dur));
+        dur.dhnc = 1;
+        dur.dhnq = 1;
+        memcpy(dur.file_id, o.file_id, 16);
+        st = smb2_create_dur(c3, "", FILE_OPEN, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD, NULL, &dur, &r3);
+        NOTE("D5c DHnC + DHnQ reconnect -> 0x%08x dhnq_response %d", st,
+             r3.has_dhnq);
+        EXPECT(st == ST_SUCCESS,
+               "D5c DHnC + DHnQ is a legal reconnect (0x%08x)", st);
+        if (st == ST_SUCCESS) {
+            smb2_close(c3, r3.file_id);
+        }
+    }
+    smb2_quiesce(env);
+} /* sec_d5 */
+
+/* ------------------------------------------------------------------------
+ * D6 -- an open with NO durable request does not survive its connection.
+ *
+ * MS-SMB2 3.3.7.1: on a transport drop the server closes every open of the
+ * connection whose IsDurable/IsResilient/IsPersistent is FALSE.  Measured
+ * positively -- a conflicting exclusive open of the same file must succeed
+ * afterwards, which it cannot while the original handle lives.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d6(struct smb2_env *env)
+{
+    struct smb2_create_out o, r;
+    struct smb2_conn      *a, *b;
+    uint32_t               st;
+
+    printf("\n# D6 a non-durable open dies with its connection"
+           " (MS-SMB2 3.3.7.1)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+    /* ShareAccess NONE: while this handle lives, nobody else may open it. */
+    st = smb2_create(a, "d6", FILE_OPEN_IF, FILE_ALL_ACCESS, 0, NULL, &o);
+    EXPECT(st == ST_SUCCESS, "D6 exclusive-share open (st 0x%08x)", st);
+
+    b = smb2_conn_open(env);
+    smb2_handshake(b);
+    st = smb2_create(b, "d6", FILE_OPEN, FILE_ALL_ACCESS, 0, NULL, &r);
+    EXPECT(st == ST_SHARING_VIOLATION,
+           "D6 a second opener is refused while the handle lives (0x%08x)",
+           st);
+
+    smb2_conn_disconnect(a);
+    smb2_quiesce(env);
+
+    st = smb2_create(b, "d6", FILE_OPEN, FILE_ALL_ACCESS, 0, NULL, &r);
+    EXPECT(st == ST_SUCCESS,
+           "D6 the same open succeeds once the connection is gone (0x%08x)",
+           st);
+    if (st == ST_SUCCESS) {
+        smb2_close(b, r.file_id);
+    }
+    smb2_quiesce(env);
+} /* sec_d6 */
+
+/* ------------------------------------------------------------------------
+ * D7 -- a conflicting open against a PARKED durable-only holder.
+ *
+ * MS-SMB2 3.3.4.6 / 3.3.4.7: a durable open that is disconnected and whose
+ * batch oplock / write-caching lease must break has nobody to break it -- the
+ * server closes it and admits the opener.  chimera implements exactly that
+ * (chimera_smb_durable_purge_parked, the YIELDED flag), and the loser's later
+ * reclaim must then FAIL: the handle is gone, not merely busy.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d7(struct smb2_env *env)
+{
+    struct smb2_oplock_req  breq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    struct smb2_conn       *a, *b, *c;
+    uint32_t                st;
+
+    printf("\n# D7 conflicting open vs a parked durable-only holder"
+           " (MS-SMB2 3.3.4.6)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+    mk_oplock(&breq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x71);
+    st = smb2_create_dur(a, "d7", FILE_OPEN_IF, FILE_ALL_ACCESS, 0, &breq,
+                         &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q && o.oplock ==
+           SMB2_OPLOCK_LEVEL_BATCH,
+           "D7 durable BATCH holder with ShareAccess NONE (st 0x%08x opl"
+           " 0x%02x dh2q %d)", st, o.oplock, o.has_dh2q);
+    if (st != ST_SUCCESS || !o.has_dh2q) {
+        return;
+    }
+
+    smb2_conn_disconnect(a);
+    smb2_quiesce(env);
+
+    /* Serialize behind the park before letting a third party touch the file. */
+    c = smb2_conn_reopen(env, a);
+    wait_parked(c, o.file_id);
+
+    b = smb2_conn_open(env);
+    smb2_handshake(b);
+    {
+        int i0 = b->ninterim;
+
+        st = smb2_create(b, "d7", FILE_OPEN, FILE_ALL_ACCESS, 0, NULL, &r);
+        /* Does dissolving a parked holder cost an async interim?  chimera
+         * purges the parked holder and RETRIES the share check on a timer
+         * (smb_proc_create.c gen_share_retry), and a retried create announces
+         * itself first -- which the model has to predict, because `parked` is
+         * asserted field-for-field by the replayer. */
+        NOTE("D7 conflicting open against the parked durable holder -> 0x%08x"
+             " (interims %d)", st, b->ninterim - i0);
+    }
+    EXPECT(st == ST_SUCCESS,
+           "D7 a durable-only parked holder YIELDS to a conflicting open"
+           " (MS-SMB2 3.3.4.6; 0x%08x)", st);
+
+    /* The original client comes back: its handle was yielded, so the reclaim
+     * must fail rather than resurrect a handle the server already gave away. */
+    smb2_quiesce(env);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x71);
+    {
+        struct smb2_create_out r2;
+        uint32_t               st2 =
+            smb2_create_dur(c, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                            NULL, &dur, &r2);
+        EXPECT(st2 == ST_OBJECT_NAME_NOT_FOUND,
+               "D7 the yielded handle cannot be reclaimed (0x%08x)", st2);
+    }
+    if (st == ST_SUCCESS) {
+        smb2_close(b, r.file_id);
+    }
+    smb2_quiesce(env);
+
+    /* D7b -- the converse, and the one the MODEL turns on: an open that breaks
+     * nobody must not purge a parked holder either.  An attribute-only,
+     * non-truncating open takes no part in share arbitration and triggers no
+     * oplock break (MS-FSA 2.1.5.1; smb_proc_create.c break_for_open's
+     * break_trigger is exactly its inverse), so the parked handle must still be
+     * reclaimable afterwards.  Without this measurement the model's purge rule
+     * would be an inference rather than a fact. */
+    {
+        struct smb2_oplock_req  breq2;
+        struct smb2_durable_req dur2;
+        struct smb2_create_out  o2, r2;
+        struct smb2_conn       *h, *peer, *back;
+        uint32_t                st2;
+
+        h = smb2_conn_open(env);
+        smb2_handshake(h);
+        mk_oplock(&breq2, SMB2_OPLOCK_LEVEL_BATCH);
+        memset(&dur2, 0, sizeof(dur2));
+        dur2.dh2q = 1;
+        fill_guid(dur2.create_guid, 0x72);
+        st2 = smb2_create_dur(h, "d7b", FILE_OPEN_IF, FILE_ALL_ACCESS, 0,
+                              &breq2, &dur2, &o2);
+        EXPECT(st2 == ST_SUCCESS && o2.has_dh2q,
+               "D7b durable BATCH holder (st 0x%08x dh2q %d)", st2,
+               o2.has_dh2q);
+        smb2_conn_disconnect(h);
+        smb2_quiesce(env);
+        back = smb2_conn_reopen(env, h);
+        wait_parked(back, o2.file_id);
+
+        peer = smb2_conn_open(env);
+        smb2_handshake(peer);
+        /* FILE_READ_ATTRIBUTES only, FILE_OPEN: the attribute-only open. */
+        st2 = smb2_create(peer, "d7b", FILE_OPEN, 0x00000080u, 0, NULL, &r2);
+        NOTE("D7b attribute-only open against the parked holder -> 0x%08x",
+             st2);
+        EXPECT(st2 == ST_SUCCESS,
+               "D7b an attribute-only open succeeds (0x%08x)", st2);
+        if (st2 == ST_SUCCESS) {
+            smb2_close(peer, r2.file_id);
+        }
+        smb2_quiesce(env);
+
+        smb2_quiesce(env);
+        memset(&dur2, 0, sizeof(dur2));
+        dur2.dh2c = 1;
+        memcpy(dur2.file_id, o2.file_id, 16);
+        fill_guid(dur2.create_guid, 0x72);
+        st2 = smb2_create_dur(back, "", FILE_OPEN, FILE_ALL_ACCESS,
+                              FILE_SHARE_RWD, NULL, &dur2, &r2);
+        NOTE("D7b reclaim after an attribute-only open -> 0x%08x", st2);
+        EXPECT(st2 == ST_SUCCESS,
+               "D7b an open that breaks nobody does NOT purge the parked"
+               " handle (0x%08x)", st2);
+        if (st2 == ST_SUCCESS) {
+            smb2_close(back, r2.file_id);
+        }
+        smb2_quiesce(env);
+    }
+
+    /* D7c -- a COMPATIBLE open against a parked durable LEASE holder.
+     *
+     * D7 purged the parked holder with an open that share-CONFLICTED with it;
+     * D7b left it alone with an open that broke nobody.  The case in between is
+     * the one a generated trace tripped over: an open that shares everything
+     * (so no sharing violation) but is not attribute-only (so it does trigger a
+     * break).  Two things are measured, and the model needs both: what lease
+     * state the NEW opener is granted -- i.e. whether the parked holder still
+     * counts for the sole-opener rule of MS-FSA 2.1.5.18.1 -- and whether the
+     * parked handle survives to be reclaimed. */
+    {
+        struct smb2_oplock_req  lreq3, lreq3b;
+        struct smb2_durable_req dur3;
+        struct smb2_create_out  o3, n3, r3;
+        struct smb2_conn       *h3, *peer3, *back3;
+        uint32_t                st3;
+
+        h3 = smb2_conn_open(env);
+        smb2_handshake(h3);
+        mk_lease(&lreq3, 0x73, SMB2_LEASE_RWH);
+        memset(&dur3, 0, sizeof(dur3));
+        dur3.dh2q = 1;
+        fill_guid(dur3.create_guid, 0x73);
+        st3 = smb2_create_dur(h3, "d7c", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                              FILE_SHARE_RWD, &lreq3, &dur3, &o3);
+        EXPECT(st3 == ST_SUCCESS && o3.has_dh2q,
+               "D7c durable RWH-lease holder (st 0x%08x lease %s dh2q %d)",
+               st3, o3.has_lease ? lease_str(o3.lease_state) : "-",
+               o3.has_dh2q);
+        smb2_conn_disconnect(h3);
+        smb2_quiesce(env);
+        back3 = smb2_conn_reopen(env, h3);
+        wait_parked(back3, o3.file_id);
+
+        peer3 = smb2_conn_open(env);
+        smb2_handshake(peer3);
+        mk_lease(&lreq3b, 0x74, SMB2_LEASE_RWH);
+        st3 = smb2_create_dur(peer3, "d7c", FILE_OPEN, FILE_ALL_ACCESS,
+                              FILE_SHARE_RWD, &lreq3b, NULL, &n3);
+        NOTE("D7c compatible RWH-lease open behind the parked holder ->"
+             " st 0x%08x lease %s", st3,
+             n3.has_lease ? lease_str(n3.lease_state) : "-");
+        EXPECT(st3 == ST_SUCCESS, "D7c the compatible open succeeds (0x%08x)",
+               st3);
+
+        memset(&dur3, 0, sizeof(dur3));
+        dur3.dh2c = 1;
+        memcpy(dur3.file_id, o3.file_id, 16);
+        fill_guid(dur3.create_guid, 0x73);
+        st3 = smb2_create_dur(back3, "", FILE_OPEN, FILE_ALL_ACCESS,
+                              FILE_SHARE_RWD, &lreq3, &dur3, &r3);
+        NOTE("D7c reclaim after a COMPATIBLE open -> 0x%08x", st3);
+        if (st3 == ST_SUCCESS) {
+            smb2_close(back3, r3.file_id);
+        }
+        if (n3.status == ST_SUCCESS) {
+            smb2_close(peer3, n3.file_id);
+        }
+        smb2_quiesce(env);
+    }
+
+    /* D7d / D7e -- WHICH parked holders a compatible open dissolves.
+     *
+     * D7c's parked holder held a WRITE cache (an RWH lease), and the opener
+     * both got the full RWH lease and left nothing behind to reclaim.  The
+     * question the model cannot answer without measuring is whether that is
+     * because the open was compatible, or because the parked holder held a
+     * write cache that the caching-acquire path had to revoke -- a distinction
+     * a generated trace ran straight into, granting RWH where the wire granted
+     * RH.  These two rows separate the variables: same compatible opener, one
+     * parked holder WITH a write cache (batch oplock) and one WITHOUT (an RH
+     * lease). */
+    {
+        /* *INDENT-OFF* */ /* uncrustify oscillates on aligned init tables */
+        struct {
+            const char *label;
+            const char *name;
+            int         holder_is_lease;
+            uint32_t    holder_lease;   /* when holder_is_lease */
+            int         key;
+        } rows[] = {
+            { "parked RH lease (no write cache)",  "d7d",  1,
+              SMB2_LEASE_READ | SMB2_LEASE_HANDLE, 0x75 },
+            { "parked BATCH oplock (write cache)", "d7e",  0, 0, 0x76 },
+        };
+        /* *INDENT-ON* */
+
+        for (int i = 0; i < 2; i++) {
+            struct smb2_oplock_req  hreq, preq;
+            struct smb2_durable_req d4;
+            struct smb2_create_out  o4, n4, r4;
+            struct smb2_conn       *h4, *peer4, *back4;
+            uint32_t                st4;
+
+            h4 = smb2_conn_open(env);
+            smb2_handshake(h4);
+            if (rows[i].holder_is_lease) {
+                mk_lease(&hreq, rows[i].key, rows[i].holder_lease);
+            } else {
+                mk_oplock(&hreq, SMB2_OPLOCK_LEVEL_BATCH);
+            }
+            memset(&d4, 0, sizeof(d4));
+            d4.dh2q = 1;
+            fill_guid(d4.create_guid, rows[i].key);
+            st4 = smb2_create_dur(h4, rows[i].name, FILE_OPEN_IF,
+                                  FILE_ALL_ACCESS, FILE_SHARE_RWD, &hreq, &d4,
+                                  &o4);
+            EXPECT(st4 == ST_SUCCESS && o4.has_dh2q,
+                   "D7%c durable holder, %s (st 0x%08x dh2q %d)",
+                   'd' + i, rows[i].label, st4, o4.has_dh2q);
+            if (st4 != ST_SUCCESS || !o4.has_dh2q) {
+                continue;
+            }
+            smb2_conn_disconnect(h4);
+            smb2_quiesce(env);
+            back4 = smb2_conn_reopen(env, h4);
+            wait_parked(back4, o4.file_id);
+
+            /* A fully compatible open (shares everything) that is NOT
+             * attribute-only, asking for the strongest lease. */
+            peer4 = smb2_conn_open(env);
+            smb2_handshake(peer4);
+            mk_lease(&preq, rows[i].key + 0x40, SMB2_LEASE_RWH);
+            {
+                int i4 = peer4->ninterim;
+
+                st4 = smb2_create_dur(peer4, rows[i].name, FILE_OPEN,
+                                      FILE_ALL_ACCESS, FILE_SHARE_RWD, &preq,
+                                      NULL, &n4);
+                NOTE("D7%c compatible RWH-lease open behind %s -> st 0x%08x"
+                     " granted %s (interims %d)", 'd' + i, rows[i].label, st4,
+                     n4.has_lease ? lease_str(n4.lease_state) : "-",
+                     peer4->ninterim - i4);
+            }
+
+            memset(&d4, 0, sizeof(d4));
+            d4.dh2c = 1;
+            memcpy(d4.file_id, o4.file_id, 16);
+            fill_guid(d4.create_guid, rows[i].key);
+            st4 = smb2_create_dur(back4, "", FILE_OPEN, FILE_ALL_ACCESS,
+                                  FILE_SHARE_RWD,
+                                  rows[i].holder_is_lease ? &hreq : NULL, &d4,
+                                  &r4);
+            NOTE("D7%c reclaim after that open -> 0x%08x (%s)", 'd' + i, st4,
+                 st4 == ST_SUCCESS ? "SURVIVED" : "PURGED");
+            if (st4 == ST_SUCCESS) {
+                smb2_close(back4, r4.file_id);
+            }
+            if (n4.status == ST_SUCCESS) {
+                smb2_close(peer4, n4.file_id);
+            }
+            smb2_quiesce(env);
+        }
+    }
+
+    /* D7f -- a SHARE-CONFLICTING open against a parked holder that has no
+     * write cache.  D7 purged such an opener's way through a write-cache
+     * holder; D7d showed a non-write-cache holder survives a COMPATIBLE open
+     * and caps it.  The remaining corner is the conflicting open against the
+     * surviving kind: does the parked holder's share reservation refuse it, or
+     * does the share path purge the holder the way it does a write-cache one? */
+    {
+        struct smb2_oplock_req  hreq;
+        struct smb2_durable_req d5;
+        struct smb2_create_out  o5, n5, r5;
+        struct smb2_conn       *h5, *peer5, *back5;
+        uint32_t                st5;
+
+        h5 = smb2_conn_open(env);
+        smb2_handshake(h5);
+        mk_lease(&hreq, 0x77, SMB2_LEASE_READ | SMB2_LEASE_HANDLE);
+        memset(&d5, 0, sizeof(d5));
+        d5.dh2q = 1;
+        fill_guid(d5.create_guid, 0x77);
+        /* ShareAccess NONE: while this handle counts, nobody else may open. */
+        st5 = smb2_create_dur(h5, "d7f", FILE_OPEN_IF, FILE_ALL_ACCESS, 0,
+                              &hreq, &d5, &o5);
+        EXPECT(st5 == ST_SUCCESS && o5.has_dh2q,
+               "D7f durable RH-lease holder, ShareAccess NONE (st 0x%08x"
+               " lease %s dh2q %d)", st5,
+               o5.has_lease ? lease_str(o5.lease_state) : "-", o5.has_dh2q);
+        if (st5 == ST_SUCCESS && o5.has_dh2q) {
+            smb2_conn_disconnect(h5);
+            smb2_quiesce(env);
+            back5 = smb2_conn_reopen(env, h5);
+            wait_parked(back5, o5.file_id);
+
+            peer5 = smb2_conn_open(env);
+            smb2_handshake(peer5);
+            {
+                int i5 = peer5->ninterim;
+
+                st5 = smb2_create(peer5, "d7f", FILE_OPEN, FILE_ALL_ACCESS, 0,
+                                  NULL, &n5);
+                NOTE("D7f share-conflicting open behind a parked RH holder ->"
+                     " 0x%08x (interims %d)", st5, peer5->ninterim - i5);
+            }
+
+            memset(&d5, 0, sizeof(d5));
+            d5.dh2c = 1;
+            memcpy(d5.file_id, o5.file_id, 16);
+            fill_guid(d5.create_guid, 0x77);
+            st5 = smb2_create_dur(back5, "", FILE_OPEN, FILE_ALL_ACCESS,
+                                  FILE_SHARE_RWD, &hreq, &d5, &r5);
+            NOTE("D7f reclaim after that open -> 0x%08x (%s)", st5,
+                 st5 == ST_SUCCESS ? "SURVIVED" : "PURGED");
+            if (st5 == ST_SUCCESS) {
+                smb2_close(back5, r5.file_id);
+            }
+            if (n5.status == ST_SUCCESS) {
+                smb2_close(peer5, n5.file_id);
+            }
+            smb2_quiesce(env);
+        }
+    }
+} /* sec_d7 */
+
+/* ------------------------------------------------------------------------
+ * D8 -- the disconnect-survival deadline is enforced.
+ *
+ * MS-SMB2 3.3.7.1: the preserved open is discarded once Open.DurableTimeout
+ * has elapsed since the disconnect.  This is the ONE assertion in the SMB
+ * suite that involves elapsed time, and it is written so that no verdict can
+ * turn on a guess: the handle is granted a 1 ms timeout, and the reclaim is
+ * only attempted after CLOCK_MONOTONIC has PROVABLY advanced past the
+ * deadline by a wide margin.  Waiting longer never changes the answer (the
+ * entry is gone for good), so the test cannot flake in either direction --
+ * unlike a fixed sleep chosen to be "probably enough".
+ * ------------------------------------------------------------------------ */
+static void
+sec_d8(struct smb2_env *env)
+{
+    struct smb2_oplock_req  breq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    struct smb2_conn       *a, *b;
+    uint32_t                st;
+    uint64_t                t0;
+
+    printf("\n# D8 durable timeout expiry (MS-SMB2 3.3.7.1)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+    mk_oplock(&breq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q       = 1;
+    dur.timeout_ms = 1;                 /* the shortest grantable window */
+    fill_guid(dur.create_guid, 0x81);
+    st = smb2_create_dur(a, "d8", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &breq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q,
+           "D8 durable open with a 1 ms timeout (granted %u ms)",
+           o.dh2q_timeout);
+    if (st != ST_SUCCESS || !o.has_dh2q) {
+        return;
+    }
+    EXPECT(o.dh2q_timeout == 1,
+           "D8 a 1 ms request is honored verbatim (%u)", o.dh2q_timeout);
+
+    smb2_conn_disconnect(a);
+    t0 = smb2c_now_ms();
+    b  = smb2_conn_reopen(env, a);
+    /* Drive the server while the (monotonic) clock passes the deadline by
+     * two orders of magnitude.  The wait is bounded from BELOW by a proven
+     * elapsed interval, which is what makes the expectation sound. */
+    while (smb2c_now_ms() - t0 < 200) {
+        smb2_quiesce(env);
+    }
+
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0x81);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "D8 a reclaim %llu ms after a 1 ms timeout is refused (0x%08x)",
+           (unsigned long long) (smb2c_now_ms() - t0), st);
+    smb2_quiesce(env);
+} /* sec_d8 */
+
+/* ------------------------------------------------------------------------
+ * D9 -- replay (MS-SMB2 3.3.5.9.10, 3.2.4.1.5).
+ *
+ * A replay on the wire is a FRESH MessageId carrying
+ * SMB2_FLAGS_REPLAY_OPERATION, correlated to the original by the DH2Q
+ * CreateGuid -- re-sending the original MessageId is a sequence-window
+ * violation that costs the connection (DEVIATIONS-SMB.md R-10), so it is not
+ * a retry mechanism.  Two facts are pinned here: the eligibility window is
+ * exactly one operation wide, and a replay that collides with a still-live
+ * open of the same CreateGuid on another connection is
+ * STATUS_DUPLICATE_OBJECTID.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d9(struct smb2_env *env)
+{
+    struct smb2_oplock_req  lreq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o1, o2, o3;
+    struct smb2_conn       *a, *b;
+    uint32_t                st, n;
+
+    printf("\n# D9 replay: REPLAY_OPERATION + DH2Q CreateGuid"
+           " (MS-SMB2 3.3.5.9.10)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* (a) replay with nothing in between: the SAME open comes back, and the
+     * ORIGINAL CreateAction is echoed. */
+    mk_lease(&lreq, 0x91, SMB2_LEASE_RWH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x91);
+    st = smb2_create_dur(a, "d9a", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &o1);
+    EXPECT(st == ST_SUCCESS && o1.action == FILE_ACT_CREATED,
+           "D9a original create (st 0x%08x action %u)", st, o1.action);
+
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "d9a", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &o2);
+    EXPECT(st == ST_SUCCESS && memcmp(o1.file_id, o2.file_id, 16) == 0,
+           "D9a an immediate replay returns the SAME FileId (0x%08x)", st);
+    EXPECT(o2.action == o1.action,
+           "D9a the replay echoes the ORIGINAL CreateAction (%u vs %u)",
+           o2.action, o1.action);
+
+    /* (b) the eligibility window closes on the first non-replay operation. */
+    st = smb2_write(a, o1.file_id, 0, "x", 1, &n);
+    EXPECT(st == ST_SUCCESS, "D9b an ordinary WRITE on the handle");
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "d9a", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &o3);
+    NOTE("D9b replay after an intervening op -> st 0x%08x same_fid %d", st,
+         st == ST_SUCCESS && memcmp(o1.file_id, o3.file_id, 16) == 0);
+    EXPECT(st != ST_SUCCESS || memcmp(o1.file_id, o3.file_id, 16) != 0,
+           "D9b replay eligibility is ONE operation wide: the replay no"
+           " longer resolves to the original handle");
+    if (st == ST_SUCCESS) {
+        smb2_close(a, o3.file_id);
+    }
+
+    /* (c) a replay from ANOTHER connection of the same client while the
+     * original is still live: STATUS_DUPLICATE_OBJECTID. */
+    b = smb2_conn_reopen_raw(env, a);   /* same ClientGuid, new connection */
+    smb2_handshake(b);
+    {
+        struct smb2_oplock_req  l2;
+        struct smb2_durable_req d2;
+        struct smb2_create_out  c1, c2;
+
+        mk_lease(&l2, 0x92, SMB2_LEASE_RWH);
+        memset(&d2, 0, sizeof(d2));
+        d2.dh2q = 1;
+        fill_guid(d2.create_guid, 0x92);
+        st = smb2_create_dur(a, "d9c", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD, &l2, &d2, &c1);
+        EXPECT(st == ST_SUCCESS && c1.has_dh2q,
+               "D9c live durable open on connection A (st 0x%08x)", st);
+        smb2c_set_next_flags(b, SMB2_FLAGS_REPLAY_OPERATION);
+        st = smb2_create_dur(b, "d9c", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD, &l2, &d2, &c2);
+        NOTE("D9c cross-connection replay of a LIVE durable open -> 0x%08x",
+             st);
+        EXPECT(st == ST_DUPLICATE_OBJECTID,
+               "D9c a replay colliding with a live open of the same"
+               " CreateGuid -> DUPLICATE_OBJECTID (0x%08x)", st);
+        smb2_close(a, c1.file_id);
+    }
+    smb2_close(a, o1.file_id);
+    smb2_quiesce(env);
+} /* sec_d9 */
+
+/* ------------------------------------------------------------------------
+ * D10 -- FSCTL_LMR_REQUEST_RESILIENCY (MS-SMB2 2.2.31.3, 3.3.5.15.9).
+ *
+ * Resiliency is the pre-SMB3 way to ask for disconnect survival: it is
+ * requested AFTER the create, on an already-open handle, and -- unlike a
+ * durable request -- has NO caching precondition.  chimera implements it over
+ * the same durable registry, so a resilient open parks on a drop and is
+ * reclaimed with a DHnC (there is no CreateGuid to key a v2 reconnect on).
+ * ------------------------------------------------------------------------ */
+static void
+sec_d10(struct smb2_env *env)
+{
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    struct smb2_conn       *a, *b;
+    uint8_t                 buf[32];
+    uint8_t                 shortbuf[4];
+    uint32_t                st, n;
+
+    printf("\n# D10 FSCTL_LMR_REQUEST_RESILIENCY (MS-SMB2 3.3.5.15.9)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* No oplock, no lease, no durable context: resiliency has no caching
+     * precondition, which is exactly what distinguishes it from D1. */
+    st = smb2_create(a, "d10", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS, "D10 plain open (st 0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* A NETWORK_RESILIENCY_REQUEST shorter than 8 bytes is malformed. */
+    memset(shortbuf, 0, sizeof(shortbuf));
+    st = smb2_ioctl(a, SMB2_FSCTL_LMR_REQUEST_RESILIENCY, o.file_id, shortbuf,
+                    sizeof(shortbuf));
+    EXPECT(st == ST_INVALID_PARAMETER,
+           "D10 a 4-byte NETWORK_RESILIENCY_REQUEST -> INVALID_PARAMETER"
+           " (0x%08x)", st);
+
+    /* A Timeout above the server maximum MUST be refused, not clamped
+     * (MS-SMB2 3.3.5.15.9). */
+    st = smb2_resiliency(a, o.file_id, SMB2C_RESILIENCY_MAX_MS + 1);
+    EXPECT(st == ST_INVALID_PARAMETER,
+           "D10 Timeout above the maximum -> INVALID_PARAMETER (0x%08x)", st);
+
+    /* Timeout 0 selects the server default; the grant reports only SUCCESS. */
+    st = smb2_resiliency(a, o.file_id, 0);
+    EXPECT(st == ST_SUCCESS, "D10 resiliency granted, Timeout 0 (0x%08x)", st);
+
+    st = smb2_write(a, o.file_id, 0, "RESILIENT!", 10, &n);
+    EXPECT(st == ST_SUCCESS, "D10 write through the resilient handle");
+
+    smb2_conn_disconnect(a);
+    b = smb2_conn_reopen(env, a);
+    smb2_quiesce(env);
+
+    memset(&dur, 0, sizeof(dur));
+    dur.dhnc = 1;
+    memcpy(dur.file_id, o.file_id, 16);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    NOTE("D10 DHnC reclaim of a RESILIENT (not durable) handle -> 0x%08x", st);
+    EXPECT(st == ST_SUCCESS,
+           "D10 a resilient open survives its connection and is reclaimed"
+           " (MS-SMB2 3.3.5.15.9; 0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        smb2_quiesce(env);
+        return;
+    }
+    EXPECT(memcmp(r.file_id, o.file_id, 16) == 0,
+           "D10 the resilient reclaim carries the ORIGINAL FileId");
+    memset(buf, 0, sizeof(buf));
+    st = smb2_read(b, r.file_id, 0, 10, buf, &n);
+    EXPECT(st == ST_SUCCESS && n == 10 && memcmp(buf, "RESILIENT!", 10) == 0,
+           "D10 pre-drop data reads back through the resilient reclaim");
+    smb2_close(b, r.file_id);
+    smb2_quiesce(env);
+} /* sec_d10 */
+
+/* ------------------------------------------------------------------------
+ * D11 -- persistent handles on a continuously-available share.
+ *
+ * MS-SMB2 3.3.5.9.10: SMB2_DHANDLE_FLAG_PERSISTENT is honored only when the
+ * share has SHARE_CAP_CONTINUOUS_AVAILABILITY, and then the grant reports the
+ * flag back.  3.3.4.6 / chimera_smb_durable_parked_hold: a PARKED persistent
+ * holder does not yield to a conflicting opener the way a durable-only one
+ * does (D7) -- it blocks it, because a CA handle is supposed to be recoverable
+ * even across a client outage.
+ *
+ * Runs on its own server instance: continuous availability is a share
+ * property fixed at chimera_server_create_share time.
+ * ------------------------------------------------------------------------ */
+static void
+sec_d11(void)
+{
+    struct smb2_env         env;
+    struct smb2_env_opts    opts = { .oplocks                 = 1,
+                                     .leases                  = 1,
+                                     .directory_leases        = 1,
+                                     .persistent_handles      = 1,
+                                     .continuous_availability = 1 };
+    struct smb2_oplock_req  breq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    struct smb2_conn       *a, *b, *cc;
+    uint32_t                st;
+
+    printf("\n# D11 persistent handles on a CA share (MS-SMB2 3.3.5.9.10)\n");
+
+    smb2_env_start_opts(&env, &opts);
+    a = smb2_conn_open(&env);
+    smb2_handshake(a);
+
+    mk_oplock(&breq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q  = 1;
+    dur.flags = SMB2_DHANDLE_FLAG_PERSISTENT;
+    fill_guid(dur.create_guid, 0xB1);
+    st = smb2_create_dur(a, "d11", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &breq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q,
+           "D11 DH2Q with FLAG_PERSISTENT on a CA share (st 0x%08x dh2q %d)",
+           st, o.has_dh2q);
+    if (st != ST_SUCCESS || !o.has_dh2q) {
+        smb2_env_stop(&env);
+        return;
+    }
+    NOTE("D11 granted timeout %u ms flags 0x%08x", o.dh2q_timeout,
+         o.dh2q_flags);
+    EXPECT((o.dh2q_flags & SMB2_DHANDLE_FLAG_PERSISTENT) != 0,
+           "D11 the grant reports FLAG_PERSISTENT back (0x%08x)",
+           o.dh2q_flags);
+
+    smb2_conn_disconnect(a);
+    smb2_quiesce(&env);
+    b = smb2_conn_reopen(&env, a);
+    wait_parked(b, o.file_id);
+
+    /* A conflicting opener meets a PARKED PERSISTENT holder.  Unlike the
+     * durable-only holder of D7, it must not simply take the file. */
+    cc = smb2_conn_open(&env);
+    smb2_handshake(cc);
+    st = smb2_create(cc, "d11", FILE_OPEN, FILE_ALL_ACCESS, 0, NULL, &r);
+    NOTE("D11 conflicting open against a parked PERSISTENT holder -> 0x%08x",
+         st);
+    EXPECT(st != ST_SUCCESS,
+           "D11 a parked persistent holder does NOT yield the file"
+           " (0x%08x)", st);
+    if (st == ST_SUCCESS) {
+        smb2_close(cc, r.file_id);
+    }
+
+    /* The owning client reclaims with FLAG_PERSISTENT. */
+    smb2_quiesce(&env);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c            = 1;
+    dur.reconnect_flags = SMB2_DHANDLE_FLAG_PERSISTENT;
+    memcpy(dur.file_id, o.file_id, 16);
+    fill_guid(dur.create_guid, 0xB1);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    EXPECT(st == ST_SUCCESS,
+           "D11 persistent reclaim with FLAG_PERSISTENT -> 0x%08x", st);
+    if (st == ST_SUCCESS) {
+        EXPECT(memcmp(r.file_id, o.file_id, 16) == 0,
+               "D11 the persistent reclaim carries the ORIGINAL FileId");
+        smb2_close(b, r.file_id);
+    }
+
+    smb2_quiesce(&env);
+    smb2_env_stop(&env);
+} /* sec_d11 */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct smb2_env      env;
+    struct smb2_env_opts opts = { .oplocks            = 1,
+                                  .leases             = 1,
+                                  .directory_leases   = 1,
+                                  .persistent_handles = 1 };
+    struct smb2_conn    *a, *seed, *b;
+
+    (void) argc;
+    (void) argv;
+
+    smb2_env_start_opts(&env, &opts);
+    a = smb2_conn_open(&env);
+    smb2_handshake(a);
+    printf("# durable probe up; dialect=0x%04x, persistent_handles on,"
+           " continuous_availability off\n", a->dialect);
+
+    sec_d1(&env, a);
+    sec_d2(&env, a);
+
+    /* D3 consumes its connection (it disconnects it), so it gets its own. */
+    seed = smb2_conn_open(&env);
+    smb2_handshake(seed);
+    b = sec_d3(&env, seed);
+    if (b) {
+        smb2_quiesce(&env);
+    }
+
+    seed = smb2_conn_open(&env);
+    smb2_handshake(seed);
+    sec_d4(&env, seed);
+
+    sec_d5(&env);
+    sec_d6(&env);
+    sec_d7(&env);
+    sec_d8(&env);
+    sec_d9(&env);
+    sec_d10(&env);
+
+    smb2_env_stop(&env);
+
+    sec_d11();
+
+    printf("\n# summary: %d recorded deviation(s) (see DEVIATIONS-SMB.md)\n",
+           ndev);
+    if (nfail) {
+        fprintf(stderr, "%d durable-handle MANDATE check(s) FAILED\n", nfail);
+        return 1;
+    }
+    printf("all SMB2 durable/persistent/resilient mandate checks passed"
+           " (%d documented deviation(s))\n", ndev);
+    return 0;
+} /* main */

--- a/src/server/smb/tests/quint/smb2_mbt_common.h
+++ b/src/server/smb/tests/quint/smb2_mbt_common.h
@@ -301,6 +301,23 @@ struct smb2_env_opts {
     int continuous_availability;
 };
 
+/* Do the two profiles configure the server identically?  Compared field by
+ * field rather than with memcmp: the struct has padding, and a bytewise
+ * compare would silently start reporting spurious differences the moment a
+ * field of another width is added. */
+static inline int
+smb2_env_opts_eq(
+    const struct smb2_env_opts *a,
+    const struct smb2_env_opts *b)
+{
+    return a->oplocks == b->oplocks &&
+           a->leases == b->leases &&
+           a->directory_leases == b->directory_leases &&
+           a->persistent_handles == b->persistent_handles &&
+           a->force_level2 == b->force_level2 &&
+           a->continuous_availability == b->continuous_availability;
+} /* smb2_env_opts_eq */
+
 /* Connections are never recycled: a transport drop RETIRES a connection (it
  * keeps its slot so its struct outlives evpl_destroy) and the reconnect takes a
  * fresh one, so a long durable/replay walk consumes one slot per drop.
@@ -920,6 +937,22 @@ smb2c_set_context(const char *ctx)
 /* Build the 4-byte NetBIOS header + 64-byte SMB2 header into c->sbuf for
  * `command`; zero a generous body region so all Reserved bytes are clean;
  * returns the offset of the body (== 4 + SMB2_HDR_SIZE). */
+/* Report a request built with no connection and die.  Marked noreturn so both
+ * the reader and the static analyzer know the dereference below it is
+ * unreachable with a NULL connection -- otherwise every builder that touches
+ * c->sbuf after calling smb2c_begin looks like a null dereference. */
+__attribute__((noreturn))
+static inline void
+smb2c_no_conn(uint16_t command)
+{
+    fprintf(stderr,
+            "smb2 harness: BUG -- request 0x%04x built with no connection"
+            "%s%s\n", command,
+            smb2c_context_str ? "\n  while replaying: " : "",
+            smb2c_context_str ? smb2c_context_str : "");
+    exit(5);
+} /* smb2c_no_conn */
+
 static inline int
 smb2c_begin(
     struct smb2_conn *c,
@@ -936,12 +969,7 @@ smb2c_begin(
     * crash and is not one.  Fail here instead, naming the command and the
     * replay context, so the caller's bookkeeping bug is the diagnosis. */
     if (!c) {
-        fprintf(stderr,
-                "smb2 harness: BUG -- request 0x%04x built with no connection"
-                "%s%s\n", command,
-                smb2c_context_str ? "\n  while replaying: " : "",
-                smb2c_context_str ? smb2c_context_str : "");
-        exit(5);
+        smb2c_no_conn(command);
     }
 
     h = c->sbuf + 4;            /* SMB2 header start */
@@ -2118,8 +2146,15 @@ smb2_set_info(
     const void       *buf,
     uint32_t          buf_len)
 {
-    int      b       = smb2c_begin(c, SMB2_SET_INFO, 0);
-    uint8_t *body    = c->sbuf + b;
+    int      b;
+    uint8_t *body;
+
+    if (!c) {
+        smb2c_no_conn(SMB2_SET_INFO);
+    }
+
+    b    = smb2c_begin(c, SMB2_SET_INFO, 0);
+    body = c->sbuf + b;
     int      buf_off = SMB2_HDR_SIZE + 32;
 
     p16(body, 0, 33);                  /* StructureSize */

--- a/src/server/smb/tests/quint/smb2_mbt_common.h
+++ b/src/server/smb/tests/quint/smb2_mbt_common.h
@@ -847,6 +847,11 @@ smb2_conn_reset(struct smb2_env *env)
     for (int i = 0; i < env->nconns; i++) {
         free(env->conns[i]->sbuf);
         free(env->conns[i]->rbuf);
+        /* xbuf too -- smb2_conn_open allocates three buffers per connection.
+         * Missing it leaks SMB2C_BUFSZ per connection, which a batched run
+         * that resets its connections once per trace turns into hundreds of
+         * megabytes. */
+        free(env->conns[i]->xbuf);
         free(env->conns[i]);
     }
     env->nconns = 0;

--- a/src/server/smb/tests/quint/smb2_mbt_common.h
+++ b/src/server/smb/tests/quint/smb2_mbt_common.h
@@ -52,6 +52,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <time.h>
 
 #include "server/server.h"
 #include "common/tcp_flavor.h"
@@ -74,12 +75,22 @@
 #define SMB2_FLUSH                        0x0007
 #define SMB2_READ                         0x0008
 #define SMB2_WRITE                        0x0009
+#define SMB2_IOCTL                        0x000B
+#define SMB2_CANCEL                       0x000C
+#define SMB2_LOCK                         0x000A
+#define SMB2_QUERY_INFO                   0x0010
+#define SMB2_SET_INFO                     0x0011
+#define SMB2_ECHO                         0x000D
 #define SMB2_OPLOCK_BREAK                 0x0012
 
 /* smb2 header flags (smb2.h:789) */
 #define SMB2_FLAGS_SERVER_TO_REDIR        0x00000001
 #define SMB2_FLAGS_ASYNC_COMMAND          0x00000002
 #define SMB2_FLAGS_RELATED_OPERATIONS     0x00000004
+/* MS-SMB2 2.2.1.2: the client sets this on a request it is RE-SENDING after a
+ * channel/transport failure, so the server can apply exactly-once semantics.
+ * Note the value: 0x20000000, NOT 0x00000020 (smb2.h:795). */
+#define SMB2_FLAGS_REPLAY_OPERATION       0x20000000
 
 /* NTSTATUS (MS-ERREF) */
 #define ST_SUCCESS                        0x00000000u
@@ -91,6 +102,22 @@
 #define ST_INVALID_DEVICE_STATE           0xC0000184u
 #define ST_INVALID_OPLOCK_PROTOCOL        0xC00000E3u
 #define ST_REQUEST_NOT_ACCEPTED           0xC00000D0u
+#define ST_END_OF_FILE                    0xC0000011u
+#define ST_ACCESS_DENIED                  0xC0000022u
+#define ST_OBJECT_NAME_NOT_FOUND          0xC0000034u
+#define ST_OBJECT_NAME_COLLISION          0xC0000035u
+#define ST_OBJECT_PATH_NOT_FOUND          0xC000003Au
+#define ST_NOT_SUPPORTED                  0xC00000BBu
+#define ST_CANCELLED                      0xC0000120u
+#define ST_FILE_CLOSED                    0xC0000128u
+/* 0xC000022A, STATUS_DUPLICATE_OBJECTID -- the reply to a NON-replay CREATE
+* whose DH2Q CreateGuid collides with a live durable open of the same client
+* (MS-SMB2 3.3.5.9.10).  It is NOT 0xC000021B (STATUS_DATA_NOT_ACCEPTED). */
+#define ST_DUPLICATE_OBJECTID             0xC000022Au
+/* 0xC0000467, STATUS_FILE_NOT_AVAILABLE -- a stale ChannelSequence on a
+ * mutating op (MS-SMB2 3.3.5.2.10), and a replayed create whose original is
+ * still pending (3.3.5.9.10). */
+#define ST_FILE_NOT_AVAILABLE             0xC0000467u
 
 /* Dialects (smb2.h:20) */
 #define SMB2_DIALECT_0210                 0x0210
@@ -129,6 +156,7 @@
 #define FILE_OVERWRITE                    0x00000004u
 #define FILE_OVERWRITE_IF                 0x00000005u
 #define FILE_ALL_ACCESS                   0x001F01FFu
+#define FILE_READ_ATTRIBUTES              0x00000080u /* attribute-only access */
 #define FILE_READ_ACCESS                  0x00120089u /* R data/attr/EA + SYNC */
 #define FILE_WRITE_ACCESS                 0x00120116u /* W data/attr/EA + SYNC */
 #define FILE_ATTRIBUTE_NORMAL             0x00000080u
@@ -145,6 +173,32 @@
 #define FILE_ACT_OPENED                   1
 #define FILE_ACT_CREATED                  2
 #define FILE_ACT_OVERWRITTEN              3
+
+/* Durable-handle context Flags (MS-SMB2 2.2.13.2.11). */
+#define SMB2_DHANDLE_FLAG_PERSISTENT      0x00000002u
+
+/* FSCTL codes + the IOCTL IsFsctl flag (MS-SMB2 2.2.31). */
+/* SMB2_LOCK_ELEMENT Flags (MS-SMB2 2.2.26.1). */
+#define SMB2_LOCKFLAG_SHARED              0x00000001u
+#define SMB2_LOCKFLAG_EXCLUSIVE           0x00000002u
+#define SMB2_LOCKFLAG_UNLOCK              0x00000004u
+#define SMB2_LOCKFLAG_FAIL_IMMEDIATELY    0x00000010u
+
+#define ST_LOCK_NOT_GRANTED               0xC0000055u
+#define ST_FILE_LOCK_CONFLICT             0xC0000054u
+
+#define SMB2_FSCTL_SET_SPARSE             0x000900C4u
+#define SMB2_FSCTL_LMR_REQUEST_RESILIENCY 0x001401D4u
+#define SMB2C_IOCTL_IS_FSCTL              1u
+
+/* chimera's own resiliency/durable policy constants, mirrored here so a probe
+ * asserts against a NAMED policy rather than a magic number (smb2.h:1073,
+ * smb_proc_create.c).  A probe that disagrees with these is a finding. */
+#define SMB2C_RESILIENCY_DEFAULT_MS       120000u
+#define SMB2C_RESILIENCY_MAX_MS           300000u
+#define SMB2C_RESILIENCY_MIN_MS           1000u
+#define SMB2C_DURABLE_TIMEOUT_DEFAULT_MS  60000u
+#define SMB2C_DURABLE_TIMEOUT_MAX_MS      300000u
 
 #define SMB2C_BUFSZ                       (1 << 20) /* per-connection scratch */
 #define SMB2C_MAX_BREAKS                  16
@@ -236,9 +290,25 @@ struct smb2_env_opts {
     int leases;             /* advertise SMB2 leases (set_smb_leases) */
     int directory_leases;   /* advertise directory leases */
     int persistent_handles; /* advertise durable/persistent handles */
+    /* SMB2_SHAREFLAG_FORCE_LEVELII_OPLOCK on the share: the server caps every
+     * caching grant to a read (LEVEL_II / R) cache (MS-SMB2 2.2.10; the WPTS
+     * OplockOnShareWithForceLevel2 / ShareForceLevel2 families). */
+    int force_level2;
+    /* SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY on the share.  This is what makes
+     * a PERSISTENT durable handle (DH2Q with SMB2_DHANDLE_FLAG_PERSISTENT)
+     * grantable at all (MS-SMB2 3.3.5.9.10); on a non-CA share the server
+     * grants an ordinary durable handle instead. */
+    int continuous_availability;
 };
 
-#define SMB2C_MAX_CONNS 8
+/* Connections are never recycled: a transport drop RETIRES a connection (it
+ * keeps its slot so its struct outlives evpl_destroy) and the reconnect takes a
+ * fresh one, so a long durable/replay walk consumes one slot per drop.
+ * Measured on the registered stepDurable batch: 36 slots at depth 120, 44 at
+ * 160, 67 at 240.  smb2_conn_open refuses to exceed this rather than running
+ * off the end of the array, and smb2_mbt_replay.c static-asserts its own
+ * MAX_SESS against it. */
+#define SMB2C_MAX_CONNS 128
 
 struct smb2_conn;
 
@@ -253,6 +323,10 @@ struct smb2_env {
      * use-after-free. */
     struct smb2_conn          *conns[SMB2C_MAX_CONNS];
     int                        nconns;
+    /* Copied at open time so smb2_env_fs_setup(), which the batch replayer
+     * calls once per trace with only (env, fsname), can still apply the
+     * share-level feature options. */
+    struct smb2_env_opts       opts;
 };
 
 /* A break notification the server pushed to this connection (the holder). */
@@ -272,9 +346,23 @@ struct smb2_break {
 
 struct smb2_conn {
     struct smb2_env  *env;
+    int               conn_index;   /* stable per-env index (ClientGuid seed) */
+    /* ClientGuid seed actually put on the wire by smb2_negotiate.  Defaults to
+     * conn_index (one client per connection).  Set it equal to another
+     * connection's guid_tag BEFORE the handshake to make the two connections
+     * ONE client -- chimera derives the caching-grant owner's client key from
+     * the ClientGuid (chimera_smb_lease_client_key), so this is the only way
+     * for the harness to present two connections of a single client, which is
+     * what the same-OplockKey / same-client arbitration rules turn on. */
+    int               guid_tag;
     struct evpl_bind *bind;
     int               connected;
     int               disconnected;
+    /* Set by smb2_conn_disconnect: THIS side closed the transport.  Without it
+     * `disconnected` conflates "the server hung up on us" (a finding) with "we
+     * dropped the link on purpose" (the premise of every durable/replay test),
+     * and the pump loops would report the former for the latter. */
+    int               closed_by_client;
 
     uint64_t          session_id;
     uint32_t          tree_id;
@@ -283,26 +371,115 @@ struct smb2_conn {
 
     uint8_t          *sbuf;       /* request scratch */
     uint8_t          *rbuf;       /* last reply (framed, NetBIOS included) */
+    uint8_t          *xbuf;       /* receive scratch (breaks land here) */
     int               rlen;
     int               reply_ready;
+    /* Identity and count of FINAL replies (not interims, not breaks) promoted
+     * into rbuf.  smb2_echo_barrier() needs both: it waits for the reply that
+     * carries ITS MessageId, and reports how many other final replies -- i.e.
+     * previously parked requests completing -- landed while it was
+     * outstanding. */
+    uint64_t          reply_mid;
+    int               nreply;
+    /* Final replies EXCLUDING the harness's own ECHO barrier round trips, so
+     * a caller can sample it before posting a request and ask afterwards
+     * "did anything of mine complete?" without having to subtract the
+     * barrier's own traffic. */
+    int               nreply_app;
+
+    /* Async interim (STATUS_PENDING) accounting.  An interim tells the caller
+     * the request PARKED server-side (smb_async_interim.c: the interim is sent
+     * the instant a handler decides it must block, never on a latency
+     * threshold), so observing one is a first-class fact -- the model's
+     * ST_PENDING maps onto exactly this.  The final response carries the same
+     * AsyncId, which is the original MessageId. */
+    int               ninterim;   /* interims seen on this connection */
+    uint64_t          last_async_id;
+    int               interim_pending; /* an interim arrived, final not yet */
+
+    /* One-shot request-header modifiers, armed by the smb2c_set_next_* /
+     * smb2c_pin_msg_id helpers and CONSUMED (cleared) by the next smb2c_send.
+     * They are one-shot on purpose: a replay test arms exactly one request and
+     * must not silently taint every request that follows it. */
+    uint32_t          next_flags;         /* OR'd into the header Flags */
+    int               next_flags_armed;
+    uint16_t          next_cs;            /* header offset 8: ChannelSequence */
+    int               next_cs_armed;
+    uint64_t          pin_msg_id;         /* send with THIS MessageId ... */
+    int               pin_armed;          /* ... and do not advance msg_id */
+    uint64_t          last_msg_id;        /* MessageId actually stamped */
 
     /* unsolicited oplock/lease break notifications, oldest first */
     struct smb2_break brk[SMB2C_MAX_BREAKS];
     int               nbrk;
 };
 
+/* One CREATE context to serialize onto a request (MS-SMB2 2.2.13.2).  `name`
+ * is the raw context-name bytes: a 4-byte tag ("RqLs", "DH2Q", ...) or a
+ * 16-byte GUID for the GUID-named contexts. */
+struct smb2_cctx {
+    const uint8_t *name;
+    int            name_len;
+    const uint8_t *data;
+    int            data_len;
+};
+
+/* A CREATE-response context, recorded VERBATIM.  The parser records every
+ * context the server emitted, not just the ones it knows how to interpret:
+ * "the server sent a context we did not expect" and "the server omitted one we
+ * did" are both findings, and neither is observable if the parser only looks
+ * for the tags it cares about. */
+#define SMB2C_MAX_RSP_CTX      8
+#define SMB2C_MAX_RSP_CTX_DATA 128
+
+struct smb2_rsp_ctx {
+    uint8_t  name[16];
+    int      name_len;
+    uint8_t  data[SMB2C_MAX_RSP_CTX_DATA];
+    uint32_t data_len;     /* bytes captured (capped at the buffer size) */
+    uint32_t wire_len;     /* DataLength as it was on the wire */
+};
+
+/* Durable-handle contexts to attach to a CREATE.  Request side: DHnQ (v1) /
+ * DH2Q (v2).  Reconnect side: DHnC (v1) / DH2C (v2).  Combinations are
+ * deliberately expressible -- several of them are ILLEGAL (MS-SMB2 3.3.5.9.12
+ * rejects DH2C with any other durable context) and a probe must be able to
+ * send an illegal one to pin the rejection. */
+struct smb2_durable_req {
+    int      dhnq;             /* request a v1 durable handle */
+    int      dh2q;             /* request a v2 durable handle */
+    uint32_t timeout_ms;       /* DH2Q Timeout (0 = server default) */
+    uint32_t flags;            /* DH2Q Flags (SMB2_DHANDLE_FLAG_PERSISTENT) */
+    uint8_t  create_guid[16];  /* DH2Q/DH2C CreateGuid: the replay identity */
+    int      dhnc;             /* v1 reconnect */
+    int      dh2c;             /* v2 reconnect */
+    uint8_t  file_id[16];      /* DHnC/DH2C FileId being reclaimed */
+    uint32_t reconnect_flags;  /* DH2C Flags */
+};
+
 /* Parsed CREATE reply. */
 struct smb2_create_out {
-    uint32_t status;
-    uint8_t  oplock;         /* reply OplockLevel byte */
-    uint32_t action;         /* CreateAction */
-    uint64_t end_of_file;
-    uint64_t change_time;
-    uint8_t  file_id[16];
-    int      has_lease;      /* an RqLs response context was present */
-    uint32_t lease_state;    /* granted SMB lease bits */
-    uint32_t lease_flags;
-    uint16_t lease_epoch;
+    uint32_t            status;
+    uint8_t             oplock; /* reply OplockLevel byte */
+    uint32_t            action; /* CreateAction */
+    uint64_t            end_of_file;
+    uint64_t            change_time;
+    uint8_t             file_id[16];
+    int                 has_lease; /* an RqLs response context was present */
+    uint32_t            lease_state; /* granted SMB lease bits */
+    uint32_t            lease_flags;
+    uint16_t            lease_epoch;
+
+    /* Every response context, in wire order. */
+    struct smb2_rsp_ctx ctx[SMB2C_MAX_RSP_CTX];
+    int                 nctx;
+    int                 ctx_overflow;   /* more than SMB2C_MAX_RSP_CTX arrived */
+
+    /* Interpreted durable-handle response contexts. */
+    int                 has_dh2q; /* a DH2Q response context was present */
+    uint32_t            dh2q_timeout; /* granted Timeout, ms */
+    uint32_t            dh2q_flags; /* granted Flags (PERSISTENT set or not) */
+    int                 has_dhnq; /* a DHnQ response context was present */
 };
 
 /* An oplock/lease request attached to a CREATE. */
@@ -312,6 +489,11 @@ struct smb2_oplock_req {
     uint8_t  lease_key[16];
     uint32_t lease_state;    /* requested SMB lease bits (R/H/W) */
     uint16_t lease_epoch;    /* v2 request epoch */
+    /* Force a v1 (32-byte) RqLs context even on a 3.x dialect.  A v1 lease is
+     * not epoch-versioned (it breaks with epoch 0) and can never carry a
+     * directory lease, so the v1/v2 split is a real behavioral axis rather
+     * than a dialect artifact (MS-SMB2 2.2.13.2.8 vs 2.2.13.2.10). */
+    int      force_v1;
 };
 
 /* ---- evpl stream plumbing ---------------------------------------------- */
@@ -385,11 +567,16 @@ smb2c_notify(
             break;
         case EVPL_NOTIFY_RECV_MSG: {
             int off = 0;
+            /* Receive into a scratch buffer, not rbuf: an unsolicited break
+             * notification can arrive while a reply already sits in rbuf
+             * (a holder connection that is itself mid-request), and copying
+             * the break over it would corrupt the reply the caller is about
+             * to parse.  Only a real reply is promoted into rbuf. */
             for (unsigned int i = 0; i < notify->recv_msg.niov; i++) {
                 void *d   = evpl_iovec_data(&notify->recv_msg.iovec[i]);
                 int   len = evpl_iovec_length(&notify->recv_msg.iovec[i]);
                 if (off + len <= SMB2C_BUFSZ) {
-                    memcpy(c->rbuf + off, d, len);
+                    memcpy(c->xbuf + off, d, len);
                 }
                 off += len;
             }
@@ -397,28 +584,43 @@ smb2c_notify(
                 evpl_iovec_release(evpl, &notify->recv_msg.iovec[i]);
             }
             if (off >= 4 + SMB2_HDR_SIZE) {
-                uint16_t cmd    = g16(c->rbuf + 4, 12);
-                uint64_t mid    = g64(c->rbuf + 4, 24);
-                uint32_t status = g32(c->rbuf + 4, 8);
-                uint32_t hflags = g32(c->rbuf + 4, 16);
+                uint16_t cmd    = g16(c->xbuf + 4, 12);
+                uint64_t mid    = g64(c->xbuf + 4, 24);
+                uint32_t status = g32(c->xbuf + 4, 8);
+                uint32_t hflags = g32(c->xbuf + 4, 16);
                 /* Unsolicited break: command 18, MessageId all-ones
                  * (smb_proc_oplock_break.c:58). */
                 if (cmd == SMB2_OPLOCK_BREAK &&
                     mid == 0xFFFFFFFFFFFFFFFFull) {
-                    smb2c_record_break(c, c->rbuf + 4 + SMB2_HDR_SIZE);
+                    smb2c_record_break(c, c->xbuf + 4 + SMB2_HDR_SIZE);
                     break;
                 }
                 /* Async interim: a parked op (e.g. a CREATE deferred behind
                  * an oplock/lease break) gets a STATUS_PENDING response with
-                 * the ASYNC flag first, then the real reply.  Skip the
-                 * interim -- the final response follows (smb_async_interim.c). */
+                 * the ASYNC flag first, then the real reply on the SAME
+                 * request, tagged with the same AsyncId (= the original
+                 * MessageId).  Record it -- "did this request park?" is the
+                 * wire fact the model's ST_PENDING names -- and keep waiting
+                 * for the final response (smb_async_interim.c). */
                 if (status == ST_PENDING &&
                     (hflags & SMB2_FLAGS_ASYNC_COMMAND)) {
+                    c->ninterim++;
+                    c->interim_pending = 1;
+                    c->last_async_id   = g64(c->xbuf + 4, 32);
                     break;
                 }
             }
+            memcpy(c->rbuf, c->xbuf, (size_t) (off <= SMB2C_BUFSZ
+                                               ? off : SMB2C_BUFSZ));
             c->rlen        = off;
             c->reply_ready = 1;
+            if (off >= 4 + SMB2_HDR_SIZE) {
+                c->reply_mid = g64(c->xbuf + 4, 24);
+                c->nreply++;
+                if (g16(c->xbuf + 4, 12) != SMB2_ECHO) {
+                    c->nreply_app++;
+                }
+            }
             break;
         } /* EVPL_NOTIFY_RECV_MSG */
     } /* switch */
@@ -475,10 +677,26 @@ smb2_env_open_opts(
                                                          opts->persistent_handles);
     }
 
+    if (opts) {
+        env->opts = *opts;
+    }
+
     env->server = chimera_server_init(config, env->metrics);
     chimera_server_start(env->server);
 
-    env->evpl = evpl_create(NULL);
+    /* The CLIENT loop's idle poll interval.  Not a test deadline: every wait
+     * here is a `while (!condition) { pump; }`, so the value only trades pump
+     * latency against CPU.  A bound is required rather than merely nice -- the
+     * default (-1) parks evpl_continue in the poller until something happens,
+     * and a pump that runs while this side is idle would block forever.
+     * MEASURED: 0 (pure spin) is 3x SLOWER end to end for the smb_mbt suite
+     * (33.8 s against 11.3 s at 1 ms), because the spinning client thread
+     * starves the server's evpl threads on the container's CPU budget.
+     * evpl_create() takes ownership of the config. */
+    struct evpl_thread_config *tcfg = evpl_thread_config_init();
+
+    evpl_thread_config_set_wait_ms(tcfg, 1);
+    env->evpl = evpl_create(tcfg);
 } /* smb2_env_open_opts */
 
 /* Create a fresh memfs filesystem `fsname` and mount the "share" onto it.  A
@@ -496,7 +714,15 @@ smb2_env_fs_setup(
         exit(1);
     }
     chimera_server_mount(env->server, "share", "memfs", fsname, NULL);
-    chimera_server_create_share(env->server, "share", "share", 0);
+    /* The share carries the env's feature options: continuous availability
+     * gates persistent handles, and force-level2 caps every caching grant on
+     * the share (probe O10). */
+    chimera_server_create_share(env->server, "share", "share",
+                                env->opts.continuous_availability);
+
+    if (env->opts.force_level2) {
+        chimera_server_share_set_force_level2_oplock(env->server, "share");
+    }
 } /* smb2_env_fs_setup */
 
 /* Tear the share/mount/filesystem back down.  rmfs is EBUSY while mounted, so
@@ -555,14 +781,30 @@ smb2_pump(struct smb2_env *env)
 static inline struct smb2_conn *
 smb2_conn_open(struct smb2_env *env)
 {
-    struct smb2_conn     *c  = calloc(1, sizeof(*c));
-    struct evpl_endpoint *ep =
+    struct smb2_conn     *c;
+    struct evpl_endpoint *ep;
+
+    if (env->nconns >= SMB2C_MAX_CONNS) {
+        fprintf(stderr,
+                "smb2 harness: out of connection slots (SMB2C_MAX_CONNS=%d).\n"
+                "Connections are retired, never recycled, so a long walk with\n"
+                "many transport drops needs a larger bound -- raise it (and\n"
+                "MAX_SESS in smb2_mbt_replay.c) rather than reusing a slot.\n",
+                SMB2C_MAX_CONNS);
+        exit(1);
+    }
+
+    c  = calloc(1, sizeof(*c));
+    ep =
         chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
                                            "127.0.0.1", 445);
 
-    c->env  = env;
-    c->sbuf = malloc(SMB2C_BUFSZ);
-    c->rbuf = malloc(SMB2C_BUFSZ);
+    c->env        = env;
+    c->conn_index = env->nconns;
+    c->guid_tag   = env->nconns;
+    c->sbuf       = malloc(SMB2C_BUFSZ);
+    c->rbuf       = malloc(SMB2C_BUFSZ);
+    c->xbuf       = malloc(SMB2C_BUFSZ);
 
     c->bind = evpl_connect(env->evpl, EVPL_STREAM_INPROC, NULL, ep,
                            smb2c_notify, smb2c_segment, c);
@@ -588,7 +830,16 @@ smb2_conn_reset(struct smb2_env *env)
 {
     for (int i = 0; i < env->nconns; i++) {
         struct smb2_conn *c = env->conns[i];
-        evpl_close(env->evpl, c->bind);
+
+        /* A trace may already have dropped this connection itself: a durable
+         * or replay trace calls smb2_conn_disconnect to park its handles and
+         * reconnect.  evpl treats closing a bind twice as fatal ("bind %p
+         * already closed"), so close only what is still open.  The wait below
+         * still runs either way -- a client-initiated close is only complete
+         * once evpl has delivered DISCONNECTED. */
+        if (!c->closed_by_client) {
+            evpl_close(env->evpl, c->bind);
+        }
         while (!c->disconnected) {
             smb2_pump(env);
         }
@@ -612,6 +863,7 @@ smb2_env_stop(struct smb2_env *env)
     for (int i = 0; i < env->nconns; i++) {
         free(env->conns[i]->sbuf);
         free(env->conns[i]->rbuf);
+        free(env->conns[i]->xbuf);
         free(env->conns[i]);
     }
     chimera_server_destroy(env->server);
@@ -647,6 +899,17 @@ smb2_conn_pop_break(
     return 1;
 } /* smb2_conn_pop_break */
 
+/* What the harness is currently doing, for the wedge diagnostic.  A caller
+ * that has a name for the step (the replayer names the trace and the command)
+ * points this at it; NULL just omits the line. */
+static const char *smb2c_context_str = NULL;
+
+static inline void
+smb2c_set_context(const char *ctx)
+{
+    smb2c_context_str = ctx;
+} /* smb2c_set_context */
+
 /* ---- one SMB2 request / response --------------------------------------- */
 
 /* Build the 4-byte NetBIOS header + 64-byte SMB2 header into c->sbuf for
@@ -658,7 +921,25 @@ smb2c_begin(
     uint16_t          command,
     uint32_t          flags)
 {
-    uint8_t *h = c->sbuf + 4;   /* SMB2 header start */
+    uint8_t *h;
+
+    /* A PDU is built into a CONNECTION's send buffer, so there is no such
+    * thing as building one without a connection.  Callers that resolve a
+    * connection from a table -- the MBT replayer maps a model session id to
+    * one -- can produce a NULL, and before this check that NULL reached
+    * `c->sbuf` and died as a SEGV inside the harness, which reads as a server
+    * crash and is not one.  Fail here instead, naming the command and the
+    * replay context, so the caller's bookkeeping bug is the diagnosis. */
+    if (!c) {
+        fprintf(stderr,
+                "smb2 harness: BUG -- request 0x%04x built with no connection"
+                "%s%s\n", command,
+                smb2c_context_str ? "\n  while replaying: " : "",
+                smb2c_context_str ? smb2c_context_str : "");
+        exit(5);
+    }
+
+    h = c->sbuf + 4;            /* SMB2 header start */
 
     memset(c->sbuf, 0, 4 + SMB2_HDR_SIZE + 256);
     h[0] = 0xFE;
@@ -684,16 +965,226 @@ smb2c_send(
     int               body_len)
 {
     uint32_t payload = SMB2_HDR_SIZE + body_len;
+    uint8_t *h       = c->sbuf + 4;
+
+    /* Apply the one-shot header modifiers.  They patch the header AFTER the
+     * per-command builder wrote it, which is what makes them command-agnostic:
+     * any request can be marked a replay, given a ChannelSequence, or pinned to
+     * a specific MessageId without every builder growing three parameters. */
+    if (c->next_flags_armed) {
+        p32(h, 16, g32(h, 16) | c->next_flags);
+    }
+    if (c->next_cs_armed) {
+        /* Header offset 8..11 is the (Status, Reserved) pair on a RESPONSE and
+         * (ChannelSequence, Reserved) on a REQUEST -- the same four bytes
+         * (MS-SMB2 2.2.1.2).  Status is only ever read out of c->rbuf, never
+         * out of c->sbuf, so writing here cannot perturb status parsing. */
+        p16(h, 8, c->next_cs);
+        p16(h, 10, 0);
+    }
+    if (c->pin_armed) {
+        p64(h, 24, c->pin_msg_id);
+    }
+    c->last_msg_id = g64(h, 24);
 
     c->sbuf[0] = 0;
     c->sbuf[1] = (uint8_t) (payload >> 16);
     c->sbuf[2] = (uint8_t) (payload >> 8);
     c->sbuf[3] = (uint8_t) payload;
 
-    c->reply_ready = 0;
+    c->reply_ready     = 0;
+    c->interim_pending = 0;
     evpl_send(c->env->evpl, c->bind, c->sbuf, 4 + payload);
-    c->msg_id++;
+    if (!c->pin_armed) {
+        c->msg_id++;
+    }
+    c->next_flags       = 0;
+    c->next_flags_armed = 0;
+    c->next_cs          = 0;
+    c->next_cs_armed    = 0;
+    c->pin_armed        = 0;
 } /* smb2c_send */
+
+/* ---- one-shot request-header modifiers ---------------------------------
+ *
+ * MS-SMB2 3.2.4.1.2: after a channel/transport failure the client RE-SENDS the
+ * request with SMB2_FLAGS_REPLAY_OPERATION set, and the server must apply it
+ * exactly once.  What a conformant client does NOT do is reuse the MessageId:
+ * 3.3.5.2.3 makes the server drop the connection when a MessageId falls outside
+ * the command-sequence window, and chimera does exactly that (measured: it logs
+ * "MessageId N ... outside the command sequence window" and closes, with no
+ * reply).  So a WIRE replay is a FRESH MessageId carrying the replay flag,
+ * correlated by DH2Q CreateGuid (creates) or ChannelSequence (mutating ops).
+ *
+ * smb2c_pin_msg_id is therefore NOT the replay primitive.  It exists for the
+ * two things that legitimately reuse a MessageId: testing the sequence-window
+ * rule itself, and SMB2_CANCEL (which addresses its target BY MessageId). */
+
+/* Send the next request with `mid` as its MessageId and do NOT advance the
+ * connection's counter. */
+static inline void
+smb2c_pin_msg_id(
+    struct smb2_conn *c,
+    uint64_t          mid)
+{
+    c->pin_msg_id = mid;
+    c->pin_armed  = 1;
+} /* smb2c_pin_msg_id */
+
+/* OR `flags` into the next request's header Flags (SMB2_FLAGS_REPLAY_OPERATION,
+ * SMB2_FLAGS_DFS_OPERATIONS, ...). */
+static inline void
+smb2c_set_next_flags(
+    struct smb2_conn *c,
+    uint32_t          flags)
+{
+    c->next_flags       = flags;
+    c->next_flags_armed = 1;
+} /* smb2c_set_next_flags */
+
+/* Stamp the next request's ChannelSequence (MS-SMB2 3.3.5.2.10). */
+static inline void
+smb2c_set_next_channel_sequence(
+    struct smb2_conn *c,
+    uint16_t          cs)
+{
+    c->next_cs       = cs;
+    c->next_cs_armed = 1;
+} /* smb2c_set_next_channel_sequence */
+
+/* Disarm every pending one-shot without sending. */
+static inline void
+smb2c_clear_next(struct smb2_conn *c)
+{
+    c->next_flags       = 0;
+    c->next_flags_armed = 0;
+    c->next_cs          = 0;
+    c->next_cs_armed    = 0;
+    c->pin_armed        = 0;
+} /* smb2c_clear_next */
+
+static inline uint64_t
+smb2c_now_ms(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t) ts.tv_sec * 1000u + (uint64_t) (ts.tv_nsec / 1000000);
+} /* smb2c_now_ms */
+
+/* ---- hang guard ---------------------------------------------------------
+ *
+ * No VERDICT in this harness is decided by elapsed wall-clock time.  Every
+ * assertion is settled by an EVENT: a reply arriving, a break notification
+ * arriving, or an echo barrier (below) completing.  What the ceiling here buys
+ * is the opposite of a timing dependence -- when the server genuinely wedges,
+ * the harness must fail loudly and name the wait it wedged on rather than
+ * spin until ctest kills it and reports nothing.
+ *
+ * It is set far above any healthy wait (a healthy wait is microseconds, and
+ * every one of them exits on its event) precisely so that a loaded machine can
+ * never turn it into a verdict, and just under chimera's own oplock-break
+ * deadline (CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS = 30 s, armed by
+ * smb_proc_create.c on a parked CREATE) so the harness's diagnostic fires
+ * before the server starts force-revoking parked opens and rewriting the state
+ * the diagnostic is meant to describe. */
+#define SMB2C_HANG_MS 20000
+
+/* The connection went away while we were waiting on it.  Which of the two
+ * reasons it was decides whether this is a server finding or a harness bug, so
+ * say which. */
+static inline void
+smb2c_dead(struct smb2_conn *c)
+{
+    if (c->closed_by_client) {
+        fprintf(stderr,
+                "smb2 harness: waiting for a reply on conn %d, which THIS side\n"
+                "closed with smb2_conn_disconnect().  Use the connection\n"
+                "returned by smb2_conn_reopen() instead.%s%s\n",
+                c->conn_index,
+                smb2c_context_str ? "\n  while replaying: " : "",
+                smb2c_context_str ? smb2c_context_str : "");
+        exit(4);
+    }
+    fprintf(stderr, "SMB server dropped the connection%s%s\n",
+            smb2c_context_str ? "\n  while replaying: " : "",
+            smb2c_context_str ? smb2c_context_str : "");
+    exit(3);
+} /* smb2c_dead */
+
+static inline void
+smb2c_hang(
+    struct smb2_conn *c,
+    const char       *what)
+{
+    fprintf(stderr,
+            "smb2 harness: WEDGED waiting for %s on conn %d after %d ms "
+            "(%d interim(s) seen, %d break(s) queued, reply_ready=%d).\n"
+            "The request is parked on an event nobody is driving -- a server\n"
+            "deferral that never resumed, or a harness step that forgot to\n"
+            "acknowledge a break.\n",
+            what, c->conn_index, SMB2C_HANG_MS, c->ninterim, c->nbrk,
+            c->reply_ready);
+    if (smb2c_context_str) {
+        fprintf(stderr, "  while replaying: %s\n", smb2c_context_str);
+    }
+    exit(4);
+} /* smb2c_hang */
+
+/* Pump the shared loop until `c`'s reply lands.  A reply that never arrives is
+ * a wedge, not an outcome: abort with a diagnostic naming `what`. */
+static inline void
+smb2c_pump_for_reply(
+    struct smb2_conn *c,
+    const char       *what)
+{
+    uint64_t deadline = smb2c_now_ms() + SMB2C_HANG_MS;
+
+    while (!c->reply_ready) {
+        smb2_pump(c->env);
+        if (c->disconnected) {
+            smb2c_dead(c);
+        }
+        if (smb2c_now_ms() >= deadline) {
+            smb2c_hang(c, what);
+        }
+    }
+} /* smb2c_pump_for_reply */
+
+/* Pump until a final non-barrier reply beyond `mark` (a previously sampled
+ * c->nreply_app) lands.  Unlike smb2c_pump_for_reply this tolerates
+ * c->reply_ready already being set by an unrelated reply -- notably an ECHO
+ * barrier's own -- so it is the right wait for "the request I parked earlier
+ * now completes".
+ *
+ * Returns 1 when it arrives.  On the hang ceiling it returns 0 after printing
+ * a diagnostic, so the CALLER's assertion is what fails: a wedged deferral
+ * reports as a named probe failure, never as an opaque ctest timeout. */
+static inline int
+smb2c_pump_for_nreply(
+    struct smb2_conn *c,
+    int               mark,
+    const char       *what)
+{
+    uint64_t deadline = smb2c_now_ms() + SMB2C_HANG_MS;
+
+    while (c->nreply_app <= mark) {
+        smb2_pump(c->env);
+        if (c->disconnected) {
+            smb2c_dead(c);
+        }
+        if (smb2c_now_ms() >= deadline) {
+            fprintf(stderr,
+                    "smb2 harness: WEDGED waiting for %s on conn %d after "
+                    "%d ms (%d interim(s) seen, %d break(s) queued)%s%s\n",
+                    what, c->conn_index, SMB2C_HANG_MS, c->ninterim, c->nbrk,
+                    smb2c_context_str ? "\n  while replaying: " : "",
+                    smb2c_context_str ? smb2c_context_str : "");
+            return 0;
+        }
+    }
+    return 1;
+} /* smb2c_pump_for_nreply */
 
 /* Pump until THIS connection's reply lands.  Only safe when the reply does
  * not depend on another connection acting first (setup + quiescent ops);
@@ -701,15 +1192,167 @@ smb2c_send(
 static inline uint32_t
 smb2c_wait(struct smb2_conn *c)
 {
-    while (!c->reply_ready) {
-        smb2_pump(c->env);
-        if (c->disconnected) {
-            fprintf(stderr, "SMB server dropped the connection\n");
-            exit(3);
-        }
-    }
+    smb2c_pump_for_reply(c, "a request reply");
     return g32(c->rbuf + 4, 8);   /* reply header Status */
 } /* smb2c_wait */
+
+/* ---- causal settle barrier ----------------------------------------------
+ *
+ * The hard question in this harness is "has the server finished reacting to
+ * what I just did?", and its hard sub-case is "prove that NOTHING more is
+ * coming" -- proving a negative.  Sleeping for N milliseconds answers neither:
+ * it makes the verdict a function of machine load, which is the thing a test
+ * must never be.
+ *
+ * SMB2 ECHO answers both, causally.  chimera completes an ECHO synchronously
+ * on the connection's own server thread (smb_proc_echo.c: chimera_smb_echo ->
+ * chimera_smb_complete_request, no VFS call, no deferral) and queues the reply
+ * on the SAME evpl bind that thread uses for deferred completions and for the
+ * oplock/lease break notifications it flushes from its doorbell.  So an ECHO
+ * reply is proof that that thread ran complete event-loop passes after the
+ * barrier was posted -- and it is proof no matter how long those passes took.
+ *
+ * TWO round trips, not one.  A break destined for this connection is queued by
+ * whichever thread ran the conflicting operation, which then rings this
+ * thread's doorbell (smb.c: lease_resume_doorbell / the lease-break flush).
+ * That doorbell is pending before the barrier's first ECHO is even parsed, but
+ * evpl does not promise to service doorbells ahead of socket reads within one
+ * pass, so a single round trip could in principle overtake it.  It cannot
+ * overtake two: whatever was pending when the barrier started has been
+ * serviced by the end of the first pass, and the second round trip cannot
+ * complete until a pass after that one has finished.  The second round trip is
+ * load-bearing even inside smb2_quiesce()'s fixpoint loop, and for a reason
+ * that is easy to miss: with one round the CLIENT stops pumping the instant
+ * the echo reply lands, so a notification the server sent later in that same
+ * server-side pass is still in flight when the quiesce loop reads its event
+ * count, sees no change, and declares the system quiet.
+ *
+ * One barrier on one connection settles ONE thread against work that was
+ * already queued for it.  It does NOT settle a CHAIN -- B's CREATE has to run
+ * on B's thread before A's thread has anything to flush -- so a barrier is the
+ * primitive, and smb2_quiesce() below is what callers should reach for.
+ *
+ * Returns the number of OTHER final replies that landed while the barrier was
+ * outstanding -- i.e. how many previously-parked requests on this connection
+ * completed.  Break notifications are unsolicited and keep accumulating in
+ * c->brk as usual, so "has the break been delivered yet?" is answered by
+ * reading smb2_conn_nbreaks() after the barrier returns.
+ *
+ * Costs one SMB2 round trip per round; it replaces multi-second sleeps. */
+#define SMB2C_BARRIER_ROUNDS 2
+
+static inline int
+smb2_echo_barrier(struct smb2_conn *c)
+{
+    int others = 0;
+
+    for (int round = 0; round < SMB2C_BARRIER_ROUNDS; round++) {
+        uint64_t mid      = c->msg_id;
+        int      napp0    = c->nreply_app;
+        uint64_t deadline = smb2c_now_ms() + SMB2C_HANG_MS;
+        int      b        = smb2c_begin(c, SMB2_ECHO, 0);
+        uint8_t *body     = c->sbuf + b;
+
+        p16(body, 0, 4);      /* StructureSize */
+        p16(body, 2, 0);      /* Reserved */
+        smb2c_send(c, 4);
+
+        while (!(c->reply_ready && c->reply_mid == mid)) {
+            smb2_pump(c->env);
+            if (c->disconnected) {
+                smb2c_dead(c);
+            }
+            if (smb2c_now_ms() >= deadline) {
+                smb2c_hang(c, "an ECHO barrier round trip");
+            }
+        }
+        /* Everything that arrived in this window other than the barrier's own
+         * ECHO reply was a parked request completing. */
+        others += c->nreply_app - napp0;
+    }
+    return others;
+} /* smb2_echo_barrier */
+
+/* Barrier EVERY connection of the env: one pass over all of them. */
+static inline int
+smb2_settle(struct smb2_env *env)
+{
+    int others = 0;
+
+    for (int i = 0; i < env->nconns; i++) {
+        struct smb2_conn *c = env->conns[i];
+
+        if (c && c->connected && !c->disconnected && c->session_id) {
+            others += smb2_echo_barrier(c);
+        }
+    }
+    return others;
+} /* smb2_settle */
+
+/* Everything the harness can observe the server doing, summed over all
+ * connections: break notifications delivered, async interims sent, and final
+ * replies other than the barrier's own echoes. */
+static inline int
+smb2_event_count(struct smb2_env *env)
+{
+    int n = 0;
+
+    for (int i = 0; i < env->nconns; i++) {
+        struct smb2_conn *c = env->conns[i];
+
+        if (c) {
+            n += c->nbrk + c->ninterim + c->nreply_app;
+        }
+    }
+    return n;
+} /* smb2_event_count */
+
+/* Drive the server to QUIESCENCE: settle every connection repeatedly until a
+ * whole pass produces no new observable event, then stop.
+ *
+ * This, not a single barrier, is what "the server has finished reacting to
+ * what I just did" means, because reacting is a CHAIN across threads.  A
+ * conflicting CREATE on B's thread has to run before it queues a break for A
+ * and rings A's doorbell; only then does a barrier on A have anything to
+ * flush.  Settling A first proves nothing -- and settling A then B exactly
+ * once is a race, which is how a fixed two-barrier version of this failed
+ * about 1 run in 20 under `ctest --repeat until-fail:20`, reporting
+ * `A breaks pending=0` for a break that had simply not been handed off yet.
+ *
+ * The stopping rule is a fixpoint, not a duration: each pass advances every
+ * server thread by at least one complete event-loop iteration, so a reaction
+ * chain of depth d is exhausted in d passes and the (d+1)th pass observes
+ * nothing new.  A quiet system therefore costs exactly ONE pass.  Nothing here
+ * consults the clock except the per-round-trip wedge guard.
+ *
+ * The pass cap is a wedge guard, not a tuning knob: reaction chains in this
+ * server are a handful of hops (break -> ack -> resume -> re-arbitrate), so
+ * hitting 64 means something is generating events forever, which is a finding
+ * rather than a wait to be extended.
+ *
+ * Returns the number of parked requests that completed while quiescing. */
+#define SMB2C_QUIESCE_MAX_PASSES 64
+
+static inline int
+smb2_quiesce(struct smb2_env *env)
+{
+    int completed = 0;
+
+    for (int pass = 0; pass < SMB2C_QUIESCE_MAX_PASSES; pass++) {
+        int before = smb2_event_count(env);
+
+        completed += smb2_settle(env);
+        if (smb2_event_count(env) == before) {
+            return completed;
+        }
+    }
+    fprintf(stderr,
+            "smb2 harness: the server never went quiet -- %d settle passes "
+            "each produced new events%s%s\n", SMB2C_QUIESCE_MAX_PASSES,
+            smb2c_context_str ? "\n  while replaying: " : "",
+            smb2c_context_str ? smb2c_context_str : "");
+    exit(4);
+} /* smb2_quiesce */
 
 static inline uint32_t
 smb2c_xfer(
@@ -732,7 +1375,16 @@ smb2_negotiate(struct smb2_conn *c)
     p16(body, 0, 36);                 /* StructureSize */
     p16(body, 2, 2);                  /* DialectCount */
     p16(body, 4, 1);                  /* SecurityMode = SIGNING_ENABLED */
+    /* ClientGuid: DISTINCT per connection.  The server derives the lease owner
+     * key from it (chimera_smb_lease_client_key, FNV-1a over the guid), so a
+     * shared guid would make every connection ONE client -- silently coalescing
+     * same-lease-key opens across what the model treats as separate clients,
+     * and masking cross-client arbitration.  One guid per conn keeps the
+     * harness's connections distinct clients, which is what the model means by
+     * distinct sessions.  A probe that needs two connections of ONE client sets
+     * c->guid_tag to the peer's before the handshake. */
     memset(body + 12, 0x11, 16);      /* ClientGuid */
+    body[12] = (uint8_t) (0x40 + c->guid_tag);
     /* Offer 2.1 + 3.0: 3.0 unlocks lease v2 (epochs) needed for the cascade
      * test, and avoids the mandatory 3.1.1 negotiate contexts. */
     p16(body, 36, SMB2_DIALECT_0210);
@@ -875,6 +1527,32 @@ smb2c_parse_create(
         uint16_t name_len = g16(p, 6);
         uint16_t data_off = g16(p, 10);
         uint32_t data_len = g32(p, 12);
+
+        /* Record it verbatim FIRST, whatever it is.  An unexpected response
+         * context is as much a finding as a missing one, and neither is
+         * observable to a caller if the parser only recognizes known tags. */
+        if (out->nctx < SMB2C_MAX_RSP_CTX) {
+            struct smb2_rsp_ctx *rc = &out->ctx[out->nctx];
+            uint32_t             n  = data_len;
+
+            memset(rc, 0, sizeof(*rc));
+            rc->name_len = name_len > 16 ? 16 : name_len;
+            if (p + name_off + rc->name_len <= limit) {
+                memcpy(rc->name, p + name_off, (size_t) rc->name_len);
+            }
+            rc->wire_len = data_len;
+            if (n > SMB2C_MAX_RSP_CTX_DATA) {
+                n = SMB2C_MAX_RSP_CTX_DATA;
+            }
+            if (p + data_off + n <= limit) {
+                memcpy(rc->data, p + data_off, (size_t) n);
+                rc->data_len = n;
+            }
+            out->nctx++;
+        } else {
+            out->ctx_overflow = 1;
+        }
+
         if (name_len == 4 && memcmp(p + name_off, "RqLs", 4) == 0 &&
             data_len >= 32) {
             const uint8_t *d = p + data_off;
@@ -885,6 +1563,20 @@ smb2c_parse_create(
                 out->lease_epoch = g16(d, 48);
             }
         }
+        /* DH2Q response (MS-SMB2 2.2.14.2.12): Timeout(4) | Flags(4). */
+        if (name_len == 4 && memcmp(p + name_off, "DH2Q", 4) == 0 &&
+            data_len >= 8) {
+            const uint8_t *d = p + data_off;
+            out->has_dh2q     = 1;
+            out->dh2q_timeout = g32(d, 0);
+            out->dh2q_flags   = g32(d, 4);
+        }
+        /* DHnQ response (MS-SMB2 2.2.14.2.3) carries no fields at all: 8
+         * reserved bytes.  Its PRESENCE is the entire grant signal. */
+        if (name_len == 4 && memcmp(p + name_off, "DHnQ", 4) == 0) {
+            out->has_dhnq = 1;
+        }
+
         if (next == 0) {
             break;
         }
@@ -892,25 +1584,172 @@ smb2c_parse_create(
     }
 } /* smb2c_parse_create */
 
-/* Build a CREATE into c->sbuf; returns the body length.  When req->is_lease
-* an RqLs context is appended (v2 with epoch on dialect >= 3.0, else v1). */
+/* Look up a recorded response context by its 4-byte tag; NULL if absent. */
+static inline const struct smb2_rsp_ctx *
+smb2c_create_ctx_find(
+    const struct smb2_create_out *out,
+    const char                   *tag)
+{
+    int tlen = (int) strlen(tag);
+
+    for (int i = 0; i < out->nctx; i++) {
+        if (out->ctx[i].name_len == tlen &&
+            memcmp(out->ctx[i].name, tag, (size_t) tlen) == 0) {
+            return &out->ctx[i];
+        }
+    }
+    return NULL;
+} /* smb2c_create_ctx_find */
+
+/* Serialize a CREATE-context CHAIN into c->sbuf.
+ *
+ * `name_end` is the offset, FROM THE SMB2 HEADER START, one past the last byte
+ * of the CREATE's Name field.  The chain starts at the next 8-aligned offset;
+ * every context but the last carries Next = its own 8-PADDED size, and the last
+ * carries Next = 0 and is NOT padded (MS-SMB2 2.2.13.2).
+ *
+ * Returns CreateContextsLength and stores the chain's header-relative offset in
+ * *r_off (both 0 when n == 0).  With a single 4-byte-tagged context the output
+ * is byte-identical to the hand-rolled single-RqLs builder this replaced.
+ */
+static inline uint32_t
+smb2c_build_contexts(
+    struct smb2_conn       *c,
+    int                     name_end,
+    const struct smb2_cctx *ctxs,
+    int                     n,
+    int                    *r_off)
+{
+    int base = (name_end + 7) & ~7;
+    int pos  = 0;
+
+    *r_off = 0;
+    if (n <= 0) {
+        return 0;
+    }
+    *r_off = base;
+
+    /* Zero the alignment pad between the name and the chain. */
+    memset(c->sbuf + 4 + name_end, 0, (size_t) (base - name_end));
+
+    for (int i = 0; i < n; i++) {
+        int      nl = ctxs[i].name_len;
+        /* DataOffset is measured from the START OF THIS CONTEXT: the 16-byte
+         * fixed part, then the name padded to 8.  A 4-byte tag gives 24; a
+         * 16-byte GUID name gives 32. */
+        int      doff   = 16 + ((nl + 7) & ~7);
+        int      size   = doff + ctxs[i].data_len;
+        int      padded = (size + 7) & ~7;
+        int      last   = (i + 1 == n);
+        uint8_t *p      = c->sbuf + 4 + base + pos;
+
+        memset(p, 0, (size_t) padded);
+        p32(p, 0, last ? 0u : (uint32_t) padded);   /* Next */
+        p16(p, 4, 16);                              /* NameOffset */
+        p16(p, 6, (uint16_t) nl);                   /* NameLength */
+        p16(p, 10, (uint16_t) doff);                /* DataOffset */
+        p32(p, 12, (uint32_t) ctxs[i].data_len);    /* DataLength */
+        memcpy(p + 16, ctxs[i].name, (size_t) nl);
+        if (ctxs[i].data_len > 0) {
+            memcpy(p + doff, ctxs[i].data, (size_t) ctxs[i].data_len);
+        }
+        pos += last ? size : padded;
+    }
+    return (uint32_t) pos;
+} /* smb2c_build_contexts */
+
+/* Serialize a smb2_durable_req into up to four contexts appended to `out`
+* (which must have room), using `buf` (>= 100 bytes) as their data scratch.
+* Returns the number of contexts written.  Order is DHnQ, DH2Q, DHnC, DH2C.
+*
+* Every body layout below is cross-checked against the server's own parsers
+* (smb_proc_create.c parse_ctx_dhnc / parse_ctx_dh2q / parse_ctx_dh2c). */
 static inline int
-smb2c_build_create(
+smb2c_durable_contexts(
+    const struct smb2_durable_req *d,
+    uint8_t                       *buf,
+    struct smb2_cctx              *out)
+{
+    int n = 0;
+
+    if (!d) {
+        return 0;
+    }
+
+    if (d->dhnq) {
+        /* DHnQ request body: 16 reserved bytes (MS-SMB2 2.2.13.2.3). */
+        memset(buf + 0, 0, 16);
+        out[n].name     = (const uint8_t *) "DHnQ";
+        out[n].name_len = 4;
+        out[n].data     = buf + 0;
+        out[n].data_len = 16;
+        n++;
+    }
+    if (d->dh2q) {
+        /* DH2Q: Timeout(4) | Flags(4) | Reserved(8) | CreateGuid(16). */
+        memset(buf + 16, 0, 32);
+        p32(buf + 16, 0, d->timeout_ms);
+        p32(buf + 16, 4, d->flags);
+        memcpy(buf + 16 + 16, d->create_guid, 16);
+        out[n].name     = (const uint8_t *) "DH2Q";
+        out[n].name_len = 4;
+        out[n].data     = buf + 16;
+        out[n].data_len = 32;
+        n++;
+    }
+    if (d->dhnc) {
+        /* DHnC: FileId(16). */
+        memcpy(buf + 48, d->file_id, 16);
+        out[n].name     = (const uint8_t *) "DHnC";
+        out[n].name_len = 4;
+        out[n].data     = buf + 48;
+        out[n].data_len = 16;
+        n++;
+    }
+    if (d->dh2c) {
+        /* DH2C: FileId(16) | CreateGuid(16) | Flags(4). */
+        memset(buf + 64, 0, 36);
+        memcpy(buf + 64, d->file_id, 16);
+        memcpy(buf + 64 + 16, d->create_guid, 16);
+        p32(buf + 64, 32, d->reconnect_flags);
+        out[n].name     = (const uint8_t *) "DH2C";
+        out[n].name_len = 4;
+        out[n].data     = buf + 64;
+        out[n].data_len = 36;
+        n++;
+    }
+    return n;
+} /* smb2c_durable_contexts */
+
+#define SMB2C_MAX_REQ_CTX 8
+
+/* Build a CREATE into c->sbuf; returns the body length.  When req->is_lease an
+ * RqLs context LEADS the chain (v2 with epoch on dialect >= 3.0, else v1);
+ * `extra` follows in caller order. */
+static inline int
+smb2c_build_create_full(
     struct smb2_conn             *c,
     const char                   *name,
     uint32_t                      disp,
     uint32_t                      access,
     uint32_t                      share,
     uint32_t                      create_options,
-    const struct smb2_oplock_req *req)
+    const struct smb2_oplock_req *req,
+    const struct smb2_cctx       *extra,
+    int                           nextra)
 {
-    int      b        = smb2c_begin(c, SMB2_CREATE, 0);
-    uint8_t *body     = c->sbuf + b;
-    int      name_off = SMB2_HDR_SIZE + 56;
-    int      nlen     = utf16le(name, body + 56);
-    uint8_t  oplevel  =
+    int              b        = smb2c_begin(c, SMB2_CREATE, 0);
+    uint8_t         *body     = c->sbuf + b;
+    int              name_off = SMB2_HDR_SIZE + 56;
+    int              nlen     = utf16le(name, body + 56);
+    uint8_t          oplevel  =
         req ? (req->is_lease ? SMB2_OPLOCK_LEVEL_LEASE : req->level)
             : SMB2_OPLOCK_LEVEL_NONE;
+    struct smb2_cctx ctxs[SMB2C_MAX_REQ_CTX];
+    uint8_t          rqls[52];
+    int              nctx = 0;
+    int              cc_hoff;
+    uint32_t         cc_len;
 
     p16(body, 0, 57);                 /* StructureSize */
     body[3] = oplevel;                /* RequestedOplockLevel */
@@ -923,43 +1762,56 @@ smb2c_build_create(
     p16(body, 44, name_off);          /* NameOffset */
     p16(body, 46, nlen);              /* NameLength */
 
-    if (!req || !req->is_lease) {
+    if (req && req->is_lease) {
+        int v2   = c->dialect >= SMB2_DIALECT_0300 && !req->force_v1;
+        int dlen = v2 ? 52 : 32;
+
+        memset(rqls, 0, sizeof(rqls));
+        memcpy(rqls, req->lease_key, 16);
+        p32(rqls, 16, req->lease_state);
+        p32(rqls, 20, 0);             /* LeaseFlags */
+        p64(rqls, 24, 0);             /* LeaseDuration */
+        if (v2) {
+            /* ParentLeaseKey (16, zero) + Epoch (2) + Reserved (2) */
+            p16(rqls, 48, req->lease_epoch);
+        }
+        ctxs[nctx].name     = (const uint8_t *) "RqLs";
+        ctxs[nctx].name_len = 4;
+        ctxs[nctx].data     = rqls;
+        ctxs[nctx].data_len = dlen;
+        nctx++;
+    }
+
+    for (int i = 0; i < nextra && nctx < SMB2C_MAX_REQ_CTX; i++) {
+        ctxs[nctx++] = extra[i];
+    }
+
+    if (nctx == 0) {
         p32(body, 48, 0);             /* CreateContextsOffset */
         p32(body, 52, 0);             /* CreateContextsLength */
         return 56 + nlen;
     }
 
-    /* Append one RqLs create context, 8-aligned after the name.  Offsets are
-     * measured from the SMB2 header start. */
-    int      cc_hoff = (SMB2_HDR_SIZE + 56 + nlen + 7) & ~7; /* from header */
-    int      v2      = c->dialect >= SMB2_DIALECT_0300;
-    int      dlen    = v2 ? 52 : 32;
-    uint8_t *cc      = c->sbuf + 4 + cc_hoff;
+    cc_len = smb2c_build_contexts(c, SMB2_HDR_SIZE + 56 + nlen, ctxs, nctx,
+                                  &cc_hoff);
+    p32(body, 48, (uint32_t) cc_hoff);  /* CreateContextsOffset */
+    p32(body, 52, cc_len);            /* CreateContextsLength */
 
-    /* zero the pad between name-end and the context, plus the context */
-    memset(c->sbuf + 4 + SMB2_HDR_SIZE + 56 + nlen, 0,
-           (cc_hoff - (SMB2_HDR_SIZE + 56 + nlen)) + 24 + dlen);
+    return (cc_hoff - SMB2_HDR_SIZE) + (int) cc_len;
+} /* smb2c_build_create_full */
 
-    p32(cc, 0, 0);                    /* Next = 0 (only context) */
-    p16(cc, 4, 16);                   /* NameOffset */
-    p16(cc, 6, 4);                    /* NameLength */
-    p16(cc, 10, 24);                  /* DataOffset */
-    p32(cc, 12, dlen);                /* DataLength */
-    memcpy(cc + 16, "RqLs", 4);       /* context name */
-    /* data at +24 */
-    memcpy(cc + 24 + 0, req->lease_key, 16);
-    p32(cc + 24, 16, req->lease_state);
-    p32(cc + 24, 20, 0);              /* LeaseFlags */
-    p64(cc + 24, 24, 0);              /* LeaseDuration */
-    if (v2) {
-        /* ParentLeaseKey (16, zero) + Epoch (2) + Reserved (2) */
-        p16(cc + 24, 48, req->lease_epoch);
-    }
-
-    p32(body, 48, cc_hoff);           /* CreateContextsOffset */
-    p32(body, 52, (uint32_t) (24 + dlen)); /* CreateContextsLength */
-
-    return (cc_hoff - SMB2_HDR_SIZE) + 24 + dlen;
+static inline int
+smb2c_build_create(
+    struct smb2_conn             *c,
+    const char                   *name,
+    uint32_t                      disp,
+    uint32_t                      access,
+    uint32_t                      share,
+    uint32_t                      create_options,
+    const struct smb2_oplock_req *req)
+{
+    return smb2c_build_create_full(c, name, disp, access, share,
+                                   create_options, req, NULL, 0);
 } /* smb2c_build_create */
 
 /* Non-blocking CREATE with explicit CreateOptions (post only). */
@@ -1023,6 +1875,68 @@ smb2_create(
     return smb2_create_opts(c, name, disp, access, share,
                             FILE_NON_DIRECTORY_FILE, req, out);
 } /* smb2_create */
+
+/* ---- CREATE with durable-handle contexts -------------------------------- */
+
+/* Non-blocking CREATE carrying an oplock/lease request and/or the durable
+ * contexts described by `dur` (post only). */
+static inline void
+smb2_create_dur_post(
+    struct smb2_conn              *c,
+    const char                    *name,
+    uint32_t                       disp,
+    uint32_t                       access,
+    uint32_t                       share,
+    uint32_t                       create_options,
+    const struct smb2_oplock_req  *req,
+    const struct smb2_durable_req *dur)
+{
+    struct smb2_cctx ctxs[4];
+    uint8_t          buf[100];
+    int              n = smb2c_durable_contexts(dur, buf, ctxs);
+
+    smb2c_send(c, smb2c_build_create_full(c, name, disp, access, share,
+                                          create_options, req, ctxs, n));
+} /* smb2_create_dur_post */
+
+/* Blocking CREATE with durable contexts and explicit CreateOptions. */
+static inline uint32_t
+smb2_create_dur_opts(
+    struct smb2_conn              *c,
+    const char                    *name,
+    uint32_t                       disp,
+    uint32_t                       access,
+    uint32_t                       share,
+    uint32_t                       create_options,
+    const struct smb2_oplock_req  *req,
+    const struct smb2_durable_req *dur,
+    struct smb2_create_out        *out)
+{
+    smb2_create_dur_post(c, name, disp, access, share, create_options, req,
+                         dur);
+    smb2c_wait(c);
+    smb2c_parse_create(c, out);
+    return out->status;
+} /* smb2_create_dur_opts */
+
+/* Blocking CREATE of a non-directory file with durable contexts.
+ *
+ * A DHnC/DH2C RECONNECT carries an EMPTY name: the open being reclaimed is
+ * named by its FileId, not by a path (MS-SMB2 3.3.5.9.7 / 3.3.5.9.12). */
+static inline uint32_t
+smb2_create_dur(
+    struct smb2_conn              *c,
+    const char                    *name,
+    uint32_t                       disp,
+    uint32_t                       access,
+    uint32_t                       share,
+    const struct smb2_oplock_req  *req,
+    const struct smb2_durable_req *dur,
+    struct smb2_create_out        *out)
+{
+    return smb2_create_dur_opts(c, name, disp, access, share,
+                                FILE_NON_DIRECTORY_FILE, req, dur, out);
+} /* smb2_create_dur */
 
 /* ---- WRITE / READ / CLOSE ----------------------------------------------- */
 
@@ -1139,6 +2053,324 @@ smb2_close(
     return smb2c_xfer(c, 24);
 } /* smb2_close */
 
+/* ---- LOCK ---------------------------------------------------------------
+ *
+ * MS-SMB2 2.2.26: StructureSize 48, a 24-byte fixed body, then LockCount
+ * SMB2_LOCK_ELEMENTs of 24 bytes each (Offset, Length, Flags, Reserved).  One
+ * element is all this harness needs.  LOCK is NOT in the
+ * ChannelSequence-checked set, which is exactly why it is useful for probing
+ * WHERE the gate sits relative to lock enforcement on the ops that are. */
+static inline uint32_t
+smb2_lock(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16],
+    uint64_t          offset,
+    uint64_t          length,
+    uint32_t          flags)
+{
+    int      b    = smb2c_begin(c, SMB2_LOCK, 0);
+    uint8_t *body = c->sbuf + b;
+
+    p16(body, 0, 48);                 /* StructureSize */
+    p16(body, 2, 1);                  /* LockCount */
+    p32(body, 4, 0);                  /* LockSequenceNumber/Index */
+    memcpy(body + 8, file_id, 16);    /* FileId */
+    p64(body, 24, offset);            /* Element[0].Offset */
+    p64(body, 32, length);            /* Element[0].Length */
+    p32(body, 40, flags);             /* Element[0].Flags */
+    p32(body, 44, 0);                 /* Element[0].Reserved */
+
+    return smb2c_xfer(c, 48);
+} /* smb2_lock */
+
+/* ---- SET_INFO -----------------------------------------------------------
+ *
+ * MS-SMB2 2.2.39: StructureSize 33, a 32-byte fixed body, the input buffer
+ * immediately after it (header(64) + 32 = 96, 8-aligned).  SET_INFO is one of
+ * the ChannelSequence-checked mutating operations (MS-SMB2 3.3.5.2.10). */
+#define SMB2_INFO_FILE_T              0x01
+#define SMB2_INFO_FILESYSTEM_T        0x02
+#define SMB2_FILE_BASIC_INFO_T        0x04
+#define SMB2_FILE_STANDARD_INFO_T     0x05
+#define SMB2_FILE_INTERNAL_INFO_T     0x06
+#define SMB2_FILE_RENAME_INFO_T       0x0A
+#define SMB2_FILE_DISPOSITION_T       0x0D
+#define SMB2_FILE_ENDOFFILE_INFO_T    0x14
+#define SMB2_FILE_ALL_INFO_T          0x12
+#define SMB2_FILE_NETWORK_OPEN_T      0x22
+#define SMB2_FS_SIZE_INFO_T           0x03
+
+/* FILE_ATTRIBUTE_DIRECTORY (MS-FSCC 2.6): the one attribute bit the model
+ * constrains, because it is the wire spelling of `ftype == FDir`. */
+#define SMB2_FILE_ATTRIBUTE_DIRECTORY 0x00000010u
+
+static inline uint32_t
+smb2_set_info(
+    struct smb2_conn *c,
+    uint8_t           info_type,
+    uint8_t           info_class,
+    const uint8_t     file_id[16],
+    const void       *buf,
+    uint32_t          buf_len)
+{
+    int      b       = smb2c_begin(c, SMB2_SET_INFO, 0);
+    uint8_t *body    = c->sbuf + b;
+    int      buf_off = SMB2_HDR_SIZE + 32;
+
+    p16(body, 0, 33);                  /* StructureSize */
+    body[2] = info_type;
+    body[3] = info_class;
+    p32(body, 4, buf_len);             /* BufferLength */
+    p16(body, 8, (uint16_t) buf_off);  /* BufferOffset */
+    p16(body, 10, 0);                  /* Reserved */
+    p32(body, 12, 0);                  /* AdditionalInformation */
+    memcpy(body + 16, file_id, 16);    /* FileId */
+    if (buf_len > 0) {
+        memcpy(body + 32, buf, buf_len);
+    }
+    return smb2c_xfer(c, 32 + (int) buf_len);
+} /* smb2_set_info */
+
+/* FILE_END_OF_FILE_INFORMATION (MS-FSCC 2.4.13): a single EndOfFile LONGLONG.
+ * Truncating a file is the cleanest NON-IDEMPOTENT-looking mutating op to test
+ * the ChannelSequence rule against, because its EFFECT (the file size) is
+ * directly observable afterwards. */
+static inline uint32_t
+smb2_set_eof(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16],
+    uint64_t          eof)
+{
+    uint8_t buf[8];
+
+    p64(buf, 0, eof);
+    return smb2_set_info(c, SMB2_INFO_FILE_T, SMB2_FILE_ENDOFFILE_INFO_T,
+                         file_id, buf, sizeof(buf));
+} /* smb2_set_eof */
+
+/* FILE_RENAME_INFORMATION (MS-FSCC 2.4.37): ReplaceIfExists(1) | Reserved(7) |
+ * RootDirectory(8) | FileNameLength(4) | FileName.  A rename is genuinely
+ * non-idempotent -- applying it twice cannot succeed twice -- which is what
+ * makes it the sharpest probe of whether a replayed mutation is re-applied. */
+static inline uint32_t
+smb2_rename(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16],
+    const char       *new_name,
+    int               replace_if_exists)
+{
+    uint8_t buf[20 + 512];
+    int     nlen = utf16le(new_name, buf + 20);
+
+    memset(buf, 0, 20);
+    buf[0] = (uint8_t) (replace_if_exists ? 1 : 0);
+    p64(buf, 8, 0);                    /* RootDirectory */
+    p32(buf, 16, (uint32_t) nlen);     /* FileNameLength */
+    return smb2_set_info(c, SMB2_INFO_FILE_T, SMB2_FILE_RENAME_INFO_T,
+                         file_id, buf, (uint32_t) (20 + nlen));
+} /* smb2_rename */
+
+/* FILE_DISPOSITION_INFORMATION (MS-FSCC 2.4.11): a single DeletePending byte.
+ * This is the SMB spelling of "unlink on last close" -- there is no path-based
+ * REMOVE -- so it is the mutation the delete-on-close lifecycle runs through
+ * once a handle already exists. */
+static inline uint32_t
+smb2_set_disposition(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16],
+    int               delete_pending)
+{
+    uint8_t buf[1];
+
+    buf[0] = (uint8_t) (delete_pending ? 1 : 0);
+    return smb2_set_info(c, SMB2_INFO_FILE_T, SMB2_FILE_DISPOSITION_T,
+                         file_id, buf, sizeof(buf));
+} /* smb2_set_disposition */
+
+/* ---- QUERY_INFO ---------------------------------------------------------
+ *
+ * MS-SMB2 2.2.37: StructureSize 41, a 40-byte fixed body, the (unused here)
+ * input buffer after it.  The reply (2.2.38) is StructureSize 9 with
+ * OutputBufferOffset / OutputBufferLength naming the payload inside the PDU.
+ *
+ * OutputBufferLength on the REQUEST is deliberately generous: a value below
+ * the info level's fixed size is answered STATUS_INFO_LENGTH_MISMATCH
+ * (MS-SMB2 3.3.5.20.1), which is a different behavior from the one the model
+ * predicts and must not be reached by accident. */
+static inline uint32_t
+smb2_query_info(
+    struct smb2_conn *c,
+    uint8_t           info_type,
+    uint8_t           info_class,
+    const uint8_t     file_id[16],
+    uint32_t          addl_info,
+    uint8_t          *out,
+    uint32_t          out_cap,
+    uint32_t         *out_len)
+{
+    int      b    = smb2c_begin(c, SMB2_QUERY_INFO, 0);
+    uint8_t *body = c->sbuf + b;
+    uint32_t st;
+
+    p16(body, 0, 41);                  /* StructureSize */
+    body[2] = info_type;               /* InfoType */
+    body[3] = info_class;              /* FileInfoClass */
+    p32(body, 4, 65536);               /* OutputBufferLength */
+    p16(body, 8, 0);                   /* InputBufferOffset */
+    p16(body, 10, 0);                  /* Reserved */
+    p32(body, 12, 0);                  /* InputBufferLength */
+    p32(body, 16, addl_info);          /* AdditionalInformation */
+    p32(body, 20, 0);                  /* Flags */
+    memcpy(body + 24, file_id, 16);    /* FileId */
+
+    st = smb2c_xfer(c, 40);
+    if (out_len) {
+        *out_len = 0;
+    }
+    if (st == ST_SUCCESS) {
+        const uint8_t *rb   = c->rbuf + 4 + SMB2_HDR_SIZE;
+        uint16_t       doff = g16(rb, 2);
+        uint32_t       dlen = g32(rb, 4);
+
+        if (dlen > out_cap) {
+            dlen = out_cap;
+        }
+        if (out) {
+            memcpy(out, c->rbuf + 4 + doff, dlen);
+        }
+        if (out_len) {
+            *out_len = dlen;
+        }
+    }
+    return st;
+} /* smb2_query_info */
+
+/* ---- FLUSH --------------------------------------------------------------
+ *
+ * MS-SMB2 2.2.17: StructureSize 24, Reserved1(2) | Reserved2(4) | FileId(16). */
+static inline uint32_t
+smb2_flush(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16])
+{
+    int      b    = smb2c_begin(c, SMB2_FLUSH, 0);
+    uint8_t *body = c->sbuf + b;
+
+    p16(body, 0, 24);                 /* StructureSize */
+    memcpy(body + 8, file_id, 16);    /* FileId */
+
+    return smb2c_xfer(c, 24);
+} /* smb2_flush */
+
+/* ---- LOGOFF / TREE_DISCONNECT -------------------------------------------
+ *
+ * MS-SMB2 2.2.7 and 2.2.11: both are StructureSize 4 with a 2-byte Reserved,
+ * and both are session/tree teardown the model owns -- a LOGOFF closes every
+ * open on the session, a TREE_DISCONNECT every open on the tree. */
+static inline uint32_t
+smb2_logoff(struct smb2_conn *c)
+{
+    int      b    = smb2c_begin(c, SMB2_LOGOFF, 0);
+    uint8_t *body = c->sbuf + b;
+
+    p16(body, 0, 4);                  /* StructureSize */
+    p16(body, 2, 0);                  /* Reserved */
+
+    return smb2c_xfer(c, 4);
+} /* smb2_logoff */
+
+static inline uint32_t
+smb2_tree_disconnect(struct smb2_conn *c)
+{
+    int      b    = smb2c_begin(c, SMB2_TREE_DISCONNECT, 0);
+    uint8_t *body = c->sbuf + b;
+
+    p16(body, 0, 4);                  /* StructureSize */
+    p16(body, 2, 0);                  /* Reserved */
+
+    return smb2c_xfer(c, 4);
+} /* smb2_tree_disconnect */
+
+/* ---- IOCTL --------------------------------------------------------------
+ *
+ * MS-SMB2 2.2.31: StructureSize 57, a 56-byte fixed body, the input buffer
+ * immediately after it.  header(64) + 56 = 120, already 8-aligned, so no pad. */
+static inline uint32_t
+smb2_ioctl(
+    struct smb2_conn *c,
+    uint32_t          ctl_code,
+    const uint8_t     file_id[16],
+    const void       *in,
+    uint32_t          in_len)
+{
+    int      b      = smb2c_begin(c, SMB2_IOCTL, 0);
+    uint8_t *body   = c->sbuf + b;
+    int      in_off = SMB2_HDR_SIZE + 56;
+
+    p16(body, 0, 57);                 /* StructureSize */
+    p32(body, 4, ctl_code);           /* CtlCode */
+    memcpy(body + 8, file_id, 16);    /* FileId */
+    p32(body, 24, (uint32_t) in_off); /* InputOffset */
+    p32(body, 28, in_len);            /* InputCount */
+    p32(body, 32, 0);                 /* MaxInputResponse */
+    p32(body, 36, (uint32_t) in_off); /* OutputOffset */
+    p32(body, 40, 0);                 /* OutputCount */
+    p32(body, 44, 4096);              /* MaxOutputResponse */
+    p32(body, 48, SMB2C_IOCTL_IS_FSCTL);
+    if (in_len > 0) {
+        memcpy(body + 56, in, in_len);
+    }
+    return smb2c_xfer(c, 56 + (int) in_len);
+} /* smb2_ioctl */
+
+/* FSCTL_LMR_REQUEST_RESILIENCY (MS-SMB2 2.2.31.3): a NETWORK_RESILIENCY_REQUEST
+ * of Timeout(4) | Reserved(4).  A resilient handle survives a transport drop
+ * WITHOUT any durable-handle context and without a caching precondition, which
+ * is exactly what distinguishes it from a durable handle. */
+static inline uint32_t
+smb2_resiliency(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16],
+    uint32_t          timeout_ms)
+{
+    uint8_t req[8];
+
+    memset(req, 0, sizeof(req));
+    p32(req, 0, timeout_ms);
+    return smb2_ioctl(c, SMB2_FSCTL_LMR_REQUEST_RESILIENCY, file_id, req,
+                      sizeof(req));
+} /* smb2_resiliency */
+
+/* ---- CANCEL -------------------------------------------------------------
+ *
+ * MS-SMB2 2.2.30 / 3.2.4.24.  SMB2_CANCEL is the ONE command that legitimately
+ * reuses a MessageId: it addresses its target by that id (or, once the target
+ * has sent an async interim, by AsyncId with the ASYNC flag set).  It gets no
+ * response of its own, so this is post-only. */
+static inline void
+smb2_cancel_post(
+    struct smb2_conn *c,
+    uint64_t          target_mid,
+    uint64_t          async_id)
+{
+    int      b;
+    uint8_t *body;
+
+    if (async_id) {
+        b    = smb2c_begin(c, SMB2_CANCEL, SMB2_FLAGS_ASYNC_COMMAND);
+        body = c->sbuf + b;
+        p64(c->sbuf + 4, 32, async_id);   /* AsyncId */
+    } else {
+        b    = smb2c_begin(c, SMB2_CANCEL, 0);
+        body = c->sbuf + b;
+    }
+    p16(body, 0, 4);                      /* StructureSize */
+    p16(body, 2, 0);                      /* Reserved */
+
+    smb2c_pin_msg_id(c, target_mid);
+    smb2c_send(c, 4);
+} /* smb2_cancel_post */
+
 /* ---- oplock / lease break acknowledgments ------------------------------- */
 
 /* OPLOCK_BREAK acknowledgment (MS-SMB2 2.2.24.1): the holder downgrades to
@@ -1201,5 +2433,95 @@ smb2_handshake(struct smb2_conn *c)
         exit(1);
     }
 } /* smb2_handshake */
+
+/* ---- transport drop and reconnect ---------------------------------------
+ *
+ * A durable/persistent handle only means anything across a TRANSPORT FAILURE,
+ * and a replay only happens because one occurred, so dropping the connection
+ * from the client side is a first-class primitive rather than a teardown step.
+ *
+ * The connection struct is deliberately NOT freed: env->conns owns every
+ * connection until after evpl_destroy (see smb2_env_stop), because evpl
+ * dispatches a final DISCONNECTED to each registered bind during teardown and
+ * that notify dereferences the conn.  A retired connection therefore keeps its
+ * slot -- which is why SMB2C_MAX_CONNS is sized for one slot per drop. */
+static inline void
+smb2_conn_disconnect(struct smb2_conn *c)
+{
+    uint64_t deadline;
+
+    if (!c || c->closed_by_client) {
+        return;
+    }
+    c->closed_by_client = 1;
+    evpl_close(c->env->evpl, c->bind);
+
+    /* Return only once the drop has actually been DELIVERED.  "The connection
+     * is gone" is then an event, not an elapsed interval -- a caller that goes
+     * on to reclaim a durable handle is not racing a close that has merely been
+     * requested.  (It still is not proof the server has PARKED the handle;
+     * that needs a separate barrier -- see the park barrier in the durable
+     * probe.) */
+    deadline = smb2c_now_ms() + SMB2C_HANG_MS;
+    while (!c->disconnected) {
+        smb2_pump(c->env);
+        if (smb2c_now_ms() >= deadline) {
+            fprintf(stderr,
+                    "smb2 harness: WEDGED waiting for conn %d to report the "
+                    "close THIS side requested, after %d ms%s%s\n",
+                    c->conn_index, SMB2C_HANG_MS,
+                    smb2c_context_str ? "\n  while replaying: " : "",
+                    smb2c_context_str ? smb2c_context_str : "");
+            exit(4);
+        }
+    }
+} /* smb2_conn_disconnect */
+
+/* Is `c` usable?  0 once either side has closed it. */
+static inline int
+smb2c_check_live(struct smb2_conn *c)
+{
+    return c && c->connected && !c->disconnected && !c->closed_by_client;
+} /* smb2c_check_live */
+
+/* Open a fresh connection, NOT yet handshaked.
+ *
+ * When `old` is non-NULL the new connection inherits its ClientGuid
+ * (guid_tag), i.e. it is the SAME CLIENT reconnecting.  That is load-bearing,
+ * not cosmetic: chimera refuses a leased or persistent reclaim whose ClientGuid
+ * does not match the parked open's (chimera_smb_durable_claim), so a reconnect
+ * that quietly took a fresh guid would turn every reclaim into a cross-client
+ * one and report OBJECT_NAME_NOT_FOUND.
+ *
+ * Pass old = NULL for the deliberate cross-client case (a "stranger" trying to
+ * steal someone else's parked handle); the connection then keeps its own
+ * distinct guid_tag.  The caller drives NEGOTIATE itself, which is the point of
+ * the _raw form: a probe that wants to vary the negotiated dialect, or to send
+ * something before SESSION_SETUP, cannot use the packaged handshake. */
+static inline struct smb2_conn *
+smb2_conn_reopen_raw(
+    struct smb2_env  *env,
+    struct smb2_conn *old)
+{
+    struct smb2_conn *c = smb2_conn_open(env);
+
+    if (old) {
+        c->guid_tag = old->guid_tag;
+    }
+    return c;
+} /* smb2_conn_reopen_raw */
+
+/* The same client, reconnecting: fresh connection, inherited ClientGuid, fully
+ * handshaked and ready to reclaim. */
+static inline struct smb2_conn *
+smb2_conn_reopen(
+    struct smb2_env  *env,
+    struct smb2_conn *old)
+{
+    struct smb2_conn *c = smb2_conn_reopen_raw(env, old);
+
+    smb2_handshake(c);
+    return c;
+} /* smb2_conn_reopen */
 
 #endif /* SMB2_MBT_COMMON_H */

--- a/src/server/smb/tests/quint/smb2_mbt_replay.c
+++ b/src/server/smb/tests/quint/smb2_mbt_replay.c
@@ -1734,8 +1734,20 @@ run_trace(
      * fsname isolates the filesystem, and zeroing the wire-value maps stops a
      * stale SessionId/TreeId/FileId from a prior trace being reused. */
     memset(g_conn_for_sess, 0, sizeof(g_conn_for_sess));
+    memset(g_conn_hist, 0, sizeof(g_conn_hist));
     memset(g_wire_tree, 0, sizeof(g_wire_tree));
     memset(g_wire_fid, 0, sizeof(g_wire_fid));
+    /* EVERY wire-identity map has to be cleared here, not just the three the
+     * single-trace harness needed.  A batched run replays many traces in one
+     * process, and a model fid is a small dense integer that every trace
+     * reuses from 0 -- so a residual g_fid_known entry makes the next trace's
+     * first CREATE look like a replay or reclaim of an open that belonged to
+     * the previous trace ("model answered from open N ... the wire returned a
+     * DIFFERENT FileId").  Keep this list in step with the globals above. */
+    memset(g_fid_known, 0, sizeof(g_fid_known));
+    memset(g_conn_for_fid, 0, sizeof(g_conn_for_fid));
+    memset(g_park_barriered, 0, sizeof(g_park_barriered));
+    memset(g_park_pending, 0, sizeof(g_park_pending));
     g_trace     = path;
     g_nmismatch = 0;
 

--- a/src/server/smb/tests/quint/smb2_mbt_replay.c
+++ b/src/server/smb/tests/quint/smb2_mbt_replay.c
@@ -17,11 +17,27 @@
  * block index i is a BS-byte block of byte value s (0 = a hole, reads zero).
  *
  * This replayer builds session/tree bootstrap, the file CREATE
- * disposition/share matrix, CLOSE, READ, WRITE and compounds on the wire.
- * The generated base corpus uses the `stepCore` flavor (delete-on-close
- * excluded until a ground-truth probe pins its removal timing -- see
- * DEVIATIONS-SMB.md Q-1).  Locks, set/query-info, rename and the oplock/lease
- * break lifecycle extend the replayer in a later pass.
+ * disposition/share matrix, CLOSE, READ, WRITE, compounds and the oplock/lease
+ * caching lifecycle on the wire.  The generated base corpus uses the
+ * `stepCore` flavor (delete-on-close excluded until a ground-truth probe pins
+ * its removal timing -- see DEVIATIONS-SMB.md Q-1).  Locks, set/query-info and
+ * rename extend the replayer in a later pass.
+ *
+ * Caching lifecycle (what makes the oplock/lease surface reachable at all):
+ *   - a CREATE carries the model's oplock/lease REQUEST (this used to be
+ *     hard-NULL, so no generated trace ever asked for a caching grant);
+ *   - the granted level / lease state / v2 epoch is compared against the exact
+ *     grant the model computed, not merely "some cache or none";
+ *   - the async interim (STATUS_PENDING) the server emits when the open must
+ *     wait behind a peer's ack-required break is a first-class assertion: the
+ *     model's `parked` flag must match whether an interim went out;
+ *   - every break NOTIFICATION is matched to the model's prediction on the
+ *     holder's own connection -- wire shape (lease vs legacy), current/new
+ *     state, acknowledgment requirement and epoch -- and any notification the
+ *     model did not predict fails the replay;
+ *   - OPLOCK_BREAK / LEASE_BREAK acknowledgments are sent in the wire form the
+ *     model chose (StructureSize 24 vs 36) and their status compared, which is
+ *     what reaches the ack handler's rejection arms.
  */
 
 #include "smb2_mbt_common.h"
@@ -31,16 +47,80 @@
 #include <jansson.h>
 
 #define BS       64              /* bytes per model block symbol */
-#define MAX_SESS 16
-#define MAX_TREE 16
-#define MAX_FID  1024
+
+/* The model's session, tree and FileId numbers are allocated from monotonic
+ * counters (StateDB.nextSess / nextTree / nextFile) and are NEVER recycled, so
+ * these tables are indexed by an id that only grows: a walk that drops and
+ * remakes sessions burns a slot per drop.  They are therefore sized for the
+ * deepest registered batch rather than for the model's LIVE limits (which are
+ * MAX_SESSIONS = 2, MAX_TREES = 3, MAX_OPENS = 6), and an id past the end is a
+ * HARNESS limit, reported as such and fatal -- never silently mapped to a NULL
+ * connection, which is what the durable flavors used to do. */
+#define MAX_SESS 512
+#define MAX_TREE 512
+#define MAX_FID  4096
 
 static struct smb2_env   g_env;
+/* The connection a live model session is bound to, NULL once a modeled
+ * transport drop has taken it away. */
 static struct smb2_conn *g_conn_for_sess[MAX_SESS];
+/* Every connection a session was EVER bound to, kept after the drop: a
+ * reconnect must present the dropped session's ClientGuid (MS-SMB2 3.3.5.9.7 --
+ * chimera refuses a leased or persistent reclaim from a different client), and
+ * the model names the client by the session it is reconnecting FOR. */
+static struct smb2_conn *g_conn_hist[MAX_SESS];
 static uint32_t          g_wire_tree[MAX_TREE];
 static uint8_t           g_wire_fid[MAX_FID][16];
+/* Has this model FileId ever been learned from the wire?  A model fid is never
+ * reused, so a SECOND reply carrying one the replayer already knows is the
+ * model asserting "this is the same open" -- a replayed CREATE answered from
+ * the reply cache, or a reclaim of a parked handle.  The wire FileId must then
+ * be byte-identical, which is the exactly-once oracle MS-SMB2 3.3.5.9.10 asks
+ * for stated as an assertion rather than a status comparison. */
+static int               g_fid_known[MAX_FID];
+/* Which connection owns each model FileId: a break notification for a handle
+ * is pushed to the HOLDER's connection, and the acknowledgment must go back on
+ * that same connection, so the fid -> conn binding is as load-bearing as the
+ * fid -> wire FileId one. */
+static struct smb2_conn *g_conn_for_fid[MAX_FID];
+/* The model lease key (a small int) each handle's grant carries, or -1.  A
+ * LEASE_BREAK acknowledgment is keyed by the 16-byte lease key, not by FileId. */
+static int               g_lease_key_for_fid[MAX_FID];
+/* Which parked handles the replayer has already waited for (see park_barrier). */
+static int               g_park_barriered[MAX_FID];
+/* The model state AFTER the message being replayed -- the `parked` map of which
+ * is what tells the disconnect handler which handles the server still owes a
+ * park. */
+static json_t           *g_post_sdb;
 static const char       *g_trace;
 static int               g_nmismatch;
+
+/* Settle every server thread so the break notifications a command owes have
+ * been delivered -- and so that "no break was sent" is a fact rather than a
+ * guess about how long to wait.
+ *
+ * A break is queued, and the holder's thread doorbell rung, by the thread that
+ * ran the conflicting operation, BEFORE that operation's reply goes out.  So by
+ * the time the command's reply has been parsed the notification exists; what is
+ * still outstanding is the holder thread flushing it, and the holder may be any
+ * connection on any thread.  smb2_quiesce() drives an ECHO barrier over every
+ * connection, repeatedly, until a whole pass produces no new break, interim or
+ * reply (see smb2_mbt_common.h) -- costing a couple of round trips, not a
+ * couple of milliseconds of sleeping, and costing exactly one pass when the
+ * command provoked nothing.
+ *
+ * This replaces two wall-clock waits: a 2 s budget for the predicted count to
+ * arrive, and -- far more expensively -- an unconditional 2 ms spin after every
+ * single command that predicted NO break, whose only purpose was to give an
+ * unpredicted break a chance to show up before a later command was blamed for
+ * it.  At the registered corpus size (24 traces x 240-500 commands) that spin
+ * alone was several seconds of pure sleeping per batch, and neither wait made
+ * the verdict any more sound: a slower machine simply got a longer window. */
+static void
+settle_breaks(void)
+{
+    smb2_quiesce(&g_env);
+} /* settle_breaks */
 
 /* ---- ITF helpers -------------------------------------------------------- */
 
@@ -102,6 +182,67 @@ mism(
     printf("\n");
     g_nmismatch++;
 } /* mism */
+
+/* A model id that has run off the end of one of the tables above is a HARNESS
+ * limit, not a divergence: the trace is fine and the replayer cannot represent
+ * it.  Say so and stop, rather than returning a slot that does not exist. */
+static void
+slot_overflow(
+    const char *what,
+    int64_t     id,
+    int         limit)
+{
+    fprintf(stderr,
+            "smb2 harness: model %s id %lld exceeds the replayer's table "
+            "(%d slots).\n  Raise MAX_%s in smb2_mbt_replay.c, or generate "
+            "this batch at a shallower depth.\n  Trace: %s\n",
+            what, (long long) id, limit,
+            strcmp(what, "session") == 0 ? "SESS"
+            : strcmp(what, "tree") == 0 ? "TREE" : "FID",
+            g_trace ? g_trace : "?");
+    exit(3);
+} /* slot_overflow */
+
+/* The live connection a model session is bound to.
+ *
+ * Returns NULL only when the session has no connection at all, which for a
+ * generated trace is a HARNESS bug and not a model one: every action in
+ * smb2.qnt draws its session from `sessions`, and a modeled transport drop
+ * removes the session (and its trees and non-durable opens) from that map in
+ * the same step -- so the model never drives a session it has disconnected.
+ * Callers therefore report a missing connection as a mismatch and refuse to
+ * run the command; nothing hands NULL onward to a PDU builder (which asserts
+ * loudly on one anyway -- smb2c_begin). */
+static struct smb2_conn *
+conn_for_sess(int64_t sess)
+{
+    if (sess < 0) {
+        return NULL;
+    }
+    if (sess >= MAX_SESS) {
+        slot_overflow("session", sess, MAX_SESS);
+    }
+    return g_conn_for_sess[sess];
+} /* conn_for_sess */
+
+/* Bind a model session id to the connection that carries it.  `hist` remembers
+ * the binding past the drop, for the reconnect's ClientGuid. */
+static void
+bind_sess(
+    int64_t           sess,
+    struct smb2_conn *c)
+{
+    if (sess < 0) {
+        return;
+    }
+    if (sess >= MAX_SESS) {
+        slot_overflow("session", sess, MAX_SESS);
+    }
+    g_conn_for_sess[sess] = c;
+    if (c) {
+        g_conn_hist[sess] = c;
+    }
+} /* bind_sess */
 
 /* ---- model -> wire field maps ------------------------------------------- */
 
@@ -171,6 +312,311 @@ sym_byte(int64_t s)
     return (uint8_t) (s == 0 ? 0 : s);
 } /* sym_byte */
 
+/* An ITF set is {"#set": [...]}; a list is a plain array. */
+static json_t *
+jset(json_t *o)
+{
+    if (json_is_object(o)) {
+        json_t *s = json_object_get(o, "#set");
+        if (s) {
+            return s;
+        }
+    }
+    return o;
+} /* jset */
+
+/* Model lease key (a small int) -> the 16-byte wire LeaseKey.  Any injective
+ * map will do; the server only ever compares keys for equality. */
+static void
+lease_key_wire(
+    int64_t  k,
+    uint8_t *out)
+{
+    memset(out, 0, 16);
+    out[0] = 'L';
+    out[1] = 'K';
+    out[2] = (uint8_t) k;
+} /* lease_key_wire */
+
+/* Model LeaseState record -> wire lease bits (R=0x01, H=0x02, W=0x04). */
+static uint32_t
+lease_bits_wire(json_t *st)
+{
+    uint32_t m = 0;
+
+    if (jbool(st, "r")) {
+        m |= SMB2_LEASE_READ;
+    }
+    if (jbool(st, "h")) {
+        m |= SMB2_LEASE_HANDLE;
+    }
+    if (jbool(st, "w")) {
+        m |= SMB2_LEASE_WRITE;
+    }
+    return m;
+} /* lease_bits_wire */
+
+static uint8_t
+oplock_level_wire(const char *tag)
+{
+    if (strcmp(tag, "OpLevelII") == 0) {
+        return SMB2_OPLOCK_LEVEL_II;
+    }
+    if (strcmp(tag, "OpExclusive") == 0) {
+        return SMB2_OPLOCK_LEVEL_EXCLUSIVE;
+    }
+    if (strcmp(tag, "OpBatch") == 0) {
+        return SMB2_OPLOCK_LEVEL_BATCH;
+    }
+    return SMB2_OPLOCK_LEVEL_NONE;
+} /* oplock_level_wire */
+
+/* Build the CREATE's oplock/lease request from the model's OplockReq.  Until
+ * now the replayer passed NULL here, so no generated trace ever asked for a
+ * caching grant and the whole oplock/lease surface was unreachable from the
+ * corpus. */
+static const struct smb2_oplock_req *
+oplock_req_of(
+    json_t                 *opl,
+    struct smb2_oplock_req *req)
+{
+    const char *tag = jtag(opl);
+
+    memset(req, 0, sizeof(*req));
+    if (strcmp(tag, "OrNone") == 0) {
+        return NULL;
+    }
+    if (strcmp(tag, "OrLease") == 0) {
+        json_t *v = jval(opl);
+
+        req->is_lease = 1;
+        lease_key_wire(jfield(v, "key"), req->lease_key);
+        req->lease_state = (jbool(v, "r") ? SMB2_LEASE_READ : 0) |
+            (jbool(v, "h") ? SMB2_LEASE_HANDLE : 0) |
+            (jbool(v, "w") ? SMB2_LEASE_WRITE : 0);
+        req->lease_epoch = (uint16_t) jfield(v, "epoch");
+        req->force_v1    = !jbool(v, "v2");
+        return req;
+    }
+    /* The REQUEST tags (OrLevelII/OrExclusive/OrBatch) are distinct from the
+     * GRANT tags (OpLevelII/...), so they are mapped here rather than through
+     * oplock_level_wire. */
+    if (strcmp(tag, "OrLevelII") == 0) {
+        req->level = SMB2_OPLOCK_LEVEL_II;
+    } else if (strcmp(tag, "OrExclusive") == 0) {
+        req->level = SMB2_OPLOCK_LEVEL_EXCLUSIVE;
+    } else if (strcmp(tag, "OrBatch") == 0) {
+        req->level = SMB2_OPLOCK_LEVEL_BATCH;
+    } else {
+        mism("unknown OplockReq tag '%s'", tag);
+        return NULL;
+    }
+    return req;
+} /* oplock_req_of */
+
+/* ---- durable-handle create contexts ------------------------------------- */
+
+/* The model names a CreateGuid by a small integer (smb2.qnt DUR_GUIDS); the
+ * wire needs 16 bytes.  The map has to be stable for the whole trace, because
+ * the CreateGuid is the identity MS-SMB2 3.3.5.9.10 keys the durable registry
+ * and the CREATE reply cache on: two creates carrying the same symbol MUST
+ * collide on the wire exactly where the model says they collide.
+ *
+ * It is deliberately NOT mixed with the connection's ClientGuid: chimera scopes
+ * the registry scan by ClientGuid, so two clients drawing the same symbol are
+ * two different durable opens -- which is what the model's per-clientTag
+ * durGuidCollision says too, and would be untestable if the harness made the
+ * guids differ by client. */
+static void
+create_guid_wire(
+    int64_t  g,
+    uint8_t *out)
+{
+    memset(out, 0, 16);
+    out[0]  = 0xC0;
+    out[1]  = 0x1D;
+    out[15] = (uint8_t) g;
+} /* create_guid_wire */
+
+/* Build the CREATE's durable contexts from the model's DurableReq.
+ *
+ * DurQ -> a durable REQUEST (DHnQ when v1, DH2Q when v2); DurC -> a
+ * RECONNECT naming the parked handle by the wire FileId the replayer learned
+ * when it was created, optionally with the matching REQUEST alongside
+ * (`alsoQ`, which is legal for v1 and INVALID_PARAMETER for v2 -- probe D4e)
+ * and optionally with SMB2_DHANDLE_FLAG_PERSISTENT set. */
+static const struct smb2_durable_req *
+durable_req_of(
+    json_t                  *dur,
+    struct smb2_durable_req *d)
+{
+    const char *tag = jtag(dur);
+    json_t     *v   = jval(dur);
+
+    memset(d, 0, sizeof(*d));
+    if (strcmp(tag, "DurNone") == 0) {
+        return NULL;
+    }
+    if (strcmp(tag, "DurQ") == 0) {
+        int v2 = jbool(v, "v2");
+
+        if (v2) {
+            d->dh2q = 1;
+            create_guid_wire(jfield(v, "guid"), d->create_guid);
+        } else {
+            d->dhnq = 1;
+        }
+        d->timeout_ms = 0;           /* 0 = the server default, 60000 ms (C-14) */
+        d->flags      = jbool(v, "persistent") ? SMB2_DHANDLE_FLAG_PERSISTENT : 0;
+        return d;
+    }
+    if (strcmp(tag, "DurC") == 0) {
+        int     v2  = jbool(v, "v2");
+        int64_t fid = jfield(v, "fid");
+
+        if (fid < 0 || fid >= MAX_FID) {
+            slot_overflow("fid", fid, MAX_FID);
+        }
+        /* An unknown fid (smbReclaimUnknown draws FileIds that were never
+         * created, or were closed) keeps the zeroed table entry, which matches
+         * no open -- exactly the OBJECT_NAME_NOT_FOUND case the model
+         * predicts. */
+        memcpy(d->file_id, g_wire_fid[fid], 16);
+        create_guid_wire(jfield(v, "guid"), d->create_guid);
+        if (v2) {
+            d->dh2c = 1;
+            d->dh2q = jbool(v, "alsoQ");
+        } else {
+            d->dhnc = 1;
+            d->dhnq = jbool(v, "alsoQ");
+        }
+        d->reconnect_flags =
+            jbool(v, "persistent") ? SMB2_DHANDLE_FLAG_PERSISTENT : 0;
+        return d;
+    }
+    mism("unknown DurableReq tag '%s'", tag);
+    return NULL;
+} /* durable_req_of */
+
+/* ---- break notifications ------------------------------------------------ */
+
+/* Assert that the break notifications the server pushed are EXACTLY the ones
+ * the model predicted for this command: same holder connection, same wire
+ * shape (lease vs legacy), same current/new state, same acknowledgment
+ * requirement and epoch.  Matched notifications are consumed; anything left
+ * over is an unpredicted break and fails the replay. */
+static void
+check_breaks(
+    json_t     *breaks,
+    const char *what)
+{
+    json_t *arr = jset(breaks);
+    size_t  n   = json_array_size(arr);
+
+    /* A break is delivered through a cross-thread doorbell, so it lands a few
+     * loop iterations after the op that triggered it.  Settle every thread
+     * first, so that both directions are decided by an event: a predicted
+     * break that has not arrived really is missing, and an UNPREDICTED break is
+     * seen HERE rather than blamed on a later command. */
+    settle_breaks();
+
+    for (size_t i = 0; i < n; i++) {
+        json_t           *b        = json_array_get(arr, i);
+        int64_t           fid      = jfield(b, "fid");
+        int               is_lease = jbool(b, "isLease");
+        struct smb2_conn *hc       =
+            (fid >= 0 && fid < MAX_FID) ? g_conn_for_fid[fid] : NULL;
+        uint8_t           key[16];
+        int               found = -1;
+
+        if (!hc) {
+            mism("%s: predicted break for fid %lld with no holder connection",
+                 what, (long long) fid);
+            continue;
+        }
+        lease_key_wire(jfield(b, "key"), key);
+
+        for (int k = 0; k < hc->nbrk; k++) {
+            struct smb2_break *q = &hc->brk[k];
+
+            if (!!q->is_lease != !!is_lease) {
+                continue;
+            }
+            if (is_lease) {
+                if (memcmp(q->lease_key, key, 16) != 0) {
+                    continue;
+                }
+            } else if (memcmp(q->file_id, g_wire_fid[fid], 16) != 0) {
+                continue;
+            }
+            found = k;
+            break;
+        }
+
+        if (found < 0) {
+            mism("%s: model predicted a %s break for fid %lld, the wire sent "
+                 "none", what, is_lease ? "LEASE" : "OPLOCK", (long long) fid);
+            continue;
+        }
+
+        struct smb2_break q = hc->brk[found];
+        for (int k = found + 1; k < hc->nbrk; k++) {
+            hc->brk[k - 1] = hc->brk[k];
+        }
+        hc->nbrk--;
+
+        if (is_lease) {
+            uint32_t exp_cur = (uint32_t) jfield(b, "curState");
+            uint32_t exp_new = (uint32_t) jfield(b, "newState");
+            int      exp_ack = jbool(b, "ackReq");
+            uint32_t exp_ep  = (uint32_t) jfield(b, "epoch");
+
+            if (q.cur_state != exp_cur || q.new_state != exp_new) {
+                mism("%s: LEASE break fid %lld state: model 0x%02x->0x%02x "
+                     "wire 0x%02x->0x%02x", what, (long long) fid, exp_cur,
+                     exp_new, q.cur_state, q.new_state);
+            }
+            if (!!q.ack_required != !!exp_ack) {
+                mism("%s: LEASE break fid %lld ack_required: model %d wire %d",
+                     what, (long long) fid, exp_ack, q.ack_required);
+            }
+            if (q.new_epoch != exp_ep) {
+                mism("%s: LEASE break fid %lld epoch: model %u wire %u", what,
+                     (long long) fid, exp_ep, q.new_epoch);
+            }
+        } else {
+            uint32_t exp_lvl = (uint32_t) jfield(b, "newLevel");
+
+            /* A legacy OPLOCK_BREAK notification carries no ack flag on the
+             * wire (MS-SMB2 2.2.23.1), so the model's ackReq is asserted
+             * indirectly instead: an acknowledgment of a break that needed
+             * none is rejected, which the CBreakAck status check covers. */
+            if (q.oplock_level != exp_lvl) {
+                mism("%s: OPLOCK break fid %lld level: model 0x%02x wire 0x%02x",
+                     what, (long long) fid, exp_lvl, q.oplock_level);
+            }
+        }
+    }
+} /* check_breaks */
+
+/* No connection may hold a break the model did not predict. */
+static void
+check_no_stray_breaks(const char *what)
+{
+    for (int i = 0; i < g_env.nconns; i++) {
+        struct smb2_conn *c = g_env.conns[i];
+
+        while (c->nbrk > 0) {
+            mism("%s: unpredicted %s break notification on connection %d", what,
+                 c->brk[0].is_lease ? "LEASE" : "OPLOCK", i);
+            for (int k = 1; k < c->nbrk; k++) {
+                c->brk[k - 1] = c->brk[k];
+            }
+            c->nbrk--;
+        }
+    }
+} /* check_no_stray_breaks */
+
 /* ---- per-command replay + compare --------------------------------------- */
 
 /* Resolve a FidSel (FidRelated -> the current compound's CREATE fid; FidRef k
@@ -204,56 +650,226 @@ wire_caches(const struct smb2_create_out *o)
     return 1;   /* II / exclusive / batch all cache */
 } /* wire_caches */
 
+/* Compare the caching grant the wire handed out against the exact grant the
+* model computed: the oplock level for a legacy grant, and the granted lease
+* state plus (for a v2 lease) the epoch for an RqLs grant.  A grant the model
+* did not predict -- or a level above the predicted one -- is a mismatch. */
+static void
+check_caching(
+    const char                   *name,
+    json_t                       *caching,
+    const struct smb2_create_out *out)
+{
+    const char *ctag = jtag(caching);
+
+    if (strcmp(ctag, "CNone") == 0) {
+        if (wire_caches(out)) {
+            mism("CREATE '%s' caching: model CNone but wire granted oplock "
+                 "0x%02x lease 0x%02x", name, out->oplock, out->lease_state);
+        }
+        return;
+    }
+    if (strcmp(ctag, "COplock") == 0) {
+        uint8_t exp = oplock_level_wire(jtag(jval(caching)));
+
+        if (out->oplock != exp) {
+            mism("CREATE '%s' oplock level: model 0x%02x wire 0x%02x", name,
+                 exp, out->oplock);
+        }
+        return;
+    }
+    /* CLease */
+    json_t  *lv     = jval(caching);
+    uint32_t exp_st = lease_bits_wire(json_object_get(lv, "st"));
+    int      exp_v2 = jbool(lv, "v2");
+    uint32_t exp_ep = (uint32_t) jfield(lv, "epoch");
+
+    if (out->oplock != SMB2_OPLOCK_LEVEL_LEASE) {
+        mism("CREATE '%s' caching: model granted a lease, wire reported "
+             "OplockLevel 0x%02x", name, out->oplock);
+        return;
+    }
+    if (!out->has_lease) {
+        mism("CREATE '%s' caching: model granted a lease but the reply carried "
+             "no RqLs response context", name);
+        return;
+    }
+    if (out->lease_state != exp_st) {
+        mism("CREATE '%s' lease state: model 0x%02x wire 0x%02x", name, exp_st,
+             out->lease_state);
+    }
+    if (exp_v2 && out->lease_epoch != exp_ep) {
+        mism("CREATE '%s' lease epoch: model %u wire %u", name, exp_ep,
+             out->lease_epoch);
+    }
+} /* check_caching */
+
 static void
 do_create(
     struct smb2_conn *c,
     json_t           *v,
     json_t           *res)
 {
-    const char            *name  = json_string_value(json_object_get(v, "name"));
-    uint32_t               disp  = disp_wire(jtag(json_object_get(v, "disp")));
-    uint32_t               acc   = access_wire(json_object_get(v, "access"));
-    uint32_t               shr   = share_wire(json_object_get(v, "share"));
-    int                    doc   = jbool(v, "delOnClose");
-    int                    isdir = jbool(v, "isDir");
-    uint32_t               opts  = isdir ? FILE_DIRECTORY_FILE
+    const char                    *name  = json_string_value(json_object_get(v, "name"));
+    uint32_t                       disp  = disp_wire(jtag(json_object_get(v, "disp")));
+    uint32_t                       acc   = access_wire(json_object_get(v, "access"));
+    uint32_t                       shr   = share_wire(json_object_get(v, "share"));
+    int                            doc   = jbool(v, "delOnClose");
+    int                            isdir = jbool(v, "isDir");
+    uint32_t                       opts  = isdir ? FILE_DIRECTORY_FILE
                                         : FILE_NON_DIRECTORY_FILE;
-    struct smb2_create_out out;
+    struct smb2_create_out         out;
+    struct smb2_oplock_req         oreq;
+    const struct smb2_oplock_req  *reqp =
+        oplock_req_of(json_object_get(v, "oplock"), &oreq);
+    struct smb2_durable_req        dreq;
+    const struct smb2_durable_req *durp =
+        durable_req_of(json_object_get(v, "durable"), &dreq);
+    int                            interim0 = c->ninterim;
 
     if (doc) {
         opts |= FILE_DELETE_ON_CLOSE;
     }
 
-    smb2_create_opts(c, name, disp, acc, shr, opts, NULL, &out);
+    smb2_create_dur_opts(c, name, disp, acc, shr, opts, reqp, durp, &out);
+    if (getenv("SMB2_MBT_DEBUG")) {
+        fprintf(stderr, "DBG create '%s' disp=%u acc=%08x shr=%u opts=%08x "
+                "reqp=%p lvl=%u lease=%d -> st=%08x opl=%02x lease=%02x\n",
+                name, disp, acc, shr, opts, (void *) reqp,
+                reqp ? reqp->level : 0, reqp ? reqp->is_lease : 0,
+                out.status, out.oplock, out.lease_state);
+    }
 
-    json_t                *rv     = jval(res);
-    uint32_t               exp_st = (uint32_t) jfield(rv, "st");
+    json_t  *rv     = jval(res);
+    uint32_t exp_st = (uint32_t) jfield(rv, "st");
 
     if (out.status != exp_st) {
         mism("CREATE '%s' status: model 0x%08x wire 0x%08x", name, exp_st,
              out.status);
         return;
     }
+
+    /* An async interim means the open was granted but held behind a peer's
+     * ack-required break (smb_async_interim.c).  The model predicts exactly
+     * that condition, so assert it rather than tolerating either shape. */
+    int exp_parked = jbool(rv, "parked");
+    int got_parked = (c->ninterim > interim0);
+    if (exp_parked != got_parked) {
+        mism("CREATE '%s' park: model %s an async interim, wire %s one", name,
+             exp_parked ? "expected" : "expected no",
+             got_parked ? "sent" : "sent none");
+    }
+
     if (out.status != ST_SUCCESS) {
         return;
     }
 
-    uint32_t    exp_act = (uint32_t) jfield(rv, "act");
+    uint32_t exp_act = (uint32_t) jfield(rv, "act");
     if (out.action != exp_act) {
         mism("CREATE '%s' action: model %u wire %u", name, exp_act, out.action);
     }
-    /* The base instance grants no caching; the wire must agree. */
-    const char *ctag = jtag(json_object_get(rv, "caching"));
-    if (strcmp(ctag, "CNone") == 0 && wire_caches(&out)) {
-        mism("CREATE '%s' caching: model CNone but wire granted oplock 0x%02x "
-             "lease 0x%02x", name, out.oplock, out.lease_state);
+    check_caching(name, json_object_get(rv, "caching"), &out);
+
+    /* The durable grant.  A DHnQ / DH2Q RESPONSE context is the grant signal
+    * on the wire -- chimera emits one only when it granted (C-13) -- so the
+    * model's boolean is asserted against its presence, not against the status.
+    * A reconnect grants nothing new and answers false (C-15/D3); a
+    * replay-driven reclaim DOES carry one, because the replayed request is a
+    * full DH2Q create (C-46).  Both directions are therefore live checks. */
+    int exp_dur = jbool(rv, "durable");
+    int got_dur = out.has_dh2q || out.has_dhnq;
+    if (exp_dur != got_dur) {
+        mism("CREATE '%s' durable: model %s a durable grant, wire %s one",
+             name, exp_dur ? "expected" : "expected no",
+             got_dur ? "reported" : "reported none");
     }
-    /* Learn the FileId for the model fid this CREATE produced. */
-    int64_t     fid = jfield(rv, "fid");
-    if (fid >= 0 && fid < MAX_FID) {
+    /* No modeled instance serves a continuously-available share, so nothing in
+     * a generated corpus may come back PERSISTENT (MS-SMB2 3.3.5.9.10; probe
+     * D11 pins the share that does grant it). */
+    if (out.has_dh2q && (out.dh2q_flags & SMB2_DHANDLE_FLAG_PERSISTENT)) {
+        mism("CREATE '%s' durable: wire granted a PERSISTENT handle on a share "
+             "with no continuous availability (flags 0x%08x)", name,
+             out.dh2q_flags);
+    }
+
+    /* Learn the FileId, the owning connection and the lease key for the model
+     * fid this CREATE produced. */
+    int64_t fid = jfield(rv, "fid");
+    if (fid >= MAX_FID) {
+        slot_overflow("fid", fid, MAX_FID);
+    }
+    if (fid >= 0) {
+        json_t *caching = json_object_get(rv, "caching");
+
+        /* A model fid is allocated from a monotonic counter and never reused,
+        * so the model returning one it has already handed out means THIS
+        * REPLY IS THE SAME OPEN: a replayed CREATE answered from the reply
+        * cache, or a reclaim of a parked handle.  MS-SMB2 3.3.5.9.10's
+        * exactly-once guarantee is precisely that the wire FileId comes back
+        * unchanged, so compare rather than overwrite -- overwriting is how a
+        * server that quietly made a SECOND open would have gone unnoticed. */
+        if (g_fid_known[fid] &&
+            memcmp(g_wire_fid[fid], out.file_id, 16) != 0) {
+            mism("CREATE '%s': model answered from open %lld (a replay or a "
+                 "reclaim) but the wire returned a DIFFERENT FileId", name,
+                 (long long) fid);
+        }
         memcpy(g_wire_fid[fid], out.file_id, 16);
+        g_fid_known[fid]         = 1;
+        g_conn_for_fid[fid]      = c;
+        g_lease_key_for_fid[fid] =
+            strcmp(jtag(caching), "CLease") == 0
+            ? (int) jfield(jval(caching), "key") : -1;
     }
 } /* do_create */
+
+/* OPLOCK_BREAK (StructureSize 24) / LEASE_BREAK (StructureSize 36)
+ * acknowledgment.  The model resolves the target handle; the wire form is
+ * chosen by the model's `asLease`, which is what the server discriminates on.
+ * Every rejection arm the server distinguishes -- FILE_CLOSED, UNSUCCESSFUL,
+ * INVALID_DEVICE_STATE / INVALID_OPLOCK_PROTOCOL, REQUEST_NOT_ACCEPTED -- is a
+ * status the model predicts here. */
+static void
+do_break_ack(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    json_t  *sel      = json_object_get(v, "fid");
+    int      as_lease = jbool(v, "asLease");
+    uint32_t exp_st   = (uint32_t) jfield(jval(res), "st");
+    int64_t  k        = -1;
+    uint32_t st;
+
+    if (strcmp(jtag(sel), "FidRef") == 0) {
+        k = jint(jval(sel));
+    }
+    if (k < 0 || k >= MAX_FID) {
+        mism("BREAK_ACK: unresolved FileId");
+        return;
+    }
+    (void) related_fid;
+    (void) have_related;
+
+    if (as_lease) {
+        uint8_t key[16];
+
+        lease_key_wire(g_lease_key_for_fid[k], key);
+        st = smb2_lease_break_ack(c, key,
+                                  lease_bits_wire(json_object_get(v,
+                                                                  "ackState")));
+    } else {
+        st = smb2_oplock_break_ack(c, g_wire_fid[k],
+                                   oplock_level_wire(jtag(json_object_get(v,
+                                                                          "ackLevel"))));
+    }
+    if (st != exp_st) {
+        mism("BREAK_ACK (%s, fid %lld) status: model 0x%08x wire 0x%08x",
+             as_lease ? "lease" : "oplock", (long long) k, exp_st, st);
+    }
+} /* do_break_ack */
 
 static void
 do_close(
@@ -367,6 +983,457 @@ do_read(
     (void) exp_eof;   /* eof already implied by count vs request length */
 } /* do_read */
 
+/* ---- the transport drop, the park barrier, and the reconnect ------------ */
+
+/* Handles the server still owes a PARK, indexed by model FileId. */
+static int g_park_pending[MAX_FID];
+
+/* Wait until the server has finished parking every handle a modeled drop left
+ * behind.
+ *
+ * A client-initiated disconnect returns as soon as the DISCONNECTED
+ * notification reaches the CLIENT bind; the server's teardown -- which is what
+ * parks the durable opens (chimera_smb_durable_conn_disconnecting) -- runs
+ * afterwards, on the dropped connection's own server thread, and smb2_quiesce()
+ * cannot order against a thread that has no connection left to echo on.  So
+ * anything that touches the file before that teardown lands is racing it: a
+ * conflicting CREATE that should purge a parked holder (probe D7) instead
+ * meets a LIVE one and is refused, or breaks it.
+ *
+ * The barrier is the durable probe's (wait_parked): a DH2C reconnect carrying
+ * a deliberately WRONG CreateGuid.  chimera_smb_durable_claim answers a
+ * not-yet-parked entry with *r_retry and chimera_smb_durable_reconnect retries
+ * on a timer until it parks, so the reply cannot come back before the park has
+ * happened; once parked, the guid mismatch answers OBJECT_NAME_NOT_FOUND and
+ * leaves the entry untouched (a refused reconnect consumes nothing -- D4j).
+ *
+ * It needs SOME live connection with a tree to send on, and a drop can leave
+ * the replayer with none, so pending handles are flushed at the top of the next
+ * command that has one.  Nothing can race the park in between: the only steps
+ * the model can take with no session are a session setup and a reconnect, and
+ * a reconnect's own reclaim is self-ordering through the same retry. */
+static void
+park_barrier_flush(struct smb2_conn *c)
+{
+    if (!smb2c_check_live(c) || c->tree_id == 0) {
+        return;
+    }
+    for (int fid = 0; fid < MAX_FID; fid++) {
+        struct smb2_durable_req dur;
+        struct smb2_create_out  r;
+        uint32_t                st;
+
+        if (!g_park_pending[fid]) {
+            continue;
+        }
+        g_park_pending[fid] = 0;
+
+        memset(&dur, 0, sizeof(dur));
+        dur.dh2c = 1;
+        memcpy(dur.file_id, g_wire_fid[fid], 16);
+        memset(dur.create_guid, 0xFE, 16);   /* cannot match any real create */
+        st = smb2_create_dur(c, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                             NULL, &dur, &r);
+        if (st != ST_OBJECT_NAME_NOT_FOUND) {
+            mism("park barrier for fid %d: a wrong-CreateGuid DH2C answered "
+                 "0x%08x, expected OBJECT_NAME_NOT_FOUND", fid, st);
+        }
+    }
+} /* park_barrier_flush */
+
+/* The modeled transport drop (MS-SMB2 3.3.7.1).  The model has already decided
+ * which of the session's opens park and which close; the replayer drops the
+ * connection for real and then waits for the park to land. */
+static void
+do_disconnect(
+    struct smb2_conn *c,
+    int64_t           sess)
+{
+    json_t *parked  = g_post_sdb ? json_object_get(g_post_sdb, "parked") : NULL;
+    json_t *entries = parked ? json_object_get(parked, "#map") : NULL;
+
+    smb2_conn_disconnect(c);
+    bind_sess(sess, NULL);
+
+    /* The fid -> connection bindings this connection owned are dead.  A parked
+     * handle acquires a new one when it is reclaimed (do_create); until then
+     * any use of one is a harness bug and must say so rather than write to a
+     * closed connection. */
+    for (int i = 0; i < MAX_FID; i++) {
+        if (g_conn_for_fid[i] == c) {
+            g_conn_for_fid[i] = NULL;
+        }
+    }
+
+    /* Which handles the model says are parked NOW -- read from the post-state
+     * rather than recomputed, so the barrier waits for exactly the set the
+     * oracle believes in. */
+    for (size_t i = 0; i < json_array_size(entries); i++) {
+        json_t *kv  = json_array_get(entries, i);
+        int64_t fid = jint(json_array_get(kv, 0));
+
+        if (fid < 0 || fid >= MAX_FID) {
+            continue;
+        }
+        if (!g_park_barriered[fid]) {
+            g_park_barriered[fid] = 1;
+            g_park_pending[fid]   = 1;
+        }
+    }
+} /* do_disconnect */
+
+/* SET_INFO / FileEndOfFileInformation.  The exactly-once flavor needs it for
+ * one reason above all: its ChannelSequence gate sits in the OPPOSITE place to
+ * WRITE's -- before the info-class check rather than after the access check
+ * (probe R12, C-44) -- so a corpus with only WRITEs cannot tell a server that
+ * put the gate in one place from one that put it in both. */
+static void
+do_set_eof(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    const uint8_t *fid = resolve_fid(json_object_get(v, "fid"), related_fid,
+                                     have_related);
+    int64_t        sz     = jfield(v, "sizeBlocks");
+    uint32_t       exp_st = (uint32_t) jfield(jval(res), "st");
+    uint32_t       st;
+
+    if (!fid) {
+        mism("SET_EOF: unresolved FileId");
+        return;
+    }
+    st = smb2_set_eof(c, fid, (uint64_t) sz * BS);
+    if (st != exp_st) {
+        mism("SET_EOF status: model 0x%08x wire 0x%08x", exp_st, st);
+    }
+} /* do_set_eof */
+
+/* ---- SET_INFO / FileDispositionInformation ------------------------------
+ *
+ * MS-FSCC 2.4.11.  This is the SMB spelling of "unlink": there is no
+ * path-based REMOVE, so the whole delete lifecycle -- mark, unmark, and the
+ * removal that happens at last close -- runs through this one byte.  The
+ * status is asserted here; the EFFECT is asserted by the rest of the trace,
+ * because the model threads `deletePending` into every later QUERY_INFO and
+ * the name's disappearance into every later CREATE. */
+static void
+do_set_disposition(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    const uint8_t *fid = resolve_fid(json_object_get(v, "fid"), related_fid,
+                                     have_related);
+    int            del    = jbool(v, "del");
+    uint32_t       exp_st = (uint32_t) jfield(jval(res), "st");
+    uint32_t       st;
+
+    if (!fid) {
+        mism("SET_DISPOSITION: unresolved FileId");
+        return;
+    }
+    st = smb2_set_disposition(c, fid, del);
+    if (st != exp_st) {
+        mism("SET_DISPOSITION(%s) status: model 0x%08x wire 0x%08x",
+             del ? "delete" : "undelete", exp_st, st);
+    }
+} /* do_set_disposition */
+
+/* ---- SET_INFO / FileRenameInformation -----------------------------------
+ *
+ * MS-FSCC 2.4.37, ReplaceIfExists = FALSE (which is what the model encodes:
+ * doCmdSetRename answers OBJECT_NAME_COLLISION for an occupied target rather
+ * than replacing it).  The rename is by HANDLE, so every open of the inode
+ * follows it -- an expectation the rest of the trace exercises, because the
+ * model re-points every open's (dir,name) and a later delete-on-close or
+ * rename through any of them must therefore target the NEW name. */
+static void
+do_set_rename(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    const uint8_t *fid = resolve_fid(json_object_get(v, "fid"), related_fid,
+                                     have_related);
+    const char    *nn     = json_string_value(json_object_get(v, "newname"));
+    uint32_t       exp_st = (uint32_t) jfield(jval(res), "st");
+    uint32_t       st;
+
+    if (!fid) {
+        mism("SET_RENAME: unresolved FileId");
+        return;
+    }
+    st = smb2_rename(c, fid, nn ? nn : "", 0);
+    if (st != exp_st) {
+        mism("SET_RENAME -> '%s' status: model 0x%08x wire 0x%08x",
+             nn ? nn : "?", exp_st, st);
+    }
+} /* do_set_rename */
+
+/* ---- FLUSH -------------------------------------------------------------- */
+static void
+do_flush(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    const uint8_t *fid    = resolve_fid(v, related_fid, have_related);
+    uint32_t       exp_st = (uint32_t) jfield(jval(res), "st");
+    uint32_t       st;
+
+    if (!fid) {
+        mism("FLUSH: unresolved FileId");
+        return;
+    }
+    st = smb2_flush(c, fid);
+    if (st != exp_st) {
+        mism("FLUSH status: model 0x%08x wire 0x%08x", exp_st, st);
+    }
+} /* do_flush */
+
+/* ---- LOCK ---------------------------------------------------------------
+ *
+ * MS-SMB2 2.2.26.  The model's lock space is measured in the same units as
+ * its I/O offsets (one model block), so a lock over [lo,hi) is the byte range
+ * [lo*BS, hi*BS) on the wire -- the same scaling READ and WRITE use.  Getting
+ * that wrong would make every lock disjoint from every I/O and the mandatory-
+ * lock rule (MS-FSA 2.1.4.2/2.1.4.3) would go untested while every status
+ * still matched. */
+static void
+do_lock(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    const uint8_t *fid = resolve_fid(json_object_get(v, "fid"), related_fid,
+                                     have_related);
+    int64_t        lo     = jfield(v, "lo");
+    int64_t        hi     = jfield(v, "hi");
+    int            unlock = jbool(v, "unlock");
+    int            wr     = jbool(v, "wr");
+    int            fail   = jbool(v, "failImmediately");
+    uint32_t       exp_st = (uint32_t) jfield(jval(res), "st");
+    uint32_t       flags, st;
+
+    if (!fid) {
+        mism("LOCK: unresolved FileId");
+        return;
+    }
+    /* MS-SMB2 2.2.26.1: UNLOCK is exclusive of the other flags -- it must not
+     * carry SHARED/EXCLUSIVE/FAIL_IMMEDIATELY, and a server is entitled to
+     * reject the combination with INVALID_PARAMETER. */
+    if (unlock) {
+        flags = SMB2_LOCKFLAG_UNLOCK;
+    } else {
+        flags = (wr ? SMB2_LOCKFLAG_EXCLUSIVE : SMB2_LOCKFLAG_SHARED) |
+            (fail ? SMB2_LOCKFLAG_FAIL_IMMEDIATELY : 0);
+    }
+    st = smb2_lock(c, fid, (uint64_t) lo * BS, (uint64_t) (hi - lo) * BS,
+                   flags);
+    if (st != exp_st) {
+        mism("%s [%lld,%lld) %s status: model 0x%08x wire 0x%08x",
+             unlock ? "UNLOCK" : "LOCK", (long long) lo, (long long) hi,
+             unlock ? "" : (wr ? "excl" : "shared"), exp_st, st);
+    }
+} /* do_lock */
+
+/* ---- QUERY_INFO ---------------------------------------------------------
+ *
+ * The model's CQueryBasic carries a full attribute prediction -- type, link
+ * count, size and delete-pending -- so the oracle is the CONTENT of the
+ * reply, not just its status.  Three info classes are driven per model
+ * command, each answered by a different marshaller in smb_proc_query_info.c
+ * and each checked against the SAME prediction, so a class that disagrees
+ * with its siblings is caught as well as one that disagrees with the model:
+ *
+ *   FileStandardInformation  (MS-FSCC 2.4.41) -- size, links, delete-pending,
+ *                                                directory flag;
+ *   FileBasicInformation     (MS-FSCC 2.4.7)  -- the FILE_ATTRIBUTE_DIRECTORY
+ *                                                bit, and the READ_ATTRIBUTES
+ *                                                gate that guards this class;
+ *   FileAllInformation       (MS-FSCC 2.4.2)  -- the same four fields again,
+ *                                                marshalled by a different
+ *                                                path at different offsets.
+ *
+ * The model's `change` counter is deliberately NOT compared: it is an
+ * abstract version stamp with no wire spelling (chimera reports real
+ * timestamps), and asserting it against anything would be inventing an
+ * expectation.  Everything else the model predicts is checked. */
+static void
+do_query(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    const uint8_t *fid    = resolve_fid(v, related_fid, have_related);
+    json_t        *rv     = jval(res);
+    uint32_t       exp_st = (uint32_t) jfield(rv, "st");
+    json_t        *attrs  = json_object_get(rv, "attrs");
+    uint8_t        buf[512];
+    uint32_t       blen = 0, st;
+    int            exp_dir;
+    int64_t        exp_nlink, exp_size;
+    int            exp_delpend;
+
+    if (!fid) {
+        mism("QUERY_INFO: unresolved FileId");
+        return;
+    }
+
+    st = smb2_query_info(c, SMB2_INFO_FILE_T, SMB2_FILE_STANDARD_INFO_T, fid,
+                         0, buf, sizeof(buf), &blen);
+    if (st != exp_st) {
+        mism("QUERY_INFO(FileStandardInformation) status: model 0x%08x "
+             "wire 0x%08x", exp_st, st);
+        return;
+    }
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    exp_dir     = strcmp(jtag(json_object_get(attrs, "ftype")), "FDir") == 0;
+    exp_nlink   = jfield(attrs, "nlink");
+    exp_size    = jfield(attrs, "sizeBlocks") * BS;
+    exp_delpend = jbool(attrs, "deletePending");
+
+    if (blen < 24) {
+        mism("QUERY_INFO(FileStandardInformation): reply carried %u bytes, "
+             "MS-FSCC 2.4.41 is 24", blen);
+        return;
+    }
+    {
+        uint64_t eof    = g64(buf, 8);
+        uint32_t nlink  = g32(buf, 16);
+        int      delpen = buf[20] != 0;
+        int      isdir  = buf[21] != 0;
+
+        if ((int64_t) eof != exp_size) {
+            mism("QUERY_INFO EndOfFile: model %lld wire %llu",
+                 (long long) exp_size, (unsigned long long) eof);
+        }
+        if ((int64_t) nlink != exp_nlink) {
+            mism("QUERY_INFO NumberOfLinks: model %lld wire %u",
+                 (long long) exp_nlink, nlink);
+        }
+        if (delpen != exp_delpend) {
+            mism("QUERY_INFO DeletePending: model %d wire %d", exp_delpend,
+                 delpen);
+        }
+        if (isdir != exp_dir) {
+            mism("QUERY_INFO Directory: model %d wire %d", exp_dir, isdir);
+        }
+    }
+
+    /* FileBasicInformation: the attribute word.  Every open the model makes
+     * carries FILE_READ_ATTRIBUTES (access_wire sets it unconditionally), so
+     * this class must never be refused -- a refusal here would mean the
+     * gate has moved, which is worth failing on. */
+    st = smb2_query_info(c, SMB2_INFO_FILE_T, SMB2_FILE_BASIC_INFO_T, fid, 0,
+                         buf, sizeof(buf), &blen);
+    if (st != ST_SUCCESS) {
+        mism("QUERY_INFO(FileBasicInformation) status: wire 0x%08x on a handle "
+             "that holds FILE_READ_ATTRIBUTES", st);
+    } else if (blen < 40) {
+        mism("QUERY_INFO(FileBasicInformation): reply carried %u bytes, "
+             "MS-FSCC 2.4.7 is 40", blen);
+    } else {
+        uint32_t fattr = g32(buf, 32);
+        int      isdir = (fattr & SMB2_FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+        if (isdir != exp_dir) {
+            mism("QUERY_INFO FileAttributes: model %s wire 0x%08x",
+                 exp_dir ? "a directory" : "a file", fattr);
+        }
+    }
+
+    /* FileAllInformation: the same four facts, a different marshaller.
+     * MS-FSCC 2.4.2 lays Basic(40) | Standard(24) | Internal(8) | Ea(4) |
+     * Access(4) | Position(8) | Mode(4) | Alignment(4) | Name(...), so the
+     * standard block starts at 40. */
+    st = smb2_query_info(c, SMB2_INFO_FILE_T, SMB2_FILE_ALL_INFO_T, fid, 0,
+                         buf, sizeof(buf), &blen);
+    if (st != ST_SUCCESS) {
+        mism("QUERY_INFO(FileAllInformation) status: wire 0x%08x on a handle "
+             "that holds FILE_READ_ATTRIBUTES", st);
+    } else if (blen < 64) {
+        mism("QUERY_INFO(FileAllInformation): reply carried %u bytes, the "
+             "Basic+Standard prefix alone is 64", blen);
+    } else {
+        uint64_t eof    = g64(buf, 40 + 8);
+        uint32_t nlink  = g32(buf, 40 + 16);
+        int      delpen = buf[40 + 20] != 0;
+        int      isdir  = buf[40 + 21] != 0;
+
+        if ((int64_t) eof != exp_size || (int64_t) nlink != exp_nlink ||
+            delpen != exp_delpend || isdir != exp_dir) {
+            mism("QUERY_INFO(FileAllInformation) disagrees: model "
+                 "(size %lld, links %lld, delpend %d, dir %d) wire "
+                 "(size %llu, links %u, delpend %d, dir %d)",
+                 (long long) exp_size, (long long) exp_nlink, exp_delpend,
+                 exp_dir, (unsigned long long) eof, nlink, delpen, isdir);
+        }
+    }
+} /* do_query */
+
+/* ---- LOGOFF / TREE_DISCONNECT -------------------------------------------
+ *
+ * Session and tree teardown (MS-SMB2 3.3.5.6 / 3.3.5.8).  Both close every
+ * open underneath them, which the model encodes and the rest of the trace
+ * then checks: a handle the teardown destroyed can only be met again as a
+ * fresh CREATE, and the objects those opens pinned become removable. */
+static void
+do_logoff(
+    struct smb2_conn *c,
+    json_t           *res,
+    int64_t           sess)
+{
+    uint32_t exp_st = (uint32_t) jfield(jval(res), "st");
+    uint32_t st     = smb2_logoff(c);
+
+    if (st != exp_st) {
+        mism("LOGOFF status: model 0x%08x wire 0x%08x", exp_st, st);
+    }
+    if (st == ST_SUCCESS) {
+        /* The session id is dead.  Unbind it so a later command that names it
+         * is reported as a harness bookkeeping bug rather than being sent on a
+         * connection whose session the server has already destroyed.  The
+         * connection itself stays in the history: a reconnect may still want
+         * its ClientGuid. */
+        bind_sess(sess, NULL);
+        for (int i = 0; i < MAX_FID; i++) {
+            if (g_conn_for_fid[i] == c) {
+                g_conn_for_fid[i] = NULL;
+            }
+        }
+    }
+} /* do_logoff */
+
+static void
+do_tree_disconnect(
+    struct smb2_conn *c,
+    json_t           *res)
+{
+    uint32_t exp_st = (uint32_t) jfield(jval(res), "st");
+    uint32_t st     = smb2_tree_disconnect(c);
+
+    if (st != exp_st) {
+        mism("TREE_DISCONNECT status: model 0x%08x wire 0x%08x", exp_st, st);
+    }
+} /* do_tree_disconnect */
+
 /* Dispatch one command; returns its wire status so a related compound can
  * stop on the first error (SMB2 first-error-stops). */
 static void
@@ -375,16 +1442,60 @@ dispatch_cmd(
     json_t  *res,
     int64_t  sess,
     int64_t  tree,
+    int64_t  cs,
+    int      replay,
     uint8_t *related_fid,
     int     *have_related)
 {
     const char       *tag = jtag(cmd);
     json_t           *v   = jval(cmd);
-    struct smb2_conn *c   =
-        (sess >= 0 && sess < MAX_SESS) ? g_conn_for_sess[sess] : NULL;
+    struct smb2_conn *c   = conn_for_sess(sess);
+    static char       ctx[192];
 
-    if (c && tree >= 0 && tree < MAX_TREE) {
+    /* Name the step for the wedge diagnostic: a replay that parks forever must
+     * say WHICH command of WHICH trace parked, not just that something did. */
+    snprintf(ctx, sizeof(ctx), "%s command %s (session %lld, tree %lld)",
+             g_trace ? g_trace : "?", tag ? tag : "?", (long long) sess,
+             (long long) tree);
+    smb2c_set_context(ctx);
+
+    if (tree >= MAX_TREE) {
+        slot_overflow("tree", tree, MAX_TREE);
+    }
+    if (c && tree >= 0) {
         c->tree_id = g_wire_tree[tree];
+    }
+
+    /* Any handle a previous drop left mid-park is settled before this command
+     * can race it (see park_barrier_flush). */
+    park_barrier_flush(c);
+
+    /* A command that needs a connection and has none cannot be replayed, and
+     * -- this is the point -- must not be handed to a PDU builder either.  The
+     * model never drives a session it has disconnected (every action draws its
+     * session from the live `sessions` map, which a drop empties in the same
+     * step), so this is always a HARNESS bookkeeping failure and is reported
+     * as a mismatch rather than papered over: a silent skip would leave the
+     * rest of the trace testing a state neither side believes in. */
+    if (!c &&
+        strcmp(tag, "CSessionSetup") != 0 && strcmp(tag, "CReconnect") != 0) {
+        mism("%s: no connection for session %lld (harness bookkeeping bug -- "
+             "the model does not drive a disconnected session)", tag,
+             (long long) sess);
+        return;
+    }
+
+    /* The two exactly-once header fields (MS-SMB2 2.2.1.2) belong to the
+     * MESSAGE, so every request the message expands into carries them.  They
+     * are one-shot arms in the harness, consumed by the send, so they are
+     * re-armed here per command rather than once per message. */
+    if (c) {
+        if (cs != 0) {
+            smb2c_set_next_channel_sequence(c, (uint16_t) cs);
+        }
+        if (replay) {
+            smb2c_set_next_flags(c, SMB2_FLAGS_REPLAY_OPERATION);
+        }
     }
 
     if (strcmp(tag, "CSessionSetup") == 0) {
@@ -396,35 +1507,65 @@ dispatch_cmd(
         if (st != exp_st) {
             mism("SESSION_SETUP status: model 0x%08x wire 0x%08x", exp_st, st);
         }
-        int64_t           rs = jfield(jval(res), "sess");
-        if (rs >= 0 && rs < MAX_SESS) {
-            g_conn_for_sess[rs] = nc;
+        bind_sess(jfield(jval(res), "sess"), nc);
+    } else if (strcmp(tag, "CReconnect") == 0) {
+        /* A fresh connection presenting the SAME ClientGuid as `prev`.  That
+         * identity is the whole point: chimera refuses a leased or persistent
+         * reclaim whose ClientGuid does not match the parked open's, so a
+         * reconnect that quietly took a new guid would turn every reclaim in
+         * the corpus into the cross-client denial (C-17) and the batch would
+         * "pass" while testing nothing.  `prev` is usually a session the drop
+         * already destroyed, which is why the connection history outlives the
+         * binding. */
+        int64_t           prev   = jfield(v, "prev");
+        uint32_t          exp_st = (uint32_t) jfield(jval(res), "st");
+        struct smb2_conn *old    = NULL;
+        struct smb2_conn *nc;
+        uint32_t          st;
+
+        if (prev >= MAX_SESS) {
+            slot_overflow("session", prev, MAX_SESS);
         }
+        if (prev >= 0) {
+            old = g_conn_hist[prev];
+        }
+        if (!old) {
+            mism("RECONNECT: no connection history for session %lld -- the "
+                 "reconnect would present a fresh ClientGuid and could not "
+                 "reclaim anything", (long long) prev);
+            return;
+        }
+        nc = smb2_conn_reopen_raw(&g_env, old);
+        smb2_negotiate(nc);
+        st = smb2_session_setup(nc);
+        if (st != exp_st) {
+            mism("RECONNECT status: model 0x%08x wire 0x%08x", exp_st, st);
+        }
+        bind_sess(jfield(jval(res), "sess"), nc);
+    } else if (strcmp(tag, "CDisconnect") == 0) {
+        do_disconnect(c, sess);
     } else if (strcmp(tag, "CTreeConnect") == 0) {
         uint32_t exp_st = (uint32_t) jfield(jval(res), "st");
         uint32_t st;
-        if (!c) {
-            mism("TREE_CONNECT: no connection for session %lld",
-                 (long long) sess);
-            return;
-        }
         st = smb2_tree_connect(c, "\\\\server\\share");
         if (st != exp_st) {
             mism("TREE_CONNECT status: model 0x%08x wire 0x%08x", exp_st, st);
         }
-        int64_t rt = jfield(jval(res), "tree");
-        if (rt >= 0 && rt < MAX_TREE) {
+        int64_t  rt = jfield(jval(res), "tree");
+        if (rt >= MAX_TREE) {
+            slot_overflow("tree", rt, MAX_TREE);
+        }
+        if (rt >= 0) {
             g_wire_tree[rt] = c->tree_id;
         }
     } else if (strcmp(tag, "CCreate") == 0) {
-        if (!c) {
-            mism("CREATE: no connection for session %lld", (long long) sess);
-            return;
-        }
         do_create(c, v, res);
         /* thread the FileId to the rest of a related compound */
         int64_t fid = jfield(jval(res), "fid");
-        if (fid >= 0 && fid < MAX_FID &&
+        if (fid >= MAX_FID) {
+            slot_overflow("fid", fid, MAX_FID);
+        }
+        if (fid >= 0 &&
             (uint32_t) jfield(jval(res), "st") == ST_SUCCESS) {
             memcpy(related_fid, g_wire_fid[fid], 16);
             *have_related = 1;
@@ -435,8 +1576,45 @@ dispatch_cmd(
         do_write(c, v, res, related_fid, *have_related);
     } else if (strcmp(tag, "CRead") == 0) {
         do_read(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CSetEof") == 0) {
+        do_set_eof(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CSetDisposition") == 0) {
+        do_set_disposition(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CSetRename") == 0) {
+        do_set_rename(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CFlush") == 0) {
+        do_flush(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CLock") == 0) {
+        do_lock(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CQueryBasic") == 0) {
+        do_query(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CLogoff") == 0) {
+        do_logoff(c, res, sess);
+    } else if (strcmp(tag, "CTreeDisconnect") == 0) {
+        do_tree_disconnect(c, res);
+    } else if (strcmp(tag, "CBreakAck") == 0) {
+        do_break_ack(c, v, res, related_fid, *have_related);
     } else {
         mism("unhandled command tag '%s' (extend the replayer)", tag);
+    }
+
+    /* Nothing may leave a one-shot header modifier armed: it would land on
+     * whatever request went out next -- an ECHO barrier, the next trace step --
+     * and silently move a handle's ChannelSequence mark. */
+    if (c) {
+        smb2c_clear_next(c);
+    }
+
+    /* Every command that can recall a peer's caching grant carries the set of
+     * break notifications the model says the server must push.  Assert them
+     * before moving on, so a missing, extra or misshapen break fails here
+     * rather than surfacing as an unrelated status divergence later. */
+    json_t *rv = jval(res);
+    if (rv && json_is_object(rv)) {
+        json_t *breaks = json_object_get(rv, "breaks");
+        if (breaks) {
+            check_breaks(breaks, tag);
+        }
     }
 } /* dispatch_cmd */
 
@@ -448,6 +1626,8 @@ do_message(json_t *lmsg_value)
     json_t *cmds    = json_object_get(msg, "cmds");
     int64_t sess    = jfield(msg, "sess");
     int64_t tree    = jfield(msg, "tree");
+    int64_t cs      = jfield(msg, "cs");
+    int     replay  = jbool(msg, "replay");
     uint8_t related_fid[16];
     int     have_related = 0;
 
@@ -458,8 +1638,9 @@ do_message(json_t *lmsg_value)
 
     for (size_t i = 0; i < n && i < json_array_size(cmds); i++) {
         dispatch_cmd(json_array_get(cmds, i), json_array_get(results, i),
-                     sess, tree, related_fid, &have_related);
+                     sess, tree, cs, replay, related_fid, &have_related);
     }
+    check_no_stray_breaks("message");
 } /* do_message */
 
 /* ---- trace driver ------------------------------------------------------- */
@@ -514,6 +1695,7 @@ read_caps(
     opts->leases             = jbool(caps, "leases");
     opts->directory_leases   = jbool(caps, "dirLeases");
     opts->persistent_handles = jbool(caps, "durable");
+    opts->force_level2       = jbool(caps, "forceLevel2");
     json_decref(root);
     return 0;
 } /* read_caps */
@@ -557,15 +1739,32 @@ run_trace(
     g_trace     = path;
     g_nmismatch = 0;
 
+    /* Per-trace too: a fid's lease key must not survive into the next trace.
+     * -1 means 'no lease key bound to this fid'. */
+    for (int i = 0; i < MAX_FID; i++) {
+        g_lease_key_for_fid[i] = -1;
+    }
+
     smb2_env_fs_setup(&g_env, fsname);
 
+    /* The state variable holding the whole protocol state, named the same way
+     * lastOp is (`<instance>::smb2::sdb`).  The disconnect handler reads its
+     * `parked` map to learn which handles the server still owes a park. */
+    char        sdbkey[256];
+    const char *sep = strstr(lokey, "::lastOp");
+    snprintf(sdbkey, sizeof(sdbkey), "%.*s::sdb",
+             (int) (sep ? (size_t) (sep - lokey) : strlen(lokey)), lokey);
+
     for (size_t i = 1; i < ns; i++) {
-        json_t *lo = json_object_get(json_array_get(states, i), lokey);
+        json_t *st_i = json_array_get(states, i);
+        json_t *lo   = json_object_get(st_i, lokey);
         if (!lo || strcmp(jtag(lo), "LMsg") != 0) {
             continue;
         }
+        g_post_sdb = json_object_get(st_i, sdbkey);
         do_message(jval(lo));
     }
+    g_post_sdb = NULL;
 
     smb2_conn_reset(&g_env);
     smb2_env_fs_teardown(&g_env, fsname);
@@ -596,24 +1795,51 @@ main(
         return 2;
     }
 
-    /* Every trace in one batch shares a capability profile (one profile per
-     * generation instance -- see smb2_mbt_add_batch in CMakeLists), so the
-     * shared server is configured once from the first trace's LInit. */
-    if (read_caps(traces[0], &opts) != 0) {
-        mbt_free_traces(traces, ntraces);
-        return 2;
-    }
-
-    smb2_env_open_opts(&g_env, &opts);
-
+    /* A trace's capability profile configures the SERVER, which is shared
+     * across the batch -- so traces may only share a server if their profiles
+     * agree.  One --trace-dir now spans several generation instances
+     * (smb2Base has leases off, smb2Durable has durable on), so rather than
+     * assuming one profile per batch, walk the traces in order and restart the
+     * server whenever the profile changes.  Traces from one instance are
+     * generated with a common basename prefix and so arrive adjacent, making
+     * this one server start per instance rather than per trace. */
     int total = 0;
-    for (int i = 0; i < ntraces; i++) {
-        char fsname[32];
-        snprintf(fsname, sizeof(fsname), "fs_%d", i);
-        total += run_trace(fsname, traces[i]);
+    int i     = 0;
+
+    while (i < ntraces) {
+        struct smb2_env_opts group = { 0 };
+
+        if (read_caps(traces[i], &group) != 0) {
+            mbt_free_traces(traces, ntraces);
+            return 2;
+        }
+
+        smb2_env_open_opts(&g_env, &group);
+
+        int first = i;
+        do {
+            char fsname[32];
+            snprintf(fsname, sizeof(fsname), "fs_%d", i);
+            total += run_trace(fsname, traces[i]);
+            i++;
+            if (i >= ntraces) {
+                break;
+            }
+            if (read_caps(traces[i], &opts) != 0) {
+                smb2_env_stop(&g_env);
+                mbt_free_traces(traces, ntraces);
+                return 2;
+            }
+        } while (memcmp(&opts, &group, sizeof(opts)) == 0);
+
+        smb2_env_stop(&g_env);
+
+        if (getenv("SMB2_MBT_VERBOSE")) {
+            fprintf(stderr, "profile group: %d trace(s) from %s\n",
+                    i - first, traces[first]);
+        }
     }
 
-    smb2_env_stop(&g_env);
     mbt_free_traces(traces, ntraces);
 
     if (total) {

--- a/src/server/smb/tests/quint/smb2_mbt_replay.c
+++ b/src/server/smb/tests/quint/smb2_mbt_replay.c
@@ -725,7 +725,16 @@ do_create(
     struct smb2_durable_req        dreq;
     const struct smb2_durable_req *durp =
         durable_req_of(json_object_get(v, "durable"), &dreq);
-    int                            interim0 = c->ninterim;
+    int                            interim0;
+
+    if (!c) {
+        /* dispatch_cmd rejects a connectionless command before it gets here;
+         * this is the belt to that braces, and keeps the deref below provably
+         * safe rather than safe-by-inspection. */
+        smb2c_no_conn(SMB2_CREATE);
+    }
+
+    interim0 = c->ninterim;
 
     if (doc) {
         opts |= FILE_DELETE_ON_CLOSE;
@@ -1468,6 +1477,14 @@ dispatch_cmd(
 
     /* Any handle a previous drop left mid-park is settled before this command
      * can race it (see park_barrier_flush). */
+    /* A trace whose command carries no tag is malformed.  Every use below is a
+     * strcmp, so report it as a mismatch rather than dereferencing NULL --
+     * a corrupt corpus should fail the trace, not the process. */
+    if (!tag) {
+        mism("command with no tag for session %lld", (long long) sess);
+        return;
+    }
+
     park_barrier_flush(c);
 
     /* A command that needs a connection and has none cannot be replayed, and
@@ -1842,7 +1859,7 @@ main(
                 mbt_free_traces(traces, ntraces);
                 return 2;
             }
-        } while (memcmp(&opts, &group, sizeof(opts)) == 0);
+        } while (smb2_env_opts_eq(&opts, &group));
 
         smb2_env_stop(&g_env);
 

--- a/src/server/smb/tests/quint/smb2_oplock_probe.c
+++ b/src/server/smb/tests/quint/smb2_oplock_probe.c
@@ -17,11 +17,28 @@
  *
  * Sections:
  *   O1  grant           -- sole opener gets the requested oplock / lease
- *   O2  break-on-open   -- a conflicting open breaks a batch oplock (II), the
- *                          opener parks (PENDING) until the holder acks
+ *   O2  break-on-open   -- a conflicting open breaks a batch oplock (II) and
+ *                          completes once the holder acks
  *   O3  break-on-write  -- no read cache survives a conflicting write
  *   O4  lease break     -- write-lease downgrade, epoch bump, ack idempotency
  *   O5  grant denial    -- exclusive/batch is refused while a peer open exists
+ *   O6  parking         -- WHICH conflicting opens emit an async interim, and
+ *                          whether the interim is a wait or just a marker
+ *   O7  coalescing      -- two opens under one lease key share one grant
+ *   O8  no-ack breaks   -- a read-only break settles at once; acking it is an
+ *                          error, not a no-op
+ *   O9  lease v1 vs v2  -- only a v2 lease versions its state with an epoch
+ *   O10 force-level-2   -- the share flag caps every grant to a read cache
+ *   O11 grant matrix    -- legacy oplock grant across DesiredAccess /
+ *                          ShareAccess / disposition
+ *   O12 peer-open cap   -- WHICH peer open caps a fresh grant: same client
+ *                          (same conn / same ClientGuid), a distinct client,
+ *                          and an attribute-only peer
+ *
+ * Each connection gets its own ClientGuid: chimera derives the lease owner's
+ * client key from it, so a shared guid would make every connection ONE client
+ * and silently disable cross-client arbitration (that is exactly how the
+ * retired S-1 "deviation" arose -- see DEVIATIONS-SMB.md).
  */
 
 #include "smb2_mbt_common.h"
@@ -114,8 +131,8 @@ conflicting_open(
     struct smb2_break            *breaks,
     int                          *nbreaks)
 {
-    int n     = 0;
-    int guard = 0;
+    int      n        = 0;
+    uint64_t deadline = smb2c_now_ms() + SMB2C_HANG_MS;
 
     smb2_create_post(opener, name, disp, access, share, req);
 
@@ -133,9 +150,17 @@ conflicting_open(
                 smb2_oplock_break_ack(holder, b.file_id, b.oplock_level);
             }
         }
-        if (opener->disconnected || ++guard > 2000000) {
-            fprintf(stderr, "conflicting_open: opener never completed\n");
-            exit(4);
+        if (opener->disconnected) {
+            fprintf(stderr, "conflicting_open('%s'): connection dropped\n",
+                    name);
+            exit(3);
+        }
+        if (smb2c_now_ms() >= deadline) {
+            /* Not a modeled outcome: the opener is parked on an event this
+             * driver is not producing.  Fail loudly and name it rather than
+             * spinning until ctest reports an opaque timeout. */
+            smb2c_hang(opener, "a conflicting open to complete "
+                       "(every break delivered so far was acknowledged)");
         }
     }
     smb2c_parse_create(opener, out);
@@ -307,6 +332,38 @@ sec_o3(
     int a_had_read_cache = (oa.oplock == SMB2_OPLOCK_LEVEL_II ||
                             oa.oplock == SMB2_OPLOCK_LEVEL_EXCLUSIVE ||
                             oa.oplock == SMB2_OPLOCK_LEVEL_BATCH);
+
+    /* B's WRITE reply can land BEFORE the break notification reaches A: the
+     * break travels through a cross-thread doorbell, so it is not ordered
+     * against the reply.  Waiting only on the reply therefore leaves a break
+     * sitting in A's queue that a LATER section pops as if it were its own --
+     * which is exactly how this probe used to fail intermittently under load
+     * (O4 would see O3's legacy OPLOCK_BREAK and report "break is not a
+     * LEASE_BREAK").
+     *
+     * Settle causally instead of waiting on the clock: smb2_quiesce() drives
+     * every server thread until a whole pass produces nothing new, so whatever
+     * break A was owed has been sent -- and if none has arrived by then, none
+     * is coming.  The previous form here slept out a five-second budget on
+     * EVERY run, because the break had usually already been popped by the
+     * write loop above and the "wait for nbreaks != 0" condition could then
+     * never be satisfied. */
+    if (a_had_read_cache) {
+        struct smb2_break bz;
+
+        smb2_quiesce(env);
+        while (smb2_conn_pop_break(a, &bz)) {
+            got_break = 1;
+            b0        = bz;
+            if (bz.is_lease) {
+                smb2_lease_break_ack(a, bz.lease_key, bz.new_state);
+            } else {
+                smb2_oplock_break_ack(a, bz.file_id, bz.oplock_level);
+            }
+        }
+    }
+    EXPECT(smb2_conn_nbreaks(a) == 0 && smb2_conn_nbreaks(b) == 0,
+           "O3 leaves no undelivered break behind (section isolation)");
     if (a_had_read_cache) {
         EXPECT(got_break,
                "O3 A's read cache is broken by B's write (MS-FSA 2.1.5.3)");
@@ -452,6 +509,855 @@ sec_o5(
     smb2_close(b, ob.file_id);
 } /* sec_o5 */
 
+/* ---- O6: when does a conflicting open actually PARK? -------------------- */
+
+/* The model's ST_PENDING must name the same event the wire does.  On the wire a
+ * CREATE parks (emits an async interim, then completes later on the SAME
+ * request) only when its SHARE acquire comes back BREAKING -- i.e. only when it
+ * both conflicts on share modes with, and is blocked behind, a handle-caching
+ * holder that is mid-break (smb_proc_create.c: the CHIMERA_VFS_LEASE_BREAKING
+ * arm of the share try_insert).  A conflicting open that breaks a peer's oplock
+ * but has NO share conflict is answered immediately: the break is fired and the
+ * open proceeds without waiting for the ack.
+ *
+ * That distinction is invisible to O2 (whose driver acks in the pump loop), and
+ * it is exactly the fact a generated trace must get right, so pin it here by
+ * settling the server WITHOUT acking and checking that no final response came.
+ *
+ * ---- how "no response arrives" is proved, and why not with a sleep --------
+ *
+ * This is the one assertion in the suite that is a negative, and a negative
+ * needs a bound.  The bound used here is CAUSAL, not temporal: enumerate every
+ * edge that can complete the parked CREATE, then show that none of them has
+ * fired.  From the server source there are exactly two.
+ *
+ *   1. The holder's break settling.  O6a's caching wait is resumed by
+ *      chimera_smb_create_resume_parked off the thread's lease_resume_doorbell
+ *      (smb.c); O6b's share wait is resumed by the lease ticket that
+ *      chimera_vfs_lease_acquire enqueued (smb_proc_create.c, the
+ *      CHIMERA_VFS_LEASE_BREAKING arm of the share try_insert), which fires
+ *      through chimera_smb_create_share_park_cb.  BOTH need the holder to ack
+ *      or to close, and the probe deliberately does neither until after the
+ *      assertion.  Neither is on a timer.
+ *   2. chimera's own oplock-break deadline: smb_proc_create.c arms a one-shot
+ *      timer for vfs_state->default_break_deadline_ms
+ *      (CHIMERA_VFS_STATE_DEFAULT_BREAK_DEADLINE_MS = 30 000) which revokes the
+ *      unacked holder and completes the open anyway.  That is the ONLY
+ *      time-driven edge, it is a server constant rather than a property of the
+ *      machine, and this section runs three orders of magnitude below it.
+ *
+ * smb2_quiesce() discharges (1): an SMB2 ECHO is completed synchronously on
+ * the very thread that owns the parked request and would emit its completion,
+ * so a returned ECHO proves that thread ran complete event-loop passes --
+ * doorbells included -- with the CREATE still parked; and quiescing repeats
+ * that over every connection until a whole pass produces nothing new, which is
+ * what covers the cross-thread CHAIN (B's thread runs the CREATE, only then
+ * does A's thread have a break to flush).  The verdict is then simply whether
+ * b's count of non-barrier replies moved.
+ *
+ * What this replaces: a 5 s sleep per sub-section that asserted silence by
+ * outlasting it.  That made the verdict a function of machine load (a slow
+ * enough host could have completed the open inside the window and a fast
+ * enough one could not), and it cost 10 s of the probe's 15 s runtime. */
+static void
+sec_o6(
+    struct smb2_env  *env,
+    struct smb2_conn *a,
+    struct smb2_conn *b)
+{
+    struct smb2_create_out oa, ob;
+    struct smb2_oplock_req req;
+    struct smb2_break      bx;
+    int                    got_reply, ninterim0, nreply0, mark;
+
+    printf("\n== O6: which conflicting opens park (async interim)? ==\n");
+
+    /* --- O6a: batch holder, share-compatible conflicting open --- */
+    memset(&req, 0, sizeof(req));
+    req.level = SMB2_OPLOCK_LEVEL_BATCH;
+    smb2_create(a, "o6a", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                &req, &oa);
+    EXPECT(oa.status == ST_SUCCESS && oa.oplock == SMB2_OPLOCK_LEVEL_BATCH,
+           "O6a holder A granted BATCH");
+
+    ninterim0 = b->ninterim;
+    nreply0   = b->nreply_app;
+    smb2_create_post(b, "o6a", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                     NULL);
+    /* Drive the whole server to quiescence (smb2_mbt_common.h): B's thread has
+     * to run the CREATE before A's thread has a break to flush, so this is a
+     * chain, and a fixed number of barriers would be a race.  The silence
+     * verdict is read off b->nreply_app sampled BEFORE the CREATE was posted,
+     * so it covers the entire span from the post to the end of the settle --
+     * quiescing pumps the shared loop, and a completion landing anywhere in
+     * there has to count. */
+    smb2_quiesce(env);
+    got_reply = (b->nreply_app > nreply0);
+    NOTE("O6a share-compatible open: reply=%d interim=%d (A breaks pending=%d)",
+         got_reply, b->ninterim - ninterim0, smb2_conn_nbreaks(a));
+    EXPECT(smb2_conn_nbreaks(a) >= 1,
+           "O6a the batch oplock is broken by the conflicting open "
+           "(MS-FSA 2.1.5.1.2)");
+    EXPECT(b->ninterim > ninterim0,
+           "O6a the deferred open announces itself with an async interim "
+           "STATUS_PENDING (MS-SMB2 3.3.5.9 pending-open)");
+    EXPECT(!got_reply,
+           "O6a and then WAITS: no final response arrives while the holder "
+           "has not acknowledged");
+    mark = b->nreply_app;
+    while (smb2_conn_pop_break(a, &bx)) {
+        smb2_oplock_break_ack(a, bx.file_id, bx.oplock_level);
+    }
+    got_reply = smb2c_pump_for_nreply(b, mark,
+                                      "O6a's parked CREATE to complete after "
+                                      "the holder's acknowledgment");
+    EXPECT(got_reply, "O6a the parked open completes once the holder acks");
+    if (got_reply) {
+        smb2c_parse_create(b, &ob);
+        NOTE("O6a deferred completion status = 0x%08x", ob.status);
+        EXPECT(ob.status == ST_SUCCESS,
+               "O6a share-compatible open succeeds after the break drains");
+        if (ob.status == ST_SUCCESS) {
+            smb2_close(b, ob.file_id);
+        }
+    }
+    smb2_close(a, oa.file_id);
+
+    /* --- O6b: batch holder that DENIES sharing.  The conflicting open must
+     * still wait -- the holder may close its deferred handle and dissolve the
+     * conflict -- but this park goes through the SHARE acquire rather than the
+     * caching wait, and that path emits NO async interim. --- */
+    memset(&req, 0, sizeof(req));
+    req.level = SMB2_OPLOCK_LEVEL_BATCH;
+    smb2_create(a, "o6b", FILE_OPEN_IF, FILE_ALL_ACCESS, 0 /* share NONE */,
+                &req, &oa);
+    EXPECT(oa.status == ST_SUCCESS && oa.oplock == SMB2_OPLOCK_LEVEL_BATCH,
+           "O6b holder A granted BATCH with ShareAccess=NONE");
+
+    ninterim0 = b->ninterim;
+    nreply0   = b->nreply_app;
+    smb2_create_post(b, "o6b", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                     NULL);
+    smb2_quiesce(env);
+    got_reply = (b->nreply_app > nreply0);
+    NOTE("O6b share-CONFLICTING open: reply=%d interim=%d (A breaks pending=%d)",
+         got_reply, b->ninterim - ninterim0, smb2_conn_nbreaks(a));
+    EXPECT(smb2_conn_nbreaks(a) >= 1,
+           "O6b the batch holder is broken BEFORE the share check "
+           "(MS-FSA 2.1.5.1: a batch holder may close and dissolve the "
+           "conflict)");
+    EXPECT(!got_reply,
+           "O6b the share-conflicting open WAITS for the batch holder's "
+           "answer rather than refusing immediately");
+    /* Both waits now announce themselves.  This assertion used to pin the
+     * opposite -- a silent share-acquire park was recorded as Q-3, on the
+     * grounds that MS-SMB2 3.3.5.9's pending-open contract exists so a client
+     * can correlate and CANCEL a deferred create rather than time out.  The
+     * server since emits the interim on this path too, for that exact reason,
+     * so the assertion flips to the mandate: a park of either kind is
+     * announced. */
+    EXPECT(b->ninterim > ninterim0,
+           "O6b the share-acquire park emits an async interim "
+           "(MS-SMB2 3.3.5.9)");
+    /* Release it: the holder acks but keeps its handle, so the deferred
+     * completion must be SHARING_VIOLATION. */
+    mark = b->nreply_app;
+    while (smb2_conn_pop_break(a, &bx)) {
+        smb2_oplock_break_ack(a, bx.file_id, bx.oplock_level);
+    }
+    got_reply = smb2c_pump_for_nreply(b, mark,
+                                      "O6b's parked CREATE to complete after "
+                                      "the holder's acknowledgment");
+    EXPECT(got_reply, "O6b the parked open completes once the holder acks");
+    if (got_reply) {
+        smb2c_parse_create(b, &ob);
+        NOTE("O6b deferred completion status = 0x%08x", ob.status);
+        EXPECT(ob.status == ST_SHARING_VIOLATION,
+               "O6b holder acked but kept its handle -> SHARING_VIOLATION");
+        if (ob.status == ST_SUCCESS) {
+            smb2_close(b, ob.file_id);
+        }
+    }
+    smb2_close(a, oa.file_id);
+} /* sec_o6 */
+
+/* ---- O7: same-lease-key coalescing --------------------------------------- */
+
+/* MS-SMB2 3.3.5.9.8: two opens of one file under ONE lease key share a single
+ * lease -- the second open joins the grant (it does not create a second one,
+ * and it never downgrades the first).  The model must coalesce identically or
+ * it will predict two independent grants, two epochs and two break
+ * notifications where the wire has one of each. */
+static void
+sec_o7(
+    struct smb2_env  *env,
+    struct smb2_conn *a,
+    struct smb2_conn *b)
+{
+    struct smb2_create_out o1, o2, ob;
+    struct smb2_oplock_req req, breq;
+    struct smb2_break      breaks[8];
+    int                    nbreaks = 0;
+
+    printf("\n== O7: two opens under one lease key coalesce ==\n");
+
+    memset(&req, 0, sizeof(req));
+    req.is_lease     = 1;
+    req.lease_key[0] = 0xC7;
+    req.lease_state  = SMB2_LEASE_RWH;
+    req.lease_epoch  = 1;
+    smb2_create(a, "o7", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                &req, &o1);
+    EXPECT(o1.status == ST_SUCCESS && o1.lease_state == SMB2_LEASE_RWH,
+           "O7 first open under key C7 granted RWH");
+
+    /* Second open, SAME key, asking for LESS (R only). */
+    memset(&req, 0, sizeof(req));
+    req.is_lease     = 1;
+    req.lease_key[0] = 0xC7;
+    req.lease_state  = SMB2_LEASE_READ;
+    req.lease_epoch  = 1;
+    smb2_create(a, "o7", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                &req, &o2);
+    EXPECT(o2.status == ST_SUCCESS, "O7 second open under key C7 succeeds");
+    NOTE("O7 second same-key open reports lease=%s epoch=%u (first: %s epoch=%u)",
+         lease_str(o2.lease_state), o2.lease_epoch,
+         lease_str(o1.lease_state), o1.lease_epoch);
+    EXPECT(o2.lease_state == o1.lease_state,
+           "O7 a same-key re-open joins the existing lease and does NOT "
+           "reduce it (MS-SMB2 3.3.5.9.8)");
+    EXPECT(o2.lease_epoch == o1.lease_epoch,
+           "O7 coalesced opens share ONE epoch counter (MS-SMB2 3.3.5.9.11)");
+
+    /* A conflicting open by another client must produce exactly ONE break for
+     * the shared lease, not one per member open. */
+    memset(&breq, 0, sizeof(breq));
+    breq.is_lease     = 1;
+    breq.lease_key[0] = 0xC8;
+    breq.lease_state  = SMB2_LEASE_RH;
+    breq.lease_epoch  = 1;
+    conflicting_open(env, b, a, "o7", FILE_OPEN, FILE_READ_ACCESS,
+                     FILE_SHARE_RWD, &breq, &ob, breaks, &nbreaks);
+    NOTE("O7 conflicting open produced %d break notification(s) for the "
+         "coalesced lease", nbreaks);
+    EXPECT(nbreaks == 1,
+           "O7 the coalesced lease breaks ONCE, not once per member open");
+    EXPECT(ob.status == ST_SUCCESS, "O7 opener B completes");
+
+    smb2_close(a, o1.file_id);
+    smb2_close(a, o2.file_id);
+    smb2_close(b, ob.file_id);
+} /* sec_o7 */
+
+/* ---- O8: which breaks require an acknowledgment? ------------------------- */
+
+/* smb_proc_oplock_break.c: an ack is required only when the break strips WRITE
+ * or HANDLE caching (lease), or when the holder held EXCLUSIVE/BATCH (legacy
+ * oplock).  A break that removes only READ caching settles immediately and is
+ * never acknowledged -- an ack for it is a protocol error.  A model that marks
+ * every broken grant "awaiting ack" would generate acks the server rejects. */
+static void
+sec_o8(
+    struct smb2_env  *env,
+    struct smb2_conn *a,
+    struct smb2_conn *b)
+{
+    struct smb2_create_out oa, ob;
+    struct smb2_oplock_req req;
+    struct smb2_break      bx;
+    uint32_t               st;
+    const char             data[] = "x";
+    int                    got    = 0;
+
+    printf("\n== O8: read-only breaks need no acknowledgment ==\n");
+
+    /* A takes a LEVEL_II (read-cache-only) oplock as the sole opener. */
+    memset(&req, 0, sizeof(req));
+    req.level = SMB2_OPLOCK_LEVEL_II;
+    smb2_create(a, "o8", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                &req, &oa);
+    EXPECT(oa.status == ST_SUCCESS, "O8 holder A opened");
+    NOTE("O8 A granted oplock = %s", oplock_name(oa.oplock));
+
+    /* B opens for write and writes: A's read cache must be invalidated. */
+    smb2_create(b, "o8", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD, NULL, &ob);
+    EXPECT(ob.status == ST_SUCCESS, "O8 writer B opened");
+
+    smb2_write_post(b, ob.file_id, 0, data, 1);
+    while (!b->reply_ready) {
+        smb2_pump(env);
+        while (smb2_conn_pop_break(a, &bx)) {
+            got = 1;
+            NOTE("O8 break to A: is_lease=%d level=%s ack_required=%d",
+                 bx.is_lease, oplock_name(bx.oplock_level), bx.ack_required);
+        }
+    }
+    st = g32(b->rbuf + 4, 8);
+    EXPECT(st == ST_SUCCESS, "O8 B's WRITE succeeds -> 0x%08x", st);
+    if (got && oa.oplock == SMB2_OPLOCK_LEVEL_II) {
+        /* An unsolicited ack for a LEVEL_II break is a protocol error
+         * (MS-SMB2 3.3.5.22.1); the server must reject it. */
+        st = smb2_oplock_break_ack(a, oa.file_id, SMB2_OPLOCK_LEVEL_NONE);
+        NOTE("O8 ack for a LEVEL_II (no-ack) break -> 0x%08x", st);
+        EXPECT(st != ST_SUCCESS,
+               "O8 acking a break that required no ack is rejected "
+               "(MS-SMB2 3.3.5.22.1)");
+    }
+
+    smb2_close(a, oa.file_id);
+    smb2_close(b, ob.file_id);
+} /* sec_o8 */
+
+/* ---- O9: lease v1 vs v2 (epoch versioning) ------------------------------- */
+
+static void
+sec_o9(
+    struct smb2_env  *env,
+    struct smb2_conn *a,
+    struct smb2_conn *b)
+{
+    struct smb2_create_out oa, ob;
+    struct smb2_oplock_req req, breq;
+    struct smb2_break      breaks[8];
+    int                    nbreaks = 0;
+
+    printf("\n== O9: a v1 lease is not epoch-versioned ==\n");
+
+    memset(&req, 0, sizeof(req));
+    req.is_lease     = 1;
+    req.force_v1     = 1;
+    req.lease_key[0] = 0xD9;
+    req.lease_state  = SMB2_LEASE_RWH;
+    smb2_create(a, "o9", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                &req, &oa);
+    EXPECT(oa.status == ST_SUCCESS && oa.has_lease,
+           "O9 v1 RqLs open granted a lease");
+    NOTE("O9 v1 grant: state=%s epoch=%u", lease_str(oa.lease_state),
+         oa.lease_epoch);
+
+    memset(&breq, 0, sizeof(breq));
+    breq.is_lease     = 1;
+    breq.force_v1     = 1;
+    breq.lease_key[0] = 0xDA;
+    breq.lease_state  = SMB2_LEASE_RH;
+    conflicting_open(env, b, a, "o9", FILE_OPEN, FILE_READ_ACCESS,
+                     FILE_SHARE_RWD, &breq, &ob, breaks, &nbreaks);
+    EXPECT(nbreaks >= 1, "O9 the v1 write lease breaks (%d)", nbreaks);
+    if (nbreaks >= 1) {
+        NOTE("O9 v1 break: cur=%s new=%s epoch=%u",
+             lease_str(breaks[0].cur_state), lease_str(breaks[0].new_state),
+             breaks[0].new_epoch);
+        EXPECT(breaks[0].new_epoch == 0,
+               "O9 a v1 lease breaks with epoch 0 (only v2 versions state; "
+               "MS-SMB2 2.2.23.2)");
+    }
+    EXPECT(ob.status == ST_SUCCESS, "O9 opener B completes");
+
+    smb2_close(a, oa.file_id);
+    smb2_close(b, ob.file_id);
+} /* sec_o9 */
+
+/* ---- O10: SMB2_SHAREFLAG_FORCE_LEVELII_OPLOCK --------------------------- */
+
+/* Runs on its own server instance: the share flag is set at share-creation
+ * time.  WPTS ShareForceLevel2 is 112 of the 156 green oplock cases, so this
+ * is the single highest-volume oplock axis in the catalog. */
+static void
+sec_o10(void)
+{
+    struct smb2_env        env;
+    struct smb2_env_opts   opts = { .oplocks      = 1, .leases = 1,
+                                    .force_level2 = 1 };
+    struct smb2_conn      *a;
+    struct smb2_create_out o;
+    struct smb2_oplock_req req;
+
+    printf("\n== O10: a force-level-2 share caps every grant to a read cache ==\n");
+
+    smb2_env_start_opts(&env, &opts);
+    a = smb2_conn_open(&env);
+    smb2_handshake(a);
+
+    memset(&req, 0, sizeof(req));
+    req.level = SMB2_OPLOCK_LEVEL_BATCH;
+    smb2_create(a, "f1", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                &req, &o);
+    EXPECT(o.status == ST_SUCCESS, "O10 CREATE(batch) on a force-level-2 share");
+    NOTE("O10 batch request granted %s", oplock_name(o.oplock));
+    EXPECT(o.oplock == SMB2_OPLOCK_LEVEL_II || o.oplock == SMB2_OPLOCK_LEVEL_NONE,
+           "O10 a batch oplock is capped to at most LEVEL_II on a "
+           "force-level-2 share (MS-SMB2 2.2.10)");
+    smb2_close(a, o.file_id);
+
+    memset(&req, 0, sizeof(req));
+    req.is_lease     = 1;
+    req.lease_key[0] = 0xF2;
+    req.lease_state  = SMB2_LEASE_RWH;
+    req.lease_epoch  = 1;
+    smb2_create(a, "f2", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                &req, &o);
+    EXPECT(o.status == ST_SUCCESS, "O10 CREATE(lease RWH) on a force-level-2 share");
+    NOTE("O10 RWH lease request granted %s", lease_str(o.lease_state));
+    EXPECT((o.lease_state & (SMB2_LEASE_WRITE | SMB2_LEASE_HANDLE)) == 0,
+           "O10 write/handle caching is stripped on a force-level-2 share");
+    smb2_close(a, o.file_id);
+
+    smb2_env_stop(&env);
+} /* sec_o10 */
+
+/* ---- O11: which sole-opener requests actually get a legacy oplock? ------- */
+
+/* A generated trace draws DesiredAccess / ShareAccess / CreateDisposition
+ * independently of the oplock request, so the model must know the grant rule
+ * for the whole matrix, not just for the FILE_ALL_ACCESS / share-everything
+ * corner O1 pins.  Every open here is the SOLE open of a FRESH file, so
+ * MS-FSA 2.1.5.17.1 says the requested oplock is grantable in every row; the
+ * probe RECORDS what chimera returns (the grant level is discretion --
+ * MS-SMB2 3.3.5.9) so the model can be pinned to it rather than to a guess. */
+static void
+sec_o11(
+    struct smb2_env  *env,
+    struct smb2_conn *a)
+{
+    static const struct {
+        const char *label;
+        uint32_t    disp;
+        uint32_t    access;
+        uint32_t    share;
+    } rows[] = {
+        { "OPEN_IF  RA|RD|WD  share RWD",  FILE_OPEN_IF,
+          0x80u | 0x01u | 0x02u, FILE_SHARE_RWD },
+        { "OPEN_IF  RA|WD     share RWD",  FILE_OPEN_IF,
+          0x80u | 0x02u, FILE_SHARE_RWD },
+        { "OPEN_IF  RA|RD     share RWD",  FILE_OPEN_IF,
+          0x80u | 0x01u, FILE_SHARE_RWD },
+        { "OPEN_IF  RA|RD|WD  share R",    FILE_OPEN_IF,
+          0x80u | 0x01u | 0x02u, FILE_SHARE_READ },
+        { "OPEN_IF  RA|RD|WD  share -",    FILE_OPEN_IF,
+          0x80u | 0x01u | 0x02u, 0 },
+        { "OVERWRITE_IF RA|WD share R",    FILE_OVERWRITE_IF,
+          0x80u | 0x02u, FILE_SHARE_READ },
+        { "OPEN_IF  RA|RD|WD|DEL sh RW",   FILE_OPEN_IF,
+          0x80u | 0x01u | 0x02u | 0x00010000u,
+          FILE_SHARE_READ | FILE_SHARE_WRITE },
+        { "OPEN_IF  ALL_ACCESS share RWD", FILE_OPEN_IF,        FILE_ALL_ACCESS,
+          FILE_SHARE_RWD },
+    };
+    int n = (int) (sizeof(rows) / sizeof(rows[0]));
+
+    printf("\n== O11: legacy oplock grant across the request matrix ==\n");
+
+    for (int i = 0; i < n; i++) {
+        struct smb2_create_out o;
+        struct smb2_oplock_req req;
+        char                   name[32];
+
+        snprintf(name, sizeof(name), "o11_%d", i);
+        memset(&req, 0, sizeof(req));
+        req.level = SMB2_OPLOCK_LEVEL_BATCH;
+        smb2_create(a, name, rows[i].disp, rows[i].access, rows[i].share,
+                    &req, &o);
+        EXPECT(o.status == ST_SUCCESS, "O11[%d] %s -> 0x%08x", i, rows[i].label,
+               o.status);
+        if (o.status != ST_SUCCESS) {
+            continue;
+        }
+        NOTE("O11[%d] %-30s BATCH request granted %s", i, rows[i].label,
+             oplock_name(o.oplock));
+        /* Whatever the level, a sole opener of a fresh file must not be
+         * refused caching outright when oplocks are enabled: that would make
+         * the whole break lifecycle unreachable for this request shape. */
+        EXPECT(o.oplock != SMB2_OPLOCK_LEVEL_NONE,
+               "O11[%d] a sole opener of a fresh file is granted SOME oplock "
+               "(MS-FSA 2.1.5.17.1)", i);
+        smb2_close(a, o.file_id);
+    }
+} /* sec_o11 */
+
+/* ---- O12: WHICH peer open caps a fresh grant, and for whom? ------------- */
+
+/* O5 establishes one cell of a matrix: a data open by a DISTINCT client caps a
+ * batch request to LEVEL_II.  The generator needs the whole matrix, because a
+ * generated trace draws the peer's client (session), the peer's DesiredAccess
+ * (including the attribute-only profile) and the requested oplock/lease
+ * independently.  Until that matrix was measured, the generator simply refused
+ * to request any caching grant behind a peer open (the `grantAgreed` guard in
+ * smb2.qnt), which suppressed exactly the WPTS Oplocks/Leases surface.
+ *
+ * The mandate being checked is MS-FSA 2.1.5.18.1 "Algorithm to Request an
+ * Exclusive Oplock" (numbered 2.1.5.17.2 in the revision this suite's older
+ * citations use):
+ *
+ *   "If Open.File.OpenList contains more than one Open whose Stream is the
+ *    same as Open.Stream, and NO_OPLOCK is present in Open.Stream.Oplock.State
+ *    -- the operation MUST be failed with Status set to
+ *    STATUS_OPLOCK_NOT_GRANTED."
+ *
+ * Note what that clause does NOT say: it has no TargetOplockKey exemption and
+ * no client-identity exemption.  The key exemptions in 2.1.5.18.1 apply only
+ * to UPGRADING a stream that already holds an R / RH oplock; a fresh exclusive
+ * grant on a stream with NO_OPLOCK is refused by the mere existence of a
+ * second Open, whoever owns it.  (A same-lease-key second open never reaches
+ * this algorithm at all: MS-SMB2 3.3.5.9.8 coalesces it onto the existing
+ * lease above the FSA layer -- probe O7 / C-6.)
+ *
+ * WRITE_CACHING is the discriminator: BATCH (R|W|H), EXCLUSIVE (R|W) and an
+ * RWH/RW lease are "exclusive oplock" requests routed through 2.1.5.18.1,
+ * while LEVEL_II, an R lease and an RH lease are SHARED requests
+ * (MS-FSA 2.1.5.18.2), which have no sole-open condition at all.
+ *
+ * Granting LESS than was asked for is server discretion (MS-SMB2 3.3.5.9), so
+ * a row whose grant merely lands below the request is recorded as policy, not
+ * failed.  Granting a W (or H, for legacy) cache while a peer Open exists is
+ * the direction the spec forbids, and is reported as a DEVIATION. */
+
+enum o12_peer {
+    O12_P_NONE = 0,   /* sole opener (control row) */
+    O12_P_SELF,       /* same client, SAME connection */
+    O12_P_GUID,       /* same client, a second connection sharing ClientGuid */
+    O12_P_OTHER,      /* a genuinely distinct client (distinct ClientGuid) */
+    O12_P_OATTR, /* distinct client, ATTRIBUTE-ONLY (stat) open */
+    O12_P_LEAS_O,/* distinct client holding an RH lease (other key) */
+    O12_P_LEAS_S  /* SAME client holding an RH lease under another key */
+};
+
+enum o12_req {
+    O12_R_BATCH = 0,       /* legacy BATCH   -> FSA R|W|H  (exclusive) */
+    O12_R_EXCL,            /* legacy EXCLUSIVE -> FSA R|W  (exclusive) */
+    O12_R_II,              /* legacy LEVEL_II  -> FSA LEVEL_TWO (shared) */
+    O12_R_RWH,             /* RqLs lease RWH   -> FSA R|W|H (exclusive) */
+    O12_R_RH,              /* RqLs lease RH    -> FSA R|H   (shared) */
+    O12_R_BSTAT       /* BATCH requested by an ATTRIBUTE-ONLY open */
+};
+
+/* DesiredAccess of an attribute-only open: exactly what the model's ACCESS_H
+ * profile puts on the wire (smb2_mbt_replay.c access_wire). */
+#define O12_ATTR_ONLY 0x00000080u
+
+static const char *
+o12_peer_name(int p)
+{
+    switch (p) {
+        case O12_P_NONE:       return "no peer open";
+        case O12_P_SELF:       return "peer: same client, same conn";
+        case O12_P_GUID:       return "peer: same client, 2nd conn";
+        case O12_P_OTHER:      return "peer: OTHER client, data open";
+        case O12_P_OATTR: return "peer: OTHER client, attr-only";
+        case O12_P_LEAS_O: return "peer: OTHER client, RH lease";
+        case O12_P_LEAS_S:  return "peer: same client, RH lease";
+        default:                  return "?";
+    } /* switch */
+} /* o12_peer_name */
+
+static const char *
+o12_req_name(int r)
+{
+    switch (r) {
+        case O12_R_BATCH:      return "BATCH";
+        case O12_R_EXCL:       return "EXCLUSIVE";
+        case O12_R_II:         return "LEVEL_II";
+        case O12_R_RWH:        return "lease RWH";
+        case O12_R_RH:         return "lease RH";
+        case O12_R_BSTAT: return "BATCH (attr-only opener)";
+        default:             return "?";
+    } /* switch */
+} /* o12_req_name */
+
+/* Short aliases so the row table below stays inside the line limit; the
+ * granted-level and lease-state constants are the wire values. */
+#define O12_L_NONE  SMB2_OPLOCK_LEVEL_NONE
+#define O12_L_II    SMB2_OPLOCK_LEVEL_II
+#define O12_L_EXCL  SMB2_OPLOCK_LEVEL_EXCLUSIVE
+#define O12_L_BATCH SMB2_OPLOCK_LEVEL_BATCH
+#define O12_L_LEASE SMB2_OPLOCK_LEVEL_LEASE
+#define O12_S_R     SMB2_LEASE_READ
+#define O12_S_RH    SMB2_LEASE_RH
+#define O12_S_RWH   SMB2_LEASE_RWH
+
+static void
+sec_o12(
+    struct smb2_env  *env,
+    struct smb2_conn *a,     /* the requester */
+    struct smb2_conn *b,     /* a distinct client */
+    struct smb2_conn *g)     /* a second connection of a's client */
+{
+    /* exp_opl / exp_lease pin the OBSERVED policy (discretion, MS-SMB2
+     * 3.3.5.9): they are what chimera returns today, so the model can be
+     * written against a measurement rather than a guess, and a silent change
+     * of grant policy fails here first.
+     *
+     * The rows run in peer groups: no peer, same client on the same
+     * connection, same client on a second connection (one ClientGuid), a
+     * distinct client with a data open, a distinct client with an
+     * attribute-only open, and finally peers holding an RH LEASE (one under
+     * another client, one under this one).  Four results in the table are
+     * worth reading twice, because each one corrected a guess made from the
+     * server source:
+     *
+     *   - an RqLs lease IS capped (to R) by its own client's plain open, while
+     *     a legacy oplock in the same position is not: the share-reservation
+     *     cap exempts a peer open only when that peer is itself LEASE-backed.
+     *     The legacy half of that asymmetry is DEVIATIONS-SMB.md S-3;
+     *   - an attribute-only REQUESTER is not refused outright behind a peer
+     *     open.  The strict "oplock-transparent" cap only bites when even a
+     *     read cache would have to break someone, so with a peer that holds no
+     *     cache the request lands at LEVEL_II like a data open;
+     *   - behind a peer holding an RH lease the HANDLE bit survives (two RqLs
+     *     leases coexist at R+H) while W is arbitrated by the
+     *     caching-vs-caching path;
+     *   - a LEGACY oplock request by a client that already holds an H lease on
+     *     the file is granted NOTHING -- at LEVEL_II as well as at BATCH.
+     *     Handle caching already owns the handle and the oplock must not
+     *     recall the requester's own lease (smb_proc_create.c
+     *     chimera_vfs_client_holds_handle_lease). */
+    static const struct {
+        int      peer;
+        int      req;
+        uint8_t  exp_opl;
+        uint32_t exp_lease;   /* meaningful when exp_opl == LEASE */
+    } rows[] = {
+        { O12_P_NONE,   O12_R_BATCH,
+          O12_L_BATCH, 0 },
+        { O12_P_NONE,   O12_R_EXCL,
+          O12_L_EXCL, 0 },
+        { O12_P_NONE,   O12_R_II,
+          O12_L_II, 0 },
+        { O12_P_NONE,   O12_R_RWH,
+          O12_L_LEASE, O12_S_RWH },
+        { O12_P_NONE,   O12_R_RH,
+          O12_L_LEASE, O12_S_RH },
+        { O12_P_NONE,   O12_R_BSTAT,
+          O12_L_BATCH, 0 },
+        { O12_P_SELF,   O12_R_BATCH,
+          O12_L_BATCH, 0 },
+        { O12_P_SELF,   O12_R_EXCL,
+          O12_L_EXCL, 0 },
+        { O12_P_SELF,   O12_R_II,
+          O12_L_II, 0 },
+        { O12_P_SELF,   O12_R_RWH,
+          O12_L_LEASE, O12_S_R },
+        { O12_P_SELF,   O12_R_RH,
+          O12_L_LEASE, O12_S_R },
+        { O12_P_SELF,   O12_R_BSTAT,
+          O12_L_BATCH, 0 },
+        { O12_P_GUID,   O12_R_BATCH,
+          O12_L_BATCH, 0 },
+        { O12_P_GUID,   O12_R_RWH,
+          O12_L_LEASE, O12_S_R },
+        { O12_P_OTHER,  O12_R_BATCH,
+          O12_L_II, 0 },
+        { O12_P_OTHER,  O12_R_EXCL,
+          O12_L_II, 0 },
+        { O12_P_OTHER,  O12_R_II,
+          O12_L_II, 0 },
+        { O12_P_OTHER,  O12_R_RWH,
+          O12_L_LEASE, O12_S_R },
+        { O12_P_OTHER,  O12_R_RH,
+          O12_L_LEASE, O12_S_R },
+        { O12_P_OTHER,  O12_R_BSTAT,
+          O12_L_II, 0 },
+        { O12_P_OATTR,  O12_R_BATCH,
+          O12_L_BATCH, 0 },
+        { O12_P_OATTR,  O12_R_EXCL,
+          O12_L_EXCL, 0 },
+        { O12_P_OATTR,  O12_R_II,
+          O12_L_II, 0 },
+        { O12_P_OATTR,  O12_R_RWH,
+          O12_L_LEASE, O12_S_RWH },
+        { O12_P_OATTR,  O12_R_RH,
+          O12_L_LEASE, O12_S_RH },
+        { O12_P_OATTR,  O12_R_BSTAT,
+          O12_L_BATCH, 0 },
+        { O12_P_LEAS_O, O12_R_RWH,
+          O12_L_LEASE, O12_S_RH },
+        { O12_P_LEAS_O, O12_R_RH,
+          O12_L_LEASE, O12_S_RH },
+        { O12_P_LEAS_O, O12_R_BATCH,
+          O12_L_II, 0 },
+        { O12_P_LEAS_O, O12_R_II,
+          O12_L_II, 0 },
+        { O12_P_LEAS_S, O12_R_RWH,
+          O12_L_LEASE, O12_S_RH },
+        { O12_P_LEAS_S, O12_R_RH,
+          O12_L_LEASE, O12_S_RH },
+        { O12_P_LEAS_S, O12_R_BATCH,
+          O12_L_NONE, 0 },
+        { O12_P_LEAS_S, O12_R_II,
+          O12_L_NONE, 0 },
+    };
+    int n = (int) (sizeof(rows) / sizeof(rows[0]));
+
+    printf("\n== O12: which peer OPEN caps a fresh oplock/lease grant? ==\n");
+
+    for (int i = 0; i < n; i++) {
+        struct smb2_conn       *peer = NULL;
+        struct smb2_create_out  po, o;
+        struct smb2_oplock_req  req, peer_req;
+        struct smb2_oplock_req *peer_reqp = NULL;
+        struct smb2_break       breaks[8];
+        int                     nbreaks     = 0;
+        uint32_t                peer_access = FILE_READ_ACCESS;
+        uint32_t                req_access  = FILE_READ_ACCESS;
+        char                    name[32];
+        int                     has_w;
+
+        memset(&peer_req, 0, sizeof(peer_req));
+
+        switch (rows[i].peer) {
+            case O12_P_SELF:  peer = a; break;
+            case O12_P_GUID:  peer = g; break;
+            case O12_P_OTHER: peer = b; break;
+            case O12_P_OATTR:
+                peer        = b;
+                peer_access = O12_ATTR_ONLY;
+                break;
+            case O12_P_LEAS_O:
+            case O12_P_LEAS_S:
+                peer = rows[i].peer == O12_P_LEAS_S
+                    ? g : b;
+                peer_req.is_lease     = 1;
+                peer_req.lease_key[0] = (uint8_t) (0xE0 + i);
+                peer_req.lease_state  = SMB2_LEASE_RH;
+                peer_req.lease_epoch  = 1;
+                peer_reqp             = &peer_req;
+                break;
+            default: break;
+        } /* switch */
+
+        snprintf(name, sizeof(name), "o12_%d", i);
+
+        if (peer) {
+            smb2_create(peer, name, FILE_OPEN_IF, peer_access,
+                        FILE_SHARE_RWD, peer_reqp, &po);
+            EXPECT(po.status == ST_SUCCESS,
+                   "O12[%d] peer open (%s) -> 0x%08x", i,
+                   o12_peer_name(rows[i].peer), po.status);
+            if (po.status != ST_SUCCESS) {
+                continue;
+            }
+            if (peer_reqp) {
+                NOTE("O12[%d] peer holds lease %s (epoch %u)", i,
+                     lease_str(po.lease_state), po.lease_epoch);
+            }
+        }
+
+        memset(&req, 0, sizeof(req));
+        switch (rows[i].req) {
+            case O12_R_BATCH:
+                req.level = SMB2_OPLOCK_LEVEL_BATCH;
+                break;
+            case O12_R_EXCL:
+                req.level = SMB2_OPLOCK_LEVEL_EXCLUSIVE;
+                break;
+            case O12_R_II:
+                req.level = SMB2_OPLOCK_LEVEL_II;
+                break;
+            case O12_R_RWH:
+                req.is_lease     = 1;
+                req.lease_key[0] = (uint8_t) (0xC0 + i);
+                req.lease_state  = SMB2_LEASE_RWH;
+                req.lease_epoch  = 1;
+                break;
+            case O12_R_RH:
+                req.is_lease     = 1;
+                req.lease_key[0] = (uint8_t) (0xC0 + i);
+                req.lease_state  = SMB2_LEASE_RH;
+                req.lease_epoch  = 1;
+                break;
+            case O12_R_BSTAT:
+                req.level  = SMB2_OPLOCK_LEVEL_BATCH;
+                req_access = O12_ATTR_ONLY;
+                break;
+            default: break;
+        } /* switch */
+
+        /* Drive through the shared helper so a row that unexpectedly parks
+         * behind a break still completes (and the break is counted) instead of
+         * hanging the probe.  No row here is expected to break anything: every
+         * peer holds an open, never a cache. */
+        conflicting_open(env, a, peer ? peer : a, name, FILE_OPEN_IF,
+                         req_access, FILE_SHARE_RWD, &req, &o,
+                         breaks, &nbreaks);
+        EXPECT(o.status == ST_SUCCESS, "O12[%d] requester CREATE -> 0x%08x", i,
+               o.status);
+        if (o.status != ST_SUCCESS) {
+            if (peer) {
+                smb2_close(peer, po.file_id);
+            }
+            continue;
+        }
+
+        if (o.oplock == SMB2_OPLOCK_LEVEL_LEASE) {
+            NOTE("O12[%d] %-32s %-24s -> LEASE %s (epoch %u)", i,
+                 o12_peer_name(rows[i].peer), o12_req_name(rows[i].req),
+                 lease_str(o.lease_state), o.lease_epoch);
+        } else {
+            NOTE("O12[%d] %-32s %-24s -> %s", i, o12_peer_name(rows[i].peer),
+                 o12_req_name(rows[i].req), oplock_name(o.oplock));
+        }
+
+        if (peer_reqp) {
+            NOTE("O12[%d] peer break notification(s): %d", i, nbreaks);
+        } else {
+            EXPECT(nbreaks == 0,
+                   "O12[%d] a peer that holds no cache is not broken "
+                   "(%d break(s))", i, nbreaks);
+        }
+
+        /* Policy pin (discretion: MS-SMB2 3.3.5.9 lets the server grant a
+         * lesser level).  This is what chimera grants TODAY and what the model
+         * encodes; it is not a spec mandate. */
+        EXPECT(o.oplock == rows[i].exp_opl,
+               "O12[%d] granted level %s, policy says %s "
+               "(discretion, MS-SMB2 3.3.5.9)", i, oplock_name(o.oplock),
+               oplock_name(rows[i].exp_opl));
+        if (rows[i].exp_opl == SMB2_OPLOCK_LEVEL_LEASE &&
+            o.oplock == SMB2_OPLOCK_LEVEL_LEASE) {
+            EXPECT(o.lease_state == rows[i].exp_lease,
+                   "O12[%d] granted lease %s, policy says %s "
+                   "(discretion, MS-SMB2 3.3.5.9)", i,
+                   lease_str(o.lease_state), lease_str(rows[i].exp_lease));
+        }
+
+        /* The MANDATE.  With a peer Open on the stream and no pre-existing
+         * oplock, MS-FSA 2.1.5.18.1 refuses an exclusive request outright, so
+         * no WRITE cache (legacy EXCLUSIVE/BATCH, or a lease carrying W) may be
+         * handed out.  HANDLE caching rides along on the same clause for a
+         * legacy BATCH oplock (BATCH == R|W|H is one exclusive request), while
+         * an RH lease is a SHARED request (2.1.5.18.2) and is unconstrained
+         * here. */
+        has_w = (o.oplock == SMB2_OPLOCK_LEVEL_LEASE)
+            ? ((o.lease_state & SMB2_LEASE_WRITE) != 0)
+            : (o.oplock == SMB2_OPLOCK_LEVEL_EXCLUSIVE ||
+               o.oplock == SMB2_OPLOCK_LEVEL_BATCH);
+
+        if (rows[i].peer != O12_P_NONE) {
+            if (has_w) {
+                DEVIATION("S-3",
+                          "O12[%d] %s: a %s request was granted a WRITE cache "
+                          "(%s %s) while a peer Open is on the stream; "
+                          "MS-FSA 2.1.5.18.1 refuses an exclusive oplock when "
+                          "Open.File.OpenList holds more than one Open on the "
+                          "stream -- that clause has no OplockKey and no "
+                          "client-identity exemption. See DEVIATIONS-SMB.md.",
+                          i, o12_peer_name(rows[i].peer),
+                          o12_req_name(rows[i].req), oplock_name(o.oplock),
+                          o.oplock == SMB2_OPLOCK_LEVEL_LEASE
+                          ? lease_str(o.lease_state) : "");
+            } else {
+                EXPECT(1,
+                       "O12[%d] no write cache is granted behind a peer Open "
+                       "(MS-FSA 2.1.5.18.1)", i);
+            }
+        }
+
+        smb2_close(a, o.file_id);
+        if (peer) {
+            smb2_close(peer, po.file_id);
+        }
+    }
+} /* sec_o12 */
+
 int
 main(
     int   argc,
@@ -460,13 +1366,19 @@ main(
     struct smb2_env      env;
     struct smb2_env_opts opts = { .oplocks          = 1, .leases = 1,
                                   .directory_leases = 1 };
-    struct smb2_conn    *a, *b;
+    struct smb2_conn    *a, *b, *g;
 
     smb2_env_start_opts(&env, &opts);
     a = smb2_conn_open(&env);
     b = smb2_conn_open(&env);
+    /* A second connection of A's CLIENT: same ClientGuid, so chimera derives
+     * the same lease client key for it (O12 needs a same-client peer that is
+     * not merely a same-connection peer). */
+    g           = smb2_conn_open(&env);
+    g->guid_tag = a->guid_tag;
     smb2_handshake(a);
     smb2_handshake(b);
+    smb2_handshake(g);
     printf("# holder A and opener B connected; dialect=0x%04x\n", a->dialect);
 
     sec_o1(&env, a);
@@ -474,8 +1386,16 @@ main(
     sec_o3(&env, a, b);
     sec_o4(&env, a, b);
     sec_o5(&env, a, b);
+    sec_o6(&env, a, b);
+    sec_o7(&env, a, b);
+    sec_o8(&env, a, b);
+    sec_o9(&env, a, b);
+    sec_o11(&env, a);
+    sec_o12(&env, a, b, g);
 
     smb2_env_stop(&env);
+
+    sec_o10();
 
     printf("\n# summary: %d recorded deviation(s) (see DEVIATIONS-SMB.md)\n",
            ndev);

--- a/src/server/smb/tests/quint/smb2_oplock_probe.c
+++ b/src/server/smb/tests/quint/smb2_oplock_probe.c
@@ -1180,8 +1180,15 @@ sec_o12(
           O12_L_LEASE, O12_S_RH },
         { O12_P_LEAS_S, O12_R_RH,
           O12_L_LEASE, O12_S_RH },
+        /* Re-pinned on the claim core: a BATCH request behind the SAME
+         * client's RH lease used to be refused outright (NONE); it is now
+         * downgraded to a LEVEL_II read cache, which coexists with the peer's
+         * R lease and breaks no one (the probe observes 0 break
+         * notifications).  Both answers are permitted -- this row is a policy
+         * pin under MS-SMB2 3.3.5.9's grant-a-lesser-level discretion, not a
+         * mandate -- and II is the more useful of the two. */
         { O12_P_LEAS_S, O12_R_BATCH,
-          O12_L_NONE, 0 },
+          O12_L_II, 0 },
         { O12_P_LEAS_S, O12_R_II,
           O12_L_NONE, 0 },
     };

--- a/src/server/smb/tests/quint/smb2_replay_probe.c
+++ b/src/server/smb/tests/quint/smb2_replay_probe.c
@@ -1,0 +1,1672 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * SMB2 replay / ChannelSequence ground-truth probe -- ROADMAP-SMB.md blocker
+ * B4, the exactly-once layer.  This is the third of the ground-truth probes
+ * (smb2_oplock_probe.c, smb2_durable_probe.c) and it pins the behavior the
+ * single largest WPTS family exercises: ~573 cases across ReplayFileOperation,
+ * ReplayCreateDurableHandleV1/V2/V2Persistent, ReplayCreateNormalHandle,
+ * ReplayCreateWithoutHandle and the wire Replay tests.
+ *
+ * WHAT "REPLAY" MEANS ON THE WIRE (measured here, section R1, not assumed).
+ * After a channel or transport failure a client RE-SENDS a request with
+ * SMB2_FLAGS_REPLAY_OPERATION (0x20000000) set.  What it does NOT do is reuse
+ * the MessageId: MS-SMB2 3.3.5.2.3 makes the server tear the connection down
+ * when a MessageId falls outside the command-sequence window, and R1 shows
+ * chimera doing exactly that.  So a wire replay is a FRESH MessageId carrying
+ * the replay flag, and the request is correlated with its original by
+ * something in the payload:
+ *
+ *   - a CREATE by its DH2Q CreateGuid  -- a true reply cache: the original
+ *     open is RETURNED, its effect is not re-applied (R3);
+ *   - a mutating op by its ChannelSequence -- NOT a reply cache: there is no
+ *     cached reply, the rule is that a request from a SUPERSEDED channel is
+ *     REJECTED so it cannot clobber newer data (R6, R7).
+ *
+ * Those are two different mechanisms with two different oracles, and the
+ * distinction is the whole point of the section split below.  A model that
+ * treats them alike will be wrong about one of them.
+ *
+ * ORACLE STRENGTH.  A replayed operation that was applied twice and one that
+ * was applied once are indistinguishable if the only thing asserted is the
+ * status code -- both say STATUS_SUCCESS.  Every exactly-once claim below is
+ * therefore asserted on the EFFECT:
+ *   - a replayed FILE_CREATE reports CreateAction = CREATED, which a second
+ *     application could not (it would collide), and leaves exactly ONE open,
+ *     proved by handing the file to a share-conflicting opener after a single
+ *     CLOSE (R3);
+ *   - a rejected stale WRITE leaves the file CONTENT unchanged (R6);
+ *   - a rejected stale SET_INFO leaves the file SIZE unchanged (R7).
+ *
+ * Conformance discipline (DEVIATIONS-SMB.md): every EXPECT cites the clause it
+ * asserts.  Server-discretion values are NOTE()d.  A divergence from a mandate
+ * becomes a DEVIATIONS-SMB.md entry, never a weakened assertion.
+ *
+ * Sections:
+ *   R1  wire mechanics  -- a re-sent MessageId is fatal to the connection, so
+ *                          a replay must carry a fresh one
+ *   R2  eligibility     -- what makes a CREATE replayable at all: the DH2Q
+ *                          context, or the durable GRANT?
+ *   R3  exactly once    -- the core: a replayed FILE_CREATE is answered from
+ *                          the original open and is NOT re-applied
+ *   R4  classifier      -- the four outcomes of chimera's create_guid replay
+ *                          classification: RECLAIM / DUPLICATE / DENIED / NONE
+ *   R5  no key          -- a replay flag with no CreateGuid has no idempotence
+ *                          key and IS re-applied
+ *   R6  CS window       -- the ChannelSequence accept/reject window and its
+ *                          effect on file content
+ *   R7  CS sites        -- WRITE / SET_INFO / IOCTL reject a stale sequence;
+ *                          READ does not, and what each does to the tracked
+ *                          high-water mark
+ *   R8  CS scope        -- the tracked sequence is per-OPEN, not per-session
+ *   R9  CS vs flag      -- the replay flag plays no part in the CS rule
+ */
+
+#include "smb2_mbt_common.h"
+
+static int nfail = 0;
+static int ndev  = 0;
+
+/* A spec-mandated assertion.  Fails the probe (and CI) on a violation. */
+#define EXPECT(ok, ...)                              \
+        do {                                         \
+            if (ok) { printf("ok   - "); }           \
+            else { printf("FAIL - "); nfail++; }     \
+            printf(__VA_ARGS__);                     \
+            printf("\n");                            \
+        } while (0)
+
+/* A ground-truth observation (server discretion / recorded behavior). */
+#define NOTE(...)                                    \
+        do { printf("note - "); printf(__VA_ARGS__); printf("\n"); } while (0)
+
+/* A recorded, spec-cited DEVIATION.  Loud and counted, but does not fail CI:
+ * it pins a known non-conformance so the probe stays a regression anchor.
+ * Every use has a DEVIATIONS-SMB.md entry. */
+#define DEVIATION(id, ...)                                       \
+        do {                                                     \
+            printf("DEVIATION %s - ", id); ndev++;               \
+            printf(__VA_ARGS__);                                 \
+            printf("\n");                                        \
+        } while (0)
+
+/* ---- helpers ------------------------------------------------------------ */
+
+static void
+fill_guid(
+    uint8_t guid[16],
+    int     tag)
+{
+    memset(guid, 0, 16);
+    guid[0]  = (uint8_t) tag;
+    guid[1]  = 0x9E;
+    guid[15] = (uint8_t) ~tag;
+} /* fill_guid */
+
+static void
+mk_lease(
+    struct smb2_oplock_req *r,
+    int                     key_tag,
+    uint32_t                state)
+{
+    memset(r, 0, sizeof(*r));
+    r->is_lease     = 1;
+    r->lease_key[0] = (uint8_t) key_tag;
+    r->lease_key[1] = 0x5E;
+    r->lease_state  = state;
+    r->lease_epoch  = 1;
+} /* mk_lease */
+
+static void
+mk_oplock(
+    struct smb2_oplock_req *r,
+    uint8_t                 level)
+{
+    memset(r, 0, sizeof(*r));
+    r->level = level;
+} /* mk_oplock */
+
+/* Pump until either a reply lands or the connection dies.  Returns 1 for a
+ * reply, 0 for a drop, -1 for the wedge ceiling.  The packaged waits treat a
+ * drop as fatal, which is exactly wrong for R1 -- there the drop IS the
+ * expected outcome and has to be observable as a value. */
+static int
+pump_reply_or_drop(struct smb2_conn *c)
+{
+    uint64_t deadline = smb2c_now_ms() + SMB2C_HANG_MS;
+
+    while (!c->reply_ready && !c->disconnected) {
+        smb2_pump(c->env);
+        if (smb2c_now_ms() >= deadline) {
+            return -1;
+        }
+    }
+    return c->reply_ready ? 1 : 0;
+} /* pump_reply_or_drop */
+
+/* Barrier for "the server has PARKED the handles of the connection we just
+ * dropped".  A client-side close returns as soon as the drop is delivered,
+ * which is strictly earlier than the server finishing its teardown, so a
+ * reclaim issued immediately afterwards would be racing.
+ *
+ * A DH2C carrying a deliberately WRONG CreateGuid is the barrier: chimera
+ * answers a not-yet-parked entry with a reconnect RETRY rather than a refusal,
+ * so the OBJECT_NAME_NOT_FOUND can only be produced once the park has actually
+ * happened -- and a guid mismatch consumes nothing. */
+static void
+wait_parked(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16])
+{
+    struct smb2_durable_req dur;
+    struct smb2_create_out  r;
+    uint32_t                st;
+
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2c = 1;
+    memcpy(dur.file_id, file_id, 16);
+    memset(dur.create_guid, 0xFE, 16);   /* cannot match any real create */
+
+    st = smb2_create_dur(c, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    EXPECT(st == ST_OBJECT_NAME_NOT_FOUND,
+           "park barrier: a wrong-CreateGuid DH2C is refused (0x%08x)", st);
+} /* wait_parked */
+
+/* The file's current EndOfFile, read through a fresh share-everything open on
+ * `c`.  Observing the EFFECT of a mutating op needs a channel independent of
+ * the handle whose ChannelSequence is under test. */
+static uint64_t
+file_size(
+    struct smb2_conn *c,
+    const char       *name,
+    uint32_t         *r_status)
+{
+    struct smb2_create_out o;
+    uint32_t               st = smb2_create(c, name, FILE_OPEN, FILE_READ_ACCESS,
+                                            FILE_SHARE_RWD, NULL, &o);
+
+    if (r_status) {
+        *r_status = st;
+    }
+    if (st != ST_SUCCESS) {
+        return (uint64_t) -1;
+    }
+    smb2_close(c, o.file_id);
+    return o.end_of_file;
+} /* file_size */
+
+/* Read the first `len` bytes of the open `file_id` into a NUL-terminated
+ * buffer, so a content assertion can be printed as well as compared.
+ *
+ * The ChannelSequence is an EXPLICIT parameter and callers pass the Open's
+ * current high-water mark.  That is not pedantry: a READ carries a
+ * ChannelSequence like any other request, an unset one is 0, and 0 against a
+ * mark in the upper half of the space is a FORWARD jump under the modular
+ * rule -- so an "innocent" verification read would silently reset the very
+ * mark the surrounding test is measuring.  (R7 pins that behavior on
+ * purpose; here it must not contaminate.) */
+static void
+read_text(
+    struct smb2_conn *c,
+    const uint8_t     file_id[16],
+    char             *out,
+    uint32_t          len,
+    uint16_t          cs)
+{
+    uint32_t got = 0;
+
+    memset(out, 0, len + 1);
+    smb2c_set_next_channel_sequence(c, cs);
+    smb2_read(c, file_id, 0, len, (uint8_t *) out, &got);
+    out[got] = 0;
+} /* read_text */
+
+/* ------------------------------------------------------------------------
+ * R1  A RE-SENT MessageId is fatal; a replay must carry a fresh one.
+ *
+ * MS-SMB2 3.3.5.2.3: the server maintains a command-sequence window and MUST
+ * disconnect when a request's MessageId falls outside it.  A MessageId already
+ * consumed is outside it.  This is the fact that decides what "replay" can
+ * mean on the wire, so it is measured rather than assumed -- and it is the
+ * reason smb2c_pin_msg_id() is not the replay primitive.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r1(struct smb2_env *env)
+{
+    struct smb2_conn      *c;
+    struct smb2_create_out o;
+    uint32_t               st;
+    uint64_t               reused;
+    int                    r;
+
+    printf("\n# R1 the command-sequence window (MS-SMB2 3.3.5.2.3)\n");
+
+    c = smb2_conn_open(env);
+    smb2_handshake(c);
+
+    st = smb2_create(c, "r1", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS, "R1 setup CREATE (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+    reused = c->last_msg_id;          /* this CREATE's MessageId, now consumed */
+    smb2_close(c, o.file_id);
+
+    /* A fresh MessageId carrying the replay flag is ACCEPTED -- establish that
+     * first, so the drop below cannot be blamed on the flag. */
+    smb2c_set_next_flags(c, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create(c, "r1", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS,
+           "R1 a replay-flagged request with a FRESH MessageId is answered"
+           " normally (0x%08x)", st);
+    if (st == ST_SUCCESS) {
+        smb2_close(c, o.file_id);
+    }
+
+    /* Now the same request with a MessageId that has already been used. */
+    uint64_t before = c->msg_id;
+
+    smb2c_pin_msg_id(c, reused);
+    smb2c_set_next_flags(c, SMB2_FLAGS_REPLAY_OPERATION);
+    smb2_create_post(c, "r1", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD, NULL);
+
+    r = pump_reply_or_drop(c);
+    NOTE("R1 re-sent MessageId %" PRIu64 " -> %s", reused,
+         r == 1 ? "a reply" : r == 0 ? "the connection was dropped"
+         : "nothing (wedged)");
+    EXPECT(r == 0,
+           "R1 a request re-using a consumed MessageId gets NO reply and the"
+           " connection is torn down (MS-SMB2 3.3.5.2.3)");
+    EXPECT(c->last_msg_id == reused,
+           "R1 the request really carried the re-used MessageId %" PRIu64
+           " (stamped %" PRIu64 ")", reused, c->last_msg_id);
+    EXPECT(c->msg_id == before,
+           "R1 a pinned send does not advance the client's MessageId counter"
+           " (%" PRIu64 " vs %" PRIu64 ")", c->msg_id, before);
+
+    NOTE("R1 CONSEQUENCE: a wire replay is a FRESH MessageId + "
+         "SMB2_FLAGS_REPLAY_OPERATION, correlated by DH2Q CreateGuid (creates)"
+         " or ChannelSequence (mutating ops) -- never by re-sending an id");
+} /* sec_r1 */
+
+/* ------------------------------------------------------------------------
+ * R2  What makes a CREATE replayable: the DH2Q context, not the durable GRANT.
+ *
+ * chimera_smb_create_grant_durable records the create_guid and sets
+ * IsReplayEligible for ANY create carrying a DH2Q context, whether or not the
+ * caching precondition for a durable grant was met.  That is a real behavioral
+ * fork the model has to get right: a replayable open and a durable open are
+ * not the same set.  (Both are gated on the persistent_handles config: with it
+ * off, grant_durable returns immediately and nothing is replayable.)
+ * ------------------------------------------------------------------------ */
+static void
+sec_r2(struct smb2_env *env)
+{
+    struct smb2_conn       *a;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    uint32_t                st;
+
+    printf("\n# R2 replay eligibility vs. the durable grant"
+           " (MS-SMB2 3.3.5.9.10)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* No oplock, no lease: the durable request CANNOT be granted (pinned by
+     * the durable probe's D1 grant matrix). */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x21);
+
+    st = smb2_create_dur(a, "r2", FILE_CREATE, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &o);
+    EXPECT(st == ST_SUCCESS, "R2 non-caching create with a DH2Q (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+    EXPECT(!o.has_dh2q,
+           "R2 the durable request is REFUSED (no caching precondition)");
+    EXPECT(o.action == FILE_ACT_CREATED, "R2 the original action is CREATED");
+
+    /* ... and yet the create IS replayable. */
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r2", FILE_CREATE, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &dur, &r);
+    NOTE("R2 replay of a NON-durable DH2Q create -> 0x%08x, same fid %d,"
+         " action %u", st, memcmp(r.file_id, o.file_id, 16) == 0, r.action);
+    EXPECT(st == ST_SUCCESS && memcmp(r.file_id, o.file_id, 16) == 0,
+           "R2 a DH2Q create is replay-eligible even when NO durable handle was"
+           " granted (0x%08x)", st);
+    EXPECT(r.action == FILE_ACT_CREATED,
+           "R2 the replay echoes the ORIGINAL CreateAction (%u), which a"
+           " re-applied FILE_CREATE could not produce", r.action);
+    NOTE("R2 the replay reply: dh2q %d, %d context(s)", r.has_dh2q, r.nctx);
+    EXPECT(!r.has_dh2q,
+           "R2 ... and it advertises no durable grant, because none was made"
+           " (%d)", r.has_dh2q);
+
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r2 */
+
+/* ------------------------------------------------------------------------
+ * R3  EXACTLY ONCE: a replayed FILE_CREATE is answered, not re-applied.
+ *
+ * This is the property the whole ReplayCreate* family exists to test, and it
+ * is the one place where asserting the status code alone would be worthless:
+ * "applied once" and "applied twice" both report STATUS_SUCCESS.  Three
+ * independent effect-level oracles are used instead.
+ *
+ *   1. CreateAction.  The replay reports CREATED.  A genuine second
+ *      application of FILE_CREATE against a file that now exists could not
+ *      report CREATED -- it would report OBJECT_NAME_COLLISION.  R3a proves
+ *      that premise on the same server before relying on it.
+ *   2. Handle identity.  The reply carries the ORIGINAL FileId.
+ *   3. Open count.  The file is opened with ShareAccess NONE.  ONE close
+ *      releases it: a share-conflicting opener then succeeds.  Had the replay
+ *      produced a second open, the reservation would have outlived that close.
+ *
+ * R3e is the non-vacuity control: the identical request WITHOUT the replay
+ * flag must NOT be answered from the original.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r3(struct smb2_env *env)
+{
+    struct smb2_conn       *a, *b;
+    struct smb2_oplock_req  oreq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r, o2;
+    uint32_t                st;
+
+    printf("\n# R3 exactly-once CREATE replay (MS-SMB2 3.3.5.9.10)\n");
+
+    a = smb2_conn_open(env);
+    b = smb2_conn_open(env);
+    smb2_handshake(a);
+    smb2_handshake(b);
+
+    /* (a) The premise: FILE_CREATE is NOT idempotent on this server. */
+    st = smb2_create(a, "r3ctl", FILE_CREATE, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS && o.action == FILE_ACT_CREATED,
+           "R3a control: the first FILE_CREATE succeeds with action CREATED"
+           " (0x%08x action %u)", st, o.action);
+    smb2_close(a, o.file_id);
+    st = smb2_create(a, "r3ctl", FILE_CREATE, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o2);
+    EXPECT(st == ST_OBJECT_NAME_COLLISION,
+           "R3a control: a SECOND FILE_CREATE collides -- so 'action CREATED'"
+           " below can only come from a cached reply (0x%08x)", st);
+
+    /* (b) The original: durable, batch-oplocked, ShareAccess NONE. */
+    mk_oplock(&oreq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x31);
+
+    st = smb2_create_dur(a, "r3", FILE_CREATE, FILE_ALL_ACCESS,
+                         0 /* ShareAccess NONE */, &oreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.action == FILE_ACT_CREATED && o.has_dh2q,
+           "R3b original durable FILE_CREATE (0x%08x action %u dh2q %d)",
+           st, o.action, o.has_dh2q);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* (c) The replay: byte-identical request, fresh MessageId, replay flag. */
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r3", FILE_CREATE, FILE_ALL_ACCESS, 0, &oreq,
+                         &dur, &r);
+    EXPECT(st == ST_SUCCESS,
+           "R3c the replay is answered SUCCESS, not OBJECT_NAME_COLLISION"
+           " (0x%08x)", st);
+    EXPECT(memcmp(r.file_id, o.file_id, 16) == 0,
+           "R3c the replay returns the ORIGINAL FileId");
+    EXPECT(r.action == FILE_ACT_CREATED,
+           "R3c the replay echoes CreateAction = CREATED (%u): the create was"
+           " NOT re-evaluated", r.action);
+    /* Whether the replay's reply re-advertises the durable grant is a wire
+     * fact the model has to predict, and it is not obvious either way: the
+     * request carried a DH2Q, but nothing new was granted. */
+    NOTE("R3c the replay reply: dh2q %d (timeout %u flags 0x%08x), lease %d,"
+         " %d context(s)", r.has_dh2q, r.dh2q_timeout, r.dh2q_flags,
+         r.has_lease, r.nctx);
+    EXPECT(r.has_dh2q == o.has_dh2q,
+           "R3c the replay re-advertises the durable grant exactly as the"
+           " original did (%d vs %d)", r.has_dh2q, o.has_dh2q);
+
+    /* (d) The effect: exactly ONE open exists. */
+    st = smb2_close(a, o.file_id);
+    EXPECT(st == ST_SUCCESS, "R3d one CLOSE of the FileId (0x%08x)", st);
+    st = smb2_close(a, o.file_id);
+    EXPECT(st == ST_FILE_CLOSED,
+           "R3d a SECOND close finds nothing -- the replay produced no second"
+           " handle (0x%08x)", st);
+    smb2_quiesce(env);
+    st = smb2_create(b, "r3", FILE_OPEN, FILE_ALL_ACCESS,
+                     0 /* ShareAccess NONE */, NULL, &o2);
+    EXPECT(st == ST_SUCCESS,
+           "R3d ... and one CLOSE released the ShareAccess-NONE reservation:"
+           " the replay created NO second open (0x%08x)", st);
+    if (st == ST_SUCCESS) {
+        smb2_close(b, o2.file_id);
+    }
+    smb2_quiesce(env);
+
+    /* (e) Non-vacuity: the SAME request without the flag is not a replay. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x32);
+    st = smb2_create_dur(a, "r3e", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q, "R3e original (0x%08x)", st);
+
+    st = smb2_create_dur(a, "r3e", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &r);
+    NOTE("R3e the identical create WITHOUT the replay flag -> 0x%08x", st);
+    EXPECT(st == ST_DUPLICATE_OBJECTID,
+           "R3e a NON-replay create colliding on CreateGuid is"
+           " DUPLICATE_OBJECTID -- the flag is what buys exactly-once"
+           " (0x%08x)", st);
+    if (st == ST_SUCCESS) {
+        smb2_close(a, r.file_id);
+    }
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r3 */
+
+/* ------------------------------------------------------------------------
+ * R4  The four outcomes of chimera's create_guid classification
+ * (chimera_smb_durable_claim_by_guid): RECLAIM / DUPLICATE / DENIED / NONE.
+ *
+ * Order matters and is deliberate: DUPLICATE and DENIED must not consume the
+ * parked entry, so they are exercised BEFORE the RECLAIM that does.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r4(struct smb2_env *env)
+{
+    struct smb2_conn       *a, *b;
+    struct smb2_oplock_req  lreq, wrongkey;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    uint32_t                st;
+
+    printf("\n# R4 create_guid replay classification"
+           " (MS-SMB2 3.3.5.9.10)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    mk_lease(&lreq, 0x44, SMB2_LEASE_RWH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x44);
+
+    st = smb2_create_dur(a, "r4", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q && o.has_lease,
+           "R4 durable leased open (0x%08x dh2q %d lease %d)", st, o.has_dh2q,
+           o.has_lease);
+    if (st != ST_SUCCESS || !o.has_dh2q) {
+        return;
+    }
+
+    smb2_conn_disconnect(a);
+    b = smb2_conn_reopen(env, a);
+    wait_parked(b, o.file_id);
+
+    /* (1) DUPLICATE: a NON-replay create whose guid matches a parked open. */
+    st = smb2_create_dur(b, "r4", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &r);
+    EXPECT(st == ST_DUPLICATE_OBJECTID,
+           "R4/DUPLICATE a non-replay create colliding with a PARKED open"
+           " (0x%08x)", st);
+
+    /* (2) DENIED: a replay whose handle TYPE differs from the parked open's --
+     * the parked open is leased, this replay carries no lease context. */
+    smb2c_set_next_flags(b, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(b, "r4", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, NULL, &dur, &r);
+    EXPECT(st == ST_ACCESS_DENIED,
+           "R4/DENIED a replay of a LEASED parked open that carries no lease"
+           " context -> ACCESS_DENIED (0x%08x)", st);
+
+    /* (2b) DENIED: right type, wrong lease key. */
+    mk_lease(&wrongkey, 0x45, SMB2_LEASE_RWH);
+    smb2c_set_next_flags(b, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(b, "r4", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &wrongkey, &dur, &r);
+    EXPECT(st == ST_ACCESS_DENIED,
+           "R4/DENIED a replay with the WRONG LeaseKey -> ACCESS_DENIED"
+           " (0x%08x)", st);
+
+    NOTE("R4 contrast: the DH2C RECONNECT path answers both of those with"
+         " OBJECT_NAME_NOT_FOUND (durable probe D4b/D4c); the REPLAY path"
+         " answers ACCESS_DENIED -- two different mandates, MS-SMB2 3.3.5.9.12"
+         " vs 3.3.5.9.10");
+
+    /* (3) NONE: a replay whose guid matches nothing falls through to a fresh
+     * open of the file, which already exists -> OPENED, a NEW FileId. */
+    {
+        struct smb2_durable_req other = dur;
+
+        fill_guid(other.create_guid, 0x46);
+        smb2c_set_next_flags(b, SMB2_FLAGS_REPLAY_OPERATION);
+        st = smb2_create_dur(b, "r4b", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                             FILE_SHARE_RWD, NULL, &other, &r);
+        EXPECT(st == ST_SUCCESS && r.action == FILE_ACT_CREATED,
+               "R4/NONE a replay whose CreateGuid matches nothing is an"
+               " ORDINARY create (0x%08x action %u)", st, r.action);
+        if (st == ST_SUCCESS) {
+            smb2_close(b, r.file_id);
+        }
+    }
+
+    /* (4) RECLAIM: the replay that matches, with the right handle type. */
+    smb2c_set_next_flags(b, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(b, "r4", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &lreq, &dur, &r);
+    EXPECT(st == ST_SUCCESS,
+           "R4/RECLAIM a matching replay reclaims the parked open (0x%08x)",
+           st);
+    EXPECT(memcmp(r.file_id, o.file_id, 16) == 0,
+           "R4/RECLAIM ... and returns the ORIGINAL FileId");
+    NOTE("R4/RECLAIM reply: dh2q %d, lease %d, %d context(s)", r.has_dh2q,
+         r.has_lease, r.nctx);
+    /* MEASURED, and NOT what the DH2C reconnect path does.  A DH2C reclaim
+     * carries no DH2Q response context (durable probe D3) because the request
+     * carried none; a REPLAY-driven reclaim of the same parked handle carries
+     * one, because the replayed request is a full DH2Q create and chimera's
+     * response emitters key on the REQUEST's context mask.  Same reclaim, two
+     * different replies, decided by how it was asked for. */
+    EXPECT(r.has_dh2q,
+           "R4/RECLAIM a REPLAY-driven reclaim DOES carry a DH2Q response"
+           " context -- unlike a DH2C reclaim of the same handle (%d)",
+           r.has_dh2q);
+    NOTE("R4/RECLAIM reclaim action %u (the original open's), lease %d",
+         r.action, r.has_lease);
+
+    if (st == ST_SUCCESS) {
+        smb2_close(b, r.file_id);
+    }
+    smb2_quiesce(env);
+} /* sec_r4 */
+
+/* ------------------------------------------------------------------------
+ * R5  A replay with NO idempotence key is re-applied.
+ *
+ * The negative half that gives the CreateGuid mechanism its meaning, and the
+ * shape WPTS ReplayCreateWithoutHandle / ReplayCreateNormalHandle drive: the
+ * replay FLAG on its own carries no correlation information, so the server has
+ * nothing to answer from and must execute the request.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r5(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out o, r;
+    uint32_t               st;
+
+    printf("\n# R5 a replay with no CreateGuid has no idempotence key\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    st = smb2_create(a, "r5", FILE_CREATE, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS && o.action == FILE_ACT_CREATED,
+           "R5 original FILE_CREATE, no create context (0x%08x)", st);
+
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create(a, "r5", FILE_CREATE, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &r);
+    NOTE("R5 replay-flagged FILE_CREATE without a DH2Q -> 0x%08x", st);
+    EXPECT(st == ST_OBJECT_NAME_COLLISION,
+           "R5 the replay is EXECUTED, not answered: with no CreateGuid there"
+           " is no key to answer from (0x%08x)", st);
+
+    if (st == ST_SUCCESS) {
+        smb2_close(a, r.file_id);
+    }
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r5 */
+
+/* ------------------------------------------------------------------------
+ * R6  The ChannelSequence window, asserted on FILE CONTENT.
+ *
+ * MS-SMB2 3.3.5.2.10.  The Open tracks a high-water ChannelSequence, seeded
+ * from its CREATE.  For a mutating op, delta = req_cs - open_cs computed mod
+ * 2^16: delta >= 0x8000 means the request comes from a SUPERSEDED channel and
+ * is rejected with STATUS_FILE_NOT_AVAILABLE; anything else is accepted and
+ * becomes the new high-water mark.
+ *
+ * This is NOT a reply cache.  Nothing is remembered about the reply; a request
+ * at the SAME sequence is simply executed again (R6/4 shows that directly).
+ * The exactly-once guarantee for a write is entirely negative: the write that
+ * would have clobbered newer data is refused.  Every row here therefore reads
+ * the file back -- the status code alone cannot tell the two apart.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r6(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out o;
+    uint32_t               st, n;
+    char                   txt[16];
+
+    printf("\n# R6 the ChannelSequence window (MS-SMB2 3.3.5.2.10)\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* The CREATE carries ChannelSequence 0, which seeds the Open. */
+    st = smb2_create(a, "r6", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS, "R6 open, seeding ChannelSequence 0 (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* (1) a forward jump is accepted and becomes the high-water mark */
+    smb2c_set_next_channel_sequence(a, 5);
+    st = smb2_write(a, o.file_id, 0, "AAAA", 4, &n);
+    EXPECT(st == ST_SUCCESS && n == 4,
+           "R6/1 WRITE at CS 5 (forward from 0) is accepted (0x%08x)", st);
+    read_text(a, o.file_id, txt, 4, 5);
+    EXPECT(strcmp(txt, "AAAA") == 0, "R6/1 content is 'AAAA' (got '%s')", txt);
+
+    /* (2) a stale sequence is rejected AND CHANGES NOTHING */
+    smb2c_set_next_channel_sequence(a, 0);
+    st = smb2_write(a, o.file_id, 0, "BBBB", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R6/2 WRITE at the superseded CS 0 -> FILE_NOT_AVAILABLE (0x%08x)",
+           st);
+    read_text(a, o.file_id, txt, 4, 5);
+    EXPECT(strcmp(txt, "AAAA") == 0,
+           "R6/2 THE EFFECT: the rejected write did not touch the file"
+           " (content '%s')", txt);
+
+    /* (3) the rejection did not disturb the high-water mark */
+    smb2c_set_next_channel_sequence(a, 5);
+    st = smb2_write(a, o.file_id, 0, "CCCC", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R6/3 WRITE at CS 5 still works: a rejected request does not move"
+           " the mark (0x%08x)", st);
+
+    /* (4) the SAME sequence is re-executed -- there is no reply cache */
+    smb2c_set_next_channel_sequence(a, 5);
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_write(a, o.file_id, 0, "DDDD", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R6/4 a replay-flagged WRITE at the SAME CS is accepted (0x%08x)",
+           st);
+    read_text(a, o.file_id, txt, 4, 5);
+    EXPECT(strcmp(txt, "DDDD") == 0,
+           "R6/4 THE EFFECT: it was RE-EXECUTED, not answered from a cache"
+           " (content '%s') -- writes have no reply cache; the exactly-once"
+           " guarantee is the stale-rejection of R6/2 alone", txt);
+
+    /* (5) the accept boundary: delta 0x7FFF is still forward */
+    smb2c_set_next_channel_sequence(a, (uint16_t) (5 + 0x7FFF));
+    st = smb2_write(a, o.file_id, 0, "EEEE", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R6/5 delta 0x7FFF is forward and accepted (CS 0x%04x, 0x%08x)",
+           5 + 0x7FFF, st);
+
+    /* (6) the reject boundary: delta 0x8000 exactly is stale */
+    smb2c_set_next_channel_sequence(a, (uint16_t) (5 + 0x7FFF + 0x8000));
+    st = smb2_write(a, o.file_id, 0, "FFFF", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R6/6 delta 0x8000 exactly is stale (CS 0x%04x, 0x%08x)",
+           (uint16_t) (5 + 0x7FFF + 0x8000), st);
+    read_text(a, o.file_id, txt, 4, (uint16_t) (5 + 0x7FFF));
+    EXPECT(strcmp(txt, "EEEE") == 0,
+           "R6/6 THE EFFECT: unchanged at the boundary (content '%s')", txt);
+
+    /* (7) the comparison is MODULAR: from 0xFFFF, CS 0x0001 is FORWARD by 2.
+     * A naive unsigned `<` would have called it stale and refused it. */
+    smb2c_set_next_channel_sequence(a, 0xFFFF);
+    st = smb2_write(a, o.file_id, 0, "GGGG", 4, &n);
+    EXPECT(st == ST_SUCCESS, "R6/7 advance to CS 0xFFFF (0x%08x)", st);
+
+    smb2c_set_next_channel_sequence(a, 0x0001);
+    st = smb2_write(a, o.file_id, 0, "HHHH", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R6/7 CS 0x0001 after 0xFFFF WRAPS FORWARD and is accepted"
+           " (0x%08x)", st);
+    read_text(a, o.file_id, txt, 4, 0x0001);
+    EXPECT(strcmp(txt, "HHHH") == 0, "R6/7 content is 'HHHH' (got '%s')", txt);
+
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r6 */
+
+/* ------------------------------------------------------------------------
+ * R7  Which operations consult the ChannelSequence, and what each does to the
+ * tracked mark.  MS-SMB2 3.3.5.2.10 names the mutating set (WRITE, SET_INFO,
+ * IOCTL); READ is explicitly NOT rejected.  chimera's implementation adds a
+ * detail the spec text does not spell out and the model must reproduce: a READ
+ * that jumps FORWARD still ADVANCES the mark, so a subsequent write at the old
+ * sequence becomes stale.  That is measured, not assumed.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r7(struct smb2_env *env)
+{
+    struct smb2_conn      *a, *w;
+    struct smb2_create_out o;
+    uint32_t               st, n, sz_st;
+    uint64_t               sz;
+    uint8_t                sparse = 1;
+    char                   txt[16];
+
+    printf("\n# R7 the channel-sequence-checked operation set\n");
+
+    a = smb2_conn_open(env);
+    w = smb2_conn_open(env);
+    smb2_handshake(a);
+    smb2_handshake(w);
+
+    st = smb2_create(a, "r7", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS, "R7 open (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* Advance the mark to 10. */
+    smb2c_set_next_channel_sequence(a, 10);
+    st = smb2_write(a, o.file_id, 0, "0123456789", 10, &n);
+    EXPECT(st == ST_SUCCESS, "R7 seed: WRITE at CS 10 (0x%08x)", st);
+
+    /* SET_INFO: rejected when stale, and the SIZE is the effect. */
+    smb2c_set_next_channel_sequence(a, 10);
+    st = smb2_set_eof(a, o.file_id, 4096);
+    EXPECT(st == ST_SUCCESS, "R7 SET_INFO EndOfFile 4096 at CS 10 (0x%08x)",
+           st);
+    sz = file_size(w, "r7", &sz_st);
+    EXPECT(sz_st == ST_SUCCESS && sz == 4096,
+           "R7 ... the size really is 4096 (%" PRIu64 ")", sz);
+
+    smb2c_set_next_channel_sequence(a, 1);
+    st = smb2_set_eof(a, o.file_id, 0);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R7 SET_INFO at the superseded CS 1 -> FILE_NOT_AVAILABLE"
+           " (0x%08x)", st);
+    sz = file_size(w, "r7", &sz_st);
+    EXPECT(sz_st == ST_SUCCESS && sz == 4096,
+           "R7 THE EFFECT: the rejected SET_INFO did not truncate the file"
+           " (%" PRIu64 ")", sz);
+
+    /* IOCTL: in the checked set. */
+    smb2c_set_next_channel_sequence(a, 10);
+    st = smb2_ioctl(a, SMB2_FSCTL_SET_SPARSE, o.file_id, &sparse, 1);
+    NOTE("R7 IOCTL FSCTL_SET_SPARSE at the current CS 10 -> 0x%08x", st);
+
+    smb2c_set_next_channel_sequence(a, 1);
+    st = smb2_ioctl(a, SMB2_FSCTL_SET_SPARSE, o.file_id, &sparse, 1);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R7 IOCTL at the superseded CS 1 -> FILE_NOT_AVAILABLE (0x%08x)",
+           st);
+
+    /* READ at a stale sequence is NOT rejected, and does NOT move the mark. */
+    smb2c_set_next_channel_sequence(a, 1);
+    memset(txt, 0, sizeof(txt));
+    st = smb2_read(a, o.file_id, 0, 4, (uint8_t *) txt, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R7 READ at the superseded CS 1 is NOT rejected (0x%08x)", st);
+
+    smb2c_set_next_channel_sequence(a, 10);
+    st = smb2_write(a, o.file_id, 0, "ZZZZ", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R7 ... and it did not move the mark backwards: CS 10 still works"
+           " (0x%08x)", st);
+
+    /* A READ that jumps FORWARD, however, DOES move the mark. */
+    smb2c_set_next_channel_sequence(a, 200);
+    st = smb2_read(a, o.file_id, 0, 4, (uint8_t *) txt, &n);
+    EXPECT(st == ST_SUCCESS, "R7 READ at CS 200 (forward) (0x%08x)", st);
+
+    smb2c_set_next_channel_sequence(a, 10);
+    st = smb2_write(a, o.file_id, 0, "YYYY", 4, &n);
+    NOTE("R7 WRITE back at CS 10 after a forward READ at CS 200 -> 0x%08x",
+         st);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R7 a FORWARD READ advances the tracked high-water sequence, so the"
+           " earlier sequence is now stale (0x%08x)", st);
+    read_text(a, o.file_id, txt, 4, 200);
+    EXPECT(strcmp(txt, "ZZZZ") == 0,
+           "R7 THE EFFECT: that write did not land (content '%s')", txt);
+
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r7 */
+
+/* ------------------------------------------------------------------------
+ * R8  The tracked sequence is per-OPEN.
+ *
+ * MS-SMB2 3.3.5.2.10 attaches the high-water mark to the Open, not to the
+ * session or the connection.  If the model attached it anywhere else, a
+ * two-handle trace would diverge immediately.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r8(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out o1, o2;
+    uint32_t               st, n;
+
+    printf("\n# R8 the ChannelSequence high-water mark is per-Open\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    st = smb2_create(a, "r8", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o1);
+    EXPECT(st == ST_SUCCESS, "R8 first open (0x%08x)", st);
+    st = smb2_create(a, "r8", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o2);
+    EXPECT(st == ST_SUCCESS, "R8 second open of the same file (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+    EXPECT(memcmp(o1.file_id, o2.file_id, 16) != 0,
+           "R8 the two opens are distinct handles");
+
+    /* Drive handle 1 far forward. */
+    smb2c_set_next_channel_sequence(a, 1000);
+    st = smb2_write(a, o1.file_id, 0, "AAAA", 4, &n);
+    EXPECT(st == ST_SUCCESS, "R8 handle 1 advanced to CS 1000 (0x%08x)", st);
+
+    /* Handle 2 was seeded at 0 by its own CREATE and is unaffected. */
+    smb2c_set_next_channel_sequence(a, 1);
+    st = smb2_write(a, o2.file_id, 0, "BBBB", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R8 handle 2 accepts CS 1: the mark did not leak across opens"
+           " (0x%08x)", st);
+
+    /* ... and handle 1 still rejects it. */
+    smb2c_set_next_channel_sequence(a, 1);
+    st = smb2_write(a, o1.file_id, 0, "CCCC", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R8 handle 1 still rejects CS 1 (0x%08x)", st);
+
+    smb2_close(a, o1.file_id);
+    smb2_close(a, o2.file_id);
+    smb2_quiesce(env);
+} /* sec_r8 */
+
+/* ------------------------------------------------------------------------
+ * R9  SMB2_FLAGS_REPLAY_OPERATION plays NO part in the ChannelSequence rule.
+ *
+ * Worth its own section because it is a live question in the tree: chimera's
+ * comment on chimera_smb_channel_sequence_stale records that the Windows
+ * reference behavior treats a replayed and a fresh forward jump identically,
+ * contradicting the premise of issue #1290.  If the model gated the rule on
+ * the flag it would be wrong in both directions, so both are measured.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r9(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out o;
+    uint32_t               st, n;
+    char                   txt[16];
+
+    printf("\n# R9 the replay flag does not change the ChannelSequence rule\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    st = smb2_create(a, "r9", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS, "R9 open (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    smb2c_set_next_channel_sequence(a, 50);
+    st = smb2_write(a, o.file_id, 0, "AAAA", 4, &n);
+    EXPECT(st == ST_SUCCESS, "R9 advance to CS 50 (0x%08x)", st);
+
+    /* stale + replay flag is still stale */
+    smb2c_set_next_channel_sequence(a, 1);
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_write(a, o.file_id, 0, "BBBB", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R9 a REPLAY-flagged stale WRITE is still rejected (0x%08x)", st);
+    read_text(a, o.file_id, txt, 4, 50);
+    EXPECT(strcmp(txt, "AAAA") == 0,
+           "R9 THE EFFECT: the flag bought it nothing (content '%s')", txt);
+
+    /* forward + replay flag still advances */
+    smb2c_set_next_channel_sequence(a, 60);
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_write(a, o.file_id, 0, "CCCC", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R9 a REPLAY-flagged forward WRITE is accepted (0x%08x)", st);
+
+    smb2c_set_next_channel_sequence(a, 50);
+    st = smb2_write(a, o.file_id, 0, "DDDD", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R9 ... and it ADVANCED the mark exactly as a fresh request would"
+           " (0x%08x)", st);
+
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r9 */
+
+/* ------------------------------------------------------------------------
+ * R10  Two consequences of the comparison being MODULAR that a model built
+ * from the prose alone would get wrong.
+ *
+ *  (a) A forward jump is bounded.  delta is computed mod 2^16 and "stale" is
+ *      delta >= 0x8000, so a single step of MORE than +0x7FFF is indis-
+ *      tinguishable from going backwards and is REFUSED.  The sequence space
+ *      is a circle, not a line.
+ *
+ *  (b) ChannelSequence 0 is not a neutral value.  Every request carries the
+ *      field, and a client that never sets it sends 0.  Against a mark in the
+ *      upper half of the space, 0 is a FORWARD jump -- so an unadorned request
+ *      is accepted and RESETS the mark to 0, after which the high sequences
+ *      that were valid a moment ago are stale.  (This probe tripped over it:
+ *      an innocent verification read at an unset sequence silently moved the
+ *      mark out from under the test.)
+ * ------------------------------------------------------------------------ */
+static void
+sec_r10(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out o;
+    uint32_t               st, n;
+
+    printf("\n# R10 consequences of the modular comparison\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    st = smb2_create(a, "r10", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS, "R10 open, mark seeded at 0 (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* (a) a jump of more than +0x7FFF in one step is refused */
+    smb2c_set_next_channel_sequence(a, 0x9000);
+    st = smb2_write(a, o.file_id, 0, "AAAA", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R10a a single jump of +0x9000 from mark 0 is STALE, not forward:"
+           " the space is modular (0x%08x)", st);
+
+    /* ... but the same distance in two legal steps is fine */
+    smb2c_set_next_channel_sequence(a, 0x7000);
+    st = smb2_write(a, o.file_id, 0, "BBBB", 4, &n);
+    EXPECT(st == ST_SUCCESS, "R10a step 1 to 0x7000 (0x%08x)", st);
+    smb2c_set_next_channel_sequence(a, 0xE000);
+    st = smb2_write(a, o.file_id, 0, "CCCC", 4, &n);
+    EXPECT(st == ST_SUCCESS, "R10a step 2 to 0xE000 (0x%08x)", st);
+
+    /* (b) an unset ChannelSequence (0) is forward from 0xE000 */
+    st = smb2_write(a, o.file_id, 0, "DDDD", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R10b a request with an UNSET ChannelSequence (0) is accepted from"
+           " a mark of 0xE000 -- 0 is forward by 0x2000 (0x%08x)", st);
+
+    smb2c_set_next_channel_sequence(a, 0xE000);
+    st = smb2_write(a, o.file_id, 0, "EEEE", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R10b ... and it RESET the mark to 0: 0xE000 is now stale"
+           " (0x%08x)", st);
+
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r10 */
+
+/* ------------------------------------------------------------------------
+ * R11  Where the Open's high-water sequence COMES FROM.
+ *
+ * chimera seeds it from the CREATE's own ChannelSequence (smb_proc_create.c
+ * sets channel_sequence / channel_sequence_valid at grant time) rather than
+ * starting every Open at 0 and letting the first operation seed it.  The two
+ * are indistinguishable in every test above, because every CREATE there
+ * carried sequence 0 -- so this row is the one that separates them, and the
+ * model needs the answer to predict the first operation on a handle opened by
+ * a client that has already failed over once.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r11(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out o;
+    uint32_t               st, n;
+
+    printf("\n# R11 the Open's sequence is seeded by its CREATE\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* The CREATE itself carries ChannelSequence 0x0100. */
+    smb2c_set_next_channel_sequence(a, 0x0100);
+    st = smb2_create(a, "r11", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &o);
+    EXPECT(st == ST_SUCCESS, "R11 CREATE at CS 0x0100 (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* A WRITE at 0 is delta 0xFF00 from 0x0100 -- stale IF the CREATE seeded
+     * the Open, and an ordinary forward-from-0 if it did not. */
+    smb2c_set_next_channel_sequence(a, 0);
+    st = smb2_write(a, o.file_id, 0, "AAAA", 4, &n);
+    NOTE("R11 WRITE at CS 0 against an Open created at CS 0x0100 -> 0x%08x",
+         st);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R11 the CREATE SEEDED the Open at 0x0100, so CS 0 is already"
+           " stale: an Open does not start at 0 (0x%08x)", st);
+
+    smb2c_set_next_channel_sequence(a, 0x0100);
+    st = smb2_write(a, o.file_id, 0, "BBBB", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R11 ... and the seeded value itself is accepted (0x%08x)", st);
+
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r11 */
+
+/* ------------------------------------------------------------------------
+ * R12  WHERE the ChannelSequence check sits among the other rejections.
+ *
+ * A model has to place the gate, not merely own it: if the gate runs before
+ * the access check the model answers FILE_NOT_AVAILABLE where the server
+ * answers ACCESS_DENIED, and every trace that lands on that pair diverges.
+ * chimera's WRITE handler resolves the handle, rejects on access, and only
+ * then consults the sequence -- measured here rather than read off the source.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r12(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out ro, rw;
+    uint32_t               st, n;
+
+    printf("\n# R12 ordering of the ChannelSequence gate\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* Two handles on one file: one read-only, one writable.  Both are seeded
+     * at ChannelSequence 0 by their CREATEs, so a request at 0x9000 is a jump
+     * of +0x9000 -- STALE under the modular rule (R10a). */
+    st = smb2_create(a, "r12", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &rw);
+    EXPECT(st == ST_SUCCESS, "R12 writable open (0x%08x)", st);
+    st = smb2_create(a, "r12", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                     NULL, &ro);
+    EXPECT(st == ST_SUCCESS, "R12 read-only open of the same file (0x%08x)",
+           st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* The control: on the WRITABLE handle that request really is stale. */
+    smb2c_set_next_channel_sequence(a, 0x9000);
+    st = smb2_write(a, rw.file_id, 0, "AAAA", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R12 control: CS 0x9000 from a mark of 0 IS stale (0x%08x)", st);
+
+    /* The same request on the READ-ONLY handle: both faults apply at once. */
+    smb2c_set_next_channel_sequence(a, 0x9000);
+    st = smb2_write(a, ro.file_id, 0, "AAAA", 4, &n);
+    NOTE("R12 a WRITE that is both unauthorized and stale -> 0x%08x", st);
+    EXPECT(st == ST_ACCESS_DENIED,
+           "R12 ACCESS_DENIED outranks the stale sequence: the gate sits AFTER"
+           " the access check (0x%08x)", st);
+
+    /* SET_INFO is the OTHER way round, and the asymmetry is real: chimera's
+     * SET_INFO consults the sequence immediately after resolving the handle,
+     * before any per-info-class check -- so on SET_INFO a stale sequence
+     * outranks the access fault that outranked it on WRITE. */
+    smb2c_set_next_channel_sequence(a, 0x9000);
+    st = smb2_set_eof(a, ro.file_id, 0);
+    NOTE("R12 SET_INFO EndOfFile on a read-only handle at a stale CS ->"
+         " 0x%08x", st);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R12 on SET_INFO the sequence gate runs BEFORE the class check, so"
+           " it outranks what WRITE lets outrank it (0x%08x)", st);
+
+    /* And a closed handle outranks both -- the gate needs a resolved Open. */
+    smb2_close(a, ro.file_id);
+    smb2c_set_next_channel_sequence(a, 0x9000);
+    st = smb2_write(a, ro.file_id, 0, "AAAA", 4, &n);
+    EXPECT(st == ST_FILE_CLOSED,
+           "R12 FILE_CLOSED outranks it too: the gate needs a resolved Open"
+           " (0x%08x)", st);
+
+    smb2_close(a, rw.file_id);
+    smb2_quiesce(env);
+} /* sec_r12 */
+
+/* ------------------------------------------------------------------------
+ * R13  Which requests close the replay-eligibility window.
+ *
+ * chimera clears IsReplayEligible inside chimera_smb_open_file_resolve, so
+ * every operation that resolves a handle by FileId closes the window -- and
+ * an OPLOCK-form break acknowledgment resolves by FileId while a LEASE-form
+ * one resolves by lease key through a different function.  That predicts a
+ * split, which is exactly the kind of prediction that must be measured before
+ * a model encodes it.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r13(struct smb2_env *env)
+{
+    struct smb2_conn       *a, *b;
+    struct smb2_oplock_req  oreq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r, ob;
+    struct smb2_break       brk;
+    uint32_t                st;
+    int                     got;
+
+    printf("\n# R13 what closes the replay-eligibility window\n");
+
+    a = smb2_conn_open(env);
+    b = smb2_conn_open(env);
+    smb2_handshake(a);
+    smb2_handshake(b);
+
+    /* (1) a QUERY -- a NON-mutating, fid-targeted op -- closes it. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x61);
+    st = smb2_create_dur(a, "r13a", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, NULL, &dur, &o);
+    EXPECT(st == ST_SUCCESS, "R13/1 replay-eligible create (0x%08x)", st);
+    {
+        char     txt[8];
+        uint32_t n = 0;
+
+        smb2_read(a, o.file_id, 0, 4, (uint8_t *) txt, &n);
+    }
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r13a", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, NULL, &dur, &r);
+    NOTE("R13/1 replay after a READ -> 0x%08x", st);
+    EXPECT(st != ST_SUCCESS || memcmp(r.file_id, o.file_id, 16) != 0,
+           "R13/1 a plain READ closes the window: the replay no longer"
+           " resolves to the original handle (0x%08x)", st);
+    if (st == ST_SUCCESS) {
+        smb2_close(a, r.file_id);
+    }
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+
+    /* (2) an OPLOCK-form break acknowledgment resolves by FileId. */
+    mk_oplock(&oreq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x62);
+    st = smb2_create_dur(a, "r13b", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.oplock == SMB2_OPLOCK_LEVEL_BATCH,
+           "R13/2 batch-oplocked replay-eligible create (0x%08x opl 0x%02x)",
+           st, o.oplock);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* B's conflicting open breaks A's batch oplock. */
+    smb2_create_post(b, "r13b", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                     NULL);
+    smb2_quiesce(env);
+    got = smb2_conn_pop_break(a, &brk);
+    EXPECT(got && !brk.is_lease,
+           "R13/2 A received an oplock break notification (got %d lease %d)",
+           got, got ? brk.is_lease : -1);
+    if (got) {
+        st = smb2_oplock_break_ack(a, brk.file_id, SMB2_OPLOCK_LEVEL_II);
+        NOTE("R13/2 oplock break ack -> 0x%08x", st);
+    }
+    smb2_quiesce(env);
+    smb2c_wait(b);
+    smb2c_parse_create(b, &ob);
+    if (ob.status == ST_SUCCESS) {
+        smb2_close(b, ob.file_id);
+    }
+    smb2_quiesce(env);
+
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r13b", FILE_CREATE, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &r);
+    NOTE("R13/2 replay after an OPLOCK-form break ack -> 0x%08x, same fid %d",
+         st, st == ST_SUCCESS ? memcmp(r.file_id, o.file_id, 16) == 0 : -1);
+    EXPECT(st != ST_SUCCESS || memcmp(r.file_id, o.file_id, 16) != 0,
+           "R13/2 an OPLOCK-form break ack resolves by FileId and therefore"
+           " CLOSES the window (0x%08x)", st);
+    if (st == ST_SUCCESS) {
+        smb2_close(a, r.file_id);
+    }
+    smb2_close(a, o.file_id);
+    smb2_quiesce(env);
+} /* sec_r13 */
+
+/* ------------------------------------------------------------------------
+ * R14  WHEN the mark advances: at the gate, or when the operation succeeds?
+ *
+ * The distinction is invisible until an operation clears the sequence gate and
+ * is then refused for some LATER reason.  chimera advances inside the gate
+ * itself (chimera_smb_channel_sequence_stale advances on its accept path), and
+ * on WRITE that gate runs before byte-range-lock enforcement -- so a write
+ * refused for a lock conflict has still moved the mark.  A model that advanced
+ * only on success would answer the NEXT request wrongly, which is why this is
+ * measured rather than reasoned about.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r14(struct smb2_env *env)
+{
+    struct smb2_conn      *a, *b;
+    struct smb2_create_out oa, ob;
+    uint32_t               st, n;
+
+    printf("\n# R14 the mark advances at the gate, not at success\n");
+
+    a = smb2_conn_open(env);
+    b = smb2_conn_open(env);
+    smb2_handshake(a);
+    smb2_handshake(b);
+
+    st = smb2_create(a, "r14", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &oa);
+    EXPECT(st == ST_SUCCESS, "R14 opener A (0x%08x)", st);
+    st = smb2_create(b, "r14", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &ob);
+    EXPECT(st == ST_SUCCESS, "R14 opener B (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* A takes an exclusive byte-range lock over [0, 16). */
+    st = smb2_lock(a, oa.file_id, 0, 16,
+                   SMB2_LOCKFLAG_EXCLUSIVE | SMB2_LOCKFLAG_FAIL_IMMEDIATELY);
+    EXPECT(st == ST_SUCCESS, "R14 A holds an exclusive lock on [0,16) (0x%08x)",
+           st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* B writes into the locked range at ChannelSequence 100.  The sequence is
+     * forward, so the gate PASSES; the lock then refuses the write. */
+    smb2c_set_next_channel_sequence(b, 100);
+    st = smb2_write(b, ob.file_id, 0, "AAAA", 4, &n);
+    NOTE("R14 B's write into the locked range at CS 100 -> 0x%08x", st);
+    EXPECT(st == ST_FILE_LOCK_CONFLICT || st == ST_LOCK_NOT_GRANTED,
+           "R14 the write cleared the sequence gate and was refused by the"
+           " LOCK (0x%08x)", st);
+
+    /* Now the question: did that refused write move B's mark to 100?  A write
+     * OUTSIDE the locked range at the earlier sequence answers it. */
+    smb2c_set_next_channel_sequence(b, 1);
+    st = smb2_write(b, ob.file_id, 32, "BBBB", 4, &n);
+    NOTE("R14 B's unconflicted write at CS 1 afterwards -> 0x%08x", st);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R14 the lock-refused write ALREADY advanced the mark: the gate"
+           " advances, success does not (0x%08x)", st);
+
+    /* ... and at the advanced sequence it goes through. */
+    smb2c_set_next_channel_sequence(b, 100);
+    st = smb2_write(b, ob.file_id, 32, "BBBB", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R14 ... and CS 100 is now the mark (0x%08x)", st);
+
+    smb2_close(b, ob.file_id);
+    smb2_close(a, oa.file_id);
+    smb2_quiesce(env);
+} /* sec_r14 */
+
+/* ------------------------------------------------------------------------
+ * R15  Is a SET_INFO access-checked at all?
+ *
+ * R12 measured only the STALE arm of SET_INFO -- a read-only handle at a
+ * superseded ChannelSequence answers FILE_NOT_AVAILABLE -- and concluded that
+ * the sequence gate runs BEFORE the per-class check.  That is true, and it
+ * left the more basic question unasked: with a FRESH sequence, does the class
+ * check reject the unauthorized set at all?
+ *
+ * MS-FSA 2.1.5.14 answers it.  Setting file information is gated on the access
+ * the class requires -- FileEndOfFileInformation and FileAllocationInformation
+ * on FILE_WRITE_DATA -- and the operation MUST be failed with
+ * STATUS_ACCESS_DENIED when Open.GrantedAccess does not contain it.  MS-SMB2
+ * 3.3.5.21 routes SMB2 SET_INFO straight into that algorithm.
+ *
+ * Found by the generated exactly-once corpus (smb2Replay/stepReplay), which
+ * drew a SET_EOF on a read-only handle at a non-stale sequence and disagreed
+ * with the model.  Measured here so the finding rests on a run of its own, and
+ * asserted on the EFFECT (the file's size afterwards) as well as the status:
+ * a status alone cannot tell "refused" from "accepted and did nothing".
+ * ------------------------------------------------------------------------ */
+static void
+sec_r15(struct smb2_env *env)
+{
+    struct smb2_conn      *a;
+    struct smb2_create_out rw, ro, at, chk;
+    uint32_t               st;
+
+    printf("\n# R15 the SET_INFO access check\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* The control first: on a WRITABLE handle a SET_EOF really does resize. */
+    st = smb2_create(a, "r15", FILE_OPEN_IF, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                     NULL, &rw);
+    EXPECT(st == ST_SUCCESS, "R15 writable open (0x%08x)", st);
+    st = smb2_set_eof(a, rw.file_id, 4096);
+    EXPECT(st == ST_SUCCESS, "R15 control: SET_EOF on a writable handle "
+           "(0x%08x)", st);
+    st = smb2_create(a, "r15", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                     NULL, &chk);
+    EXPECT(st == ST_SUCCESS && chk.end_of_file == 4096,
+           "R15 control: the file is %llu bytes, expected 4096",
+           (unsigned long long) chk.end_of_file);
+    smb2_close(a, chk.file_id);
+
+    /* A handle with FILE_READ_DATA and no FILE_WRITE_DATA. */
+    st = smb2_create(a, "r15", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                     NULL, &ro);
+    EXPECT(st == ST_SUCCESS, "R15 read-only open (0x%08x)", st);
+    st = smb2_set_eof(a, ro.file_id, 8192);
+    NOTE("R15 SET_EOF through a read-only handle -> 0x%08x", st);
+    if (st == ST_ACCESS_DENIED) {
+        EXPECT(1, "R15 MS-FSA 2.1.5.14: SET_EOF without FILE_WRITE_DATA is "
+               "ACCESS_DENIED");
+    } else {
+        DEVIATION("S-4", "SET_EOF through a handle with no FILE_WRITE_DATA "
+                  "answered 0x%08x; MS-FSA 2.1.5.14 mandates "
+                  "STATUS_ACCESS_DENIED", st);
+    }
+    st = smb2_create(a, "r15", FILE_OPEN, FILE_READ_ACCESS, FILE_SHARE_RWD,
+                     NULL, &chk);
+    if (st == ST_SUCCESS) {
+        if (chk.end_of_file == 4096) {
+            EXPECT(1, "R15 the unauthorized set changed nothing (4096 bytes)");
+        } else {
+            DEVIATION("S-4", "the unauthorized set TOOK EFFECT: the file is "
+                      "%llu bytes, was 4096",
+                      (unsigned long long) chk.end_of_file);
+        }
+        smb2_close(a, chk.file_id);
+    }
+    smb2_close(a, ro.file_id);
+
+    /* And an ATTRIBUTE-ONLY handle: FILE_READ_ATTRIBUTES alone, which is the
+     * shape the generated corpus drew (an open whose DesiredAccess carries no
+     * R/W/D at all).  It has strictly less access than the read-only handle
+     * above, so a server that refuses one must refuse this. */
+    st = smb2_create(a, "r15", FILE_OPEN, FILE_READ_ATTRIBUTES,
+                     FILE_SHARE_RWD, NULL, &at);
+    EXPECT(st == ST_SUCCESS, "R15 attribute-only open (0x%08x)", st);
+    if (st == ST_SUCCESS) {
+        st = smb2_set_eof(a, at.file_id, 16384);
+        NOTE("R15 SET_EOF through an attribute-only handle -> 0x%08x", st);
+        if (st != ST_ACCESS_DENIED) {
+            DEVIATION("S-4", "SET_EOF through an attribute-only handle "
+                      "answered 0x%08x; MS-FSA 2.1.5.14 mandates "
+                      "STATUS_ACCESS_DENIED", st);
+        }
+        smb2_close(a, at.file_id);
+    }
+
+    smb2_close(a, rw.file_id);
+    smb2_quiesce(env);
+} /* sec_r15 */
+
+/* ------------------------------------------------------------------------
+ * R16  WHAT a replayed CREATE reports when the replay asks for something
+ *      DIFFERENT from what the original was granted.
+ *
+ * R3c pinned the identical-request case: replay the same DH2Q create and the
+ * durable grant is re-advertised.  A generated exactly-once trace drew the
+ * case R3c cannot see -- a replay carrying the same CreateGuid but a LESSER
+ * oplock request -- and the model, which reports the OPEN's current grant,
+ * disagreed with the wire twice over.
+ *
+ * chimera says why in its own source, citing the WPTS case: on an oplock (non
+ * lease) create_guid replay the reply echoes "the requested oplock level", and
+ * build_dh2q_response refuses to emit a durable response at all unless the
+ * REQUESTED level is BATCH ("MS-SMB2 replay-dhv2-oplock2 expects
+ * durable_open_v2=false, timeout=0, no blobs").  A LEASE handle is the other
+ * way round: the reply reports the grant's CURRENT granted mode, because a
+ * coalesced lease may have been upgraded by a sibling open since.
+ *
+ * Measured here so the model's rule rests on a run.  DEVIATIONS-SMB.md M-15.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r16(struct smb2_env *env)
+{
+    struct smb2_conn       *a;
+    struct smb2_oplock_req  oreq;
+    struct smb2_durable_req dur;
+    struct smb2_create_out  o, r;
+    uint32_t                st;
+
+    printf("\n# R16 a replay that asks for a different oplock than it holds\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    /* The original: BATCH + DH2Q, so the open really does hold a batch oplock
+     * and a durable v2 grant. */
+    mk_oplock(&oreq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x61);
+    st = smb2_create_dur(a, "r16", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.oplock == SMB2_OPLOCK_LEVEL_BATCH &&
+           o.has_dh2q,
+           "R16 original: BATCH + durable v2 (0x%08x oplock 0x%02x dh2q %d)",
+           st, o.oplock, o.has_dh2q);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* The replay, same CreateGuid, asking for NO oplock at all. */
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r16", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, NULL, &dur, &r);
+    EXPECT(st == ST_SUCCESS && memcmp(r.file_id, o.file_id, 16) == 0,
+           "R16 the replay returns the ORIGINAL handle (0x%08x)", st);
+    EXPECT(r.oplock == SMB2_OPLOCK_LEVEL_NONE,
+           "R16 the reply echoes the REQUESTED oplock level, not the one the "
+           "open holds: 0x%02x (open holds BATCH)", r.oplock);
+    EXPECT(!r.has_dh2q,
+           "R16 and emits NO durable response, because the requested level "
+           "could not itself have earned one (has_dh2q %d)", r.has_dh2q);
+
+    /* The same replay asking for BATCH: both come back. */
+    mk_oplock(&oreq, SMB2_OPLOCK_LEVEL_BATCH);
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r16", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &r);
+    EXPECT(st == ST_SUCCESS && memcmp(r.file_id, o.file_id, 16) == 0 &&
+           r.oplock == SMB2_OPLOCK_LEVEL_BATCH && r.has_dh2q,
+           "R16 asking for BATCH again reports BATCH and the durable grant "
+           "(0x%08x oplock 0x%02x dh2q %d)", st, r.oplock, r.has_dh2q);
+
+    /* A LEVEL_II request against the same batch-oplocked open: echoed, and
+     * still no durable response -- LEVEL_II could not have earned one. */
+    mk_oplock(&oreq, SMB2_OPLOCK_LEVEL_II);
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r16", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &r);
+    EXPECT(st == ST_SUCCESS && r.oplock == SMB2_OPLOCK_LEVEL_II && !r.has_dh2q,
+           "R16 a LEVEL_II replay echoes LEVEL_II with no durable response "
+           "(0x%08x oplock 0x%02x dh2q %d)", st, r.oplock, r.has_dh2q);
+    smb2_close(a, o.file_id);
+
+    /* The LEASE half: a lease handle reports the GRANT's current state and
+     * keeps its durable response, whatever epoch the replay presents. */
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x62);
+    mk_lease(&oreq, 0x62, SMB2_LEASE_READ | SMB2_LEASE_HANDLE |
+             SMB2_LEASE_WRITE);
+    st = smb2_create_dur(a, "r16b", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.oplock == SMB2_OPLOCK_LEVEL_LEASE &&
+           o.has_dh2q,
+           "R16 lease original: RWH + durable v2 (0x%08x lease 0x%02x dh2q %d)",
+           st, o.lease_state, o.has_dh2q);
+    mk_lease(&oreq, 0x62, SMB2_LEASE_READ);
+    smb2c_set_next_flags(a, SMB2_FLAGS_REPLAY_OPERATION);
+    st = smb2_create_dur(a, "r16b", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &r);
+    EXPECT(st == ST_SUCCESS && memcmp(r.file_id, o.file_id, 16) == 0,
+           "R16 the lease replay returns the ORIGINAL handle (0x%08x)", st);
+    EXPECT(r.lease_state == o.lease_state,
+           "R16 a lease replay reports the GRANT's current state, not the "
+           "requested one: 0x%02x (asked for R alone)", r.lease_state);
+    EXPECT(r.has_dh2q,
+           "R16 and keeps its durable response (has_dh2q %d)", r.has_dh2q);
+    smb2_close(a, o.file_id);
+
+    smb2_quiesce(env);
+} /* sec_r16 */
+
+/* ------------------------------------------------------------------------
+ * R17  A reclaim RESEEDS the Open's ChannelSequence high-water mark.
+ *
+ * The mark tracks a channel (MS-SMB2 3.3.5.2.10) and a reclaim arrives on a
+ * new one, so the question is whether the surviving Open keeps the mark it had
+ * before the drop or takes the reclaiming CREATE's.  chimera reseeds
+ * (chimera_smb_durable_rehome: "Reseed the channel-sequence baseline from the
+ * reconnecting CREATE"), which a generated exactly-once trace found the hard
+ * way: the model kept a pre-drop mark of 3 and refused a WRITE at 0 that the
+ * wire executed.
+ *
+ * Measured with a mark deliberately far from the reclaiming sequence, so
+ * "kept" and "reseeded" give opposite verdicts for both following writes.
+ * DEVIATIONS-SMB.md M-16.
+ * ------------------------------------------------------------------------ */
+static void
+sec_r17(struct smb2_env *env)
+{
+    struct smb2_conn       *a, *b;
+    struct smb2_oplock_req  oreq;
+    struct smb2_durable_req dur, rec;
+    struct smb2_create_out  o, r;
+    uint32_t                st, n;
+
+    printf("\n# R17 a reclaim reseeds the ChannelSequence mark\n");
+
+    a = smb2_conn_open(env);
+    smb2_handshake(a);
+
+    mk_oplock(&oreq, SMB2_OPLOCK_LEVEL_BATCH);
+    memset(&dur, 0, sizeof(dur));
+    dur.dh2q = 1;
+    fill_guid(dur.create_guid, 0x71);
+    st = smb2_create_dur(a, "r17", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                         FILE_SHARE_RWD, &oreq, &dur, &o);
+    EXPECT(st == ST_SUCCESS && o.has_dh2q,
+           "R17 durable batch open, seeded at ChannelSequence 0 (0x%08x)", st);
+    if (st != ST_SUCCESS || !o.has_dh2q) {
+        return;
+    }
+
+    /* Drive the mark up to 100. */
+    smb2c_set_next_channel_sequence(a, 100);
+    st = smb2_write(a, o.file_id, 0, "AAAA", 4, &n);
+    EXPECT(st == ST_SUCCESS, "R17 a write at CS 100 advances the mark (0x%08x)",
+           st);
+    smb2c_set_next_channel_sequence(a, 99);
+    st = smb2_write(a, o.file_id, 0, "BBBB", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R17 control: CS 99 is now stale (0x%08x)", st);
+
+    /* Drop, reclaim with a CREATE carrying ChannelSequence 5. */
+    smb2_conn_disconnect(a);
+    b = smb2_conn_reopen(env, a);
+    wait_parked(b, o.file_id);
+
+    memset(&rec, 0, sizeof(rec));
+    rec.dh2c = 1;
+    memcpy(rec.file_id, o.file_id, 16);
+    fill_guid(rec.create_guid, 0x71);
+    smb2c_set_next_channel_sequence(b, 5);
+    st = smb2_create_dur(b, "", FILE_OPEN, FILE_ALL_ACCESS, FILE_SHARE_RWD,
+                         NULL, &rec, &r);
+    EXPECT(st == ST_SUCCESS && memcmp(r.file_id, o.file_id, 16) == 0,
+           "R17 the DH2C reclaim returns the original handle (0x%08x)", st);
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* If the mark had been KEPT at 100, a write at 5 would be stale; if it was
+     * RESEEDED to 5, a write at 5 is accepted and one at 4 is stale. */
+    smb2c_set_next_channel_sequence(b, 5);
+    st = smb2_write(b, r.file_id, 0, "CCCC", 4, &n);
+    EXPECT(st == ST_SUCCESS,
+           "R17 a write at the reclaiming CREATE's own CS 5 is accepted, so "
+           "the mark was RESEEDED, not kept at 100 (0x%08x)", st);
+    smb2c_set_next_channel_sequence(b, 4);
+    st = smb2_write(b, r.file_id, 0, "DDDD", 4, &n);
+    EXPECT(st == ST_FILE_NOT_AVAILABLE,
+           "R17 and CS 4 is stale against the reseeded mark (0x%08x)", st);
+
+    smb2_close(b, r.file_id);
+    smb2_quiesce(env);
+} /* sec_r17 */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct smb2_env      env;
+    struct smb2_env_opts opts = { .oplocks            = 1,
+                                  .leases             = 1,
+                                  .directory_leases   = 1,
+                                  .persistent_handles = 1 };
+
+    (void) argc;
+    (void) argv;
+
+    smb2_env_start_opts(&env, &opts);
+    printf("# replay/ChannelSequence probe up; persistent_handles on\n");
+
+    sec_r1(&env);
+    sec_r2(&env);
+    sec_r3(&env);
+    sec_r4(&env);
+    sec_r5(&env);
+    sec_r6(&env);
+    sec_r7(&env);
+    sec_r8(&env);
+    sec_r9(&env);
+    sec_r10(&env);
+    sec_r11(&env);
+    sec_r12(&env);
+    sec_r13(&env);
+    sec_r14(&env);
+    sec_r15(&env);
+    sec_r16(&env);
+    sec_r17(&env);
+
+    smb2_env_stop(&env);
+
+    printf("\n# summary: %d recorded deviation(s) (see DEVIATIONS-SMB.md)\n",
+           ndev);
+    if (nfail) {
+        printf("%d SMB2 replay/ChannelSequence check(s) FAILED\n", nfail);
+        return 1;
+    }
+    printf("all SMB2 replay/ChannelSequence mandate checks passed"
+           " (%d documented deviation(s))\n", ndev);
+    return 0;
+} /* main */


### PR DESCRIPTION
Builds on the merged quint MBT suite. Consumes [chimera-nas/specs#1](https://github.com/chimera-nas/specs/pull/1) (merged) and bumps the submodule.

## Why

The SMB2 model implemented far more than the corpus generated: one batch (`smb2Base/stepCore`, 60 steps, 6 traces) with oplocks, leases, directory leases and durable handles all pinned off. Measured with clang source-based coverage, that corpus reached **16.9%** of the 20,427 instrumented lines in `src/server/smb`, while the suite's four hand-written probes reached **25.7%** — the probes out-covered the entire model-based corpus.

Generated-corpus coverage is now **25.6%**, level with the probes; the whole suite reaches 29.7%.

## Server fixes

Two, both found by the widened corpus and both standalone:

**`smb: refcount the share so a tree cannot outlive it`** — a heap-use-after-free. `chimera_smb_remove_share()` unlinked the share, destroyed its sharemode table and freed it in one step with no regard for references. A tree holds one for the life of the tree connect, and its open files release reservations through `&tree->share->sharemode` as they are torn down — asynchronously, on the server's own threads. Removing a share while a client is disconnecting freed the table out from under `chimera_smb_sharemode_release()`. The window is small at low load, which is why it went unnoticed; at depth 500 it reproduced on the first run, every run. The share now carries one reference for its place on `shared->shares` plus one per connected tree, and `TREE_CONNECT` takes its reference under `shares_lock` so it cannot race the unlink.

**`smb: fill the attribute word for FileStandardInformation`** — a standalone `FileStandardInformation` query reported whatever the reused request memory held in the Directory byte. `chimera_smb_marshal_standard_attrs` never set `smb_attributes`, and `SMB_ATTR_MASK_STANDARD` does not require it, so the append-time assert could not catch it. `FileAllInformation` was unaffected. Found because one model QUERY_INFO drives three info classes against a single prediction, so the classes cross-check each other.

## Harness

The replayer had no durable/reconnect support: a durable trace's `CReconnect` printed `unhandled command tag`, its session was never bound, and the next command dereferenced NULL. Adds the client-initiated drop, reconnect inheriting the dropped ClientGuid, the four durable create contexts, the park barrier, and ChannelSequence/replay-flag stamping. A NULL connection can no longer reach a PDU builder — `smb2c_begin` refuses one loudly rather than skipping, since a skipped step leaves the trace testing a state neither side believes in.

Six modeled commands had no builder, so ~2,000 server lines sat at zero: QUERY_INFO, FLUSH, LOCK/UNLOCK, SET_INFO EndOfFile/Disposition/Rename, plus LOGOFF and TREE_DISCONNECT. Each checks its reply — sending a command without comparing the reply is coverage without an oracle. Lock ranges are scaled by the block size the way READ/WRITE are; unscaled, every lock would be disjoint from every I/O and every status would still have matched.

Two fixes the batched replay needed once it ran a real corpus: `smb2_conn_open` allocates three buffers per connection and `smb2_conn_reset` freed two, leaking 592 MB across 565 connections (`smb2_env_stop` already freed all three); and `run_trace` cleared three of the wire-identity maps but not the rest, so a residual `g_fid_known` entry made the next trace's first CREATE look like a replay of the previous trace's open.

Also: the batch replayer configured the shared server from `traces[0]` on the grounds that a batch has one capability profile. The corpus now spans several generation instances, so it groups adjacent traces by profile and restarts the server when it changes.

## Notes for review

- `O12[32]` is re-pinned: a BATCH request behind the same client's RH lease used to be refused outright and now yields a LEVEL_II read cache. That row is a policy pin under MS-SMB2 3.3.5.9 discretion, not a mandate, and the probe observes zero break notifications — this records what the claim core does today.
- Two flavors are deliberately unregistered, recorded where they are declared: `stepReplay` (CreateGuid collisions make affected traces nondeterministic) and `stepDurable` (parked handles outlive the per-trace filesystem teardown).
- `batch_memfs` timeout raised 120s → 600s: 40 traces at depth 500 under ASAN measured 55–105s, close enough to the ceiling to flake.

`ctest -L smb_mbt`: 5/5, repeated. `quint test --main=smb2Test`: 65 passing. uncrustify clean on every changed file.