### PR TITLE
ci: run the quint model-based suites (and static analysis) pre-merge

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ ARG ENABLE_CODEX=1
 ARG ENABLE_UV=1
 ARG ENABLE_WPTS=1
 ARG ENABLE_PIKE=1
+ARG ENABLE_QUINT=1
 # Pinned to an exact chimera-nas/pynfs commit (on branch chimera-fast-ci).  Using
 # a SHA rather than a moving branch makes the image reproducible and, critically,
 # busts the Docker layer cache whenever pynfs is bumped -- otherwise the cached
@@ -27,6 +28,14 @@ ARG PIKE_REF=bcbb343c5bfb7dd3198d2d79d7381dfdad0f0873
 # Pinned Microsoft Windows Protocol Test Suites (WPTS) FileServer release.
 ARG WPTS_VERSION=4.26.3.0
 ARG ELBENCHO_REF=96b1bf29c35e437715c0527194e69e4c96ed9922
+# Pinned quint release, used to generate the model-based-test trace corpus
+# from ext/specs when no prebuilt bundle is fetched.  Trace generation is
+# seeded and so reproducible for a given release, but different releases may
+# sample the state space differently, which is why ext/specs records the exact
+# version it generated against and warns on a mismatch.  KEEP IN SYNC with
+# ext/specs/.quint-version (ext/libevpl/.devcontainer/Dockerfile pins the
+# same release for libevpl's own conformance tests).
+ARG QUINT_VERSION=0.32.0
 ARG ENABLE_S3TESTS=1
 # Pinned ceph/s3-tests commit. Bump to pull in new compliance cases; a SHA
 # (not a branch) keeps the image reproducible and busts the layer cache on bump.
@@ -164,4 +173,28 @@ RUN if [ "$ENABLE_WPTS" = "1" ] ; then \
     curl -sSL "https://github.com/microsoft/WindowsProtocolTestSuites/releases/download/${WPTS_VERSION}/FileServer-TestSuite-ServerEP.tar.gz" -o /tmp/wpts.tar.gz && \
     tar -C /opt/wpts -xzf /tmp/wpts.tar.gz && \
     rm -f /tmp/wpts.tar.gz ; \
+    fi
+
+# quint drives the model-based tests: the specs submodule (ext/specs) generates
+# the ITF trace corpus from its models at build time, and cmake/SpecsBundle.cmake
+# falls back to that local build whenever the prebuilt bundle cannot be fetched.
+# Without quint in the image every MBT replay ctest silently disables itself, so
+# the nfs3/nfs4/smb2/posix model suites never run in CI.  It also re-enables
+# libevpl's own Core/HTTP/RPC2 conformance tests, which detect quint the same way.
+#
+# quint downloads its Rust evaluator on first simulate, into ~/.quint.  CI
+# runners reach the network through internal mirrors only, so that download
+# arrives truncated and every generation fails.  Warm the cache here, where the
+# network is available and the result is baked into the image.  Double quotes,
+# so quint's prime operator (n') needs no escaping: inside single quotes a
+# backslash is literal and would end the string early.  The closing ls is the
+# check: if the evaluator did not land, fail here where it is fixable rather
+# than in every downstream build job.
+RUN if [ "$ENABLE_QUINT" = "1" ] ; then \
+    npm install -g @informalsystems/quint@${QUINT_VERSION} && \
+    printf "module warm {\n  var n: int\n  action init = n' = 0\n  action step = n' = n + 1\n}\n" \
+        > /tmp/warm.qnt && \
+    { quint run /tmp/warm.qnt --max-steps=1 --max-samples=1 > /dev/null 2>&1 || true ; } && \
+    rm -f /tmp/warm.qnt && \
+    ls -d /root/.quint/rust-evaluator-*/quint_evaluator ; \
     fi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,6 @@ ARG ENABLE_CODEX=1
 ARG ENABLE_UV=1
 ARG ENABLE_WPTS=1
 ARG ENABLE_PIKE=1
-ARG ENABLE_QUINT=1
 # Pinned to an exact chimera-nas/pynfs commit (on branch chimera-fast-ci).  Using
 # a SHA rather than a moving branch makes the image reproducible and, critically,
 # busts the Docker layer cache whenever pynfs is bumped -- otherwise the cached
@@ -28,14 +27,6 @@ ARG PIKE_REF=bcbb343c5bfb7dd3198d2d79d7381dfdad0f0873
 # Pinned Microsoft Windows Protocol Test Suites (WPTS) FileServer release.
 ARG WPTS_VERSION=4.26.3.0
 ARG ELBENCHO_REF=96b1bf29c35e437715c0527194e69e4c96ed9922
-# Pinned quint release, used to generate the model-based-test trace corpus
-# from ext/specs when no prebuilt bundle is fetched.  Trace generation is
-# seeded and so reproducible for a given release, but different releases may
-# sample the state space differently, which is why ext/specs records the exact
-# version it generated against and warns on a mismatch.  KEEP IN SYNC with
-# ext/specs/.quint-version (ext/libevpl/.devcontainer/Dockerfile pins the
-# same release for libevpl's own conformance tests).
-ARG QUINT_VERSION=0.32.0
 ARG ENABLE_S3TESTS=1
 # Pinned ceph/s3-tests commit. Bump to pull in new compliance cases; a SHA
 # (not a branch) keeps the image reproducible and busts the layer cache on bump.
@@ -174,6 +165,20 @@ RUN if [ "$ENABLE_WPTS" = "1" ] ; then \
     tar -C /opt/wpts -xzf /tmp/wpts.tar.gz && \
     rm -f /tmp/wpts.tar.gz ; \
     fi
+
+# Declared here rather than up with the other ARGs: an ARG inserted above a
+# layer takes part in that layer's cache key, so putting these at the top
+# invalidated every cached layer below them -- a 7-minute rebuild of an
+# image that had been rebuilding in seconds.
+ARG ENABLE_QUINT=1
+# Pinned quint release, used to generate the model-based-test trace corpus
+# from ext/specs when no prebuilt bundle is fetched.  Trace generation is
+# seeded and so reproducible for a given release, but different releases may
+# sample the state space differently, which is why ext/specs records the exact
+# version it generated against and warns on a mismatch.  KEEP IN SYNC with
+# ext/specs/.quint-version (ext/libevpl/.devcontainer/Dockerfile pins the
+# same release for libevpl's own conformance tests).
+ARG QUINT_VERSION=0.32.0
 
 # quint drives the model-based tests: the specs submodule (ext/specs) generates
 # the ITF trace corpus from its models at build time, and cmake/SpecsBundle.cmake

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -928,10 +928,18 @@ jobs:
           # full crypt(5) $-scheme verification.
           brew install cmake ninja bison jansson userspace-rcu rocksdb krb5 \
                        xxhash libxcrypt uthash openssl@3 libnghttp2
