### PR TITLE
vfs: resolve group SIDs through the identity layer

### DIFF
--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -375,7 +375,7 @@ chimera_smb_sd_to_acl(
         }
     }
 
-    /* Group SID -> gid. */
+    /* Group SID -> gid (modefromsid first, then general idmap). */
     if (offset_group && offset_group + 8 <= sd_len) {
         struct chimera_principal p;
 
@@ -383,11 +383,20 @@ chimera_smb_sd_to_acl(
             attrs->va_gid       = value;
             attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
         } else if (sid_bin_to_str(sd_buf + offset_group, sd_len - offset_group,
-                                  sidstr, sizeof(sidstr)) > 0 &&
-                   chimera_idmap_sid_to_principal(sidstr, &p) == 0 &&
-                   p.type != CHIMERA_PRINCIPAL_SPECIAL) {
-            attrs->va_gid       = p.id;
-            attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
+                                  sidstr, sizeof(sidstr)) > 0) {
+            if (chimera_idmap_sid_to_principal(sidstr, &p) == 0 &&
+                p.type != CHIMERA_PRINCIPAL_SPECIAL) {
+                attrs->va_gid       = p.id;
+                attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
+            } else if (vfs &&
+                       chimera_vfs_identity_sid_to_gid(vfs, sidstr, &value) == 0) {
+                /* A real (e.g. AD) group SID resolved via the user cache. */
+                attrs->va_gid       = value;
+                attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
+            } else {
+                /* Real SID not yet cached: record it for async resolution. */
+                smb_unres_record(unres, sidstr);
+            }
         }
     }
 
