### PR TITLE
smb: supply the implied Z(24) when a client omits the LM response

### DIFF
--- a/src/server/smb/smb_wbclient.c
+++ b/src/server/smb/smb_wbclient.c
@@ -113,6 +113,8 @@ smb_wbclient_auth_ntlm(
     struct wbcDomainSid     *groups_sids = NULL;
     uint32_t                 num_groups  = 0;
     uint32_t                 i;
+    const uint8_t           *lm_data;
+    uint32_t                 lm_len;
 
     memset(&params, 0, sizeof(params));
 
@@ -129,8 +131,10 @@ smb_wbclient_auth_ntlm(
     // Set up challenge/response authentication
     memcpy(params.password.response.challenge, challenge, 8);
 
-    params.password.response.lm_length = lm_response_len;
-    params.password.response.lm_data   = (uint8_t *) lm_response;
+    smb_wbclient_lm_response(lm_response, lm_response_len, &lm_data, &lm_len);
+
+    params.password.response.lm_length = lm_len;
+    params.password.response.lm_data   = (uint8_t *) lm_data;
 
     params.password.response.nt_length = nt_response_len;
     params.password.response.nt_data   = (uint8_t *) nt_response;
@@ -138,7 +142,7 @@ smb_wbclient_auth_ntlm(
     wbc_err = wbcAuthenticateUserEx(&params, &info, &error);
 
     if (wbc_err != WBC_ERR_SUCCESS) {
-        chimera_smb_debug("wbcAuthenticateUserEx failed: %s",
+        chimera_smb_error("wbcAuthenticateUserEx failed: %s",
                           error ? error->display_string : wbcErrorString(wbc_err));
         if (error) {
             wbcFreeMemory(error);
@@ -466,7 +470,7 @@ smb_wbclient_auth_password(
     wbc_err = wbcAuthenticateUserEx(&params, &info, &error);
 
     if (wbc_err != WBC_ERR_SUCCESS) {
-        chimera_smb_debug("wbcAuthenticateUserEx (plain) failed: %s",
+        chimera_smb_error("wbcAuthenticateUserEx (plain) failed: %s",
                           error ? error->display_string : wbcErrorString(
                               wbc_err));
         if (error) {

--- a/src/server/smb/smb_wbclient.h
+++ b/src/server/smb/smb_wbclient.h
@@ -14,6 +14,39 @@ struct chimera_vfs_user;
 #define SMB_WBCLIENT_MAX_GROUPS  32
 #define SMB_WBCLIENT_SID_MAX_LEN 80
 
+/* Resolve the LmChallengeResponse to hand a winbind network logon.
+ *
+ * MS-NLMP 3.2.5.1.2: a client that authenticates with NTLMv2 alone may send a
+ * zero-length LmChallengeResponse, which the server reads as the implied Z(24).
+ * Samba's own clients and Windows send those 24 zero bytes explicitly; the Linux
+ * kernel cifs client (mount.cifs) sends length 0, and winbind's auth_crap
+ * interface refuses a zero-length LM response even when the NTLMv2 response
+ * verifies.  Materialize the implied value so the NTLMv2 proof alone decides the
+ * logon.  Safe: `lanman auth = no` is the Samba default, so the LM branch is
+ * never tried, and 24 zero bytes cannot validate against a real LM hash anyway.
+ *
+ * This normalization belongs here and NOT at parse time: validate_authenticate()
+ * uses `lm_response_len <= 1` to detect an anonymous logon (kernel
+ * `mount -o sec=none`) and must keep seeing the length the client really sent.
+ */
+static inline void
+smb_wbclient_lm_response(
+    const uint8_t  *lm_response,
+    size_t          lm_response_len,
+    const uint8_t **out_data,
+    uint32_t       *out_len)
+{
+    static const uint8_t lm_implied_zeros[24] = { 0 };
+
+    if (lm_response_len == 0) {
+        *out_data = lm_implied_zeros;
+        *out_len  = sizeof(lm_implied_zeros);
+    } else {
+        *out_data = lm_response;
+        *out_len  = (uint32_t) lm_response_len;
+    }
+} // smb_wbclient_lm_response
+
 // Authenticate a user via winbind using NTLM challenge/response
 // Returns: 0 on success, -1 on failure
 // sid_out should be at least SMB_WBCLIENT_SID_MAX_LEN bytes (can be NULL)

--- a/src/server/smb/tests/smb_auth_test.c
+++ b/src/server/smb/tests/smb_auth_test.c
@@ -26,6 +26,7 @@
 
 #include "vfs/vfs.h"
 #include "vfs/vfs_user_cache.h"
+#include "server/smb/smb_wbclient.h"
 
 #define TEST_PASS(name) do { fprintf(stderr, "  PASS: %s\n", name); passed++; } while (0)
 #define TEST_FAIL(name) do { fprintf(stderr, "  FAIL: %s\n", name); failed++; } while (0)
@@ -578,6 +579,75 @@ test_cache_capacity(void)
     chimera_vfs_user_cache_destroy(cache);
 } /* test_cache_capacity */
 
+/*
+ * Test the LmChallengeResponse normalization the winbind logon path applies.
+ *
+ * MS-NLMP 3.2.5.1.2 lets a client that authenticates with NTLMv2 alone send a
+ * zero-length LmChallengeResponse, which the server must read as the implied
+ * Z(24).  winbind's auth_crap interface refuses length 0 outright -- even when
+ * the NTLMv2 proof verifies -- so smb_wbclient_lm_response() materializes those
+ * 24 zero bytes; without it every mount.cifs logon against a winbind-backed
+ * server fails with STATUS_LOGON_FAILURE.  A client that did send a real LM
+ * field must be forwarded untouched, and a single-byte field must stay
+ * single-byte: validate_authenticate() keys anonymous-logon detection off
+ * `lm_response_len <= 1` and must keep seeing the length as sent.
+ */
+static void
+test_wbclient_lm_implied_zeros(void)
+{
+    const uint8_t  real_lm[24] = { 0xAA, 0xBB, 0xCC, 0xDD };
+    const uint8_t  one_byte[1] = { 0x00 };
+    const uint8_t *data;
+    uint32_t       len;
+    int            all_zero;
+
+    fprintf(stderr, "\nTesting winbind LM response normalization...\n");
+
+    /* Zero length -> the implied Z(24).  Passed a NULL buffer on purpose: the
+     * normalizer must not dereference a field the client omitted. */
+    data = NULL;
+    len  = 0xFFFFFFFF;
+    smb_wbclient_lm_response(NULL, 0, &data, &len);
+
+    if (len == 24) {
+        TEST_PASS("Zero-length LM response becomes 24 bytes");
+    } else {
+        TEST_FAIL("Zero-length LM response becomes 24 bytes");
+    }
+
+    all_zero = (data != NULL);
+    for (uint32_t i = 0; data && i < len; i++) {
+        if (data[i] != 0) {
+            all_zero = 0;
+        }
+    }
+
+    if (all_zero) {
+        TEST_PASS("Implied LM response is 24 zero bytes");
+    } else {
+        TEST_FAIL("Implied LM response is 24 zero bytes");
+    }
+
+    /* A real 24-byte LM field (what smbclient and Windows send) is forwarded
+     * verbatim. */
+    smb_wbclient_lm_response(real_lm, sizeof(real_lm), &data, &len);
+
+    if (len == sizeof(real_lm) && data == real_lm) {
+        TEST_PASS("24-byte LM response passes through unchanged");
+    } else {
+        TEST_FAIL("24-byte LM response passes through unchanged");
+    }
+
+    /* A single byte must NOT be padded, or the anonymous logon signal breaks. */
+    smb_wbclient_lm_response(one_byte, sizeof(one_byte), &data, &len);
+
+    if (len == 1 && data == one_byte) {
+        TEST_PASS("Single-byte LM response is not padded");
+    } else {
+        TEST_FAIL("Single-byte LM response is not padded");
+    }
+} /* test_wbclient_lm_implied_zeros */
+
 static void
 usage(const char *prog)
 {
@@ -643,6 +713,7 @@ main(
         test_user_full_fields();
         test_user_update();
         test_cache_capacity();
+        test_wbclient_lm_implied_zeros();
     }
 
     if (test_mode == TEST_MODE_ALL || test_mode == TEST_MODE_NTLM_WINBIND) {


### PR DESCRIPTION
## Problem

The Linux kernel cifs client (`mount.cifs`) authenticates with NTLMv2 only and
sends `LmChallengeResponse` with `Length = 0`. Per MS-NLMP 3.2.5.1.2 the server
must read that as the implied `Z(24)`; Samba's own clients and Windows send
those 24 zero bytes explicitly.

`smb_wbclient_auth_ntlm()` forwarded the field verbatim, and winbind's
`auth_crap` interface refuses a zero-length LM response even when the NTLMv2
response verifies. Every `mount.cifs` logon against a winbind-backed server
therefore failed with `STATUS_LOGON_FAILURE` while `smbclient` and Windows
succeeded with the same credentials — and the only server-side trace was the
generic `Authentication failed (mechanism: NTLM)` from the session-setup path,
because the `wbcAuthenticateUserEx failed` message carrying winbind's
`NT_STATUS` logged at debug level.

All Linux SMB clients are affected (`mount.cifs`, autofs, Kubernetes CSI) once
SMB authentication is routed through winbind. Windows, macOS and `smbclient`
are unaffected.

## Evidence

Both clients send a cryptographically correct proof — recomputed offline as
`NTOWFv2 = HMAC-MD5(MD4(pw), UPPER(user) + domain)` and
`NTProofStr = HMAC-MD5(NTOWFv2, server_challenge || temp)`. The LM field is the
only difference:

| field | smbclient (accepted) | kernel cifs (rejected) |
| --- | --- | --- |
| `LmChallengeResponse` | len 24 (all zeros) | **len 0** |
| `NtChallengeResponse` | 302 bytes, proof verifies | 222 bytes, proof verifies |

Varying one AUTHENTICATE field at a time against a live winbind/ldapsam-backed
directory, everything else held constant, the rule is exactly
"length == 0 is refused":

```
lm_len=0  -> 0xc000006d LOGON_FAILURE     lm_len=16 -> SUCCESS
lm_len=1  -> SUCCESS                      lm_len=24 -> SUCCESS
lm_len=8  -> SUCCESS                      lm_len=48 -> SUCCESS
```

Nothing else contributes: an empty `DomainName` (what `mount.cifs` sends with no
`domain=` option), lowercase domain, `MsvAvTargetName` presence or absence, the
NTLMSSP flag word, the version block, the workstation name, and an NT response
padded past 256 bytes make no difference either way.

With `lm_len=24` a kernel-shaped logon completes end to end: the server's SMB2
signature on the final `SESSION_SETUP` response verifies against the
client-derived `ExportedSessionKey` (no `NTLMSSP_NEGOTIATE_KEY_EXCH`, so
`SessionBaseKey = HMAC-MD5(NTOWFv2, NTProofStr)`), and a signed `TREE_CONNECT`
returns `SUCCESS`. The LM field is the only blocker — there is nothing else
waiting behind it.

## Fix

Normalize the field in the winbind path through a new
`smb_wbclient_lm_response()`, so the NTLMv2 proof alone decides the logon.

This deliberately does **not** go at parse time: `validate_authenticate()` reads
`lm_response_len <= 1` as an anonymous logon (`mount -o sec=none`) and must keep
seeing the length the client actually sent. The accompanying unit test pins that
boundary, asserting a single-byte field is passed through unpadded.

Safe: `lanman auth = no` is the Samba default, so the LM branch is never tried,
and 24 zero bytes cannot validate against a real LM hash in any case.

The local/smbpasswd path was never affected — `validate_local_user()` verifies
only the `NTProofStr` and never looks at the LM field, which is why the defect
appears only once SMB authentication is routed through winbind.

Both `wbcAuthenticateUserEx` failure logs also move from debug to error, so
winbind's `NT_STATUS` reaches the log on a failed logon; chimera has no warning
level between the two.