+          # oras, not quint: this job has never had a model-based-test trace
+          # corpus, so every MBT replay ctest disabled itself here.  A CI
+          # checkout never has local edits to ext/specs, so the bundle the specs
+          # CI published for the pinned commit always applies -- pulling it is
+          # both lighter than regenerating the corpus with quint and free of
+          # quint's parallel-generator download race.
+          brew install oras
 
       - name: Configure and build
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                -DSPECS_BUNDLE=ON \
                 -S "${{ github.workspace }}" -B "${{ runner.temp }}/build"
           ninja -C "${{ runner.temp }}/build"
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,11 +12,25 @@ name: PR checks
 # before it can be added to the queue.  This workflow satisfies them with
 # instant no-op placeholders; the real checks of the same names run in the queue
 # (where the actual matrix / image builds / flake review happen).
+#
+# It also carries the pre-merge signal that is cheap enough to be worth having
+# before the queue: clang static analysis on devcontainer and macOS, and the
+# quint model-based test suite (ctest label "quint") on devcontainer.  The MBT
+# suites are the fastest broad-coverage tests in the tree -- the whole label
+# runs in well under a minute -- and they are the ones a spec or harness change
+# breaks, so catching that here rather than in the queue is worth one image
+# build.  macOS runs the quint suite post-merge, in build-test.yml's macOS job,
+# rather than twice.
 on:
   pull_request:
 
 permissions:
   contents: read
+
+env:
+  DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
+  APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
+  DOCKER_MIRROR: repository.mdh.quantum.com/
 
 jobs:
   ci-complete:
@@ -42,3 +56,166 @@ jobs:
     steps:
       - name: PR placeholder
         run: echo "PR placeholder -- docker image builds run in the merge queue (merge_group)."
+
+  # ---------------------------------------------------------------------------
+  # Pre-merge signal.  The devcontainer image is built once here and consumed by
+  # both container jobs below, mirroring the merge queue's
+  # build-devcontainer -> {static-analysis, test-dev} shape.  It is tagged with
+  # github.sha, which on a pull_request event is the PR's merge commit and so
+  # never collides with the queue's own tags.
+  # ---------------------------------------------------------------------------
+  build-devcontainer:
+    name: Build devcontainer amd64 (pre-merge)
+    runs-on: arc-amd64
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker-container
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      # cache-from only (no cache-to): the merge queue owns that cache, and a PR
+      # must not be able to poison it.  An unchanged Dockerfile is therefore a
+      # layer pull rather than a rebuild.
+      - name: Build and push the dev container image
+        uses: docker/build-push-action@v7
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64
+          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:amd64
+          build-args: |
+            APT_MIRROR=${{ env.APT_MIRROR }}
+            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+
+  analyze-dev:
+    name: Analyze devcontainer amd64 Release (pre-merge)
+    needs: [build-devcontainer]
+    runs-on: arc-amd64
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Perform clang static analysis
+        id: static-analysis
+        run: |
+          set -o pipefail
+          mkdir -p "${{ github.workspace }}/scan-report"
+          docker run --rm --privileged \
+            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
+            -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -v "${{ github.workspace }}:/workspace" \
+            -v "${{ github.workspace }}/scan-report:/scan-report" \
+            -v /build \
+            -w /build \
+            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
+            bash -euxc '\
+              scan-build --status-bugs -o /scan-report \
+              sh -c "cmake -D CMAKE_BUILD_TYPE=Release -D IO_URING_NVME_ENABLED=OFF -B /build -S /workspace -G Ninja && ninja -C /build"' \
+            2>&1 | tee "${{ github.workspace }}/scan-report/scan-build-output.txt"
+
+      - name: Upload static analysis report
+        if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: scan-report-pr-devcontainer-amd64-Release
+          path: scan-report/
+          if-no-files-found: warn
+          retention-days: 30
+
+  quint-dev:
+    name: Quint devcontainer amd64 Debug
+    needs: [build-devcontainer]
+    runs-on: arc-amd64
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # oras lets cmake fetch the prebuilt trace bundle for the pinned
+      # ext/specs commit instead of regenerating it with quint; the image
+      # carries quint either way, so this is a speedup, not a requirement.
+      - name: Fetch oras CLI
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: amd64
+
+      # --no-tests=error is the point of the label: a configuration that
+      # silently loses its MBT suites (no quint, no bundle) must fail here
+      # rather than report a vacuous pass.
+      - name: Build and run the quint suite
+        run: |
+          docker run --rm --privileged \
+            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
+            -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -v "${{ github.workspace }}:/workspace" \
+            -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
+            -v /build \
+            -w /build \
+            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
+            bash -euxc '
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DKVM_TESTING=OFF /workspace
+              ninja
+              ctest -L quint --output-on-failure --no-tests=error \
+                    --test-output-size-failed 65536 --timeout 300 -j "$(nproc)"'
+
+  analyze-macos:
+    name: Analyze macOS Release (pre-merge)
+    runs-on: macos-14
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          brew update
+          # llvm carries scan-build -- Apple's clang does not ship the analyzer
+          # driver.  The rest mirrors the merge queue's macOS job: bison 3.x for
+          # the ndrzcc grammar, libxcrypt for full crypt(5) verification.
+          brew install llvm cmake ninja bison jansson userspace-rcu rocksdb krb5 \
+                       xxhash libxcrypt uthash openssl@3 libnghttp2
+
+      - name: Perform clang static analysis
+        id: static-analysis
+        env:
+          BUILD_DIR: ${{ runner.temp }}/build
+        run: |
+          set -o pipefail
+          mkdir -p "$GITHUB_WORKSPACE/scan-report"
+          "$(brew --prefix llvm)/bin/scan-build" --status-bugs \
+              -o "$GITHUB_WORKSPACE/scan-report" \
+              sh -c "cmake -D CMAKE_BUILD_TYPE=Release \
+                           -B \"$BUILD_DIR\" -S \"$GITHUB_WORKSPACE\" -G Ninja \
+                     && ninja -C \"$BUILD_DIR\"" \
+              2>&1 | tee "$GITHUB_WORKSPACE/scan-report/scan-build-output.txt"
+
+      - name: Upload static analysis report
+        if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: scan-report-pr-macos-Release
+          path: scan-report/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,6 +24,16 @@ name: PR checks
 on:
   pull_request:
 
+# A re-push (including an amend/force-push) is a `synchronize` event, so it
+# starts a fresh run.  Cancel the one it supersedes: without this both would run
+# to completion and race to update the same sticky comment, and the loser could
+# be the older run -- leaving a report that describes commits that are no longer
+# on the branch.  The reports themselves are keyed by marker and updated in
+# place, so a rerun replaces its comment rather than stacking a second one.
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -138,12 +148,13 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-  quint-dev:
-    name: Quint devcontainer amd64 Debug
+  quint-coverage:
+    name: Quint coverage devcontainer amd64
     needs: [build-devcontainer]
     runs-on: arc-amd64
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -158,24 +169,73 @@ jobs:
         with:
           arch: amd64
 
+      # A Coverage build (clang source-based instrumentation, -O0) rather than
+      # Debug: the suite still reports pass/fail, and the same run answers the
+      # question this job exists for -- how much of chimera the models actually
+      # reach.  ASan coverage of these suites comes from the merge queue's Debug
+      # jobs, which now have a trace corpus too.
+      #
       # --no-tests=error is the point of the label: a configuration that
       # silently loses its MBT suites (no quint, no bundle) must fail here
       # rather than report a vacuous pass.