@@ -433,13 +442,17 @@ chimera_smb_sd_to_acl(
             }
 
             if (chimera_idmap_sid_to_principal(sidstr, &p) != 0) {
-                uint32_t cuid;
+                uint32_t cid;
 
                 /* Not an algorithmic/well-known SID: resolve a real SID to its
-                 * cached uid via the identity authority, else skip the ACE. */
+                 * cached uid -- or gid, for a domain group -- via the identity
+                 * authority, else skip the ACE. */
                 if (vfs &&
-                    chimera_vfs_identity_sid_to_uid(vfs, sidstr, &cuid) == 0) {
-                    p = chimera_idmap_uid_principal(cuid);
+                    chimera_vfs_identity_sid_to_uid(vfs, sidstr, &cid) == 0) {
+                    p = chimera_idmap_uid_principal(cid);
+                } else if (vfs &&
+                           chimera_vfs_identity_sid_to_gid(vfs, sidstr, &cid) == 0) {
+                    p = chimera_idmap_gid_principal(cid);
                 } else {
                     /* Real SID not yet cached: record for async resolution and
                      * skip the ACE this pass. */
@@ -521,6 +534,37 @@ chimera_smb_emit_owner_sid(
     return SID_UNIX_SIZE;
 } /* chimera_smb_emit_owner_sid */
 
+/*
+ * Emit the group SID into `out`: the group's real (cached) Windows SID if the
+ * identity authority knows one, else the algorithmic modefromsid unix SID.
+ * Returns the number of bytes written, or -1 if it does not fit.
+ *
+ * The fallback is deliberately write_unix_sid kind 2 (S-1-5-88-2-<gid>) rather
+ * than chimera_idmap_principal_to_sid's S-1-22-2-<gid>: the SET path recovers
+ * the gid from this field with parse_unix_sid(..., 2, ...), so the pair has to
+ * agree.
+ */
+static int
+chimera_smb_emit_group_sid(
+    uint8_t            *out,
+    int                 cap,
+    struct chimera_vfs *vfs,
+    uint32_t            gid)
+{
+    char sidstr[CHIMERA_IDMAP_SID_MAX];
+
+    if (vfs &&
+        chimera_vfs_identity_gid_to_sid(vfs, gid, sidstr, sizeof(sidstr)) > 0) {
+        return sid_str_to_bin(sidstr, out, cap);
+    }
+
+    if (cap < SID_UNIX_SIZE) {
+        return -1;
+    }
+    write_unix_sid(out, 2, gid);
+    return SID_UNIX_SIZE;
+} /* chimera_smb_emit_group_sid */
+
 static int
 chimera_smb_acl_to_sd(
     uint32_t                  uid,
@@ -560,12 +604,13 @@ chimera_smb_acl_to_sd(
     }
 
     if (has_group) {
-        if (offset + SID_UNIX_SIZE > cap) {
+        int n = chimera_smb_emit_group_sid(&out[offset], cap - offset, vfs, gid);
+
+        if (n < 0) {
             return -1;
         }
         group_off = offset;
-        write_unix_sid(&out[offset], 2, gid);
-        offset += SID_UNIX_SIZE;
+        offset   += n;
     }
 
     if (has_dacl) {
@@ -610,12 +655,17 @@ chimera_smb_acl_to_sd(
                     }
                 }
 
-                /* Prefer the user's real (cached) SID so AD principals round
-                 * trip; fall back to the algorithmic idmap SID. */
+                /* Prefer the principal's real (cached) SID so AD users and
+                 * groups alike round trip; fall back to the algorithmic idmap
+                 * SID. */
                 if (who.type == CHIMERA_PRINCIPAL_USER && vfs &&
                     chimera_vfs_identity_uid_to_sid(vfs, who.id, sidstr,
                                                     sizeof(sidstr)) > 0) {
                     /* sidstr holds the real SID */
+                } else if (who.type == CHIMERA_PRINCIPAL_GROUP && vfs &&
+                           chimera_vfs_identity_gid_to_sid(vfs, who.id, sidstr,
+                                                           sizeof(sidstr)) > 0) {
+                    /* sidstr holds the real group SID */
                 } else if (chimera_idmap_principal_to_sid(&who, sidstr,
                                                           sizeof(sidstr)) < 0) {
                     continue;
@@ -892,10 +942,10 @@ chimera_smb_set_resolve_decr(struct chimera_smb_request *request)
 
 static void
 chimera_smb_set_resolve_cb(
-    const struct chimera_vfs_user *user,
-    void                          *private_data)
+    const struct chimera_vfs_identity_result *result,
+    void                                     *private_data)
 {
-    (void) user;
+    (void) result;
     chimera_smb_set_resolve_decr(private_data);
 } /* chimera_smb_set_resolve_cb */
 
@@ -1040,10 +1090,10 @@ chimera_smb_query_resolve_decr(struct chimera_smb_request *request)
 
 static void
 chimera_smb_query_resolve_cb(
-    const struct chimera_vfs_user *user,
-    void                          *private_data)
+    const struct chimera_vfs_identity_result *result,
+    void                                     *private_data)
 {
-    (void) user;
+    (void) result;
     chimera_smb_query_resolve_decr(private_data);
 } /* chimera_smb_query_resolve_cb */
 
@@ -1069,10 +1119,15 @@ chimera_smb_query_security_getattr_callback(
 
     acl = (attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) ? attr->va_acl : NULL;
 
-    /* The owner SID and any USER ACE need a real SID; count the principals not
-     * yet in the cache (those would block) so we know whether to resolve. */
+    /* The owner and group SIDs and any USER/GROUP ACE need a real SID; count
+     * the principals not yet in the cache (those would block) so we know
+     * whether to resolve. */
     if (!chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
                                      attr->va_uid, NULL)) {
+        nmiss++;
+    }
+    if (!chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_GID,
+                                     attr->va_gid, NULL)) {
         nmiss++;
     }
     if (acl) {
@@ -1080,6 +1135,11 @@ chimera_smb_query_security_getattr_callback(
             if (acl->aces[i].who.type == CHIMERA_PRINCIPAL_USER &&
                 !chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
                                              acl->aces[i].who.id, NULL)) {
+                nmiss++;
+            } else if (acl->aces[i].who.type == CHIMERA_PRINCIPAL_GROUP &&
+                       !chimera_vfs_identity_cached(vfs,
+                                                    CHIMERA_VFS_IDENTITY_BY_GID,
+                                                    acl->aces[i].who.id, NULL)) {
                 nmiss++;
             }
         }
@@ -1118,6 +1178,13 @@ chimera_smb_query_security_getattr_callback(
                                      attr->va_uid, NULL,
                                      chimera_smb_query_resolve_cb, request);
     }
+    if (!chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_GID,
+                                     attr->va_gid, NULL)) {
+        request->query_info.sd_pending++;
+        chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_GID,
+                                     attr->va_gid, NULL,
+                                     chimera_smb_query_resolve_cb, request);
+    }
     if (acl) {
         for (i = 0; i < acl->num_aces; i++) {
             if (acl->aces[i].who.type == CHIMERA_PRINCIPAL_USER &&
@@ -1126,6 +1193,16 @@ chimera_smb_query_security_getattr_callback(
                 request->query_info.sd_pending++;
                 chimera_vfs_identity_resolve(thread,
                                              CHIMERA_VFS_IDENTITY_BY_UID,
+                                             acl->aces[i].who.id, NULL,
+                                             chimera_smb_query_resolve_cb,
+                                             request);
+            } else if (acl->aces[i].who.type == CHIMERA_PRINCIPAL_GROUP &&
+                       !chimera_vfs_identity_cached(vfs,
+                                                    CHIMERA_VFS_IDENTITY_BY_GID,
+                                                    acl->aces[i].who.id, NULL)) {
+                request->query_info.sd_pending++;
+                chimera_vfs_identity_resolve(thread,
+                                             CHIMERA_VFS_IDENTITY_BY_GID,
                                              acl->aces[i].who.id, NULL,
                                              chimera_smb_query_resolve_cb,
                                              request);

--- a/src/server/smb/smb_wbclient.c
+++ b/src/server/smb/smb_wbclient.c
@@ -11,6 +11,7 @@
 #include <wbclient.h>
 #include <string.h>
 #include <pwd.h>
+#include <grp.h>
 
 int
 smb_wbclient_available(void)
@@ -23,20 +24,26 @@ smb_wbclient_available(void)
     return (wbc_err == WBC_ERR_SUCCESS) ? 1 : 0;
 } // smb_wbclient_available
 
+/* Bounded copy that always terminates.  Deliberately not strncpy: gcc's
+ * -Wstringop-truncation fires on a constant-bounded strncpy whose source may
+ * fill the destination, and this file is built with -Werror. */
 static void
 wbc_copy_string(
     char       *dst,
     size_t      dst_len,
     const char *src)
 {
+    size_t len = 0;
+
     if (!dst || dst_len == 0) {
         return;
     }
-    dst[0] = '\0';
+
     if (src) {
-        strncpy(dst, src, dst_len - 1);
-        dst[dst_len - 1] = '\0';
+        len = strnlen(src, dst_len - 1);
+        memcpy(dst, src, len);
     }
+    dst[len] = '\0';
 } // wbc_copy_string
 
 int
@@ -81,8 +88,7 @@ wbc_sid_to_string(
         return -1;
     }
 
-    strncpy(buf, sid_str, buf_len - 1);
-    buf[buf_len - 1] = '\0';
+    wbc_copy_string(buf, buf_len, sid_str);
     wbcFreeMemory(sid_str);
     return 0;
 } // wbc_sid_to_string
@@ -233,8 +239,7 @@ smb_wbclient_map_principal(
 
     // Parse the principal name
     // Format can be "user@REALM" or "DOMAIN\user"
-    strncpy(principal_copy, principal, sizeof(principal_copy) - 1);
-    principal_copy[sizeof(principal_copy) - 1] = '\0';
+    wbc_copy_string(principal_copy, sizeof(principal_copy), principal);
 
     at_sign = strchr(principal_copy, '@');
     if (at_sign) {
@@ -347,14 +352,14 @@ wbc_fill_user(
 
     out->uid = unix_uid;
     if (sidstr) {
-        strncpy(out->sid, sidstr, sizeof(out->sid) - 1);
+        wbc_copy_string(out->sid, sizeof(out->sid), sidstr);
     }
 
     /* Primary gid + name from the winbind passwd entry. */
     wbc_err = wbcGetpwuid(unix_uid, &pwd);
     if (wbc_err == WBC_ERR_SUCCESS && pwd) {
         out->gid = pwd->pw_gid;
-        strncpy(out->username, pwd->pw_name, sizeof(out->username) - 1);
+        wbc_copy_string(out->username, sizeof(out->username), pwd->pw_name);
         out->username_len = (int) strlen(out->username);
         wbcFreeMemory(pwd);
     } else {
@@ -377,64 +382,151 @@ wbc_fill_user(
     return 0;
 } // wbc_fill_user
 
+/* Fill a chimera_vfs_group (gid/name + real SID) from a resolved group SID.
+ * Returns 0 on success, -1 if the SID does not map to a Unix group. */
+static int
+wbc_fill_group(
+    const struct wbcDomainSid *group_sid,
+    const char                *sidstr,
+    struct chimera_vfs_group  *out)
+{
+    wbcErr        wbc_err;
+    uint32_t      unix_gid;
+    struct group *grp = NULL;
+
+    wbc_err = wbcSidToGid(group_sid, &unix_gid);
+    if (wbc_err != WBC_ERR_SUCCESS) {
+        return -1;
+    }
+
+    out->gid = unix_gid;
+    if (sidstr) {
+        wbc_copy_string(out->sid, sizeof(out->sid), sidstr);
+    }
+
+    /* Name from the winbind group entry (best effort -- the gid<->SID mapping
+     * is what callers need). */
+    wbc_err = wbcGetgrgid(unix_gid, &grp);
+    if (wbc_err == WBC_ERR_SUCCESS && grp) {
+        wbc_copy_string(out->groupname, sizeof(out->groupname), grp->gr_name);
+        out->groupname_len = (int) strlen(out->groupname);
+        wbcFreeMemory(grp);
+    }
+
+    return 0;
+} // wbc_fill_group
+
+/* Non-zero if `type` names a group rather than a user. */
+static int
+wbc_sid_type_is_group(enum wbcSidType type)
+{
+    return type == WBC_SID_NAME_DOM_GRP ||
+           type == WBC_SID_NAME_ALIAS ||
+           type == WBC_SID_NAME_WKN_GRP;
+} // wbc_sid_type_is_group
+
 int
 smb_wbclient_identity_handler(
-    enum chimera_vfs_identity_key key,
-    uint32_t                      id,
-    const char                   *name,
-    struct chimera_vfs_user      *out,
-    void                         *private_data)
+    enum chimera_vfs_identity_key       key,
+    uint32_t                            id,
+    const char                         *name,
+    struct chimera_vfs_identity_result *out,
+    void                               *private_data)
 {
     wbcErr              wbc_err;
-    struct wbcDomainSid user_sid;
+    struct wbcDomainSid sid;
     enum wbcSidType     sid_type;
     char                sidbuf[SMB_WBCLIENT_SID_MAX_LEN];
+    char               *lookup_domain = NULL, *lookup_name = NULL;
     int                 rc;
 
     (void) private_data;
 
     switch (key) {
         case CHIMERA_VFS_IDENTITY_BY_UID:
-            wbc_err = wbcUidToSid(id, &user_sid);
+            wbc_err = wbcUidToSid(id, &sid);
             if (wbc_err != WBC_ERR_SUCCESS) {
                 return -1;
             }
-            if (wbc_sid_to_string(&user_sid, sidbuf, sizeof(sidbuf)) < 0) {
+            if (wbc_sid_to_string(&sid, sidbuf, sizeof(sidbuf)) < 0) {
                 return -1;
             }
-            return wbc_fill_user(&user_sid, sidbuf, out);
+            return wbc_fill_user(&sid, sidbuf, &out->user);
+
+        case CHIMERA_VFS_IDENTITY_BY_GID:
+            wbc_err = wbcGidToSid(id, &sid);
+            if (wbc_err != WBC_ERR_SUCCESS) {
+                return -1;
+            }
+            if (wbc_sid_to_string(&sid, sidbuf, sizeof(sidbuf)) < 0) {
+                return -1;
+            }
+            out->is_group = 1;
+            return wbc_fill_group(&sid, sidbuf, &out->group);
 
         case CHIMERA_VFS_IDENTITY_BY_SID:
             if (!name) {
                 return -1;
             }
-            wbc_err = wbcStringToSid(name, &user_sid);
+            wbc_err = wbcStringToSid(name, &sid);
             if (wbc_err != WBC_ERR_SUCCESS) {
                 return -1;
             }
-            return wbc_fill_user(&user_sid, name, out);
+            /* A SID is ambiguous.  Ask winbind what it names before choosing
+             * the fill: a group SID put through the user-shaped fill fails at
+             * wbcSidToUid, which is why domain-group ACEs used to be dropped. */
+            wbc_err = wbcLookupSid(&sid, &lookup_domain, &lookup_name,
+                                   &sid_type);
+            if (wbc_err != WBC_ERR_SUCCESS) {
+                /* Unknown to the DC: fall back to the historical user fill. */
+                return wbc_fill_user(&sid, name, &out->user);
+            }
+            if (lookup_domain) {
+                wbcFreeMemory(lookup_domain);
+            }
+            if (lookup_name) {
+                wbcFreeMemory(lookup_name);
+            }
+            if (wbc_sid_type_is_group(sid_type)) {
+                out->is_group = 1;
+                return wbc_fill_group(&sid, name, &out->group);
+            }
+            return wbc_fill_user(&sid, name, &out->user);
 
         case CHIMERA_VFS_IDENTITY_BY_NAME:
             if (!name) {
                 return -1;
             }
-            wbc_err = wbcLookupName("", name, &user_sid, &sid_type);
-            if (wbc_err != WBC_ERR_SUCCESS || sid_type != WBC_SID_NAME_USER) {
+            wbc_err = wbcLookupName("", name, &sid, &sid_type);
+            if (wbc_err != WBC_ERR_SUCCESS) {
                 return -1;
             }
-            if (wbc_sid_to_string(&user_sid, sidbuf, sizeof(sidbuf)) < 0) {
+            if (wbc_sid_to_string(&sid, sidbuf, sizeof(sidbuf)) < 0) {
                 sidbuf[0] = '\0';
             }
-            rc = wbc_fill_user(&user_sid, sidbuf[0] ? sidbuf : NULL, out);
-            if (rc == 0 && !out->username[0]) {
-                strncpy(out->username, name, sizeof(out->username) - 1);
-                out->username_len = (int) strlen(out->username);
+            if (wbc_sid_type_is_group(sid_type)) {
+                out->is_group = 1;
+                rc            = wbc_fill_group(&sid, sidbuf[0] ? sidbuf : NULL,
+                                               &out->group);
+                if (rc == 0 && !out->group.groupname[0]) {
+                    wbc_copy_string(out->group.groupname,
+                                    sizeof(out->group.groupname), name);
+                    out->group.groupname_len = (int) strlen(out->group.groupname);
+                }
+                return rc;
+            }
+            if (sid_type != WBC_SID_NAME_USER) {
+                return -1;
+            }
+            rc = wbc_fill_user(&sid, sidbuf[0] ? sidbuf : NULL, &out->user);
+            if (rc == 0 && !out->user.username[0]) {
+                wbc_copy_string(out->user.username,
+                                sizeof(out->user.username), name);
+                out->user.username_len = (int) strlen(out->user.username);
             }
             return rc;
 
         default:
-            /* A gid is not a user record, so the user-centric cache cannot
-             * represent it. */
             return -1;
     } // switch
 } // smb_wbclient_identity_handler
@@ -615,11 +707,11 @@ smb_wbclient_map_principal(
 
 int
 smb_wbclient_identity_handler(
-    enum chimera_vfs_identity_key key,
-    uint32_t                      id,
-    const char                   *name,
-    struct chimera_vfs_user      *out,
-    void                         *private_data)
+    enum chimera_vfs_identity_key       key,
+    uint32_t                            id,
+    const char                         *name,
+    struct chimera_vfs_identity_result *out,
+    void                               *private_data)
 {
     (void) key;
     (void) id;

--- a/src/server/smb/smb_wbclient.h
+++ b/src/server/smb/smb_wbclient.h
@@ -98,16 +98,17 @@ int smb_wbclient_netbios_identity(
     char  *dns_domain,
     size_t dns_domain_len);
 
-// Identity-resolver miss handler backed by winbind.  Resolves BY_UID / BY_SID /
-// BY_NAME to a full user record (uid/gid/groups/name/real SID) via libwbclient.
+// Identity-resolver miss handler backed by winbind.  Resolves BY_UID / BY_NAME
+// to a full user record (uid/gid/groups/name/real SID), BY_GID to a group
+// record (gid/name/real SID), and BY_SID to whichever of the two the SID names.
 // Registered with the VFS identity authority at SMB server init when winbind is
 // enabled.  Matches the chimera_vfs_identity_handler signature.
 int smb_wbclient_identity_handler(
-    enum chimera_vfs_identity_key key,
-    uint32_t                      id,
-    const char                   *name,
-    struct chimera_vfs_user      *out,
-    void                         *private_data);
+    enum chimera_vfs_identity_key       key,
+    uint32_t                            id,
+    const char                         *name,
+    struct chimera_vfs_identity_result *out,
+    void                               *private_data);
 
 // Authenticate a user via winbind using plaintext password
 // Returns: 0 on success, -1 on failure

--- a/src/vfs/tests/vfs_identity_test.c
+++ b/src/vfs/tests/vfs_identity_test.c
@@ -59,6 +59,39 @@ resolve_cb(
     p->done = 1;
 } /* resolve_cb */
 
+/*
+ * Stands in for the winbind handler: registered AFTER the built-in NSS one and,
+ * unlike NSS, able to supply a real SID for a numeric key.  `private_data`
+ * points at the one gid it claims to know, which the test picks to be a gid NSS
+ * can ALSO resolve -- that overlap is the whole point, since first-wins would
+ * hand the answer to NSS and lose the SID.
+ */
+#define TEST_WB_GID_SID "S-1-5-21-777-888-999-513"
+
+static int
+sid_bearing_handler(
+    enum chimera_vfs_identity_key       key,
+    uint32_t                            id,
+    const char                         *name,
+    struct chimera_vfs_identity_result *out,
+    void                               *private_data)
+{
+    uint32_t target = *(const uint32_t *) private_data;
+
+    (void) name;
+
+    if (key == CHIMERA_VFS_IDENTITY_BY_GID && id == target) {
+        out->is_group  = 1;
+        out->group.gid = id;
+        snprintf(out->group.groupname, sizeof(out->group.groupname), "wbgroup");
+        out->group.groupname_len = (int) strlen(out->group.groupname);
+        snprintf(out->group.sid, sizeof(out->group.sid), TEST_WB_GID_SID);
+        return 0;
+    }
+
+    return -1;
+} /* sid_bearing_handler */
+
 int
 main(
     int    argc,
@@ -74,6 +107,8 @@ main(
     struct group                 *root_gr;
     char                          sidbuf[CHIMERA_VFS_SID_MAX_LEN];
     uint32_t                      scratch_id;
+    uint32_t                      wb_gid;
+    uint32_t                      g;
 
     chimera_log_init();
 
@@ -177,7 +212,50 @@ main(
                                            &scratch_id) < 0);
     TEST_PASS("group and user chains stay disjoint");
 
-    /* --- 4. unresolvable keys complete (async) with no identity --- */
+    /* --- 4. a SID-bearing handler beats a SID-less one on a numeric key ---
+     *
+     * The field regression: NSS is registered first and, where
+     * nsswitch routes group through winbind, it resolves the gid itself and
+     * returns a name with no SID.  First-wins would stop there, cache the group
+     * SID-less, and -- because the cache hit suppresses any further resolve --
+     * pin the marshaller to the algorithmic S-1-5-88 SID permanently.  Pick a
+     * gid NSS definitely CAN resolve, so the two handlers genuinely overlap. */
+    wb_gid = 0;
+    for (g = 1; g < 100; g++) {
+        if (getgrgid(g)) {
+            wb_gid = g;
+            break;
+        }
+    }
+    assert(wb_gid != 0); /* some low non-root group exists on any host */
+    assert(getgrgid(wb_gid) != NULL);
+
+    chimera_vfs_identity_register_handler(vfs, sid_bearing_handler, &wb_gid);
+
+    memset(&p, 0, sizeof(p));
+    chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_GID, wb_gid,
+                                 NULL, resolve_cb, &p);
+    assert(p.done == 0);
+    while (!p.done) {
+        evpl_continue(evpl);
+    }
+    assert(p.found == 1);
+    assert(p.is_group == 1);
+    assert(p.gid == wb_gid);
+    /* NSS answered too, but without a SID -- the SID-bearing answer must win. */
+    assert(strcmp(p.sid, TEST_WB_GID_SID) == 0);
+    TEST_PASS("a SID-bearing handler wins over an earlier SID-less one");
+
+    /* And the SID actually reached the cache, so marshalling can find it. */
+    assert(chimera_vfs_identity_gid_to_sid(vfs, wb_gid, sidbuf,
+                                           sizeof(sidbuf)) > 0);
+    assert(strcmp(sidbuf, TEST_WB_GID_SID) == 0);
+    assert(chimera_vfs_identity_sid_to_gid(vfs, TEST_WB_GID_SID,
+                                           &scratch_id) == 0);
+    assert(scratch_id == wb_gid);
+    TEST_PASS("the winning SID is what gid_to_sid returns");
+
+    /* --- 5. unresolvable keys complete (async) with no identity --- */
     memset(&p, 0, sizeof(p));
     chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_SID, 0,
                                  "S-1-5-21-9-9-9-9", resolve_cb, &p);

--- a/src/vfs/tests/vfs_identity_test.c
+++ b/src/vfs/tests/vfs_identity_test.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <pwd.h>
+#include <grp.h>
 #undef NDEBUG
 #include <assert.h>
 
@@ -28,21 +29,32 @@ struct probe {
     int      done;
     int      inline_fired;
     int      found;
+    int      is_group;
     uint32_t uid;
+    uint32_t gid;
+    char     name[256];
     char     sid[CHIMERA_VFS_SID_MAX_LEN];
 };
 
 static void
 resolve_cb(
-    const struct chimera_vfs_user *user,
-    void                          *private_data)
+    const struct chimera_vfs_identity_result *result,
+    void                                     *private_data)
 {
     struct probe *p = private_data;
 
-    p->found = (user != NULL);
-    if (user) {
-        p->uid = user->uid;
-        snprintf(p->sid, sizeof(p->sid), "%s", user->sid);
+    p->found = (result != NULL);
+    if (result) {
+        p->is_group = result->is_group;
+        if (result->is_group) {
+            p->gid = result->group.gid;
+            snprintf(p->name, sizeof(p->name), "%s", result->group.groupname);
+            snprintf(p->sid, sizeof(p->sid), "%s", result->group.sid);
+        } else {
+            p->uid = result->user.uid;
+            snprintf(p->name, sizeof(p->name), "%s", result->user.username);
+            snprintf(p->sid, sizeof(p->sid), "%s", result->user.sid);
+        }
     }
     p->done = 1;
 } /* resolve_cb */
@@ -59,6 +71,9 @@ main(
     struct prometheus_metrics    *metrics;
     struct probe                  p;
     struct passwd                *root_pw;
+    struct group                 *root_gr;
+    char                          sidbuf[CHIMERA_VFS_SID_MAX_LEN];
+    uint32_t                      scratch_id;
 
     chimera_log_init();
 
@@ -126,7 +141,43 @@ main(
     assert(p.done == 1 && p.found == 1 && p.uid == root_pw->pw_uid);
     TEST_PASS("resolved identity is cached for synchronous reuse");
 
-    /* --- 3. unresolvable key completes (async) with no user --- */
+    /* --- 3. BY_GID resolves to a GROUP record, not a user --- */
+    root_gr = getgrgid(0);
+    assert(root_gr != NULL); /* gid 0 exists on any host/container */
+
+    memset(&p, 0, sizeof(p));
+    chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_GID, 0,
+                                 NULL, resolve_cb, &p);
+    /* A gid was never resolvable before, so this must park on a worker. */
+    assert(p.done == 0);
+    while (!p.done) {
+        evpl_continue(evpl);
+    }
+    assert(p.found == 1);
+    assert(p.is_group == 1);
+    assert(p.gid == 0);
+    assert(strcmp(p.name, root_gr->gr_name) == 0);
+    /* NSS supplies no SID, so the caller falls back to the algorithmic idmap. */
+    assert(p.sid[0] == '\0');
+    TEST_PASS("gid resolves asynchronously to a group record via NSS");
+
+    /* The worker populated the GROUP chains: now a synchronous hit. */
+    memset(&p, 0, sizeof(p));
+    chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_GID, 0,
+                                 NULL, resolve_cb, &p);
+    assert(p.done == 1 && p.found == 1 && p.is_group == 1 && p.gid == 0);
+    TEST_PASS("resolved group is cached for synchronous reuse");
+
+    /* A cached group must not be reachable as a user, and vice versa. */
+    assert(chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_GID,
+                                       0, NULL) == 1);
+    assert(chimera_vfs_identity_gid_to_sid(vfs, 4000, sidbuf,
+                                           sizeof(sidbuf)) < 0);
+    assert(chimera_vfs_identity_sid_to_gid(vfs, "S-1-5-21-111-222-333-1105",
+                                           &scratch_id) < 0);
+    TEST_PASS("group and user chains stay disjoint");
+
+    /* --- 4. unresolvable keys complete (async) with no identity --- */
     memset(&p, 0, sizeof(p));
     chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_SID, 0,
                                  "S-1-5-21-9-9-9-9", resolve_cb, &p);
@@ -136,6 +187,16 @@ main(
     }
     assert(p.found == 0);
     TEST_PASS("unresolvable SID completes with no user");
+
+    memset(&p, 0, sizeof(p));
+    chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_GID,
+                                 0x7ffffffe, NULL, resolve_cb, &p);
+    assert(p.done == 0);
+    while (!p.done) {
+        evpl_continue(evpl);
+    }
+    assert(p.found == 0);
+    TEST_PASS("unresolvable gid completes with no group");
 
     chimera_vfs_thread_destroy(thread);
     chimera_vfs_destroy(vfs);

--- a/src/vfs/tests/vfs_user_cache_test.c
+++ b/src/vfs/tests/vfs_user_cache_test.c
@@ -320,6 +320,174 @@ test_sid_index(void)
     TEST_PASS("SID index round-trips uid<->real SID and unindexes on remove");
 } /* test_sid_index */
 
+/*
+ * Group records: gid<->SID round trip, dedup by gid, TTL expiry.
+ */
+static void
+test_group_index(void)
+{
+    struct chimera_vfs_user_cache  *cache;
+    const struct chimera_vfs_group *group;
+
+    cache = chimera_vfs_user_cache_create(64, 600);
+
+    chimera_vfs_group_cache_add(cache, "Domain Users",
+                                "S-1-5-21-111-222-333-513", 513, 0);
+
+    urcu_qsbr_read_lock();
+
+    group = chimera_vfs_group_cache_lookup_by_gid(cache, 513);
+    assert(group != NULL);
+    assert(group->gid == 513);
+    assert(strcmp(group->groupname, "Domain Users") == 0);
+    assert(strcmp(group->sid, "S-1-5-21-111-222-333-513") == 0);
+
+    group = chimera_vfs_group_cache_lookup_by_sid(cache,
+                                                  "S-1-5-21-111-222-333-513");
+    assert(group != NULL);
+    assert(group->gid == 513);
+
+    /* Unknown / SID-less lookups miss. */
+    assert(chimera_vfs_group_cache_lookup_by_gid(cache, 9999) == NULL);
+    assert(chimera_vfs_group_cache_lookup_by_sid(cache, "S-1-5-21-9-9-9-9") == NULL);
+    assert(chimera_vfs_group_cache_lookup_by_sid(cache, "") == NULL);
+    assert(chimera_vfs_group_cache_lookup_by_sid(cache, NULL) == NULL);
+
+    urcu_qsbr_read_unlock();
+
+    /* A group with no SID resolves by gid but is not SID-indexed. */
+    chimera_vfs_group_cache_add(cache, "localgrp", NULL, 27, 0);
+    urcu_qsbr_read_lock();
+    group = chimera_vfs_group_cache_lookup_by_gid(cache, 27);
+    assert(group != NULL && group->sid[0] == '\0');
+    urcu_qsbr_read_unlock();
+
+    /* Re-adding the same gid replaces the record and unindexes the old SID. */
+    chimera_vfs_group_cache_add(cache, "Domain Users",
+                                "S-1-5-21-999-888-777-513", 513, 0);
+    urcu_qsbr_synchronize_rcu();
+    urcu_qsbr_read_lock();
+    assert(chimera_vfs_group_cache_lookup_by_sid(cache,
+                                                 "S-1-5-21-111-222-333-513") == NULL);
+    group = chimera_vfs_group_cache_lookup_by_sid(cache,
+                                                  "S-1-5-21-999-888-777-513");
+    assert(group != NULL && group->gid == 513);
+    /* Exactly one record per gid. */
+    group = chimera_vfs_group_cache_lookup_by_gid(cache, 513);
+    assert(group != NULL);
+    assert(strcmp(group->sid, "S-1-5-21-999-888-777-513") == 0);
+    urcu_qsbr_read_unlock();
+
+    chimera_vfs_user_cache_destroy(cache);
+
+    TEST_PASS("group index round-trips gid<->real SID and dedups by gid");
+} /* test_group_index */
+
+/*
+ * The reason groups are a distinct record type: a group must be invisible to
+ * every user-side lookup, and must not disturb a user that shares its name.
+ */
+static void
+test_group_user_isolation(void)
+{
+    struct chimera_vfs_user_cache *cache;
+    const struct chimera_vfs_user *user;
+
+    cache = chimera_vfs_user_cache_create(64, 600);
+
+    chimera_vfs_user_cache_add(cache, "shared", NULL, NULL,
+                               "S-1-5-21-111-222-333-1105",
+                               1000, 1000, 0, NULL, 0);
+
+    /* Same name, and a gid numerically equal to the user's uid -- the two
+     * collisions that a single shared record would get wrong. */
+    chimera_vfs_group_cache_add(cache, "shared",
+                                "S-1-5-21-111-222-333-513", 1000, 0);
+
+    urcu_qsbr_read_lock();
+
+    /* The user survives intact: no eviction by the group's name, no clobber. */
+    user = chimera_vfs_user_cache_lookup_by_name(cache, "shared");
+    assert(user != NULL);
+    assert(user->uid == 1000);
+    assert(strcmp(user->sid, "S-1-5-21-111-222-333-1105") == 0);
+
+    /* uid 1000 still resolves to the user, not the gid-1000 group. */
+    user = chimera_vfs_user_cache_lookup_by_uid(cache, 1000);
+    assert(user != NULL);
+    assert(strcmp(user->sid, "S-1-5-21-111-222-333-1105") == 0);
+
+    /* The group SID is not reachable through the user SID index (this is what
+     * used to make sid_to_uid hand back a meaningless uid). */
+    assert(chimera_vfs_user_cache_lookup_by_sid(cache,
+                                                "S-1-5-21-111-222-333-513") == NULL);
+
+    /* ...and the user SID is not reachable through the group SID index. */
+    assert(chimera_vfs_group_cache_lookup_by_sid(cache,
+                                                 "S-1-5-21-111-222-333-1105") == NULL);
+
+    urcu_qsbr_read_unlock();
+
+    chimera_vfs_user_cache_destroy(cache);
+
+    TEST_PASS("group records stay out of every user index");
+} /* test_group_user_isolation */
+
+static void
+test_group_ttl_expiration(void)
+{
+    struct chimera_vfs_user_cache *cache;
+
+    /* ttl 0: the entry is already expired when the sweeper next runs. */
+    cache = chimera_vfs_user_cache_create(64, 0);
+
+    chimera_vfs_group_cache_add(cache, "ephemeral",
+                                "S-1-5-21-111-222-333-514", 514, 0);
+    chimera_vfs_group_cache_add(cache, "permanent",
+                                "S-1-5-21-111-222-333-515", 515, 1);
+
+    urcu_qsbr_read_lock();
+    assert(chimera_vfs_group_cache_lookup_by_gid(cache, 514) != NULL);
+    urcu_qsbr_read_unlock();
+
+    /* Drive the sweep directly rather than waiting out its 60s period. */
+    pthread_mutex_lock(&cache->write_lock);
+    {
+        struct chimera_vfs_group *group, *next;
+        struct timespec           ts;
+        int                       i;
+
+        clock_gettime(CLOCK_REALTIME, &ts);
+        for (i = 0; i < cache->num_buckets; i++) {
+            group = cache->group_gid_buckets[i].head;
+            while (group) {
+                next = group->next_by_gid;
+                if (!group->pinned &&
+                    (ts.tv_sec > group->expiration.tv_sec ||
+                     (ts.tv_sec == group->expiration.tv_sec &&
+                      ts.tv_nsec >= group->expiration.tv_nsec))) {
+                    chimera_vfs_group_cache_remove_locked(cache, group);
+                }
+                group = next;
+            }
+        }
+    }
+    pthread_mutex_unlock(&cache->write_lock);
+
+    urcu_qsbr_synchronize_rcu();
+    urcu_qsbr_read_lock();
+    assert(chimera_vfs_group_cache_lookup_by_gid(cache, 514) == NULL);
+    assert(chimera_vfs_group_cache_lookup_by_sid(cache,
+                                                 "S-1-5-21-111-222-333-514") == NULL);
+    /* Pinned groups survive the sweep. */
+    assert(chimera_vfs_group_cache_lookup_by_gid(cache, 515) != NULL);
+    urcu_qsbr_read_unlock();
+
+    chimera_vfs_user_cache_destroy(cache);
+
+    TEST_PASS("expired groups are swept, pinned groups survive");
+} /* test_group_ttl_expiration */
+
 int
 main(void)
 {
@@ -335,6 +503,9 @@ main(void)
     test_pinned_no_expire();
     test_is_member();
     test_sid_index();
+    test_group_index();
+    test_group_user_isolation();
+    test_group_ttl_expiration();
 
     fprintf(stderr, "All tests passed.\n");
 

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -1438,6 +1438,57 @@ chimera_vfs_identity_sid_to_uid(
     return rc;
 } /* chimera_vfs_identity_sid_to_uid */
 
+SYMBOL_EXPORT int
+chimera_vfs_identity_gid_to_sid(
+    struct chimera_vfs *vfs,
+    uint32_t            gid,
+    char               *buf,
+    int                 buflen)
+{
+    const struct chimera_vfs_group *group;
+    int                             rc = -1;
+
+    urcu_qsbr_read_lock();
+
+    group = chimera_vfs_group_cache_lookup_by_gid(vfs->vfs_user_cache, gid);
+
+    if (group && group->sid[0]) {
+        int len = (int) strlen(group->sid);
+
+        if (len + 1 <= buflen) {
+            memcpy(buf, group->sid, len + 1);
+            rc = len;
+        }
+    }
+
+    urcu_qsbr_read_unlock();
+
+    return rc;
+} /* chimera_vfs_identity_gid_to_sid */
+
+SYMBOL_EXPORT int
+chimera_vfs_identity_sid_to_gid(
+    struct chimera_vfs *vfs,
+    const char         *sid,
+    uint32_t           *gid)
+{
+    const struct chimera_vfs_group *group;
+    int                             rc = -1;
+
+    urcu_qsbr_read_lock();
+
+    group = chimera_vfs_group_cache_lookup_by_sid(vfs->vfs_user_cache, sid);
+
+    if (group) {
+        *gid = group->gid;
+        rc   = 0;
+    }
+
+    urcu_qsbr_read_unlock();
+
+    return rc;
+} /* chimera_vfs_identity_sid_to_gid */
+
 
 SYMBOL_EXPORT void
 chimera_vfs_iterate_builtin_users(

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -321,8 +321,10 @@ chimera_vfs_user_is_member(
  * the cached SID for `uid` into `buf` and returns its length, or -1 when the
  * user has no known real SID (the caller then falls back to the algorithmic
  * idmap SID).  sid_to_uid resolves a SID string to its cached uid (0 on
- * success, -1 on miss).  Both are RCU-safe and must be called from a
- * VFS-registered thread.
+ * success, -1 on miss).  The gid pair is the exact group-side counterpart,
+ * backed by the group chains of the same cache, and follows the same return
+ * conventions.  All four are RCU-safe and must be called from a VFS-registered
+ * thread.
  */
 int
 chimera_vfs_identity_uid_to_sid(
@@ -336,6 +338,19 @@ chimera_vfs_identity_sid_to_uid(
     struct chimera_vfs *vfs,
     const char         *sid,
     uint32_t           *uid);
+
+int
+chimera_vfs_identity_gid_to_sid(
+    struct chimera_vfs *vfs,
+    uint32_t            gid,
+    char               *buf,
+    int                 buflen);
+
+int
+chimera_vfs_identity_sid_to_gid(
+    struct chimera_vfs *vfs,
+    const char         *sid,
+    uint32_t           *gid);
 
 
 typedef int (*chimera_vfs_user_iterate_cb)(

--- a/src/vfs/vfs_identity.c
+++ b/src/vfs/vfs_identity.c
@@ -143,14 +143,48 @@ chimera_vfs_identity_cache_probe(
     return found;
 } /* chimera_vfs_identity_cache_probe */
 
-/* Run the registered miss handlers in order until one resolves the key. */
+static inline int
+chimera_vfs_identity_result_has_sid(const struct chimera_vfs_identity_result *result)
+{
+    return result->is_group ? result->group.sid[0] != '\0'
+           : result->user.sid[0] != '\0';
+} /* chimera_vfs_identity_result_has_sid */
+
+/*
+ * Run the registered miss handlers in order until one resolves the key.
+ *
+ * For the numeric keys (BY_UID / BY_GID) a plain first-wins walk is not enough.
+ * NSS is registered first and, on a host whose nsswitch routes passwd/group
+ * through winbind, it answers those keys itself -- with a name but never a SID,
+ * because NSS has no notion of one.  That would short-circuit the winbind
+ * handler, which is the only one that can supply the real SID, and the identity
+ * would be cached SID-less; the cache hit then suppresses any further resolve,
+ * so the SID never arrives and the marshaller falls back to the algorithmic
+ * S-1-5-88 form for good.
+ *
+ * So for those two keys a SID-less success is only provisional: keep walking in
+ * case a later handler can name the same identity properly, and settle for the
+ * provisional answer only if none can.  This is safe precisely because the key
+ * is numeric -- every handler is being asked about the same uid/gid, so they
+ * can only disagree about the SID, never about which identity it is.  BY_NAME
+ * and BY_SID stay first-wins: there the key is a string that two handlers could
+ * legitimately resolve to different identities (a local "alice" and a domain
+ * "alice"), and preferring the SID-bearing answer would silently change which
+ * account wins.
+ */
 static int
 chimera_vfs_identity_run_handlers(
     struct chimera_vfs_identity         *identity,
     struct chimera_vfs_identity_request *req)
 {
     struct chimera_vfs_identity_handler_entry *entry;
+    struct chimera_vfs_identity_result         provisional;
+    int                                        have_provisional = 0;
+    int                                        prefer_sid;
     int                                        rc = -1;
+
+    prefer_sid = (req->key == CHIMERA_VFS_IDENTITY_BY_UID ||
+                  req->key == CHIMERA_VFS_IDENTITY_BY_GID);
 
     pthread_mutex_lock(&identity->handler_lock);
     entry = identity->handlers;
@@ -162,10 +196,23 @@ chimera_vfs_identity_run_handlers(
         memset(&req->result, 0, sizeof(req->result));
         if (entry->handler(req->key, req->id, req->name, &req->result,
                            entry->private_data) == 0) {
-            rc = 0;
-            break;
+            if (!prefer_sid ||
+                chimera_vfs_identity_result_has_sid(&req->result)) {
+                rc = 0;
+                break;
+            }
+            /* Resolved, but with no SID.  Hold it and keep looking. */
+            if (!have_provisional) {
+                provisional      = req->result;
+                have_provisional = 1;
+            }
         }
         entry = entry->next;
+    }
+
+    if (rc != 0 && have_provisional) {
+        req->result = provisional;
+        rc          = 0;
     }
 
     return rc;

--- a/src/vfs/vfs_identity.c
+++ b/src/vfs/vfs_identity.c
@@ -43,7 +43,7 @@ struct chimera_vfs_identity_request {
     char                                 name[CHIMERA_VFS_SID_MAX_LEN > 256 ?
                                               CHIMERA_VFS_SID_MAX_LEN : 256];
     int                                  found;
-    struct chimera_vfs_user              result;
+    struct chimera_vfs_identity_result   result;
     chimera_vfs_identity_callback        callback;
     void                                *private_data;
 };
@@ -76,20 +76,33 @@ chimera_vfs_identity_copy_user(
     dst->username_len = src->username_len;
 } /* chimera_vfs_identity_copy_user */
 
+/* Copy a cached group into a standalone result. */
+static inline void
+chimera_vfs_identity_copy_group(
+    struct chimera_vfs_group       *dst,
+    const struct chimera_vfs_group *src)
+{
+    dst->gid = src->gid;
+    memcpy(dst->groupname, src->groupname, sizeof(dst->groupname));
+    memcpy(dst->sid, src->sid, sizeof(dst->sid));
+    dst->groupname_len = src->groupname_len;
+} /* chimera_vfs_identity_copy_group */
+
 /*
  * Synchronous cache probe.  Returns 1 and fills `out` on a hit, 0 on a miss.
  * Caller need not hold the RCU read lock -- it is taken here.
  */
 static int
 chimera_vfs_identity_cache_probe(
-    struct chimera_vfs_user_cache *cache,
-    enum chimera_vfs_identity_key  key,
-    uint32_t                       id,
-    const char                    *name,
-    struct chimera_vfs_user       *out)
+    struct chimera_vfs_user_cache      *cache,
+    enum chimera_vfs_identity_key       key,
+    uint32_t                            id,
+    const char                         *name,
+    struct chimera_vfs_identity_result *out)
 {
-    const struct chimera_vfs_user *user  = NULL;
-    int                            found = 0;
+    const struct chimera_vfs_user  *user  = NULL;
+    const struct chimera_vfs_group *group = NULL;
+    int                             found = 0;
 
     urcu_qsbr_read_lock();
 
@@ -101,15 +114,27 @@ chimera_vfs_identity_cache_probe(
             user = chimera_vfs_user_cache_lookup_by_name(cache, name);
             break;
         case CHIMERA_VFS_IDENTITY_BY_SID:
+            /* A SID is ambiguous: try users first (preserving the previous
+             * behaviour), then groups. */
             user = chimera_vfs_user_cache_lookup_by_sid(cache, name);
+            if (!user) {
+                group = chimera_vfs_group_cache_lookup_by_sid(cache, name);
+            }
             break;
         case CHIMERA_VFS_IDENTITY_BY_GID:
+            group = chimera_vfs_group_cache_lookup_by_gid(cache, id);
+            break;
         default:
             break;
     } /* switch */
 
     if (user) {
-        chimera_vfs_identity_copy_user(out, user);
+        out->is_group = 0;
+        chimera_vfs_identity_copy_user(&out->user, user);
+        found = 1;
+    } else if (group) {
+        out->is_group = 1;
+        chimera_vfs_identity_copy_group(&out->group, group);
         found = 1;
     }
 
@@ -178,14 +203,23 @@ chimera_vfs_identity_worker(void *arg)
         if (chimera_vfs_identity_run_handlers(identity, req) == 0) {
             req->found = 1;
             /* Populate the cache so future lookups for this identity are
-             * synchronous (TTL-expiring, non-pinned). */
-            chimera_vfs_user_cache_add(
-                identity->vfs->vfs_user_cache,
-                req->result.username[0] ? req->result.username : "",
-                NULL, NULL,
-                req->result.sid[0] ? req->result.sid : NULL,
-                req->result.uid, req->result.gid,
-                req->result.ngids, req->result.gids, 0);
+             * synchronous (TTL-expiring, non-pinned).  A group goes to the
+             * group chains, never the user ones. */
+            if (req->result.is_group) {
+                chimera_vfs_group_cache_add(
+                    identity->vfs->vfs_user_cache,
+                    req->result.group.groupname,
+                    req->result.group.sid[0] ? req->result.group.sid : NULL,
+                    req->result.group.gid, 0);
+            } else {
+                chimera_vfs_user_cache_add(
+                    identity->vfs->vfs_user_cache,
+                    req->result.user.username[0] ? req->result.user.username : "",
+                    NULL, NULL,
+                    req->result.user.sid[0] ? req->result.user.sid : NULL,
+                    req->result.user.uid, req->result.user.gid,
+                    req->result.user.ngids, req->result.user.gids, 0);
+            }
         } else {
             req->found = 0;
         }
@@ -209,13 +243,14 @@ chimera_vfs_identity_worker(void *arg)
 
 static int
 chimera_vfs_identity_nss_handler(
-    enum chimera_vfs_identity_key key,
-    uint32_t                      id,
-    const char                   *name,
-    struct chimera_vfs_user      *out,
-    void                         *private_data)
+    enum chimera_vfs_identity_key       key,
+    uint32_t                            id,
+    const char                         *name,
+    struct chimera_vfs_identity_result *out,
+    void                               *private_data)
 {
     struct passwd       pw, *res = NULL;
+    struct group        gr, *gres = NULL;
     char                buf[16384];
     int                 rc;
     chimera_grouplist_t grps[CHIMERA_VFS_CRED_MAX_GIDS];
@@ -231,8 +266,21 @@ chimera_vfs_identity_nss_handler(
         case CHIMERA_VFS_IDENTITY_BY_NAME:
             rc = getpwnam_r(name, &pw, buf, sizeof(buf), &res);
             break;
+        case CHIMERA_VFS_IDENTITY_BY_GID:
+            rc = getgrgid_r(id, &gr, buf, sizeof(buf), &gres);
+            if (rc != 0 || gres == NULL) {
+                return -1;
+            }
+            out->is_group  = 1;
+            out->group.gid = gr.gr_gid;
+            strncpy(out->group.groupname, gr.gr_name,
+                    sizeof(out->group.groupname) - 1);
+            out->group.groupname_len = (int) strlen(out->group.groupname);
+            /* NSS supplies no SID; left empty so the algorithmic idmap is
+             * used for this group. */
+            return 0;
         default:
-            /* NSS has no notion of a Windows SID, and a gid is not a user. */
+            /* NSS has no notion of a Windows SID. */
             return -1;
     } /* switch */
 
@@ -240,10 +288,10 @@ chimera_vfs_identity_nss_handler(
         return -1;
     }
 
-    out->uid = pw.pw_uid;
-    out->gid = pw.pw_gid;
-    strncpy(out->username, pw.pw_name, sizeof(out->username) - 1);
-    out->username_len = (int) strlen(out->username);
+    out->user.uid = pw.pw_uid;
+    out->user.gid = pw.pw_gid;
+    strncpy(out->user.username, pw.pw_name, sizeof(out->user.username) - 1);
+    out->user.username_len = (int) strlen(out->user.username);
 
     /* Supplementary groups (getgrouplist includes the primary gid; storing it
      * twice is harmless for membership checks). */
@@ -253,9 +301,9 @@ chimera_vfs_identity_nss_handler(
     if (ng > CHIMERA_VFS_CRED_MAX_GIDS) {
         ng = CHIMERA_VFS_CRED_MAX_GIDS;
     }
-    out->ngids = ng;
+    out->user.ngids = ng;
     for (i = 0; i < ng; i++) {
-        out->gids[i] = grps[i];
+        out->user.gids[i] = grps[i];
     }
 
     /* NSS supplies no SID; left empty so the algorithmic idmap is used. */
@@ -384,8 +432,10 @@ chimera_vfs_identity_resolve(
     void                         *private_data)
 {
     struct chimera_vfs_identity         *identity = thread->vfs->identity;
-    struct chimera_vfs_user              hit;
+    struct chimera_vfs_identity_result   hit;
     struct chimera_vfs_identity_request *req;
+
+    memset(&hit, 0, sizeof(hit));
 
     /* Fast path: a cache hit resolves inline on this thread. */
     if (chimera_vfs_identity_cache_probe(thread->vfs->vfs_user_cache,
@@ -419,7 +469,9 @@ chimera_vfs_identity_cached(
     uint32_t                      id,
     const char                   *name)
 {
-    struct chimera_vfs_user scratch;
+    struct chimera_vfs_identity_result scratch;
+
+    memset(&scratch, 0, sizeof(scratch));
 
     return chimera_vfs_identity_cache_probe(vfs->vfs_user_cache, key, id, name,
                                             &scratch);

--- a/src/vfs/vfs_identity.h
+++ b/src/vfs/vfs_identity.h
@@ -17,9 +17,10 @@
 
 #include <stdint.h>
 
+#include "vfs_user_cache.h"
+
 struct chimera_vfs;
 struct chimera_vfs_thread;
-struct chimera_vfs_user;
 struct chimera_vfs_identity;
 
 enum chimera_vfs_identity_key {
@@ -30,26 +31,39 @@ enum chimera_vfs_identity_key {
 };
 
 /*
- * Delivered to the resolve callback.  `user` is NULL when the identity could
+ * A resolved identity.  An identity is either a user or a group, and the two
+ * are not interchangeable -- a SID in particular is ambiguous until resolved,
+ * so the resolver tags which kind came back rather than forcing a group through
+ * a user-shaped record.
+ */
+struct chimera_vfs_identity_result {
+    int                      is_group;
+    struct chimera_vfs_user  user;  /* valid when !is_group */
+    struct chimera_vfs_group group; /* valid when  is_group */
+};
+
+/*
+ * Delivered to the resolve callback.  `result` is NULL when the identity could
  * not be resolved; otherwise it points to a transient copy valid only for the
  * duration of the callback (copy out what you need).
  */
 typedef void (*chimera_vfs_identity_callback)(
-    const struct chimera_vfs_user *user,
-    void                          *private_data);
+    const struct chimera_vfs_identity_result *result,
+    void                                     *private_data);
 
 /*
  * A miss handler performs a (possibly blocking) lookup on a resolver worker
- * thread and fills `*out` (uid/gid/ngids/gids/username/sid).  Returns 0 on
+ * thread and fills `*out`: either out->user (uid/gid/ngids/gids/username/sid)
+ * or out->group (gid/groupname/sid) with out->is_group set.  Returns 0 on
  * success, -1 if it cannot resolve the key.  Handlers are tried in registration
  * order until one succeeds.
  */
 typedef int (*chimera_vfs_identity_handler)(
-    enum chimera_vfs_identity_key key,
-    uint32_t                      id,
-    const char                   *name,
-    struct chimera_vfs_user      *out,
-    void                         *private_data);
+    enum chimera_vfs_identity_key       key,
+    uint32_t                            id,
+    const char                         *name,
+    struct chimera_vfs_identity_result *out,
+    void                               *private_data);
 
 struct chimera_vfs_identity *
 chimera_vfs_identity_create(

--- a/src/vfs/vfs_user_cache.h
+++ b/src/vfs/vfs_user_cache.h
@@ -51,22 +51,48 @@ struct chimera_vfs_user {
     char                     sid[CHIMERA_VFS_SID_MAX_LEN];
 };
 
+/*
+ * A group record.  Deliberately a distinct type from chimera_vfs_user rather
+ * than a flag on it: a group is not a user, and sharing the record would put
+ * group entries in the name/uid/sid chains where lookup_by_uid, sid_to_uid and
+ * the username dedup in _add would return or clobber them.  Groups live in
+ * their own two chains below, sharing this cache's write_lock and expiry
+ * thread.
+ */
+struct chimera_vfs_group {
+    uint32_t                  gid;
+    int                       groupname_len;
+    struct timespec           expiration;
+    int                       pinned;
+    struct rcu_head           rcu;
+    struct chimera_vfs_group *next_by_gid;
+    struct chimera_vfs_group *next_by_sid;
+    char                      groupname[256];
+    char                      sid[CHIMERA_VFS_SID_MAX_LEN];
+};
+
 struct chimera_vfs_user_cache_bucket {
     struct chimera_vfs_user *head;
 };
 
+struct chimera_vfs_group_cache_bucket {
+    struct chimera_vfs_group *head;
+};
+
 struct chimera_vfs_user_cache {
-    int                                   num_buckets;
-    int                                   ttl;
-    struct chimera_vfs_user_cache_bucket *name_buckets;
-    struct chimera_vfs_user_cache_bucket *uid_buckets;
-    struct chimera_vfs_user_cache_bucket *sid_buckets;
-    struct chimera_vfs_user              *builtin_users;
-    pthread_mutex_t                       write_lock;
-    pthread_t                             expiry_thread;
-    pthread_mutex_t                       expiry_lock;
-    pthread_cond_t                        expiry_cond;
-    int                                   shutdown;
+    int                                    num_buckets;
+    int                                    ttl;
+    struct chimera_vfs_user_cache_bucket  *name_buckets;
+    struct chimera_vfs_user_cache_bucket  *uid_buckets;
+    struct chimera_vfs_user_cache_bucket  *sid_buckets;
+    struct chimera_vfs_group_cache_bucket *group_gid_buckets;
+    struct chimera_vfs_group_cache_bucket *group_sid_buckets;
+    struct chimera_vfs_user               *builtin_users;
+    pthread_mutex_t                        write_lock;
+    pthread_t                              expiry_thread;
+    pthread_mutex_t                        expiry_lock;
+    pthread_cond_t                         expiry_cond;
+    int                                    shutdown;
 };
 
 static inline unsigned int
@@ -94,6 +120,14 @@ chimera_vfs_user_cache_hash_sid(
     return chimera_vfs_hash(sid, strlen(sid)) % num_buckets;
 } // chimera_vfs_user_cache_hash_sid
 
+static inline unsigned int
+chimera_vfs_group_cache_hash_gid(
+    uint32_t gid,
+    int      num_buckets)
+{
+    return gid % num_buckets;
+} // chimera_vfs_group_cache_hash_gid
+
 static void
 chimera_vfs_user_cache_rcu_free(struct rcu_head *head)
 {
@@ -102,6 +136,55 @@ chimera_vfs_user_cache_rcu_free(struct rcu_head *head)
 
     free(user);
 } // chimera_vfs_user_cache_rcu_free
+
+static void
+chimera_vfs_group_cache_rcu_free(struct rcu_head *head)
+{
+    struct chimera_vfs_group *group = caa_container_of(
+        head, struct chimera_vfs_group, rcu);
+
+    free(group);
+} // chimera_vfs_group_cache_rcu_free
+
+/*
+ * Unlink `group` from the gid and sid chains and schedule it for RCU-deferred
+ * free.  Caller must hold cache->write_lock.
+ */
+static inline void
+chimera_vfs_group_cache_remove_locked(
+    struct chimera_vfs_user_cache *cache,
+    struct chimera_vfs_group      *group)
+{
+    unsigned int               gid_idx, sid_idx;
+    struct chimera_vfs_group **pp;
+
+    gid_idx = chimera_vfs_group_cache_hash_gid(group->gid, cache->num_buckets);
+
+    pp = &cache->group_gid_buckets[gid_idx].head;
+    while (*pp) {
+        if (*pp == group) {
+            rcu_assign_pointer(*pp, group->next_by_gid);
+            break;
+        }
+        pp = &(*pp)->next_by_gid;
+    }
+
+    /* Only indexed by SID when one is known (NSS supplies none). */
+    if (group->sid[0]) {
+        sid_idx = chimera_vfs_user_cache_hash_sid(group->sid,
+                                                  cache->num_buckets);
+        pp = &cache->group_sid_buckets[sid_idx].head;
+        while (*pp) {
+            if (*pp == group) {
+                rcu_assign_pointer(*pp, group->next_by_sid);
+                break;
+            }
+            pp = &(*pp)->next_by_sid;
+        }
+    }
+
+    call_rcu(&group->rcu, chimera_vfs_group_cache_rcu_free);
+} // chimera_vfs_group_cache_remove_locked
 
 /*
  * Unlink `user` from all three index chains and schedule it for RCU-deferred
@@ -163,6 +246,7 @@ chimera_vfs_user_cache_expiry_thread(void *arg)
 {
     struct chimera_vfs_user_cache *cache = arg;
     struct chimera_vfs_user       *user, *next;
+    struct chimera_vfs_group      *group, *group_next;
     struct timespec                ts;
     int                            i;
 
@@ -204,6 +288,21 @@ chimera_vfs_user_cache_expiry_thread(void *arg)
             }
         }
 
+        /* Same sweep, same lock, for the group chains. */
+        for (i = 0; i < cache->num_buckets; i++) {
+            group = cache->group_gid_buckets[i].head;
+            while (group) {
+                group_next = group->next_by_gid;
+                if (!group->pinned &&
+                    (ts.tv_sec > group->expiration.tv_sec ||
+                     (ts.tv_sec == group->expiration.tv_sec &&
+                      ts.tv_nsec >= group->expiration.tv_nsec))) {
+                    chimera_vfs_group_cache_remove_locked(cache, group);
+                }
+                group = group_next;
+            }
+        }
+
         pthread_mutex_unlock(&cache->write_lock);
 
         pthread_mutex_lock(&cache->expiry_lock);
@@ -233,6 +332,11 @@ chimera_vfs_user_cache_create(
     cache->sid_buckets = calloc(num_buckets,
                                 sizeof(struct chimera_vfs_user_cache_bucket));
 
+    cache->group_gid_buckets = calloc(num_buckets,
+                                      sizeof(struct chimera_vfs_group_cache_bucket));
+    cache->group_sid_buckets = calloc(num_buckets,
+                                      sizeof(struct chimera_vfs_group_cache_bucket));
+
     cache->builtin_users = NULL;
 
     pthread_mutex_init(&cache->write_lock, NULL);
@@ -248,8 +352,9 @@ chimera_vfs_user_cache_create(
 static inline void
 chimera_vfs_user_cache_destroy(struct chimera_vfs_user_cache *cache)
 {
-    struct chimera_vfs_user *user, *next;
-    int                      i;
+    struct chimera_vfs_user  *user, *next;
+    struct chimera_vfs_group *group, *group_next;
+    int                       i;
 
     pthread_mutex_lock(&cache->expiry_lock);
     cache->shutdown = 1;
@@ -269,9 +374,20 @@ chimera_vfs_user_cache_destroy(struct chimera_vfs_user_cache *cache)
         }
     }
 
+    for (i = 0; i < cache->num_buckets; i++) {
+        group = cache->group_gid_buckets[i].head;
+        while (group) {
+            group_next = group->next_by_gid;
+            free(group);
+            group = group_next;
+        }
+    }
+
     free(cache->name_buckets);
     free(cache->uid_buckets);
     free(cache->sid_buckets);
+    free(cache->group_gid_buckets);
+    free(cache->group_sid_buckets);
 
     pthread_mutex_destroy(&cache->write_lock);
     pthread_mutex_destroy(&cache->expiry_lock);
@@ -503,6 +619,133 @@ chimera_vfs_user_cache_lookup_by_sid(
     return NULL;
 } // chimera_vfs_user_cache_lookup_by_sid
 
+/*
+ * Add (or refresh) a group record.  Dedup is by gid, not by name: unlike
+ * usernames there is no unique-name guarantee across domains, and gid is the
+ * primary lookup key.  `sid` may be NULL (NSS resolves a gid to a name but
+ * supplies no SID), in which case the record is not indexed by SID and
+ * gid_to_sid will keep missing -- callers then fall back to the algorithmic
+ * idmap SID.
+ */
+static inline int
+chimera_vfs_group_cache_add(
+    struct chimera_vfs_user_cache *cache,
+    const char                    *groupname,
+    const char                    *sid,
+    uint32_t                       gid,
+    int                            pinned)
+{
+    struct chimera_vfs_group *group, *existing;
+    unsigned int              gid_idx, sid_idx;
+    struct timespec           now;
+
+    group = calloc(1, sizeof(*group));
+    snprintf(group->groupname, sizeof(group->groupname), "%s",
+             groupname ? groupname : "");
+    group->groupname_len = (int) strlen(group->groupname);
+    if (sid) {
+        snprintf(group->sid, sizeof(group->sid), "%s", sid);
+    }
+    group->gid    = gid;
+    group->pinned = pinned;
+
+    if (!pinned) {
+        clock_gettime(CLOCK_REALTIME, &now);
+        group->expiration.tv_sec  = now.tv_sec + cache->ttl;
+        group->expiration.tv_nsec = now.tv_nsec;
+    }
+
+    gid_idx = chimera_vfs_group_cache_hash_gid(gid, cache->num_buckets);
+
+    pthread_mutex_lock(&cache->write_lock);
+
+    /* Replace any existing record for this gid. */
+    existing = cache->group_gid_buckets[gid_idx].head;
+    while (existing) {
+        if (existing->gid == gid) {
+            chimera_vfs_group_cache_remove_locked(cache, existing);
+            break;
+        }
+        existing = existing->next_by_gid;
+    }
+
+    group->next_by_gid = cache->group_gid_buckets[gid_idx].head;
+    rcu_assign_pointer(cache->group_gid_buckets[gid_idx].head, group);
+
+    if (group->sid[0]) {
+        sid_idx = chimera_vfs_user_cache_hash_sid(group->sid,
+                                                  cache->num_buckets);
+        group->next_by_sid = cache->group_sid_buckets[sid_idx].head;
+        rcu_assign_pointer(cache->group_sid_buckets[sid_idx].head, group);
+    }
+
+    pthread_mutex_unlock(&cache->write_lock);
+
+    return 0;
+} // chimera_vfs_group_cache_add
+
+/*
+ * Resolve a gid to its cached group record (RCU read-side).
+ *
+ * Note this is NOT chimera_vfs_user_cache_lookup_by_gid below, which despite
+ * the similar name answers a different question: which *users* are members of
+ * a gid.
+ */
+static inline const struct chimera_vfs_group *
+chimera_vfs_group_cache_lookup_by_gid(
+    struct chimera_vfs_user_cache *cache,
+    uint32_t                       gid)
+{
+    unsigned int              gid_idx;
+    struct chimera_vfs_group *group;
+
+    gid_idx = chimera_vfs_group_cache_hash_gid(gid, cache->num_buckets);
+
+    group = rcu_dereference(cache->group_gid_buckets[gid_idx].head);
+    while (group) {
+        if (group->gid == gid) {
+            return group;
+        }
+        group = rcu_dereference(group->next_by_gid);
+    }
+
+    return NULL;
+} // chimera_vfs_group_cache_lookup_by_gid
+
+/*
+ * Resolve a Windows group SID string to its cached group (RCU read-side).
+ * Only groups added with a non-empty SID are indexed here.
+ */
+static inline const struct chimera_vfs_group *
+chimera_vfs_group_cache_lookup_by_sid(
+    struct chimera_vfs_user_cache *cache,
+    const char                    *sid)
+{
+    unsigned int              sid_idx;
+    struct chimera_vfs_group *group;
+
+    if (!sid || !sid[0]) {
+        return NULL;
+    }
+
+    sid_idx = chimera_vfs_user_cache_hash_sid(sid, cache->num_buckets);
+
+    group = rcu_dereference(cache->group_sid_buckets[sid_idx].head);
+    while (group) {
+        if (strcmp(group->sid, sid) == 0) {
+            return group;
+        }
+        group = rcu_dereference(group->next_by_sid);
+    }
+
+    return NULL;
+} // chimera_vfs_group_cache_lookup_by_sid
+
+/*
+ * Which *users* are members of `gid` (primary or supplementary).  Unrelated to
+ * chimera_vfs_group_cache_lookup_by_gid above, which resolves the gid itself to
+ * a group record.
+ */
 static inline int
 chimera_vfs_user_cache_lookup_by_gid(
     struct chimera_vfs_user_cache  *cache,


### PR DESCRIPTION
With winbind enabled, a query-security response returned the correct domain SID
for the file owner but a synthetic algorithmic SID for the group
(`S-1-5-88-2-513` instead of `S-1-5-21-...-513`). winbindd maps the gid
perfectly well; chimera never asked. The identity layer was user-centric end to
end and gids had no resolution path at all: `BY_GID` was an explicit no-op in
the cache probe, both miss handlers returned -1 for it, and there was no
`gid_to_sid` bridge. The inbound direction was equally broken -- a SET-security
carrying a real domain group SID resolved only against the user index, so
domain-group ACEs from a Windows client were silently dropped.

### `vfs: resolve group SIDs through the identity layer`

Gives groups a first-class representation rather than forcing them through the
user record. A new `struct chimera_vfs_group` lives in its own gid and SID
chains inside the existing user cache, reusing its `write_lock`, RCU discipline
and expiry sweep. Keeping the record types separate is the point: a group must
never be reachable from `lookup_by_uid` or `sid_to_uid`, and must not collide
with a user that happens to share its name.

Since a SID is ambiguous until resolved, the resolver now hands back a tagged
`chimera_vfs_identity_result` saying which kind came back, and the winbind
handler calls `wbcLookupSid` to decide before filling -- a group SID previously
failed the user-shaped fill at `wbcSidToUid`, which is what dropped those ACEs.
`BY_GID` is implemented via `wbcGidToSid`, and via `getgrgid_r` in the NSS
handler so the path works without a domain controller.

On the SMB wire, the group SID field and GROUP ACEs now go through the same
real-SID-then-algorithmic-fallback treatment the owner already got, and the
query path pre-resolves gids alongside uids. The group field's fallback stays
the `modefromsid` `S-1-5-88-2` form, since the SET path recovers the gid from it
with `parse_unix_sid`.

Storage is unchanged: this is wire-level only, under the current
numeric-at-rest design.

### `vfs: prefer a SID-bearing miss handler for numeric identity keys`

A field run on top of the above still produced the algorithmic group SID.
`chimera_vfs_identity_run_handlers` stopped at the first handler that returned
success: NSS is registered first, and on a host whose nsswitch routes group
through winbind, `getgrgid_r` succeeded inside NSS and returned the group name
-- with no SID, because NSS has no notion of one. The winbind handler, the only
one that calls `wbcGidToSid`, was never reached. The group was then cached
SID-less, and because a cache hit suppresses any further resolve, the SID could
never arrive; `gid_to_sid` missed permanently and the marshaller fell back to
`S-1-5-88-2-<gid>` for the life of the entry.

The owner escaped this only by accident of another path: session setup caches
the authenticated user together with the real SID winbind handed back at logon,
so the resolver is never consulted for the owner uid. Groups have no
equivalent, which is why the two halves of the same descriptor disagreed.

For the numeric keys, a SID-less success is now provisional: keep walking the
handler list in case a later one can name the same identity properly, and fall
back to the provisional answer only if none can. This is safe because the key
is numeric -- every handler is asked about the same uid/gid, so they can differ
on the SID but not on which identity it is. `BY_NAME` and `BY_SID` stay
first-wins, where the key is a string two handlers could legitimately resolve to
different accounts (a local "alice" and a domain "alice") and preferring the SID
would quietly change which one wins.

`BY_UID` gets the same treatment as `BY_GID`. It was latently broken in the same
way and is masked today only by the session-setup caching above, so a file owned
by a domain user who has not authenticated on this connection would have emitted
an algorithmic owner SID too.

Unit coverage comes with both commits: group records in the user cache (gid/SID
round trip, dedup by gid, TTL expiry, disjointness from the user chains), and a
resolver test that registers a stand-in SID-bearing handler after NSS for a gid
NSS can also resolve -- the overlap is the point -- asserting the SID-bearing
answer wins and reaches `gid_to_sid`.