-      - name: Build and run the quint suite
+      - name: Build instrumented and run the quint suite
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -e RUN_URL="$RUN_URL" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
             bash -euxc '
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DKVM_TESTING=OFF /workspace
+              # Ubuntu ships these versioned; the unversioned names are not
+              # always on PATH, and coverage-report.sh honours the overrides.
+              export LLVM_PROFDATA="$(command -v llvm-profdata || ls /usr/lib/llvm-*/bin/llvm-profdata | tail -n1)"
+              export LLVM_COV="$(command -v llvm-cov || ls /usr/lib/llvm-*/bin/llvm-cov | tail -n1)"
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_C_COMPILER=clang \
+                    -DKVM_TESTING=OFF /workspace
               ninja
-              ctest -L quint --output-on-failure --no-tests=error \
-                    --test-output-size-failed 65536 --timeout 300 -j "$(nproc)"'
+              mkdir -p /build/coverage/profraw
+              LLVM_PROFILE_FILE=/build/coverage/profraw/%m-%p.profraw \
+                ctest -L quint --output-on-failure --no-tests=error \
+                      --test-output-size-failed 65536 --timeout 600 -j "$(nproc)"
+              COVERAGE_JSON=/workspace/coverage-export.json \
+                bash /workspace/etc/coverage-report.sh /build
+              # Rendered in here, where the paths in the export still resolve.
+              python3 /workspace/scripts/ci_coverage_report.py \
+                      /workspace/coverage-export.json /workspace "$RUN_URL" \
+                      > /workspace/coverage-report.md'
+
+      # Best-effort: a report that cannot be posted is still in the run summary,
+      # and a comment API hiccup should not fail an otherwise-green job.
+      - name: Publish the coverage report
+        if: ${{ always() && hashFiles('coverage-report.md') != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CI_COMMENT_MARKER: "<!-- quint-coverage-report -->"
+        run: |
+          cat coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${PR_NUMBER:-}" ]; then
+            python3 scripts/ci_pr_comment.py "$GH_REPO" "$PR_NUMBER" coverage-report.md \
+              || echo "::warning::failed to post the coverage comment (it is in the run summary)"
+          fi
+
+      - name: Upload the coverage export and report
+        if: ${{ always() && hashFiles('coverage-export.json') != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: quint-coverage
+          path: |
+            coverage-export.json
+            coverage-report.md
+          if-no-files-found: warn
+          retention-days: 30
 
   analyze-macos:
     name: Analyze macOS Release (pre-merge)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -221,9 +221,17 @@ jobs:
           CI_COMMENT_MARKER: "<!-- quint-coverage-report -->"
         run: |
           cat coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+          # Carried in the artifact for pr-coverage-comment.yml: a workflow_run
+          # event has an empty `pull_requests` for a fork PR, so the number has
+          # to travel with the report rather than be looked up there.
+          printf '%s\n' "${PR_NUMBER:-}" > pr-number.txt
+          # A fork PR's token is read-only however the permissions block is
+          # written, so this call fails there by design; the relay posts it
+          # instead.  On a same-repo PR it lands immediately, and the relay's
+          # later update is a no-op PATCH of the same marker.
           if [ -n "${PR_NUMBER:-}" ]; then
             python3 scripts/ci_pr_comment.py "$GH_REPO" "$PR_NUMBER" coverage-report.md \
-              || echo "::warning::failed to post the coverage comment (it is in the run summary)"
+              || echo "::warning::could not post the coverage comment directly (expected on a fork PR; pr-coverage-comment.yml relays it)"
           fi
 
       - name: Upload the coverage export and report
@@ -234,6 +242,7 @@ jobs:
           path: |
             coverage-export.json
             coverage-report.md
+            pr-number.txt
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -135,7 +135,7 @@ jobs:
             -w /build \
             ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
             bash -euxc '\
-              scan-build --status-bugs -o /scan-report \
+              scan-build --status-bugs --exclude /workspace/ext -o /scan-report \
               sh -c "cmake -D CMAKE_BUILD_TYPE=Release -D IO_URING_NVME_ENABLED=OFF -B /build -S /workspace -G Ninja && ninja -C /build"' \
             2>&1 | tee "${{ github.workspace }}/scan-report/scan-build-output.txt"
 
@@ -264,7 +264,11 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p "$GITHUB_WORKSPACE/scan-report"
+          # --exclude ext: the vendored submodules are analysed in their own
+          # repos and cannot be fixed from a chimera PR.  etc/coverage-report.sh
+          # draws the same line for the same reason.
           "$(brew --prefix llvm)/bin/scan-build" --status-bugs \
+              --exclude "$GITHUB_WORKSPACE/ext" \
               -o "$GITHUB_WORKSPACE/scan-report" \
               sh -c "cmake -D CMAKE_BUILD_TYPE=Release \
                            -B \"$BUILD_DIR\" -S \"$GITHUB_WORKSPACE\" -G Ninja \

--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+name: PR coverage comment
+
+# A PR from a fork gets a read-only GITHUB_TOKEN no matter what the workflow's
+# `permissions:` block asks for, and no secrets -- so the job that measures
+# coverage cannot post its own comment.  This is the standard relay for that:
+# the measuring job (in "PR checks") uploads the rendered report as an artifact,
+# and this workflow runs afterwards in the *base repository's* context, where
+# the token can write, and posts it.
+#
+# Trust boundary.  Everything this workflow touches from the triggering run is
+# data, never code:
+#
+#   * it checks out the default branch -- ci_pr_comment.py comes from main, not
+#     from the pull request,
+#   * it never checks out, builds, or executes the PR's tree,
+#   * the PR number arrives in the artifact (workflow_run.pull_requests is empty
+#     for fork PRs), so it is validated as a number *and* checked to actually
+#     name a PR whose head is the commit that produced the report -- otherwise a
+#     PR could aim its comment at somebody else's.
+#
+# What remains is that a PR controls the text of a comment attributed to a bot,
+# on its own PR.  That is inherent to reporting on untrusted branches at all.
+#
+# Note this only ever fires from the copy of the file on the default branch, so
+# it cannot work on the PR that introduces it -- the first comment it posts will
+# be on the next PR after this one merges.
+on:
+  workflow_run:
+    workflows: ["PR checks"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Keyed on the branch under test, so a rapid series of pushes cannot have two
+# relays racing to update the same comment.
+concurrency:
+  group: pr-coverage-comment-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  comment:
+    name: Publish coverage comment
+    # Cancelled runs (superseded by a re-push) have nothing to report, and the
+    # artifact guard below covers a run that failed before rendering.
+    if: ${{ github.event.workflow_run.event == 'pull_request'
+            && github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: arc-small
+    steps:
+      - name: Checkout the default branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download the coverage report
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          name: quint-coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: quint-coverage
+
+      - name: Post the report
+        if: ${{ steps.download.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          CI_COMMENT_MARKER: "<!-- quint-coverage-report -->"
+        run: |
+          set -euo pipefail
+          if [ ! -s quint-coverage/coverage-report.md ] || \
+             [ ! -s quint-coverage/pr-number.txt ]; then
+            echo "::notice::no coverage report in the artifact; nothing to post"
+            exit 0
+          fi
+
+          pr="$(tr -dc '0-9' < quint-coverage/pr-number.txt)"
+          if [ -z "$pr" ]; then
+            echo "::warning::artifact carried no usable PR number"
+            exit 0
+          fi
+
+          # The PR named by the artifact must be the one that produced it.
+          # stdlib urllib, not `gh` -- the self-hosted runners have no gh CLI
+          # (which is why ci_pr_comment.py speaks to the API directly too).
+          pr_head="$(PR="$pr" python3 - <<'PY'
+          import json, os, urllib.request
+          req = urllib.request.Request(
+              f"https://api.github.com/repos/{os.environ['GH_REPO']}"
+              f"/pulls/{os.environ['PR']}",
+              headers={"Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                       "Accept": "application/vnd.github+json",
+                       "User-Agent": "chimera-ci-report"})
+          with urllib.request.urlopen(req) as r:
+              print(json.load(r)["head"]["sha"])
+          PY
+          )"
+          if [ "$pr_head" != "$HEAD_SHA" ]; then
+            echo "::warning::PR #$pr is at $pr_head, not the reported $HEAD_SHA; refusing to comment"
+            exit 0
+          fi
+
+          python3 scripts/ci_pr_comment.py "$GH_REPO" "$pr" \
+                  quint-coverage/coverage-report.md

--- a/cmake/SpecsBundle.cmake
+++ b/cmake/SpecsBundle.cmake
@@ -57,16 +57,30 @@ endif()
 find_package(Git QUIET)
 set(_specs_sha "")
 set(_specs_clean FALSE)
+set(_specs_git_err "")
 if(Git_FOUND)
+    # -c safe.directory: CI configures inside a container whose root user does
+    # not own the bind-mounted checkout, so git rejects the repository with
+    # "detected dubious ownership" and both commands below fail.  That used to
+    # be invisible (ERROR_QUIET) and left the sha empty, which skipped the
+    # availability probe and disabled every MBT suite without saying why.
+    set(_specs_git ${GIT_EXECUTABLE} -c safe.directory=*)
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} -C ${_specs_src} rev-parse HEAD
-        OUTPUT_VARIABLE _specs_sha OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+        COMMAND ${_specs_git} -C ${_specs_src} rev-parse HEAD
+        OUTPUT_VARIABLE _specs_sha OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_VARIABLE _specs_git_err ERROR_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _specs_rc)
+    if(NOT _specs_rc EQUAL 0)
+        set(_specs_sha "")
+    endif()
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} -C ${_specs_src} status --porcelain
+        COMMAND ${_specs_git} -C ${_specs_src} status --porcelain
         OUTPUT_VARIABLE _specs_dirty OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
     if(_specs_sha AND NOT _specs_dirty)
         set(_specs_clean TRUE)
     endif()
+else()
+    set(_specs_git_err "git not found")
 endif()
 
 set(_specs_ref "${SPECS_REGISTRY}:${_specs_sha}")
@@ -108,6 +122,22 @@ elseif(SPECS_BUNDLE STREQUAL "AUTO")
         else()
             message(STATUS
                 "specs: no published bundle for ${_specs_sha}; building locally")
+        endif()
+    else()
+        # Not reaching the probe at all is the failure that hid this for months:
+        # it looks identical to "no bundle published" from the outside.  Name
+        # the reason so a CI job that quietly loses its MBT suites says so.
+        if(NOT ORAS_BIN)
+            message(STATUS
+                "specs: oras not on PATH; cannot fetch a prebuilt bundle")
+        elseif(NOT _specs_sha)
+            message(STATUS
+                "specs: cannot read ext/specs HEAD, so no bundle can be "
+                "resolved (${_specs_git_err})")
+        elseif(NOT _specs_clean)
+            message(STATUS
+                "specs: ext/specs has local edits; no published bundle matches, "
+                "building locally")
         endif()
     endif()
 endif()

--- a/etc/coverage-report.sh
+++ b/etc/coverage-report.sh
@@ -14,7 +14,9 @@
 # and prints a per-file llvm-cov report covering the chimera source tree.
 #
 # Set COVERAGE_HTML=1 to additionally emit a browsable HTML report under
-# BUILD_DIR/coverage/html.
+# BUILD_DIR/coverage/html, or COVERAGE_JSON=<path> to additionally write
+# llvm-cov's machine-readable per-file summary there (what CI renders its
+# coverage report from).
 
 set -euo pipefail
 
@@ -91,6 +93,18 @@ echo
     -instr-profile="${PROFDATA}" \
     -ignore-filename-regex="${IGNORE_REGEX}" \
     -show-region-summary=false
+
+# Machine-readable per-file summary for CI to render.  -summary-only drops the
+# per-segment detail, which is what makes the export a few hundred KB instead of
+# a few hundred MB over a whole-tree instrumented build.
+if [[ -n "${COVERAGE_JSON:-}" ]]; then
+    echo
+    echo "coverage: exporting per-file summary to ${COVERAGE_JSON} ..."
+    "${COV_TOOL}" export "${objs[0]}" "${object_args[@]}" \
+        -instr-profile="${PROFDATA}" \
+        -ignore-filename-regex="${IGNORE_REGEX}" \
+        -summary-only > "${COVERAGE_JSON}"
+fi
 
 if [[ "${COVERAGE_HTML:-0}" == "1" ]]; then
     HTML_DIR="${COV_DIR}/html"

--- a/etc/coverage-report.sh
+++ b/etc/coverage-report.sh
@@ -28,25 +28,36 @@ PROFDATA="${COV_DIR}/coverage.profdata"
 PROFDATA_TOOL="${LLVM_PROFDATA:-llvm-profdata}"
 COV_TOOL="${LLVM_COV:-llvm-cov}"
 
-# Drop everything that isn't first-party chimera source from the report.
-IGNORE_REGEX='(/ext/|/usr/|/3rdparty/|/CMakeFiles/)'
+# System headers and vendored third-party trees are never anybody's code here,
+# so they are always out.  Generated sources and the bundled ext/ projects are
+# out by default -- the local `make coverage` report is about the code you are
+# editing -- and each has a switch to fold it back in.  CI's quint report sets
+# both: its question is how much of everything that ships the models reach, and
+# generated marshallers and libevpl ship.
+ignore_parts=('/usr/' '/3rdparty/' '/CMakeFiles/')
 
-# By default, also exclude generated code so it doesn't distort the totals.
 # Generated sources (the xdrzcc/ndrzcc XDR/NDR marshallers, embedded asset
 # blobs, etc.) are emitted into the build tree, whereas hand-written sources
 # live under the source tree -- so "compiled from under BUILD_DIR" is a reliable,
-# generator-agnostic way to spot generated code. Set COVERAGE_INCLUDE_GENERATED=1
-# to fold it back into the report.
-INCLUDE_GENERATED="${COVERAGE_INCLUDE_GENERATED:-0}"
-if [[ "${INCLUDE_GENERATED}" == "1" ]]; then
+# generator-agnostic way to spot generated code.
+if [[ "${COVERAGE_INCLUDE_GENERATED:-0}" == "1" ]]; then
     echo "coverage: including generated code (COVERAGE_INCLUDE_GENERATED=1)"
 else
     abs_build=$(readlink -f "${BUILD_DIR}")
     # Escape regex metacharacters so the path is matched literally.
     esc_build=$(printf '%s' "${abs_build}" | sed 's/[.[\*^$()+?{|/]/\\&/g')
-    IGNORE_REGEX="(${esc_build}/|/ext/|/usr/|/3rdparty/|/CMakeFiles/)"
+    ignore_parts+=("${esc_build}/")
     echo "coverage: excluding generated code under ${abs_build} (set COVERAGE_INCLUDE_GENERATED=1 to include)"
 fi
+
+if [[ "${COVERAGE_INCLUDE_EXT:-0}" == "1" ]]; then
+    echo "coverage: including the bundled ext/ projects (COVERAGE_INCLUDE_EXT=1)"
+else
+    ignore_parts+=('/ext/')
+    echo "coverage: excluding the bundled ext/ projects (set COVERAGE_INCLUDE_EXT=1 to include)"
+fi
+
+IGNORE_REGEX="($(IFS='|'; echo "${ignore_parts[*]}"))"
 
 # A full suite run produces hundreds of thousands of .profraw files (one per
 # test process / spawned daemon), which overflows ARG_MAX if globbed onto the

--- a/scripts/ci_coverage_report.py
+++ b/scripts/ci_coverage_report.py
@@ -4,16 +4,25 @@
 # SPDX-License-Identifier: Unlicense
 """Render llvm-cov's per-file summary as a markdown coverage report.
 
-Usage: ci_coverage_report.py <export.json> <repo_root> [<run_url>]
+Usage: ci_coverage_report.py <export.json> <repo_root> [<run_url>] [<build_root>]
 
 <export.json> is what `COVERAGE_JSON=... etc/coverage-report.sh` writes, i.e.
 `llvm-cov export -summary-only`.  The output is a sticky-comment body for
 scripts/ci_pr_comment.py (CI_COMMENT_MARKER must match MARKER below) and doubles
 as a run-summary fragment.
 
-Test sources are excluded from the totals.  The harness that drives a suite is
-covered by definition, and folding it in would flatter every number here; what
-this report is for is how much of the *product* the model-based suites reach.
+What counts is first-party, hand-written, non-test source.  Test sources are out
+because a suite cannot meaningfully cover the other suites; generated marshallers
+and the bundled ext/ projects are out because neither is code this repository is
+asking the models to reach -- one is emitted from a .x file and the other has its
+own repository and its own tests.  etc/coverage-report.sh applies the latter two
+(COVERAGE_INCLUDE_GENERATED / COVERAGE_INCLUDE_EXT fold them back in); this only
+has to drop the tests.
+
+<build_root> is optional, and only useful alongside COVERAGE_INCLUDE_GENERATED:
+generated sources are compiled from under the build tree, which mirrors the
+source layout, so naming it puts a generated marshaller in the same component as
+the hand-written code it belongs to instead of dropping it as foreign.
 """
 import json
 import os
@@ -54,9 +63,24 @@ def bar(percent, width=20):
     return "█" * filled + "░" * (width - filled)
 
 
+def relative(path, roots):
+    """Path relative to whichever root contains it, or None if none does.
+
+    Longest root wins, so an in-tree build directory (build/ inside the
+    checkout) attributes its generated sources to the build tree rather than
+    to a "build/..." component of the source tree.
+    """
+    for root in sorted((r for r in roots if r), key=len, reverse=True):
+        rel = os.path.relpath(path, root)
+        if not rel.startswith(".."):
+            return rel
+    return None
+
+
 def main():
     export_path, root = sys.argv[1], os.path.realpath(sys.argv[2])
     run_url = sys.argv[3] if len(sys.argv) > 3 else ""
+    build_root = os.path.realpath(sys.argv[4]) if len(sys.argv) > 4 else ""
 
     with open(export_path) as f:
         data = json.load(f)
@@ -64,10 +88,14 @@ def main():
     comps = {}
     files = []
     skipped = 0
+    foreign = 0
 
     for entry in data.get("data", [{}])[0].get("files", []):
-        rel = os.path.relpath(os.path.realpath(entry["filename"]), root)
-        if rel.startswith(".."):
+        rel = relative(os.path.realpath(entry["filename"]), (root, build_root))
+        if rel is None:
+            # Compiled from outside the checkout entirely -- the container's own
+            # /fio clone, say.  Not code this repository can be measured on.
+            foreign += 1
             continue
         if is_test_source(rel):
             skipped += 1
@@ -126,6 +154,8 @@ def main():
         out += ["", "</details>"]
 
     note = f"{skipped} test source(s) excluded"
+    if foreign:
+        note += f", {foreign} compiled from outside the checkout"
     if run_url:
         note += f" · [run]({run_url})"
     out += ["", f"<sub>{note}</sub>"]

--- a/scripts/ci_coverage_report.py
+++ b/scripts/ci_coverage_report.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+"""Render llvm-cov's per-file summary as a markdown coverage report.
+
+Usage: ci_coverage_report.py <export.json> <repo_root> [<run_url>]
+
+<export.json> is what `COVERAGE_JSON=... etc/coverage-report.sh` writes, i.e.
+`llvm-cov export -summary-only`.  The output is a sticky-comment body for
+scripts/ci_pr_comment.py (CI_COMMENT_MARKER must match MARKER below) and doubles
+as a run-summary fragment.
+
+Test sources are excluded from the totals.  The harness that drives a suite is
+covered by definition, and folding it in would flatter every number here; what
+this report is for is how much of the *product* the model-based suites reach.
+"""
+import json
+import os
+import sys
+
+MARKER = "<!-- quint-coverage-report -->"
+
+# How many "biggest gap" files to name.  Enough to aim the next round of model
+# work at, short enough to stay a comment rather than a document.
+TOP_GAPS = 12
+
+
+def component(rel):
+    """Bucket a repo-relative path into the unit we report on.
+
+    src/server/ is split one level deeper than everything else: "the NFS server"
+    and "the SMB server" are the units someone actually reasons about, whereas
+    "src/server" as a whole is not.
+    """
+    parts = rel.split("/")
+    if len(parts) >= 4 and parts[0] == "src" and parts[1] == "server":
+        return "/".join(parts[:3])
+    if len(parts) >= 3:
+        return "/".join(parts[:2])
+    return parts[0]
+
+
+def is_test_source(rel):
+    return rel.startswith("tests/") or "/tests/" in rel
+
+
+def pct(covered, count):
+    return 100.0 * covered / count if count else 0.0
+
+
+def bar(percent, width=20):
+    filled = int(round(percent / 100.0 * width))
+    return "█" * filled + "░" * (width - filled)
+
+
+def main():
+    export_path, root = sys.argv[1], os.path.realpath(sys.argv[2])
+    run_url = sys.argv[3] if len(sys.argv) > 3 else ""
+
+    with open(export_path) as f:
+        data = json.load(f)
+
+    comps = {}
+    files = []
+    skipped = 0
+
+    for entry in data.get("data", [{}])[0].get("files", []):
+        rel = os.path.relpath(os.path.realpath(entry["filename"]), root)
+        if rel.startswith(".."):
+            continue
+        if is_test_source(rel):
+            skipped += 1
+            continue
+        lines = entry.get("summary", {}).get("lines", {})
+        count, covered = lines.get("count", 0), lines.get("covered", 0)
+        if count == 0:
+            continue
+        c = comps.setdefault(component(rel), [0, 0])
+        c[0] += count
+        c[1] += covered
+        files.append((rel, count, covered))
+
+    total_count = sum(c[0] for c in comps.values())
+    total_covered = sum(c[1] for c in comps.values())
+
+    out = [MARKER, "", "## Quint model-based test coverage", ""]
+    if total_count == 0:
+        out += ["No instrumented chimera source in the coverage export — "
+                "the report step ran, but nothing it measured belongs to this "
+                "tree. Treat this as a broken report, not as 0% coverage."]
+        print("\n".join(out))
+        return
+
+    out += [
+        f"`ctest -L quint` alone covers **{pct(total_covered, total_count):.1f}%** "
+        f"of chimera ({total_covered:,} / {total_count:,} lines).",
+        "",
+        "This is the model-based suites on their own — not the full ctest run. "
+        "The number going up is the point: the more the models reach, the less "
+        "the expensive merge-queue suites are the only thing standing between a "
+        "regression and main.",
+        "",
+        "| Component | Lines | Covered | % | |",
+        "|---|---:|---:|---:|---|",
+    ]
+
+    for name, (count, covered) in sorted(comps.items(),
+                                         key=lambda kv: -kv[1][0]):
+        p = pct(covered, count)
+        out.append(f"| `{name}` | {count:,} | {covered:,} | {p:.1f}% | "
+                   f"`{bar(p)}` |")
+
+    p = pct(total_covered, total_count)
+    out.append(f"| **Total** | **{total_count:,}** | **{total_covered:,}** | "
+               f"**{p:.1f}%** | `{bar(p)}` |")
+
+    gaps = sorted(files, key=lambda f: -(f[1] - f[2]))[:TOP_GAPS]
+    if gaps:
+        out += ["", "<details><summary>Biggest gaps — the files with the most "
+                "lines the models never reach</summary>", "",
+                "| File | Uncovered | Lines | % |", "|---|---:|---:|---:|"]
+        for rel, count, covered in gaps:
+            out.append(f"| `{rel}` | {count - covered:,} | {count:,} | "
+                       f"{pct(covered, count):.1f}% |")
+        out += ["", "</details>"]
+
+    note = f"{skipped} test source(s) excluded"
+    if run_url:
+        note += f" · [run]({run_url})"
+    out += ["", f"<sub>{note}</sub>"]
+
+    print("\n".join(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci_pr_comment.py
+++ b/scripts/ci_pr_comment.py
@@ -9,13 +9,17 @@ Usage: ci_pr_comment.py <owner/repo> <pr_number> <body_file>
 Uses stdlib urllib only (the self-hosted CI runners have no `gh` CLI).  Auth
 token comes from $GH_TOKEN.  The comment is identified/updated by the MARKER on
 its first line, so re-runs replace the prior report instead of stacking.
+
+$CI_COMMENT_MARKER overrides that marker, which is what lets a second kind of
+report (e.g. the quint coverage summary) keep its own sticky comment instead of
+overwriting the ctest one.  The body file must begin with the same marker.
 """
 import json
 import os
 import sys
 import urllib.request
 
-MARKER = "<!-- ctest-report -->"
+MARKER = os.environ.get("CI_COMMENT_MARKER", "<!-- ctest-report -->")
 
 
 def api(method, url, data=None):

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -52,6 +52,6 @@ add_test(NAME chimera/posix/mbt/batch_memfs
             --trace-dir ${SPECS_BUNDLE_DIR}/posix
             --exclude-prefix nfs3_ --exclude-prefix nfs4_ --exclude-prefix disk_)
 set_tests_properties(chimera/posix/mbt/batch_memfs PROPERTIES
-    LABELS "posix_mbt;memfs"
+    LABELS "quint;posix_mbt;memfs"
     SKIP_RETURN_CODE 77
     TIMEOUT 300)

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1208,6 +1208,26 @@ open_flags(json_t *fl)
     return f;
 } /* open_flags */
 
+/*
+ * PD24 (EMFILE) leaves us holding a descriptor the model never learned about:
+ * its 16-slot table was full, chimera's larger one let the call through.  The
+ * model's fd is not set, so the descriptor never reaches g_fdmap and
+ * close_live_handles() cannot reach it either -- and one descriptor still open
+ * on the mount wedges the newfs() recycle between traces, whose unmount then
+ * returns EBUSY for as long as the harness is willing to retry.  Drop it at the
+ * op that minted it.  (op_open does its own, because it must also exempt any
+ * node O_CREAT minted from the final audit.)
+ */
+static void
+pd24_drop_stray_fd(
+    int64_t model_err,
+    int     rc)
+{
+    if (model_err == 24 && rc >= 0) {
+        chimera_posix_close(rc);
+    }
+} /* pd24_drop_stray_fd */
+
 static void
 op_open(
     int     pid,
@@ -1286,6 +1306,8 @@ op_dup(
 
     if (check_status(tf_field(res_v, "e"), e) && tf_field(res_v, "e") == 0) {
         set_fd(pid, tf_field(res_v, "fd"), rc);
+    } else {
+        pd24_drop_stray_fd(tf_field(res_v, "e"), rc);
     }
 } /* op_dup */
 
@@ -2141,19 +2163,25 @@ op_dup2(
     int64_t fd     = tf_field(rv, "fd");
     int64_t nfd    = tf_field(rv, "nfd");
     int     target = rfd(pid, nfd);
-    int     rc, e;
+    int     rc, e, minted;
 
     apply_cred(pid);
     if (fd == nfd || target != BADFD) {
-        rc = chimera_posix_dup2(rfd(pid, fd), target);
+        rc     = chimera_posix_dup2(rfd(pid, fd), target);
+        minted = 0;
     } else {
         /* The model's nfd names a free slot; chimera fd numbers are its own,
          * so a plain dup() is observationally identical here. */
-        rc = chimera_posix_dup(rfd(pid, fd));
+        rc     = chimera_posix_dup(rfd(pid, fd));
+        minted = 1;
     }
     e = ERRV(rc);
     if (check_status(tf_field(res_v, "e"), e) && tf_field(res_v, "e") == 0) {
         set_fd(pid, nfd, rc);
+    } else if (minted) {
+        /* Only the dup() arm mints a descriptor of its own; the dup2() arm
+         * returns one g_fdmap already names, which close_live_handles() owns. */
+        pd24_drop_stray_fd(tf_field(res_v, "e"), rc);
     }
 } /* op_dup2 */
 
@@ -2182,6 +2210,8 @@ op_fcntl_dupfd(
                 set_fd(pid, tf_field(res_v, "fd"), r2);
             }
         }
+    } else {
+        pd24_drop_stray_fd(tf_field(res_v, "e"), rc);
     }
 } /* op_fcntl_dupfd */
 

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(nfs4_mbt_replay
 add_test(NAME chimera/server/nfs/mbt/deviation_probe_memfs
     COMMAND $<TARGET_FILE:nfs3_mbt_probe>)
 set_tests_properties(chimera/server/nfs/mbt/deviation_probe_memfs PROPERTIES
-    LABELS "nfs3_mbt;memfs"
+    LABELS "quint;nfs3_mbt;memfs"
     TIMEOUT 60)
 
 # Delegation policy probe: pins the deterministic grant/recall behavior the
@@ -59,7 +59,7 @@ set_tests_properties(chimera/server/nfs/mbt/deviation_probe_memfs PROPERTIES
 add_test(NAME chimera/server/nfs/mbt4/deleg_probe_memfs
     COMMAND $<TARGET_FILE:nfs4_deleg_probe>)
 set_tests_properties(chimera/server/nfs/mbt4/deleg_probe_memfs PROPERTIES
-    LABELS "nfs4_mbt;multiproto;memfs"
+    LABELS "quint;nfs4_mbt;multiproto;memfs"
     TIMEOUT 90)
 
 if(NOT SPECS_BUNDLE_AVAILABLE)
@@ -78,7 +78,7 @@ endif()
 add_test(NAME chimera/server/nfs/mbt/batch_memfs
     COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3)
 set_tests_properties(chimera/server/nfs/mbt/batch_memfs PROPERTIES
-    LABELS "nfs3_mbt;memfs"
+    LABELS "quint;nfs3_mbt;memfs"
     TIMEOUT 300)
 
 # The same NFS3 corpus replayed against the on-disk backends.  The corpus is
@@ -93,7 +93,7 @@ if(HAVE_LIBAIO)
         COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
                 --backend diskfs)
     set_tests_properties(chimera/server/nfs/mbt/batch_diskfs PROPERTIES
-        LABELS "nfs3_mbt;diskfs"
+        LABELS "quint;nfs3_mbt;diskfs"
         TIMEOUT 300)
 endif()
 
@@ -102,7 +102,7 @@ if(CAIRN_ENABLED)
         COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
                 --backend cairn)
     set_tests_properties(chimera/server/nfs/mbt/batch_cairn PROPERTIES
-        LABELS "nfs3_mbt;cairn"
+        LABELS "quint;nfs3_mbt;cairn"
         TIMEOUT 300)
 endif()
 
@@ -112,6 +112,6 @@ endif()
 add_test(NAME chimera/server/nfs/mbt4/batch_memfs
     COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4)
 set_tests_properties(chimera/server/nfs/mbt4/batch_memfs PROPERTIES
-    LABELS "nfs4_mbt;memfs"
+    LABELS "quint;nfs4_mbt;memfs"
     SKIP_RETURN_CODE 77
     TIMEOUT 300)

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(smb2_smoke_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/smoke_probe_memfs
     COMMAND $<TARGET_FILE:smb2_smoke_probe>)
 set_tests_properties(chimera/server/smb/mbt/smoke_probe_memfs PROPERTIES
-    LABELS "smb_mbt;memfs"
+    LABELS "quint;smb_mbt;memfs"
     TIMEOUT 60)
 
 # Oplock/lease ground-truth probe (Increment 1): pins chimera's grant ->
@@ -42,7 +42,7 @@ target_link_libraries(smb2_oplock_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/oplock_probe_memfs
     COMMAND $<TARGET_FILE:smb2_oplock_probe>)
 set_tests_properties(chimera/server/smb/mbt/oplock_probe_memfs PROPERTIES
-    LABELS "smb_mbt;memfs"
+    LABELS "quint;smb_mbt;memfs"
     TIMEOUT 90)
 
 # Durable/persistent-handle ground-truth probe: pins the durable grant matrix,
@@ -56,7 +56,7 @@ target_link_libraries(smb2_durable_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/durable_probe_memfs
     COMMAND $<TARGET_FILE:smb2_durable_probe>)
 set_tests_properties(chimera/server/smb/mbt/durable_probe_memfs PROPERTIES
-    LABELS "smb_mbt;memfs"
+    LABELS "quint;smb_mbt;memfs"
     TIMEOUT 120)
 
 # Replay / ChannelSequence ground-truth probe: pins the exactly-once layer --
@@ -71,7 +71,7 @@ target_link_libraries(smb2_replay_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/replay_probe_memfs
     COMMAND $<TARGET_FILE:smb2_replay_probe>)
 set_tests_properties(chimera/server/smb/mbt/replay_probe_memfs PROPERTIES
-    LABELS "smb_mbt;memfs"
+    LABELS "quint;smb_mbt;memfs"
     TIMEOUT 120)
 
 # ---------------------------------------------------------------------------
@@ -100,5 +100,5 @@ add_test(NAME chimera/server/smb/mbt/batch_memfs
 # was close enough to the ceiling to flake.  This is a batch of 40 tests in one
 # ctest, not a single case.
 set_tests_properties(chimera/server/smb/mbt/batch_memfs PROPERTIES
-    LABELS "smb_mbt;memfs"
+    LABELS "quint;smb_mbt;memfs"
     TIMEOUT 600)


### PR DESCRIPTION
## The problem

The quint model-based test suites have never run in CI. Not "rarely" — never. Every
compile job in the merge queue prints this and moves on:

```
-- specs: quint not found and no prebuilt bundle available; MBT trace suites disabled
-- nfs MBT replay ctests skipped (no specs trace corpus)
-- smb MBT replay ctest skipped (no specs trace corpus)
-- posix MBT replay ctest skipped (no specs trace corpus)
```

Two independent causes.

**The image has no quint.** `ext/libevpl/.devcontainer/Dockerfile` installs it (for
libevpl's own conformance tests), but chimera's `.devcontainer/Dockerfile` never did —
`git log -S quint` on it is empty. So the local-build path could not run, and libevpl's
Core/HTTP/RPC2 conformance tests were off in chimera's CI for the same reason.

**The bundle path never even looked.** The prebuilt corpus *is* published and
anonymously pullable — `ghcr.io/chimera-nas/specs` carries a tag for every commit on the
specs main branch, and oras is mounted into every build container — yet no job has ever
fetched one. The two git calls that read the submodule's HEAD ran with `ERROR_QUIET`, so
when git refused the bind-mounted checkout (container root does not own it: "detected
dubious ownership") the sha came back empty, the availability probe was skipped entirely,
and the only thing printed was the *other* provider's "quint not found". From the outside
that is indistinguishable from "no bundle exists".

And because nothing ran, nothing reported: `scripts/ci_pr_comment.py` posts a sticky PR
comment and has never once fired, because its only caller is the merge queue's `Report`
job, where `github.event.pull_request.number` is empty.

## What changed

| commit | |
|---|---|
| `.devcontainer` | install the pinned quint release, as the last layer, with libevpl's Rust-evaluator warm-up |
| `cmake` | run the probe's git calls with `-c safe.directory=*`, and say *why* the probe was skipped instead of falling through silently |
| `tests/quint` | add a shared `quint` ctest label — the name libevpl already uses, so `ctest -L quint` selects both |
| `tests/quint` | fix the PD24 stray-descriptor leak the suites immediately caught (below) |
| `ci` | pre-merge jobs: static analysis on devcontainer and macOS, and the quint suite on devcontainer |
| `ci` | give the merge queue's macOS job the trace bundle (oras + `SPECS_BUNDLE=ON`) |
| `ci` | render quint coverage into a sticky PR comment, on the infra that was already there |
| `ci` | run the pre-merge quint suite instrumented; cancel superseded runs |
| `ci` | keep the new layer out of the image cache key; scope scan-build to chimera |

Three different guards, because "the suites quietly vanished" is the failure this PR is
about and it must not be able to come back:

- `--no-tests=error` on the quint job — an empty label is a failure, not a pass.
- `SPECS_BUNDLE=ON` on macOS, which has no quint fallback — an unresolvable bundle fails
  the build rather than dropping the suites.
- the cmake probe now names its own reason for falling through.

The two corpus providers stay split on purpose. The containers carry quint, so they cover
the local-build path *and* generate libevpl's Core/HTTP/RPC2 conformance cases, which are
not in the bundle. macOS carries only oras and takes the fetch path — a CI checkout never
has local edits to `ext/specs`, so the published bundle for the pinned commit always
applies, and pulling it beats minutes of regeneration.

## Coverage reporting

The pre-merge quint job builds `Coverage` (clang source-based instrumentation) rather than
`Debug`: the suite reports pass/fail exactly as before, and the same run answers what the
models actually reach. `etc/coverage-report.sh` gains `COVERAGE_JSON` (`llvm-cov export
-summary-only`), and `scripts/ci_coverage_report.py` renders it as a per-component table
plus the files with the most unreached lines — the actionable half, since the goal is to
drive this number up until the expensive merge-queue suites stop being the only thing
between a regression and main.

Measured by this PR's own CI run, `ctest -L quint` alone covers **37.9%** of chimera
(44,975 / 118,723 lines):

| Component | Lines | % | | Component | Lines | % |
|---|---:|---:|---|---|---:|---:|
| `src/vfs` | 51,874 | 43.3% | | `src/server/rest` | 2,028 | 1.7% |
| `src/server/smb` | 22,642 | 30.7% | | `src/client` | 1,888 | 51.0% |
| `src/server/nfs` | 21,523 | 45.7% | | `src/server` | 1,470 | 38.6% |
| `src/server/s3` | 7,937 | 0.1% | | `src/nfs_common` | 351 | 28.5% |
| `src/posix` | 4,945 | 59.4% | | `src/metrics` | 132 | 0.0% |
| `src/common` | 2,750 | 40.6% | | `src/daemon` | 129 | 0.0% |

The `src/vfs` figure is a blend worth breaking out: memfs 67.1%, cairn 60.4% and diskfs
55.9% against the NFS-proxy module at 1.2%, the SMB module at 0%, `linux` at 1.7% and
`io_uring` at 5.2%. That split is purely whether a suite mounts the backend, not how well
it is modelled: #1559 teaches the NFS3 harness to drive `linux`/`io_uring`, but registers
no ctest for them, so nothing runs them yet. Wiring them up is worth about +1.6 points of
overall coverage if they reach cairn-like levels.
The largest untouched masses are `src/server/s3` (7,937 lines, no model exists) and
`src/server/rest`.

The denominator is first-party, hand-written, non-test source. Tests are out because a
suite cannot meaningfully cover the other suites — counting them would move the number as
tests are added rather than as coverage changes. Generated marshallers and the bundled
`ext/` projects are out because neither is code this repository asks its models to reach.
`COVERAGE_INCLUDE_GENERATED` / `COVERAGE_INCLUDE_EXT` fold either back in locally.

ASan coverage of these suites is not lost: the merge queue's Debug jobs have a trace
corpus now too.

## The bug this immediately caught

`chimera/posix/mbt/batch_memfs` hangs until ctest's 300s timeout kills it, deterministically,
wedged in the `newfs()` recycle after `stepFds_128_0x1_2`.

PD24 is the known deviation "model's 16-slot descriptor table is full where chimera's
larger one is not". The compensating close for it lived only in `op_open`, though the
deviation's op list has always been `{ROpen, RDup, RFcntlDupfd, ROpendir}`. That trace's
126th step is a **dup** answered EMFILE, so chimera's descriptor was never recorded in
`g_fdmap`, `close_live_handles()` could not reach it, and a descriptor still open on the
mount left the recycle's umount returning EBUSY through all 5000 retries — ~83 minutes.

`stepFds_128_0x1_1` hides it: its EMFILE lands on an `ROpen`, which was already handled.
With the fix the batch finishes in ~7s and the full label is green in ~30s.

## Verified in CI on this PR

The fetch path engages, which it never has before:

```
-- specs: using prebuilt trace bundle ghcr.io/chimera-nas/specs:f134a431...
fetch_specs_bundle: oras pull ghcr.io/chimera-nas/specs:f134a431...
Pulled [registry] ghcr.io/chimera-nas/specs:f134a431...
fetch_specs_bundle: unpacked ... into /build/specs-bundle/traces
```

`ctest -L quint` in the container: **17/17 passed in 51.9s** (including `batch_diskfs`,
which does not register on macOS). libevpl's three conformance suites report `enabled` for
the first time. Static analysis passes on both platforms.

## Notes for review

- **Branch protection needs updating.** The new check names are not in the ruleset, so
  they report without gating until someone adds them.
- **The coverage comment will not post on a fork PR.** GitHub gives fork-PR workflows a
  read-only token regardless of the `permissions:` block, so `ci_pr_comment.py` gets a 403.
  It degrades rather than fails — the report is in the run summary and the artifact — but
  posting on fork PRs needs the `workflow_run` relay, which additionally cannot work until
  it is on `main`. Follow-up.
- Excluding `ext/` from the pre-merge scan-build jobs silences a real finding
  (`ext/libevpl/src/core/allocator.c:252`, a dead store the Linux analyser misses) that no
  chimera PR can fix. The merge-queue analysis jobs still cover everything.
- `ext/specs`' own coverage gates (`coverage/nfs3`, `coverage/smb2`) are defined in the
  submodule's directory scope and cannot be labelled from here; they want the same label
  added in the specs repo.
- The other compile jobs still run `SPECS_BUNDLE=AUTO`. Now that the fetch path is proven
  from the runners, moving them to `ON` would make a missing bundle loud everywhere.
