### PR TITLE
nfsaux: model-based tests for portmap, MOUNT, NLM and NSM (+3 server fixes)

### DIFF
--- a/src/nfs_common/portmap.x
+++ b/src/nfs_common/portmap.x
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: IETF Trust and the persons identified
+ * SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -40,6 +41,23 @@ struct rpcb {
 struct rp__list {
     rpcb rpcb_map;
     rp__list *next;
+};
+
+/*
+ * RFC 1833 declares the rpcbind DUMP procedures as returning a bare
+ * "rp__list *" (an optional pointer chain).  xdrzcc emits an asymmetric
+ * codec for a procedure whose result is a recursive type used directly:
+ * the marshaller writes the RFC encoding (value-follows boolean + body,
+ * repeated, terminated by a zero boolean) but the generated *client*
+ * unmarshaller decodes a single bare body and consumes no booleans, so
+ * every reply fails to decode.  Wrapping the chain in a one-field struct
+ * makes the two symmetric; the wire encoding of an optional pointer inside
+ * a struct is byte-for-byte the RFC's list, so this is not a protocol
+ * change.  mount.x carries the same wrapper (mountdumpres) for
+ * MOUNTPROC3_DUMP, for the same reason.
+ */
+struct rpcbdumpres {
+    rp__list *maps;
 };
 
 /*
@@ -162,6 +180,11 @@ struct pmaplist {
     pmaplist *next;
 };
 
+/* The PMAP v2 counterpart of rpcbdumpres; see the note there. */
+struct pmapdumpres {
+    pmaplist *maps;
+};
+
 /* Arguments to callit */
 struct call_args {
     unsigned int prog;
@@ -183,7 +206,7 @@ program PORTMAP {
         bool PMAPPROC_SET(mapping) = 1;
         bool PMAPPROC_UNSET(mapping) = 2;
         unsigned int PMAPPROC_GETPORT(mapping) = 3;
-        pmaplist PMAPPROC_DUMP(void) = 4;
+        pmapdumpres PMAPPROC_DUMP(void) = 4;
         call_result PMAPPROC_CALLIT(call_args) = 5;
     } = 2;
 
@@ -191,7 +214,7 @@ program PORTMAP {
         bool rpcbproc_set(rpcb) = 1;
         bool rpcbproc_unset(rpcb) = 2;
         string rpcbproc_getaddr(rpcb) = 3;
-        rp__list *rpcbproc_dump(void) = 4;
+        rpcbdumpres rpcbproc_dump(void) = 4;
         rpcb_rmtcallres rpcbproc_callit(rpcb_rmtcallargs) = 5;
         unsigned int rpcbproc_gettime(void) = 6;
         netbuf rpcbproc_uaddr2taddr(string) = 7;
@@ -202,7 +225,7 @@ program PORTMAP {
         bool RPCBPROC_SET(rpcb) = 1;
         bool RPCBPROC_UNSET(rpcb) = 2;
         string RPCBPROC_GETADDR(rpcb) = 3;
-        rp__list *RPCBPROC_DUMP(void) = 4;
+        rpcbdumpres RPCBPROC_DUMP(void) = 4;
 
         /*
          * NOTE: RPCBPROC_BCAST has the same functionality as CALLIT.

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -96,20 +96,53 @@ nlm_owner_owner_lo(
     return XXH3_64bits(buf, oh_len + sizeof(svid));
 } /* nlm_owner_owner_lo */
 
+/*
+ * The *_RES half of NLM is fire-and-forget: the server reports the result of
+ * an asynchronous (*_MSG) request and has no use for whatever the client
+ * answers.  It still has to hand the generated stub a reply callback, because
+ * the reply dispatcher invokes it unconditionally -- passing NULL there
+ * crashes the server the moment a client acknowledges the call, which every
+ * conforming RPC client does.
+ */
+static void
+nlm4_res_sent_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    int                          status,
+    void                        *private_data)
+{
+    (void) evpl;
+    (void) verf;
+    (void) private_data;
+
+    if (status) {
+        chimera_nfs_debug("NLM asynchronous result was not acknowledged: %d",
+                          status);
+    }
+} /* nlm4_res_sent_cb */
+
 /* -------------------------------------------------------------------------
- * Helper: send a simple nlm4_res reply
+ * Helper: deliver an nlm4_res outcome for whichever procedure asked for it.
+ *
+ * The synchronous procedures answer on their own RPC.  The asynchronous ones
+ * have already acknowledged the request with a void reply, so their outcome
+ * travels as a *_RES CALL back to the client -- which is why this needs the
+ * connection as well as the encoding.  An unhandled proc here would drop the
+ * outcome silently and leave the client waiting forever, so the default arm
+ * is loud rather than a no-op.
  * ---------------------------------------------------------------------- */
 static void
 nlm4_send_res(
     struct chimera_server_nfs_shared *shared,
     struct evpl                      *evpl,
+    struct evpl_rpc2_conn            *conn,
     struct evpl_rpc2_encoding        *encoding,
     const xdr_opaque                 *cookie,
     nlm4_stats                        stat,
     int                               proc)
 {
     struct nlm4_res res;
-    int             rc;
+    int             rc = 0;
 
     res.cookie.len  = cookie ? cookie->len : 0;
     res.cookie.data = cookie ? cookie->data : NULL;
@@ -128,11 +161,23 @@ nlm4_send_res(
         case 5:
             rc = shared->nlm_v4.send_reply_NLMPROC4_GRANTED(evpl, NULL, &res, encoding);
             break;
+        case 17:   /* NLMPROC4_LOCK_MSG   -> NLMPROC4_LOCK_RES   */
+            shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
+                                                       nlm4_res_sent_cb, NULL);
+            break;
+        case 18:   /* NLMPROC4_UNLOCK_MSG -> NLMPROC4_UNLOCK_RES */
+            shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
+                                                         nlm4_res_sent_cb, NULL);
+            break;
+        case 19:   /* NLMPROC4_CANCEL_MSG -> NLMPROC4_CANCEL_RES */
+            shared->nlm_v4.send_call_NLMPROC4_CANCEL_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
+                                                         nlm4_res_sent_cb, NULL);
+            break;
         case 22:
             rc = shared->nlm_v4.send_reply_NLMPROC4_NM_LOCK(evpl, NULL, &res, encoding);
             break;
         default:
-            rc = 0;
+            chimera_nfs_abort_if(1, "No NLM result delivery for proc %d", proc);
             break;
     } /* switch */
     chimera_nfs_abort_if(rc, "Failed to send NLM res reply");
@@ -246,7 +291,7 @@ chimera_nfs_nlm4_test_open_cb(
     if (ctx->proc == 16) {
         shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl,
                                                    ctx->conn, NULL, &res, 0, 0, NULL, 0, 0,
-                                                   NULL, NULL);
+                                                   nlm4_res_sent_cb, NULL);
     } else {
         rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &res, encoding);
         chimera_nfs_abort_if(rc, "Failed to send NLM TEST reply");
@@ -353,7 +398,7 @@ chimera_nfs_nlm4_lock_blocked_cb(void *private_data)
     if (ctx->proc == 17) {
         shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl,
                                                    ctx->conn, NULL, &res, 0, 0,
-                                                   NULL, 0, 0, NULL, NULL);
+                                                   NULL, 0, 0, nlm4_res_sent_cb, NULL);
     } else {
         rc = shared->nlm_v4.send_reply_NLMPROC4_LOCK(evpl, NULL, &res, encoding);
         chimera_nfs_abort_if(rc, "Failed to send NLM4_BLOCKED reply");
@@ -441,7 +486,7 @@ chimera_nfs_nlm4_lock_acquire_cb(
             break;
         case 17:
             shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL, 0,
-                                                       0, NULL,
+                                                       0, nlm4_res_sent_cb,
                                                        NULL);
             break;
         default:
@@ -487,7 +532,7 @@ chimera_nfs_nlm4_lock_open_cb(
             case 17:
                 shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL
                                                            , 0, 0,
-                                                           NULL, NULL);
+                                                           nlm4_res_sent_cb, NULL);
                 break;
             default:
                 rc = shared->nlm_v4.send_reply_NLMPROC4_NM_LOCK(evpl, NULL, &res, encoding);
@@ -520,7 +565,7 @@ chimera_nfs_nlm4_lock_open_cb(
             case 17:
                 shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL
                                                            , 0, 0,
-                                                           NULL, NULL);
+                                                           nlm4_res_sent_cb, NULL);
                 break;
             default:
                 rc = shared->nlm_v4.send_reply_NLMPROC4_NM_LOCK(evpl, NULL, &res, encoding);
@@ -629,7 +674,7 @@ chimera_nfs_nlm4_do_test(
         err_res.test_stat.stat = NLM4_STALE_FH;
         if (proc == 16) {
             shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &err_res, 0, 0, NULL, 0,
-                                                       0, NULL,
+                                                       0, nlm4_res_sent_cb,
                                                        NULL);
         } else {
             int rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &err_res, encoding);
@@ -646,7 +691,7 @@ chimera_nfs_nlm4_do_test(
         err_res.test_stat.stat = NLM4_DENIED_NOLOCKS;
         if (proc == 16) {
             shared->nlm_v4.send_call_NLMPROC4_TEST_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &err_res, 0, 0, NULL, 0,
-                                                       0, NULL,
+                                                       0, nlm4_res_sent_cb,
                                                        NULL);
         } else {
             int oom_rc = shared->nlm_v4.send_reply_NLMPROC4_TEST(evpl, NULL, &err_res, encoding);
@@ -756,14 +801,14 @@ chimera_nfs_nlm4_do_lock(
     if (chimera_nfs_fh_unwrap(args->alock.fh.data, args->alock.fh.len, &vexp,
                               vfh, &vfh_len, shared->fh_key, shared->fh_sign) !=
         CHIMERA_NFS_FH_OK) {
-        nlm4_send_res(shared, evpl, encoding, &args->cookie, NLM4_STALE_FH, proc);
+        nlm4_send_res(shared, evpl, conn, encoding, &args->cookie, NLM4_STALE_FH, proc);
         return;
     }
 
     /* Build the in-flight lock entry (handle filled in by open callback) */
     entry = nlm_lock_entry_alloc();
     if (!entry) {
-        nlm4_send_res(shared, evpl, encoding, &args->cookie, NLM4_DENIED_NOLOCKS, proc);
+        nlm4_send_res(shared, evpl, conn, encoding, &args->cookie, NLM4_DENIED_NOLOCKS, proc);
         return;
     }
     entry->fh_len = args->alock.fh.len < NFS4_FHSIZE ? args->alock.fh.len : NFS4_FHSIZE;
@@ -780,7 +825,7 @@ chimera_nfs_nlm4_do_lock(
     ctx = calloc(1, sizeof(*ctx));
     if (!ctx) {
         nlm_lock_entry_free(entry);
-        nlm4_send_res(shared, evpl, encoding, &args->cookie, NLM4_DENIED_NOLOCKS, proc);
+        nlm4_send_res(shared, evpl, conn, encoding, &args->cookie, NLM4_DENIED_NOLOCKS, proc);
         return;
     }
     ctx->thread   = thread;
@@ -822,7 +867,7 @@ chimera_nfs_nlm4_do_lock(
                 break;
             case 17:
                 shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0,
-                                                           0, NULL,
+                                                           0, nlm4_res_sent_cb,
                                                            NULL);
                 break;
             default:
@@ -841,7 +886,7 @@ chimera_nfs_nlm4_do_lock(
         pthread_mutex_unlock(&shared->nlm_state.mutex);
         nlm_lock_entry_free(entry);
         free(ctx);
-        nlm4_send_res(shared, evpl, encoding, &args->cookie, NLM4_DENIED_NOLOCKS, proc);
+        nlm4_send_res(shared, evpl, conn, encoding, &args->cookie, NLM4_DENIED_NOLOCKS, proc);
         return;
     }
     ctx->client = client;
@@ -871,7 +916,7 @@ chimera_nfs_nlm4_do_lock(
             case 17:
                 shared->nlm_v4.send_call_NLMPROC4_LOCK_RES(&shared->nlm_v4.rpc2, evpl, ctx->conn, NULL, &res, 0, 0, NULL
                                                            , 0, 0,
-                                                           NULL, NULL);
+                                                           nlm4_res_sent_cb, NULL);
                 break;
             default:
                 rc = shared->nlm_v4.send_reply_NLMPROC4_NM_LOCK(evpl, NULL, &res, encoding);
@@ -919,37 +964,32 @@ chimera_nfs_nlm4_lock(
                              false, 2);
 } /* chimera_nfs_nlm4_lock */
 
-void
-chimera_nfs_nlm4_cancel(
+static void
+chimera_nfs_nlm4_do_cancel(
     struct evpl               *evpl,
     struct evpl_rpc2_conn     *conn,
     struct evpl_rpc2_cred     *cred,
     struct nlm4_cancargs      *args,
     struct evpl_rpc2_encoding *encoding,
-    void                      *private_data)
+    void                      *private_data,
+    int                        proc)
 {
     struct chimera_server_nfs_thread *thread    = private_data;
     struct chimera_server_nfs_shared *shared    = thread->shared;
     struct chimera_vfs_state         *vfs_state = thread->vfs->vfs_state;
     struct nlm_client                *client;
     struct nlm_lock_entry            *entry, *match;
-    struct nlm4_res                   res;
     char                              safe_hostname[LM_MAXSTRLEN + 1];
     size_t                            hn_len;
     uint64_t                          want_length;
     bool                              cancelled       = false;
     void                             *ctx_for_lock_cb = NULL;
-    int                               rc;
 
     chimera_nfs_debug("NLM CANCEL: caller='%.*s' fh_len=%u offset=%lu len=%lu",
                       (int) args->alock.caller_name.len, args->alock.caller_name.str,
                       (unsigned) args->alock.fh.len,
                       (unsigned long) args->alock.l_offset,
                       (unsigned long) args->alock.l_len);
-
-    res.cookie.len  = args->cookie.len;
-    res.cookie.data = args->cookie.data;
-    res.stat        = NLM4_GRANTED;
 
     hn_len = args->alock.caller_name.len < LM_MAXSTRLEN
              ? args->alock.caller_name.len : LM_MAXSTRLEN;
@@ -998,13 +1038,26 @@ chimera_nfs_nlm4_cancel(
         ctx_for_lock_cb = match->ticket.private_data;
     }
 
-    rc = shared->nlm_v4.send_reply_NLMPROC4_CANCEL(evpl, NULL, &res, encoding);
-    chimera_nfs_abort_if(rc, "Failed to send NLM CANCEL reply");
+    nlm4_send_res(shared, evpl, conn, encoding, &args->cookie, NLM4_GRANTED,
+                  proc);
 
     if (cancelled && ctx_for_lock_cb) {
         chimera_nfs_nlm4_lock_acquire_cb(CHIMERA_CLAIM_DENIED, NULL, NULL,
                                          ctx_for_lock_cb);
     }
+} /* chimera_nfs_nlm4_do_cancel */
+
+void
+chimera_nfs_nlm4_cancel(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct nlm4_cancargs      *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    chimera_nfs_nlm4_do_cancel(evpl, conn, cred, args, encoding, private_data,
+                               3);
 } /* chimera_nfs_nlm4_cancel */
 
 static void
@@ -1050,7 +1103,7 @@ chimera_nfs_nlm4_do_unlock(
         res.stat        = NLM4_GRANTED;
         if (proc == 18) {
             shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
-                                                         NULL,
+                                                         nlm4_res_sent_cb,
                                                          NULL);
         } else {
             rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
@@ -1076,7 +1129,7 @@ chimera_nfs_nlm4_do_unlock(
         res.stat        = NLM4_GRANTED;
         if (proc == 18) {
             shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
-                                                         NULL,
+                                                         nlm4_res_sent_cb,
                                                          NULL);
         } else {
             rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
@@ -1113,7 +1166,7 @@ chimera_nfs_nlm4_do_unlock(
 
     if (proc == 18) {
         shared->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0,
-                                                     NULL,
+                                                     nlm4_res_sent_cb,
                                                      NULL);
     } else {
         rc = shared->nlm_v4.send_reply_NLMPROC4_UNLOCK(evpl, NULL, &res, encoding);
@@ -1212,18 +1265,17 @@ chimera_nfs_nlm4_cancel_msg(
     struct chimera_server_nfs_shared *shared = thread->shared;
     int                               rc;
 
-    struct nlm4_res                   res;
-
     chimera_nfs_debug("NLM CANCEL_MSG received");
 
     rc = shared->nlm_v4.send_reply_NLMPROC4_CANCEL_MSG(evpl, NULL, encoding);
     chimera_nfs_abort_if(rc, "Failed to send NLM CANCEL_MSG reply");
-    /* No pending-lock queue, so there is nothing to cancel.  Reply granted. */
-    res.cookie.len  = args->cookie.len;
-    res.cookie.data = args->cookie.data;
-    res.stat        = NLM4_GRANTED;
-    shared->nlm_v4.send_call_NLMPROC4_CANCEL_RES(&shared->nlm_v4.rpc2, evpl, conn, NULL, &res, 0, 0, NULL, 0, 0, NULL,
-                                                 NULL);
+
+    /* RFC 1813 gives the asynchronous form the same meaning as the
+     * synchronous one, so it does the same work -- withdrawing a queued
+     * blocking LOCK -- and reports the outcome through NLMPROC4_CANCEL_RES.
+     * Acknowledging without cancelling would leave the client's blocking
+     * LOCK queued for a range it has given up on. */
+    chimera_nfs_nlm4_do_cancel(evpl, conn, cred, args, NULL, private_data, 19);
 } /* chimera_nfs_nlm4_cancel_msg */
 
 void

--- a/src/server/nfs/nfs_nlm_granted.c
+++ b/src/server/nfs/nfs_nlm_granted.c
@@ -420,13 +420,19 @@ nlm_granter_thread_init(
     return ctx;
 } /* nlm_granter_thread_init */
 
+/*
+ * Note the private_data this receives: evpl_thread_function REPLACES the
+ * thread's private_data with whatever the init callback returned, so what
+ * arrives here is the nlm_grant_ctx, not the nlm_granter that was handed to
+ * evpl_thread_create.  The granter is reached through the ctx.
+ */
 static void
 nlm_granter_thread_shutdown(
     struct evpl *evpl,
     void        *private_data)
 {
-    struct nlm_granter      *granter = private_data;
-    struct nlm_grant_ctx    *ctx     = nlm_grant_tls_ctx;
+    struct nlm_grant_ctx    *ctx     = private_data;
+    struct nlm_granter      *granter = ctx ? ctx->granter : NULL;
     struct nlm_grant_job    *job, *tmp;
     struct nlm_grant_intake *head, *node, *next;
 
@@ -437,6 +443,11 @@ nlm_granter_thread_shutdown(
             nlm_grant_job_finish(job);
         }
         evpl_rpc2_thread_destroy(ctx->rpc2_thread);
+    }
+
+    if (!granter) {
+        nlm_grant_tls_ctx = NULL;
+        return;
     }
 
     evpl_remove_doorbell(evpl, &granter->doorbell);

--- a/src/server/nfs/nfs_portmap.c
+++ b/src/server/nfs/nfs_portmap.c
@@ -278,12 +278,12 @@ chimera_portmap_dump_v2(
 {
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
-    struct pmaplist                  *list;
+    struct pmapdumpres                res;
     int                               rc;
 
-    list = portmap_build_pmaplist(encoding->dbuf);
+    res.maps = portmap_build_pmaplist(encoding->dbuf);
 
-    rc = shared->portmap_v2.send_reply_PMAPPROC_DUMP(evpl, NULL, list, encoding);
+    rc = shared->portmap_v2.send_reply_PMAPPROC_DUMP(evpl, NULL, &res, encoding);
     chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
 } /* chimera_portmap_dump */
 
@@ -357,15 +357,15 @@ portmap_dump_common(
     int (                     *send_reply )(
         struct evpl *,
         const struct evpl_rpc2_verf *,
-        struct rp__list *,
+        struct rpcbdumpres *,
         struct evpl_rpc2_encoding *))
 {
-    struct rp__list *list;
-    int              rc;
+    struct rpcbdumpres res;
+    int                rc;
 
-    list = portmap_build_rpcblist(conn, override_addr, encoding->dbuf);
+    res.maps = portmap_build_rpcblist(conn, override_addr, encoding->dbuf);
 
-    rc = send_reply(evpl, NULL, list, encoding);
+    rc = send_reply(evpl, NULL, &res, encoding);
     chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");
 } /* portmap_dump_common */
 

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -2,14 +2,20 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
-# NFS3/NFS4 model-based tests: the Quint specifications and their trace
-# generation live in the chimera-nas/specs repo (submodule ext/specs); this
-# directory owns only the C replay harness that drives that corpus against the
-# live chimera server.  The replayers (nfs3_mbt_replay.c, nfs4_mbt_replay.c)
-# embed the chimera server (memfs backend) in the test process and replay each
-# trace over libevpl's inproc transport, failing on any divergence.  No test
-# binds a port, needs a network namespace or resource lock, or spawns a daemon
-# -- every trace runs fully parallel on any host.
+# NFS model-based tests: the Quint specifications and their trace generation
+# live in the chimera-nas/specs repo (submodule ext/specs); this directory owns
+# only the C replay harnesses that drive that corpus against the live chimera
+# server.  Three suites:
+#
+#   nfs3_mbt_replay.c     NFSv3           (specs corpus nfs3/)
+#   nfs4_mbt_replay.c     NFSv4.0/4.1/4.2 (specs corpus nfs4/)
+#   nfs_aux_mbt_replay.c  the four protocols around NFSv3 -- portmap/rpcbind,
+#                         MOUNT, NLM and NSM (specs corpus nfsaux/)
+#
+# Each embeds the chimera server (memfs backend) in the test process and replays
+# every trace over libevpl's inproc transport, failing on any divergence.  No
+# test binds a port, needs a network namespace or resource lock, or spawns a
+# daemon -- every trace runs fully parallel on any host.
 #
 # The trace corpus is resolved once, at the top level, by cmake/SpecsBundle.cmake
 # into SPECS_BUNDLE_DIR (a fetched prebuilt bundle when the submodule is clean,
@@ -18,8 +24,9 @@
 # no corpus and always run.
 
 # The C replayers + probes: chimera server + rpc2 client in one process over the
-# inproc transport (see nfs3_mbt_common.h).  They build regardless of whether a
-# trace corpus is available.
+# inproc transport (see nfs3_mbt_common.h, and nfs_aux_mbt_common.h for the
+# auxiliary protocols' client half).  They build regardless of whether a trace
+# corpus is available.
 add_executable(nfs3_mbt_replay nfs3_mbt_replay.c)
 target_include_directories(nfs3_mbt_replay PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
@@ -38,6 +45,18 @@ target_include_directories(nfs4_deleg_probe PRIVATE
 target_link_libraries(nfs4_deleg_probe
     chimera_server chimera_nfs_common jansson)
 
+add_executable(nfs_aux_probe nfs_aux_probe.c)
+target_include_directories(nfs_aux_probe PRIVATE
+    ${CMAKE_BINARY_DIR}/src/nfs_common)
+target_link_libraries(nfs_aux_probe
+    chimera_server chimera_nfs_common jansson)
+
+add_executable(nfs_aux_mbt_replay nfs_aux_mbt_replay.c)
+target_include_directories(nfs_aux_mbt_replay PRIVATE
+    ${CMAKE_BINARY_DIR}/src/nfs_common)
+target_link_libraries(nfs_aux_mbt_replay
+    chimera_server chimera_nfs_common jansson)
+
 add_executable(nfs4_mbt_replay nfs4_mbt_replay.c)
 target_include_directories(nfs4_mbt_replay PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
@@ -53,6 +72,15 @@ add_test(NAME chimera/server/nfs/mbt/deviation_probe_memfs
 set_tests_properties(chimera/server/nfs/mbt/deviation_probe_memfs PROPERTIES
     LABELS "quint;nfs3_mbt;memfs"
     TIMEOUT 60)
+
+# Auxiliary-protocol ground truth: pins which portmap/rpcbind, MOUNT, NLM and
+# NSM procedures chimera registers, and the constants their replies carry --
+# the facts the nfsaux model's configuration gate encodes.  Needs no corpus.
+add_test(NAME chimera/server/nfs/mbtaux/probe_memfs
+    COMMAND $<TARGET_FILE:nfs_aux_probe>)
+set_tests_properties(chimera/server/nfs/mbtaux/probe_memfs PROPERTIES
+    LABELS "nfsaux_mbt;memfs"
+    TIMEOUT 120)
 
 # Delegation policy probe: pins the deterministic grant/recall behavior the
 # delegation-enabled instances encode (see nfs4_deleg_probe.c).  Needs no corpus.
@@ -105,6 +133,26 @@ if(CAIRN_ENABLED)
         LABELS "quint;nfs3_mbt;cairn"
         TIMEOUT 300)
 endif()
+
+# The auxiliary protocols (portmap/rpcbind, MOUNT, NLM, NSM) replayed from the
+# nfsaux corpus.  One batch: the four protocols share one model because they
+# share state (a granted lock monitors its holder, a notify drops its locks),
+# and the mixed trace flavors are what reach those seams.
+#
+# --paranoid is on deliberately.  Comparing replies alone does not just
+# MISLOCATE a lock-table divergence -- it can miss one entirely, because a lock
+# the server failed to grant or release is invisible until some later operation
+# happens to collide with it, and nothing guarantees one does.  The flag probes
+# each file's ranges after every step against the model's own lock set, so a
+# divergence is both caught and reported where it is created.  It costs roughly
+# a quarter more wall time; the timeout is set for an instrumented build, where
+# it is several times slower than the release run it was measured in.
+add_test(NAME chimera/server/nfs/mbtaux/batch_memfs
+    COMMAND $<TARGET_FILE:nfs_aux_mbt_replay> --paranoid
+            --trace-dir ${SPECS_BUNDLE_DIR}/nfsaux)
+set_tests_properties(chimera/server/nfs/mbtaux/batch_memfs PROPERTIES
+    LABELS "nfsaux_mbt;memfs"
+    TIMEOUT 600)
 
 # SKIP_RETURN_CODE 77 still applies to NFS4: a trace whose capability profile
 # does not match the live server exits 77 individually; the batch reports SKIP

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -36,18 +36,26 @@
 #include "nfs3_xdr.h"
 #include "nfs4_xdr.h"
 #include "nfs_mount_xdr.h"
+#include "portmap_xdr.h"
+#include "nlm4_xdr.h"
+#include "sm_inter_xdr.h"
 
 #include "evpl/evpl.h"
 #include "evpl/evpl_rpc2.h"
 
-#define MBT_MAX_ENTRIES 512     /* readdir entries copied out per reply */
-#define MBT_NAME_MAX    256
-#define MBT_MAX_DATA    (4 << 20) /* read payload copy-out bound */
+#define MBT_MAX_ENTRIES  512    /* readdir entries copied out per reply */
+#define MBT_NAME_MAX     256
+#define MBT_MAX_DATA     (4 << 20) /* read payload copy-out bound */
 
 /* Must match NFS_MOUNT_PORT in nfs_external_portmap.h: under inproc the
  * port number is only a service name ("chimera-inproc-20048"), but it
- * still has to be the name the server registered. */
-#define MBT_MOUNT_PORT  20048
+ * still has to be the name the server registered.  The auxiliary services
+ * follow the same rule: 111 is hardwired in nfs.c, the other two are the
+ * nfs_lockmgr_port / nfs_nsm_port defaults (server.c). */
+#define MBT_MOUNT_PORT   20048
+#define MBT_PORTMAP_PORT 111
+#define MBT_NLM_PORT     32803
+#define MBT_NSM_PORT     32765
 
 struct mbt_fh {
     int      has;
@@ -120,6 +128,15 @@ struct mbt_env_opts {
     const char *module;           /* VFS backend: NULL/"memfs", "diskfs",
                                    * "cairn".  diskfs/cairn self-provision
                                    * scratch under the env's session_dir. */
+    /* Auxiliary NFS services (portmap/rpcbind, NLM, NSM).  Off by default:
+     * the NFS3/NFS4 suites never touch them, and connecting three more
+     * inproc services per replay process is pure overhead there. */
+    int         aux;
+    /* server.portmap_hostname: when set, portmap universal addresses are
+     * built from this host instead of the connection's local address.  The
+     * aux suite uses it to make the uaddr predictable (the inproc local
+     * address is not an IP). */
+    const char *portmap_hostname;
 };
 
 struct mbt_env {
@@ -136,6 +153,21 @@ struct mbt_env {
     struct NFS_V4              nfs_v4;
     struct NFS_V4_CB           nfs_v4_cb;
     struct evpl_rpc2_cred      cred;
+
+    /* Auxiliary services, connected only when mbt_env_opts.aux is set.  The
+     * programs are registered on the client rpc2 thread either way, which
+     * costs nothing and lets the server call back into this process (NLM's
+     * *_RES messages ride the same connection the *_MSG arrived on). */
+    struct evpl_rpc2_conn     *portmap_conn;
+    struct evpl_rpc2_conn     *nlm_conn;
+    struct evpl_rpc2_conn     *nsm_conn;
+    struct PORTMAP_V2          pm_v2;
+    struct PORTMAP_V3          pm_v3;
+    struct PORTMAP_V4          pm_v4;
+    struct NLM_V4              nlm_v4;
+    struct SM_INTER_V1         nsm_v1;
+    /* struct mbt_aux_result *, owned by nfs_aux_mbt_common.h. */
+    void                      *aux;
 
     char                       session_dir[256];
     char                       pt_root[256]; /* passthrough backing root
@@ -202,9 +234,10 @@ mbt_env_open_opts(
     const struct mbt_env_opts *opts)
 {
     struct chimera_server_config *config;
-    struct evpl_rpc2_program     *programs[4];
+    struct evpl_rpc2_program     *programs[9];
     struct evpl_endpoint         *nfs_ep;
     struct evpl_endpoint         *mount_ep;
+    int                           aux = opts && opts->aux;
 
     memset(env, 0, sizeof(*env));
 
@@ -233,6 +266,10 @@ mbt_env_open_opts(
     if (opts) {
         if (opts->nfs4_delegations) {
             chimera_server_config_set_nfs4_delegations(config, 1);
+        }
+        if (opts->portmap_hostname) {
+            chimera_server_config_set_portmap_hostname(config,
+                                                       opts->portmap_hostname);
         }
         if (opts->disable_caches) {
             chimera_server_config_set_attr_cache_enabled(config, 0);
@@ -324,13 +361,23 @@ mbt_env_open_opts(
     NFS_MOUNT_V3_init(&env->mount_v3);
     NFS_V4_init(&env->nfs_v4);
     NFS_V4_CB_init(&env->nfs_v4_cb);
+    PORTMAP_V2_init(&env->pm_v2);
+    PORTMAP_V3_init(&env->pm_v3);
+    PORTMAP_V4_init(&env->pm_v4);
+    NLM_V4_init(&env->nlm_v4);
+    SM_INTER_V1_init(&env->nsm_v1);
 
     programs[0] = &env->nfs_v3.rpc2;
     programs[1] = &env->mount_v3.rpc2;
     programs[2] = &env->nfs_v4.rpc2;
     programs[3] = &env->nfs_v4_cb.rpc2;
+    programs[4] = &env->pm_v2.rpc2;
+    programs[5] = &env->pm_v3.rpc2;
+    programs[6] = &env->pm_v4.rpc2;
+    programs[7] = &env->nlm_v4.rpc2;
+    programs[8] = &env->nsm_v1.rpc2;
 
-    env->rpc2_thread = evpl_rpc2_thread_init(env->evpl, programs, 4,
+    env->rpc2_thread = evpl_rpc2_thread_init(env->evpl, programs, 9,
                                              NULL, NULL);
 
     /* Endpoint names must match what the server derived from its ports
@@ -350,6 +397,40 @@ mbt_env_open_opts(
     if (!env->nfs_conn || !env->mount_conn) {
         fprintf(stderr, "failed to connect to in-process server\n");
         exit(1);
+    }
+
+    if (aux) {
+        /* The NLM connection also SERVES NLM_V4: the asynchronous half of the
+         * protocol (NLMPROC4_*_MSG) is answered by the server calling
+         * NLMPROC4_*_RES back on this very connection, so the client end has
+         * to export the program to receive them.  env rides along as the
+         * dispatch private_data. */
+        static struct evpl_rpc2_program *nlm_srv[1];
+        struct evpl_endpoint            *pm_ep, *nlm_ep, *nsm_ep;
+
+        pm_ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
+                                                   "127.0.0.1",
+                                                   MBT_PORTMAP_PORT);
+        nlm_ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
+                                                    "127.0.0.1", MBT_NLM_PORT);
+        nsm_ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
+                                                    "127.0.0.1", MBT_NSM_PORT);
+
+        env->portmap_conn = evpl_rpc2_client_connect(env->rpc2_thread,
+                                                     EVPL_STREAM_INPROC,
+                                                     pm_ep, NULL, 0, NULL);
+        nlm_srv[0]    = &env->nlm_v4.rpc2;
+        env->nlm_conn = evpl_rpc2_client_connect(env->rpc2_thread,
+                                                 EVPL_STREAM_INPROC,
+                                                 nlm_ep, nlm_srv, 1, env);
+        env->nsm_conn = evpl_rpc2_client_connect(env->rpc2_thread,
+                                                 EVPL_STREAM_INPROC,
+                                                 nsm_ep, NULL, 0, NULL);
+
+        if (!env->portmap_conn || !env->nlm_conn || !env->nsm_conn) {
+            fprintf(stderr, "failed to connect to in-process aux services\n");
+            exit(1);
+        }
     }
 
     /* AUTH_SYS root credential (uid 0, gid 0) so access
@@ -486,6 +567,15 @@ mbt_env_stop(struct mbt_env *env)
 {
     char cmd[300];
 
+    if (env->portmap_conn) {
+        evpl_rpc2_client_disconnect(env->rpc2_thread, env->portmap_conn);
+    }
+    if (env->nlm_conn) {
+        evpl_rpc2_client_disconnect(env->rpc2_thread, env->nlm_conn);
+    }
+    if (env->nsm_conn) {
+        evpl_rpc2_client_disconnect(env->rpc2_thread, env->nsm_conn);
+    }
     evpl_rpc2_client_disconnect(env->rpc2_thread, env->nfs_conn);
     evpl_rpc2_client_disconnect(env->rpc2_thread, env->mount_conn);
     evpl_rpc2_thread_destroy(env->rpc2_thread);
@@ -526,6 +616,23 @@ mbt_call_wait(struct mbt_env *env)
         exit(3);
     }
 } /* mbt_call_wait */
+
+/* Same pump, but an RPC-level refusal is a modeled outcome rather than a
+ * harness bug: the auxiliary suite deliberately calls procedures chimera
+ * does not implement and expects PROC_UNAVAIL (accept_stat 3) back.  A
+ * negative status still means the transport itself failed (see
+ * EVPL_RPC2_REPLY_* in evpl_rpc2_program.h) and is fatal here too. */
+static inline void
+mbt_call_wait_soft(struct mbt_env *env)
+{
+    while (!env->res.done) {
+        evpl_continue(env->evpl);
+    }
+    if (env->res.rpc_err < 0) {
+        fprintf(stderr, "rpc2 transport error %d\n", env->res.rpc_err);
+        exit(3);
+    }
+} /* mbt_call_wait_soft */
 
 /* ---- MOUNT --------------------------------------------------------------- */
 

--- a/src/server/nfs/tests/quint/nfs_aux_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs_aux_mbt_common.h
@@ -1,0 +1,1663 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * Client half of the auxiliary-NFS model-based test harness: the RPC
+ * wrappers for the four protocols that surround NFSv3 -- portmap/rpcbind
+ * (100000 v2/v3/v4), MOUNT (100005 v3), NLM (100021 v4) and NSM
+ * (100024 v1).
+ *
+ * It layers on nfs3_mbt_common.h, which owns the embedded server and the
+ * rpc2 client thread; setting mbt_env_opts.aux makes that header connect
+ * the three extra inproc services (111 / 32803 / 32765) and export NLM_V4
+ * on the lock-manager connection so the server can call NLMPROC4_*_RES
+ * back at us.
+ *
+ * Every wrapper follows the nfs3 harness's shape: fire the generated
+ * send_call_* stub, pump evpl_continue() until the reply callback lands,
+ * and copy the oracle-relevant reply fields out of the rpc2-owned decode
+ * into the caller-owned struct mbt_aux_result.  Unlike the nfs3 wrappers
+ * these use mbt_call_wait_soft(): the suite deliberately calls procedures
+ * chimera does not implement and PROC_UNAVAIL is a modeled answer, not a
+ * harness failure.
+ *
+ * Two things are asynchronous and therefore accumulate in a separate,
+ * never-cleared log (struct mbt_aux.async):
+ *   - NLMPROC4_*_RES calls the server makes in response to an
+ *     NLMPROC4_*_MSG, and
+ *   - NLMPROC4_GRANTED calls from the out-of-band grant engine when a
+ *     blocking lock that was answered NLM4_BLOCKED is finally granted.
+ * The replayer drains that log at defined points rather than inside the
+ * call that provoked it.
+ */
+
+#include "nfs3_mbt_common.h"
+
+#define MBT_AUX_MAX_MAPS    32
+#define MBT_AUX_MAX_MOUNTS  32
+#define MBT_AUX_MAX_EXPORTS 16
+#define MBT_AUX_MAX_ASYNC   64
+#define MBT_AUX_UADDR_MAX   80
+#define MBT_AUX_NAME_MAX    128
+#define MBT_AUX_COOKIE_MAX  64
+
+/* nlm4.x: UINT64_MAX in l_len means "to end of file". */
+#define MBT_NLM_LEN_EOF     UINT64_MAX
+
+struct mbt_pmap_entry {
+    uint32_t prog, vers, prot, port;
+};
+
+struct mbt_rpcb_entry {
+    uint32_t prog, vers;
+    char     netid[16];
+    char     addr[MBT_AUX_UADDR_MAX];
+    char     owner[MBT_AUX_NAME_MAX];
+};
+
+struct mbt_mount_entry {
+    char host[MBT_AUX_NAME_MAX];
+    char dir[MBT_AUX_NAME_MAX];
+};
+
+struct mbt_export_entry {
+    char dir[MBT_AUX_NAME_MAX];
+    int  ngroups;
+    char groups[4][MBT_AUX_NAME_MAX];
+};
+
+/* One asynchronous message the SERVER sent us on the NLM connection. */
+struct mbt_async_ev {
+    int      proc;              /* NLMPROC4_* of the received call */
+    uint32_t stat;              /* nlm4_stats carried by it */
+    uint32_t cookie_len;
+    uint8_t  cookie[MBT_AUX_COOKIE_MAX];
+};
+
+/* One auxiliary RPC's oracle-relevant reply fields.  Cleared per call. */
+struct mbt_aux_result {
+    /* ---- portmap / rpcbind ---- */
+    uint32_t                port;            /* PMAPPROC_GETPORT */
+    int                     boolres;         /* SET / UNSET */
+    int                     nmaps;           /* PMAPPROC_DUMP */
+    struct mbt_pmap_entry   maps[MBT_AUX_MAX_MAPS];
+    int                     nrpcb;           /* rpcbproc_dump / RPCBPROC_DUMP */
+    struct mbt_rpcb_entry   rpcb[MBT_AUX_MAX_MAPS];
+    char                    uaddr[MBT_AUX_UADDR_MAX];  /* GETADDR */
+    uint32_t                uaddr_len;
+
+    /* ---- MOUNT ---- */
+    int                     nauth;           /* MNT auth_flavors */
+    int32_t                 auth[8];
+    int                     nmounts;         /* MOUNTPROC3_DUMP */
+    struct mbt_mount_entry  mounts[MBT_AUX_MAX_MOUNTS];
+    int                     nexports;        /* MOUNTPROC3_EXPORT */
+    struct mbt_export_entry exports[MBT_AUX_MAX_EXPORTS];
+
+    /* ---- NLM ---- */
+    uint32_t                nlm_stat;
+    uint32_t                cookie_len;
+    uint8_t                 cookie[MBT_AUX_COOKIE_MAX];
+    int                     holder_exclusive;
+    int32_t                 holder_svid;
+    uint32_t                holder_oh_len;
+    uint64_t                holder_offset;
+    uint64_t                holder_length;
+    int32_t                 sequence;        /* nlm4_shareres */
+
+    /* ---- NSM ---- */
+    int32_t                 sm_res;          /* res: STAT_SUCC / STAT_FAIL */
+    int32_t                 sm_state;
+};
+
+/* Drain deadline.  The timer is FIRST so the callback can cast it straight
+ * back to the context. */
+struct mbt_aux_drain_ctx {
+    struct evpl_timer timer;
+    volatile int      ticks;
+};
+
+struct mbt_aux {
+    struct mbt_aux_result r;
+
+    /* Server-initiated messages, accumulated across calls. */
+    int                   nasync;
+    int                   async_overflow;
+    struct mbt_async_ev   async[MBT_AUX_MAX_ASYNC];
+};
+
+static inline struct mbt_aux *
+mbt_aux(struct mbt_env *env)
+{
+    return env->aux;
+} /* mbt_aux */
+
+static inline struct mbt_aux_result *
+mbt_aux_begin(struct mbt_env *env)
+{
+    struct mbt_aux *a = env->aux;
+
+    mbt_call_begin(env);
+    memset(&a->r, 0, sizeof(a->r));
+    return &a->r;
+} /* mbt_aux_begin */
+
+static inline void
+mbt_aux_copy_str(
+    char             *dst,
+    size_t            cap,
+    const xdr_string *src)
+{
+    size_t n = src->len < cap - 1 ? src->len : cap - 1;
+
+    if (n) {
+        memcpy(dst, src->str, n);
+    }
+    dst[n] = '\0';
+} /* mbt_aux_copy_str */
+
+static inline void
+mbt_aux_copy_cookie(
+    uint8_t          *dst,
+    uint32_t         *dst_len,
+    const xdr_opaque *src)
+{
+    uint32_t n = src->len < MBT_AUX_COOKIE_MAX ? src->len : MBT_AUX_COOKIE_MAX;
+
+    if (n) {
+        memcpy(dst, src->data, n);
+    }
+    *dst_len = n;
+} /* mbt_aux_copy_cookie */
+
+/* ======================================================================
+ * PORTMAP v2 (100000.2)
+ * =================================================================== */
+
+static void
+mbt_pm_null_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env *env = private_data;
+
+    env->res.rpc_err = status;
+    env->res.done    = 1;
+} /* mbt_pm_null_cb */
+
+static inline struct mbt_aux_result *
+mbt_pm_null(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->pm_v2.send_call_PMAPPROC_NULL(&env->pm_v2.rpc2, env->evpl,
+                                       env->portmap_conn, &env->cred,
+                                       0, 0, NULL, 0, 0, mbt_pm_null_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_pm_null */
+
+static void
+mbt_pm_getport_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    uint32_t                     reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env *env = private_data;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        ((struct mbt_aux *) env->aux)->r.port = reply;
+    }
+    env->res.done = 1;
+} /* mbt_pm_getport_cb */
+
+static inline struct mbt_aux_result *
+mbt_pm_getport(
+    struct mbt_env *env,
+    uint32_t        prog,
+    uint32_t        vers,
+    uint32_t        prot)
+{
+    struct mapping args;
+
+    mbt_aux_begin(env);
+    args.prog = prog;
+    args.vers = vers;
+    args.prot = prot;
+    args.port = 0;
+    env->pm_v2.send_call_PMAPPROC_GETPORT(&env->pm_v2.rpc2, env->evpl,
+                                          env->portmap_conn, &env->cred, &args,
+                                          0, 0, NULL, 0, 0, mbt_pm_getport_cb,
+                                          env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_pm_getport */
+
+static void
+mbt_pm_set_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    uint32_t                     reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env *env = private_data;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        ((struct mbt_aux *) env->aux)->r.boolres = reply ? 1 : 0;
+    }
+    env->res.done = 1;
+} /* mbt_pm_set_cb */
+
+/* PMAPPROC_SET (1) and PMAPPROC_UNSET (2): chimera registers neither, so
+ * these exist to pin the PROC_UNAVAIL answer the model predicts. */
+static inline struct mbt_aux_result *
+mbt_pm_set(
+    struct mbt_env *env,
+    uint32_t        prog,
+    uint32_t        vers,
+    uint32_t        prot,
+    uint32_t        port,
+    int             unset)
+{
+    struct mapping args;
+
+    mbt_aux_begin(env);
+    args.prog = prog;
+    args.vers = vers;
+    args.prot = prot;
+    args.port = port;
+    if (unset) {
+        env->pm_v2.send_call_PMAPPROC_UNSET(&env->pm_v2.rpc2, env->evpl,
+                                            env->portmap_conn, &env->cred,
+                                            &args, 0, 0, NULL, 0, 0,
+                                            mbt_pm_set_cb, env);
+    } else {
+        env->pm_v2.send_call_PMAPPROC_SET(&env->pm_v2.rpc2, env->evpl,
+                                          env->portmap_conn, &env->cred, &args,
+                                          0, 0, NULL, 0, 0, mbt_pm_set_cb, env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_pm_set */
+
+static void
+mbt_pm_dump_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct pmapdumpres          *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+    struct pmaplist       *cur;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        for (cur = reply->maps; cur && r->nmaps < MBT_AUX_MAX_MAPS;
+             cur = cur->next) {
+            r->maps[r->nmaps].prog = cur->map.prog;
+            r->maps[r->nmaps].vers = cur->map.vers;
+            r->maps[r->nmaps].prot = cur->map.prot;
+            r->maps[r->nmaps].port = cur->map.port;
+            r->nmaps++;
+        }
+    }
+    env->res.done = 1;
+} /* mbt_pm_dump_cb */
+
+static inline struct mbt_aux_result *
+mbt_pm_dump(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->pm_v2.send_call_PMAPPROC_DUMP(&env->pm_v2.rpc2, env->evpl,
+                                       env->portmap_conn, &env->cred,
+                                       0, 0, NULL, 0, 0, mbt_pm_dump_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_pm_dump */
+
+static void
+mbt_pm_callit_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct call_result          *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env *env = private_data;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        ((struct mbt_aux *) env->aux)->r.port = reply->port;
+    }
+    env->res.done = 1;
+} /* mbt_pm_callit_cb */
+
+/* PMAPPROC_CALLIT (5): the indirect-call proxy.  Unregistered in chimera. */
+static inline struct mbt_aux_result *
+mbt_pm_callit(
+    struct mbt_env *env,
+    uint32_t        prog,
+    uint32_t        vers,
+    uint32_t        proc)
+{
+    struct call_args args;
+
+    mbt_aux_begin(env);
+    args.prog      = prog;
+    args.vers      = vers;
+    args.proc      = proc;
+    args.args.len  = 0;
+    args.args.data = NULL;
+    env->pm_v2.send_call_PMAPPROC_CALLIT(&env->pm_v2.rpc2, env->evpl,
+                                         env->portmap_conn, &env->cred, &args,
+                                         0, 0, NULL, 0, 0, mbt_pm_callit_cb,
+                                         env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_pm_callit */
+
+/* ======================================================================
+ * RPCBIND v3 / v4 (100000.3 / 100000.4)
+ * =================================================================== */
+
+static void
+mbt_rb_getaddr_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    xdr_string                  *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        mbt_aux_copy_str(r->uaddr, sizeof(r->uaddr), reply);
+        r->uaddr_len = reply->len;
+    }
+    env->res.done = 1;
+} /* mbt_rb_getaddr_cb */
+
+/* GETADDR against rpcbind version `vers` (3 or 4). */
+static inline struct mbt_aux_result *
+mbt_rb_getaddr(
+    struct mbt_env *env,
+    int             vers,
+    uint32_t        prog,
+    uint32_t        pvers,
+    const char     *netid)
+{
+    struct rpcb args;
+
+    mbt_aux_begin(env);
+    args.r_prog = prog;
+    args.r_vers = pvers;
+    xdr_set_str_static(&args, r_netid, netid, (uint32_t) strlen(netid));
+    xdr_set_str_static(&args, r_addr, "", 0);
+    xdr_set_str_static(&args, r_owner, "", 0);
+
+    if (vers == 3) {
+        env->pm_v3.send_call_rpcbproc_getaddr(&env->pm_v3.rpc2, env->evpl,
+                                              env->portmap_conn, &env->cred,
+                                              &args, 0, 0, NULL, 0, 0,
+                                              mbt_rb_getaddr_cb, env);
+    } else {
+        env->pm_v4.send_call_RPCBPROC_GETADDR(&env->pm_v4.rpc2, env->evpl,
+                                              env->portmap_conn, &env->cred,
+                                              &args, 0, 0, NULL, 0, 0,
+                                              mbt_rb_getaddr_cb, env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_rb_getaddr */
+
+static void
+mbt_rb_dump_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct rpcbdumpres          *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+    struct rp__list       *cur;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        for (cur = reply->maps; cur && r->nrpcb < MBT_AUX_MAX_MAPS;
+             cur = cur->next) {
+            struct mbt_rpcb_entry *e = &r->rpcb[r->nrpcb];
+
+            e->prog = cur->rpcb_map.r_prog;
+            e->vers = cur->rpcb_map.r_vers;
+            mbt_aux_copy_str(e->netid, sizeof(e->netid), &cur->rpcb_map.r_netid);
+            mbt_aux_copy_str(e->addr, sizeof(e->addr), &cur->rpcb_map.r_addr);
+            mbt_aux_copy_str(e->owner, sizeof(e->owner), &cur->rpcb_map.r_owner);
+            r->nrpcb++;
+        }
+    }
+    env->res.done = 1;
+} /* mbt_rb_dump_cb */
+
+static inline struct mbt_aux_result *
+mbt_rb_dump(
+    struct mbt_env *env,
+    int             vers)
+{
+    mbt_aux_begin(env);
+    if (vers == 3) {
+        env->pm_v3.send_call_rpcbproc_dump(&env->pm_v3.rpc2, env->evpl,
+                                           env->portmap_conn, &env->cred,
+                                           0, 0, NULL, 0, 0, mbt_rb_dump_cb,
+                                           env);
+    } else {
+        env->pm_v4.send_call_RPCBPROC_DUMP(&env->pm_v4.rpc2, env->evpl,
+                                           env->portmap_conn, &env->cred,
+                                           0, 0, NULL, 0, 0, mbt_rb_dump_cb,
+                                           env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_rb_dump */
+
+static void
+mbt_rb_gettime_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    uint32_t                     reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env *env = private_data;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        ((struct mbt_aux *) env->aux)->r.port = reply;
+    }
+    env->res.done = 1;
+} /* mbt_rb_gettime_cb */
+
+/* GETTIME (proc 6) -- unregistered in chimera; pins PROC_UNAVAIL. */
+static inline struct mbt_aux_result *
+mbt_rb_gettime(
+    struct mbt_env *env,
+    int             vers)
+{
+    mbt_aux_begin(env);
+    if (vers == 3) {
+        env->pm_v3.send_call_rpcbproc_gettime(&env->pm_v3.rpc2, env->evpl,
+                                              env->portmap_conn, &env->cred,
+                                              0, 0, NULL, 0, 0,
+                                              mbt_rb_gettime_cb, env);
+    } else {
+        env->pm_v4.send_call_RPCBPROC_GETTIME(&env->pm_v4.rpc2, env->evpl,
+                                              env->portmap_conn, &env->cred,
+                                              0, 0, NULL, 0, 0,
+                                              mbt_rb_gettime_cb, env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_rb_gettime */
+
+/* GETVERSADDR (v4 proc 9) -- unregistered in chimera. */
+static inline struct mbt_aux_result *
+mbt_rb_getversaddr(
+    struct mbt_env *env,
+    uint32_t        prog,
+    uint32_t        pvers,
+    const char     *netid)
+{
+    struct rpcb args;
+
+    mbt_aux_begin(env);
+    args.r_prog = prog;
+    args.r_vers = pvers;
+    xdr_set_str_static(&args, r_netid, netid, (uint32_t) strlen(netid));
+    xdr_set_str_static(&args, r_addr, "", 0);
+    xdr_set_str_static(&args, r_owner, "", 0);
+    env->pm_v4.send_call_RPCBPROC_GETVERSADDR(&env->pm_v4.rpc2, env->evpl,
+                                              env->portmap_conn, &env->cred,
+                                              &args, 0, 0, NULL, 0, 0,
+                                              mbt_rb_getaddr_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_rb_getversaddr */
+
+/* ======================================================================
+ * MOUNT v3 (100005.3)
+ * =================================================================== */
+
+static void
+mbt_aux_mnt_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct mountres3            *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+    int                    i;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        env->res.status = reply->fhs_status;
+        if (reply->fhs_status == MNT3_OK) {
+            mbt_copy_fh(&env->res.obj_fh, &reply->mountinfo.fhandle);
+            r->nauth = reply->mountinfo.num_auth_flavors;
+            if (r->nauth > (int) (sizeof(r->auth) / sizeof(r->auth[0]))) {
+                r->nauth = sizeof(r->auth) / sizeof(r->auth[0]);
+            }
+            for (i = 0; i < r->nauth; i++) {
+                r->auth[i] = reply->mountinfo.auth_flavors[i];
+            }
+        }
+    }
+    env->res.done = 1;
+} /* mbt_aux_mnt_cb */
+
+/* MOUNTPROC3_MNT with the auth_flavors list copied out as well as the
+ * handle (mbt_mnt in the nfs3 harness keeps only the handle). */
+static inline struct mbt_aux_result *
+mbt_mount_mnt(
+    struct mbt_env *env,
+    const char     *path)
+{
+    struct mountarg3 args;
+
+    mbt_aux_begin(env);
+    xdr_set_str_static(&args, path, path, (uint32_t) strlen(path));
+    env->mount_v3.send_call_MOUNTPROC3_MNT(&env->mount_v3.rpc2, env->evpl,
+                                           env->mount_conn, &env->cred, &args,
+                                           0, 0, NULL, 0, 0, mbt_aux_mnt_cb,
+                                           env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_mount_mnt */
+
+static void
+mbt_void_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env *env = private_data;
+
+    env->res.rpc_err = status;
+    env->res.done    = 1;
+} /* mbt_void_cb */
+
+static inline struct mbt_aux_result *
+mbt_mount_null(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->mount_v3.send_call_MOUNTPROC3_NULL(&env->mount_v3.rpc2, env->evpl,
+                                            env->mount_conn, &env->cred,
+                                            0, 0, NULL, 0, 0, mbt_void_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_mount_null */
+
+static void
+mbt_mount_dump_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct mountdumpres         *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+    struct mountbody      *cur;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        for (cur = reply->mounts; cur && r->nmounts < MBT_AUX_MAX_MOUNTS;
+             cur = cur->ml_next) {
+            mbt_aux_copy_str(r->mounts[r->nmounts].host,
+                             sizeof(r->mounts[0].host), &cur->ml_hostname);
+            mbt_aux_copy_str(r->mounts[r->nmounts].dir,
+                             sizeof(r->mounts[0].dir), &cur->ml_directory);
+            r->nmounts++;
+        }
+    }
+    env->res.done = 1;
+} /* mbt_mount_dump_cb */
+
+static inline struct mbt_aux_result *
+mbt_mount_dump(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->mount_v3.send_call_MOUNTPROC3_DUMP(&env->mount_v3.rpc2, env->evpl,
+                                            env->mount_conn, &env->cred,
+                                            0, 0, NULL, 0, 0, mbt_mount_dump_cb,
+                                            env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_mount_dump */
+
+static inline struct mbt_aux_result *
+mbt_mount_umnt(
+    struct mbt_env *env,
+    const char     *path)
+{
+    struct mountarg3 args;
+
+    mbt_aux_begin(env);
+    xdr_set_str_static(&args, path, path, (uint32_t) strlen(path));
+    env->mount_v3.send_call_MOUNTPROC3_UMNT(&env->mount_v3.rpc2, env->evpl,
+                                            env->mount_conn, &env->cred, &args,
+                                            0, 0, NULL, 0, 0, mbt_void_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_mount_umnt */
+
+static inline struct mbt_aux_result *
+mbt_mount_umntall(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->mount_v3.send_call_MOUNTPROC3_UMNTALL(&env->mount_v3.rpc2, env->evpl,
+                                               env->mount_conn, &env->cred,
+                                               0, 0, NULL, 0, 0, mbt_void_cb,
+                                               env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_mount_umntall */
+
+static void
+mbt_mount_export_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct exportres            *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+    struct exportnode     *cur;
+    struct groupnode      *g;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        for (cur = reply->exports; cur && r->nexports < MBT_AUX_MAX_EXPORTS;
+             cur = cur->ex_next) {
+            struct mbt_export_entry *e = &r->exports[r->nexports];
+
+            mbt_aux_copy_str(e->dir, sizeof(e->dir), &cur->ex_dir);
+            for (g = cur->ex_groups; g && e->ngroups < 4; g = g->nextgroup) {
+                mbt_aux_copy_str(e->groups[e->ngroups], sizeof(e->groups[0]),
+                                 &g->name);
+                e->ngroups++;
+            }
+            r->nexports++;
+        }
+    }
+    env->res.done = 1;
+} /* mbt_mount_export_cb */
+
+static inline struct mbt_aux_result *
+mbt_mount_export(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->mount_v3.send_call_MOUNTPROC3_EXPORT(&env->mount_v3.rpc2, env->evpl,
+                                              env->mount_conn, &env->cred,
+                                              0, 0, NULL, 0, 0,
+                                              mbt_mount_export_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_mount_export */
+
+/* ======================================================================
+ * NLM v4 (100021.4)
+ * =================================================================== */
+
+/* Argument scratch: the generated stubs marshal from these buffers inside
+ * the send_call, and every wrapper here is synchronous, so one static set
+ * per call site is enough. */
+struct mbt_nlm_args {
+    char    caller[MBT_AUX_NAME_MAX];
+    uint8_t oh[MBT_AUX_COOKIE_MAX];
+    uint8_t cookie[MBT_AUX_COOKIE_MAX];
+};
+
+/* Fill an nlm4_lock from the model-level identity + range. */
+static inline void
+mbt_nlm_fill_lock(
+    struct nlm4_lock    *alock,
+    struct mbt_nlm_args *scratch,
+    const char          *caller,
+    const struct mbt_fh *fh,
+    const uint8_t       *oh,
+    uint32_t             oh_len,
+    int32_t              svid,
+    uint64_t             offset,
+    uint64_t             length)
+{
+    snprintf(scratch->caller, sizeof(scratch->caller), "%s", caller);
+    if (oh_len > MBT_AUX_COOKIE_MAX) {
+        oh_len = MBT_AUX_COOKIE_MAX;
+    }
+    if (oh_len) {
+        memcpy(scratch->oh, oh, oh_len);
+    }
+
+    xdr_set_str_static(alock, caller_name, scratch->caller,
+                       (uint32_t) strlen(scratch->caller));
+    alock->fh.len   = fh->len;
+    alock->fh.data  = (uint8_t *) fh->data;
+    alock->oh.len   = oh_len;
+    alock->oh.data  = scratch->oh;
+    alock->svid     = svid;
+    alock->l_offset = offset;
+    alock->l_len    = length;
+} /* mbt_nlm_fill_lock */
+
+static inline void
+mbt_nlm_fill_cookie(
+    xdr_opaque          *cookie,
+    struct mbt_nlm_args *scratch,
+    const uint8_t       *bytes,
+    uint32_t             len)
+{
+    if (len > MBT_AUX_COOKIE_MAX) {
+        len = MBT_AUX_COOKIE_MAX;
+    }
+    if (len) {
+        memcpy(scratch->cookie, bytes, len);
+    }
+    cookie->len  = len;
+    cookie->data = len ? scratch->cookie : NULL;
+} /* mbt_nlm_fill_cookie */
+
+static void
+mbt_nlm_res_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct nlm4_res             *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        r->nlm_stat = reply->stat;
+        mbt_aux_copy_cookie(r->cookie, &r->cookie_len, &reply->cookie);
+    }
+    env->res.done = 1;
+} /* mbt_nlm_res_cb */
+
+static void
+mbt_nlm_testres_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct nlm4_testres         *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        r->nlm_stat = reply->test_stat.stat;
+        mbt_aux_copy_cookie(r->cookie, &r->cookie_len, &reply->cookie);
+        if (reply->test_stat.stat == NLM4_DENIED) {
+            r->holder_exclusive = reply->test_stat.holder.exclusive ? 1 : 0;
+            r->holder_svid      = reply->test_stat.holder.svid;
+            r->holder_oh_len    = reply->test_stat.holder.oh.len;
+            r->holder_offset    = reply->test_stat.holder.l_offset;
+            r->holder_length    = reply->test_stat.holder.l_len;
+        }
+    }
+    env->res.done = 1;
+} /* mbt_nlm_testres_cb */
+
+static void
+mbt_nlm_shareres_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct nlm4_shareres        *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        r->nlm_stat = reply->stat;
+        r->sequence = reply->sequence;
+        mbt_aux_copy_cookie(r->cookie, &r->cookie_len, &reply->cookie);
+    }
+    env->res.done = 1;
+} /* mbt_nlm_shareres_cb */
+
+static inline struct mbt_aux_result *
+mbt_nlm_null(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->nlm_v4.send_call_NLMPROC4_NULL(&env->nlm_v4.rpc2, env->evpl,
+                                        env->nlm_conn, &env->cred,
+                                        0, 0, NULL, 0, 0, mbt_void_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_null */
+
+/* NLMPROC4_TEST (1) or NLMPROC4_TEST_MSG (6) when msg is set. */
+static inline struct mbt_aux_result *
+mbt_nlm_test(
+    struct mbt_env      *env,
+    int                  msg,
+    const char          *caller,
+    const struct mbt_fh *fh,
+    const uint8_t       *oh,
+    uint32_t             oh_len,
+    int32_t              svid,
+    int                  exclusive,
+    uint64_t             offset,
+    uint64_t             length,
+    const uint8_t       *cookie,
+    uint32_t             cookie_len)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_testargs       args;
+
+    mbt_aux_begin(env);
+    mbt_nlm_fill_cookie(&args.cookie, &scratch, cookie, cookie_len);
+    args.exclusive = exclusive ? true : false;
+    mbt_nlm_fill_lock(&args.alock, &scratch, caller, fh, oh, oh_len, svid,
+                      offset, length);
+
+    if (msg) {
+        env->nlm_v4.send_call_NLMPROC4_TEST_MSG(&env->nlm_v4.rpc2, env->evpl,
+                                                env->nlm_conn, &env->cred,
+                                                &args, 0, 0, NULL, 0, 0,
+                                                mbt_void_cb, env);
+    } else {
+        env->nlm_v4.send_call_NLMPROC4_TEST(&env->nlm_v4.rpc2, env->evpl,
+                                            env->nlm_conn, &env->cred, &args,
+                                            0, 0, NULL, 0, 0,
+                                            mbt_nlm_testres_cb, env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_test */
+
+/* NLMPROC4_LOCK (2), NLMPROC4_LOCK_MSG (7) or NLMPROC4_NM_LOCK (22). */
+static inline struct mbt_aux_result *
+mbt_nlm_lock(
+    struct mbt_env      *env,
+    int                  proc,
+    const char          *caller,
+    const struct mbt_fh *fh,
+    const uint8_t       *oh,
+    uint32_t             oh_len,
+    int32_t              svid,
+    int                  exclusive,
+    int                  block,
+    int                  reclaim,
+    int32_t              state,
+    uint64_t             offset,
+    uint64_t             length,
+    const uint8_t       *cookie,
+    uint32_t             cookie_len)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_lockargs       args;
+
+    mbt_aux_begin(env);
+    mbt_nlm_fill_cookie(&args.cookie, &scratch, cookie, cookie_len);
+    args.block     = block ? true : false;
+    args.exclusive = exclusive ? true : false;
+    args.reclaim   = reclaim ? true : false;
+    args.state     = state;
+    mbt_nlm_fill_lock(&args.alock, &scratch, caller, fh, oh, oh_len, svid,
+                      offset, length);
+
+    if (proc == 7) {
+        env->nlm_v4.send_call_NLMPROC4_LOCK_MSG(&env->nlm_v4.rpc2, env->evpl,
+                                                env->nlm_conn, &env->cred,
+                                                &args, 0, 0, NULL, 0, 0,
+                                                mbt_void_cb, env);
+    } else if (proc == 22) {
+        env->nlm_v4.send_call_NLMPROC4_NM_LOCK(&env->nlm_v4.rpc2, env->evpl,
+                                               env->nlm_conn, &env->cred,
+                                               &args, 0, 0, NULL, 0, 0,
+                                               mbt_nlm_res_cb, env);
+    } else {
+        env->nlm_v4.send_call_NLMPROC4_LOCK(&env->nlm_v4.rpc2, env->evpl,
+                                            env->nlm_conn, &env->cred, &args,
+                                            0, 0, NULL, 0, 0, mbt_nlm_res_cb,
+                                            env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_lock */
+
+/* NLMPROC4_CANCEL (3) or NLMPROC4_CANCEL_MSG (8). */
+static inline struct mbt_aux_result *
+mbt_nlm_cancel(
+    struct mbt_env      *env,
+    int                  msg,
+    const char          *caller,
+    const struct mbt_fh *fh,
+    const uint8_t       *oh,
+    uint32_t             oh_len,
+    int32_t              svid,
+    int                  exclusive,
+    int                  block,
+    uint64_t             offset,
+    uint64_t             length,
+    const uint8_t       *cookie,
+    uint32_t             cookie_len)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_cancargs       args;
+
+    mbt_aux_begin(env);
+    mbt_nlm_fill_cookie(&args.cookie, &scratch, cookie, cookie_len);
+    args.block     = block ? true : false;
+    args.exclusive = exclusive ? true : false;
+    mbt_nlm_fill_lock(&args.alock, &scratch, caller, fh, oh, oh_len, svid,
+                      offset, length);
+
+    if (msg) {
+        env->nlm_v4.send_call_NLMPROC4_CANCEL_MSG(&env->nlm_v4.rpc2, env->evpl,
+                                                  env->nlm_conn, &env->cred,
+                                                  &args, 0, 0, NULL, 0, 0,
+                                                  mbt_void_cb, env);
+    } else {
+        env->nlm_v4.send_call_NLMPROC4_CANCEL(&env->nlm_v4.rpc2, env->evpl,
+                                              env->nlm_conn, &env->cred, &args,
+                                              0, 0, NULL, 0, 0, mbt_nlm_res_cb,
+                                              env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_cancel */
+
+/* NLMPROC4_UNLOCK (4) or NLMPROC4_UNLOCK_MSG (9). */
+static inline struct mbt_aux_result *
+mbt_nlm_unlock(
+    struct mbt_env      *env,
+    int                  msg,
+    const char          *caller,
+    const struct mbt_fh *fh,
+    const uint8_t       *oh,
+    uint32_t             oh_len,
+    int32_t              svid,
+    uint64_t             offset,
+    uint64_t             length,
+    const uint8_t       *cookie,
+    uint32_t             cookie_len)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_unlockargs     args;
+
+    mbt_aux_begin(env);
+    mbt_nlm_fill_cookie(&args.cookie, &scratch, cookie, cookie_len);
+    mbt_nlm_fill_lock(&args.alock, &scratch, caller, fh, oh, oh_len, svid,
+                      offset, length);
+
+    if (msg) {
+        env->nlm_v4.send_call_NLMPROC4_UNLOCK_MSG(&env->nlm_v4.rpc2, env->evpl,
+                                                  env->nlm_conn, &env->cred,
+                                                  &args, 0, 0, NULL, 0, 0,
+                                                  mbt_void_cb, env);
+    } else {
+        env->nlm_v4.send_call_NLMPROC4_UNLOCK(&env->nlm_v4.rpc2, env->evpl,
+                                              env->nlm_conn, &env->cred, &args,
+                                              0, 0, NULL, 0, 0, mbt_nlm_res_cb,
+                                              env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_unlock */
+
+/* NLMPROC4_GRANTED (5) or NLMPROC4_GRANTED_MSG (10): the client-callback
+ * direction of the protocol, which a server also has to answer. */
+static inline struct mbt_aux_result *
+mbt_nlm_granted(
+    struct mbt_env      *env,
+    int                  msg,
+    const char          *caller,
+    const struct mbt_fh *fh,
+    const uint8_t       *oh,
+    uint32_t             oh_len,
+    int32_t              svid,
+    int                  exclusive,
+    uint64_t             offset,
+    uint64_t             length,
+    const uint8_t       *cookie,
+    uint32_t             cookie_len)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_testargs       args;
+
+    mbt_aux_begin(env);
+    mbt_nlm_fill_cookie(&args.cookie, &scratch, cookie, cookie_len);
+    args.exclusive = exclusive ? true : false;
+    mbt_nlm_fill_lock(&args.alock, &scratch, caller, fh, oh, oh_len, svid,
+                      offset, length);
+
+    if (msg) {
+        env->nlm_v4.send_call_NLMPROC4_GRANTED_MSG(&env->nlm_v4.rpc2, env->evpl,
+                                                   env->nlm_conn, &env->cred,
+                                                   &args, 0, 0, NULL, 0, 0,
+                                                   mbt_void_cb, env);
+    } else {
+        env->nlm_v4.send_call_NLMPROC4_GRANTED(&env->nlm_v4.rpc2, env->evpl,
+                                               env->nlm_conn, &env->cred,
+                                               &args, 0, 0, NULL, 0, 0,
+                                               mbt_nlm_res_cb, env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_granted */
+
+/* The *_RES half (procs 11-15): a client reporting an asynchronous result
+ * to the server, which acks with a void reply. */
+static inline struct mbt_aux_result *
+mbt_nlm_send_res(
+    struct mbt_env *env,
+    int             proc,
+    uint32_t        stat,
+    const uint8_t  *cookie,
+    uint32_t        cookie_len)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_res            res;
+    struct nlm4_testres        tres;
+
+    mbt_aux_begin(env);
+
+    if (proc == 11) {
+        mbt_nlm_fill_cookie(&tres.cookie, &scratch, cookie, cookie_len);
+        tres.test_stat.stat = stat;
+        /* nlm4_testrply is a union on the status: NLM4_DENIED carries a
+         * holder, every other arm is void.  The holder has to be filled in
+         * even though nothing reads it -- marshalling a netobj from
+         * uninitialised memory produces a message that never goes out, and
+         * a send_call whose marshal fails never fires its callback, so the
+         * caller waits forever rather than seeing an error. */
+        if (stat == NLM4_DENIED) {
+            tres.test_stat.holder.exclusive = true;
+            tres.test_stat.holder.svid      = 1;
+            tres.test_stat.holder.oh.len    = 0;
+            tres.test_stat.holder.oh.data   = NULL;
+            tres.test_stat.holder.l_offset  = 0;
+            tres.test_stat.holder.l_len     = 0;
+        }
+        env->nlm_v4.send_call_NLMPROC4_TEST_RES(&env->nlm_v4.rpc2, env->evpl,
+                                                env->nlm_conn, &env->cred,
+                                                &tres, 0, 0, NULL, 0, 0,
+                                                mbt_void_cb, env);
+        mbt_call_wait_soft(env);
+        return &mbt_aux(env)->r;
+    }
+
+    mbt_nlm_fill_cookie(&res.cookie, &scratch, cookie, cookie_len);
+    res.stat = stat;
+
+    switch (proc) {
+        case 12:
+            env->nlm_v4.send_call_NLMPROC4_LOCK_RES(&env->nlm_v4.rpc2,
+                                                    env->evpl, env->nlm_conn,
+                                                    &env->cred, &res, 0, 0,
+                                                    NULL, 0, 0, mbt_void_cb,
+                                                    env);
+            break;
+        case 13:
+            env->nlm_v4.send_call_NLMPROC4_CANCEL_RES(&env->nlm_v4.rpc2,
+                                                      env->evpl, env->nlm_conn,
+                                                      &env->cred, &res, 0, 0,
+                                                      NULL, 0, 0, mbt_void_cb,
+                                                      env);
+            break;
+        case 14:
+            env->nlm_v4.send_call_NLMPROC4_UNLOCK_RES(&env->nlm_v4.rpc2,
+                                                      env->evpl, env->nlm_conn,
+                                                      &env->cred, &res, 0, 0,
+                                                      NULL, 0, 0, mbt_void_cb,
+                                                      env);
+            break;
+        default:
+            env->nlm_v4.send_call_NLMPROC4_GRANTED_RES(&env->nlm_v4.rpc2,
+                                                       env->evpl, env->nlm_conn,
+                                                       &env->cred, &res, 0, 0,
+                                                       NULL, 0, 0, mbt_void_cb,
+                                                       env);
+            break;
+    } /* switch */
+
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_send_res */
+
+/* The four reserved slots (16-19): chimera acks them, which is what the
+ * model pins -- an unimplemented slot would be PROC_UNAVAIL instead. */
+static inline struct mbt_aux_result *
+mbt_nlm_reserved(
+    struct mbt_env *env,
+    int             proc)
+{
+    mbt_aux_begin(env);
+    switch (proc) {
+        case 16:
+            env->nlm_v4.send_call_NLMPROC4_RESERVED_16(&env->nlm_v4.rpc2,
+                                                       env->evpl, env->nlm_conn,
+                                                       &env->cred, 0, 0, NULL,
+                                                       0, 0, mbt_void_cb, env);
+            break;
+        case 17:
+            env->nlm_v4.send_call_NLMPROC4_RESERVED_17(&env->nlm_v4.rpc2,
+                                                       env->evpl, env->nlm_conn,
+                                                       &env->cred, 0, 0, NULL,
+                                                       0, 0, mbt_void_cb, env);
+            break;
+        case 18:
+            env->nlm_v4.send_call_NLMPROC4_RESERVED_18(&env->nlm_v4.rpc2,
+                                                       env->evpl, env->nlm_conn,
+                                                       &env->cred, 0, 0, NULL,
+                                                       0, 0, mbt_void_cb, env);
+            break;
+        default:
+            env->nlm_v4.send_call_NLMPROC4_RESERVED_19(&env->nlm_v4.rpc2,
+                                                       env->evpl, env->nlm_conn,
+                                                       &env->cred, 0, 0, NULL,
+                                                       0, 0, mbt_void_cb, env);
+            break;
+    } /* switch */
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_reserved */
+
+/* NLMPROC4_SHARE (20) / NLMPROC4_UNSHARE (21): the DOS share-mode half. */
+static inline struct mbt_aux_result *
+mbt_nlm_share(
+    struct mbt_env      *env,
+    int                  unshare,
+    const char          *caller,
+    const struct mbt_fh *fh,
+    const uint8_t       *oh,
+    uint32_t             oh_len,
+    int                  mode,
+    int                  access,
+    int                  reclaim,
+    const uint8_t       *cookie,
+    uint32_t             cookie_len)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_shareargs      args;
+
+    mbt_aux_begin(env);
+    mbt_nlm_fill_cookie(&args.cookie, &scratch, cookie, cookie_len);
+    args.reclaim = reclaim ? true : false;
+
+    snprintf(scratch.caller, sizeof(scratch.caller), "%s", caller);
+    if (oh_len > MBT_AUX_COOKIE_MAX) {
+        oh_len = MBT_AUX_COOKIE_MAX;
+    }
+    if (oh_len) {
+        memcpy(scratch.oh, oh, oh_len);
+    }
+    xdr_set_str_static(&args.share, caller_name, scratch.caller,
+                       (uint32_t) strlen(scratch.caller));
+    args.share.fh.len  = fh->len;
+    args.share.fh.data = (uint8_t *) fh->data;
+    args.share.oh.len  = oh_len;
+    args.share.oh.data = scratch.oh;
+    args.share.mode    = mode;
+    args.share.access  = access;
+
+    if (unshare) {
+        env->nlm_v4.send_call_NLMPROC4_UNSHARE(&env->nlm_v4.rpc2, env->evpl,
+                                               env->nlm_conn, &env->cred,
+                                               &args, 0, 0, NULL, 0, 0,
+                                               mbt_nlm_shareres_cb, env);
+    } else {
+        env->nlm_v4.send_call_NLMPROC4_SHARE(&env->nlm_v4.rpc2, env->evpl,
+                                             env->nlm_conn, &env->cred, &args,
+                                             0, 0, NULL, 0, 0,
+                                             mbt_nlm_shareres_cb, env);
+    }
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_share */
+
+/* NLMPROC4_FREE_ALL (23). */
+static inline struct mbt_aux_result *
+mbt_nlm_free_all(
+    struct mbt_env *env,
+    const char     *name,
+    int32_t         state)
+{
+    static struct mbt_nlm_args scratch;
+    struct nlm4_notify         args;
+
+    mbt_aux_begin(env);
+    snprintf(scratch.caller, sizeof(scratch.caller), "%s", name);
+    xdr_set_str_static(&args, name, scratch.caller,
+                       (uint32_t) strlen(scratch.caller));
+    args.state = state;
+    env->nlm_v4.send_call_NLMPROC4_FREE_ALL(&env->nlm_v4.rpc2, env->evpl,
+                                            env->nlm_conn, &env->cred, &args,
+                                            0, 0, NULL, 0, 0, mbt_void_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_nlm_free_all */
+
+/* ---- server-initiated NLM messages (the async half) -------------------- */
+
+static inline void
+mbt_aux_async_push(
+    struct mbt_env   *env,
+    int               proc,
+    uint32_t          stat,
+    const xdr_opaque *cookie)
+{
+    struct mbt_aux *a = env->aux;
+
+    if (a->nasync >= MBT_AUX_MAX_ASYNC) {
+        a->async_overflow = 1;
+        return;
+    }
+    a->async[a->nasync].proc = proc;
+    a->async[a->nasync].stat = stat;
+    mbt_aux_copy_cookie(a->async[a->nasync].cookie,
+                        &a->async[a->nasync].cookie_len, cookie);
+    a->nasync++;
+} /* mbt_aux_async_push */
+
+#define MBT_AUX_DEFINE_RES_RECV(NAME, PROC)                               \
+        static void                                                           \
+        mbt_aux_recv_ ## NAME(                                                \
+            struct evpl *evpl,                                  \
+            struct evpl_rpc2_conn *conn,                                  \
+            struct evpl_rpc2_cred *cred,                                  \
+            struct nlm4_res *args,                                  \
+            struct evpl_rpc2_encoding *encoding,                              \
+            void *private_data)                          \
+        {                                                                     \
+            struct mbt_env *env = private_data;                               \
+            int             rc;                                               \
+                                                                          \
+            mbt_aux_async_push(env, PROC, args->stat, &args->cookie);          \
+            rc = env->nlm_v4.send_reply_ ## NAME(evpl, NULL, encoding);        \
+            if (rc) {                                                         \
+                fprintf(stderr, "failed to ack " #NAME "\n");                  \
+                exit(3);                                                      \
+            }                                                                 \
+        }
+
+MBT_AUX_DEFINE_RES_RECV(NLMPROC4_LOCK_RES, 12)
+MBT_AUX_DEFINE_RES_RECV(NLMPROC4_CANCEL_RES, 13)
+MBT_AUX_DEFINE_RES_RECV(NLMPROC4_UNLOCK_RES, 14)
+MBT_AUX_DEFINE_RES_RECV(NLMPROC4_GRANTED_RES, 15)
+
+static void
+mbt_aux_recv_NLMPROC4_TEST_RES(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct nlm4_testres       *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct mbt_env *env = private_data;
+    int             rc;
+
+    mbt_aux_async_push(env, 11, args->test_stat.stat, &args->cookie);
+    rc = env->nlm_v4.send_reply_NLMPROC4_TEST_RES(evpl, NULL, encoding);
+    if (rc) {
+        fprintf(stderr, "failed to ack NLMPROC4_TEST_RES\n");
+        exit(3);
+    }
+} /* mbt_aux_recv_NLMPROC4_TEST_RES */
+
+/* The out-of-band grant engine delivers a deferred blocking lock with a
+ * GRANTED *call* rather than a *_RES.  It arrives on a connection the
+ * server opened to us, but the program is the same, so record it here. */
+static void
+mbt_aux_recv_NLMPROC4_GRANTED(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct nlm4_testargs      *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct mbt_env *env = private_data;
+    struct nlm4_res res;
+    int             rc;
+
+    mbt_aux_async_push(env, 5, NLM4_GRANTED, &args->cookie);
+
+    res.cookie = args->cookie;
+    res.stat   = NLM4_GRANTED;
+    rc         = env->nlm_v4.send_reply_NLMPROC4_GRANTED(evpl, NULL, &res,
+                                                         encoding);
+    if (rc) {
+        fprintf(stderr, "failed to ack NLMPROC4_GRANTED\n");
+        exit(3);
+    }
+} /* mbt_aux_recv_NLMPROC4_GRANTED */
+
+static void
+mbt_aux_recv_NLMPROC4_GRANTED_MSG(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct nlm4_testargs      *args,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct mbt_env *env = private_data;
+    int             rc;
+
+    mbt_aux_async_push(env, 10, NLM4_GRANTED, &args->cookie);
+    rc = env->nlm_v4.send_reply_NLMPROC4_GRANTED_MSG(evpl, NULL, encoding);
+    if (rc) {
+        fprintf(stderr, "failed to ack NLMPROC4_GRANTED_MSG\n");
+        exit(3);
+    }
+} /* mbt_aux_recv_NLMPROC4_GRANTED_MSG */
+
+/* ======================================================================
+ * NSM / sm_inter v1 (100024.1)
+ * =================================================================== */
+
+static void
+mbt_sm_statres_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct sm_stat_res          *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        r->sm_res   = reply->res_stat;
+        r->sm_state = reply->state;
+    }
+    env->res.done = 1;
+} /* mbt_sm_statres_cb */
+
+static void
+mbt_sm_stat_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct sm_stat              *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct mbt_env        *env = private_data;
+    struct mbt_aux_result *r   = &((struct mbt_aux *) env->aux)->r;
+
+    env->res.rpc_err = status;
+    if (status == 0) {
+        r->sm_state = reply->state;
+    }
+    env->res.done = 1;
+} /* mbt_sm_stat_cb */
+
+static inline struct mbt_aux_result *
+mbt_sm_null(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->nsm_v1.send_call_SM_NULL(&env->nsm_v1.rpc2, env->evpl, env->nsm_conn,
+                                  &env->cred, 0, 0, NULL, 0, 0, mbt_void_cb,
+                                  env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_sm_null */
+
+/* Scratch for the NSM string arguments, same contract as mbt_nlm_args. */
+struct mbt_sm_args {
+    char mon[MBT_AUX_NAME_MAX];
+    char my[MBT_AUX_NAME_MAX];
+};
+
+static inline struct mbt_aux_result *
+mbt_sm_stat(
+    struct mbt_env *env,
+    const char     *host)
+{
+    static struct mbt_sm_args scratch;
+    struct sm_name            args;
+
+    mbt_aux_begin(env);
+    snprintf(scratch.mon, sizeof(scratch.mon), "%s", host);
+    xdr_set_str_static(&args, mon_name, scratch.mon,
+                       (uint32_t) strlen(scratch.mon));
+    env->nsm_v1.send_call_SM_STAT(&env->nsm_v1.rpc2, env->evpl, env->nsm_conn,
+                                  &env->cred, &args, 0, 0, NULL, 0, 0,
+                                  mbt_sm_statres_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_sm_stat */
+
+static inline struct mbt_aux_result *
+mbt_sm_mon(
+    struct mbt_env *env,
+    const char     *host,
+    const char     *my_name,
+    int32_t         prog,
+    int32_t         vers,
+    int32_t         proc)
+{
+    static struct mbt_sm_args scratch;
+    struct mon                args;
+
+    mbt_aux_begin(env);
+    snprintf(scratch.mon, sizeof(scratch.mon), "%s", host);
+    snprintf(scratch.my, sizeof(scratch.my), "%s", my_name);
+    xdr_set_str_static(&args.id, mon_name, scratch.mon,
+                       (uint32_t) strlen(scratch.mon));
+    xdr_set_str_static(&args.id.id, my_name, scratch.my,
+                       (uint32_t) strlen(scratch.my));
+    args.id.id.my_prog = prog;
+    args.id.id.my_vers = vers;
+    args.id.id.my_proc = proc;
+    memset(args.priv, 0, sizeof(args.priv));
+
+    env->nsm_v1.send_call_SM_MON(&env->nsm_v1.rpc2, env->evpl, env->nsm_conn,
+                                 &env->cred, &args, 0, 0, NULL, 0, 0,
+                                 mbt_sm_statres_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_sm_mon */
+
+static inline struct mbt_aux_result *
+mbt_sm_unmon(
+    struct mbt_env *env,
+    const char     *host,
+    const char     *my_name)
+{
+    static struct mbt_sm_args scratch;
+    struct mon_id             args;
+
+    mbt_aux_begin(env);
+    snprintf(scratch.mon, sizeof(scratch.mon), "%s", host);
+    snprintf(scratch.my, sizeof(scratch.my), "%s", my_name);
+    xdr_set_str_static(&args, mon_name, scratch.mon,
+                       (uint32_t) strlen(scratch.mon));
+    xdr_set_str_static(&args.id, my_name, scratch.my,
+                       (uint32_t) strlen(scratch.my));
+    args.id.my_prog = 100021;
+    args.id.my_vers = 4;
+    args.id.my_proc = 24;
+
+    env->nsm_v1.send_call_SM_UNMON(&env->nsm_v1.rpc2, env->evpl, env->nsm_conn,
+                                   &env->cred, &args, 0, 0, NULL, 0, 0,
+                                   mbt_sm_stat_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_sm_unmon */
+
+static inline struct mbt_aux_result *
+mbt_sm_unmon_all(
+    struct mbt_env *env,
+    const char     *my_name)
+{
+    static struct mbt_sm_args scratch;
+    struct my_id              args;
+
+    mbt_aux_begin(env);
+    snprintf(scratch.my, sizeof(scratch.my), "%s", my_name);
+    xdr_set_str_static(&args, my_name, scratch.my,
+                       (uint32_t) strlen(scratch.my));
+    args.my_prog = 100021;
+    args.my_vers = 4;
+    args.my_proc = 24;
+
+    env->nsm_v1.send_call_SM_UNMON_ALL(&env->nsm_v1.rpc2, env->evpl,
+                                       env->nsm_conn, &env->cred, &args,
+                                       0, 0, NULL, 0, 0, mbt_sm_stat_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_sm_unmon_all */
+
+static inline struct mbt_aux_result *
+mbt_sm_simu_crash(struct mbt_env *env)
+{
+    mbt_aux_begin(env);
+    env->nsm_v1.send_call_SM_SIMU_CRASH(&env->nsm_v1.rpc2, env->evpl,
+                                        env->nsm_conn, &env->cred,
+                                        0, 0, NULL, 0, 0, mbt_void_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_sm_simu_crash */
+
+static inline struct mbt_aux_result *
+mbt_sm_notify(
+    struct mbt_env *env,
+    const char     *host,
+    int32_t         state)
+{
+    static struct mbt_sm_args scratch;
+    struct stat_chge          args;
+
+    mbt_aux_begin(env);
+    snprintf(scratch.mon, sizeof(scratch.mon), "%s", host);
+    xdr_set_str_static(&args, mon_name, scratch.mon,
+                       (uint32_t) strlen(scratch.mon));
+    args.state = state;
+
+    env->nsm_v1.send_call_SM_NOTIFY(&env->nsm_v1.rpc2, env->evpl, env->nsm_conn,
+                                    &env->cred, &args, 0, 0, NULL, 0, 0,
+                                    mbt_void_cb, env);
+    mbt_call_wait_soft(env);
+    return &mbt_aux(env)->r;
+} /* mbt_sm_notify */
+
+/* ======================================================================
+ * Lifecycle
+ * =================================================================== */
+
+/* Open the aux harness: the nfs3 env with the auxiliary services connected,
+ * plus this header's async receive handlers installed on NLM_V4. */
+static inline void
+mbt_aux_env_open(
+    struct mbt_env      *env,
+    struct mbt_env_opts *opts)
+{
+    static struct mbt_aux aux_storage;
+
+    opts->aux = 1;
+    mbt_env_open_opts(env, opts);
+
+    memset(&aux_storage, 0, sizeof(aux_storage));
+    env->aux = &aux_storage;
+
+    env->nlm_v4.recv_call_NLMPROC4_TEST_RES    = mbt_aux_recv_NLMPROC4_TEST_RES;
+    env->nlm_v4.recv_call_NLMPROC4_LOCK_RES    = mbt_aux_recv_NLMPROC4_LOCK_RES;
+    env->nlm_v4.recv_call_NLMPROC4_CANCEL_RES  = mbt_aux_recv_NLMPROC4_CANCEL_RES;
+    env->nlm_v4.recv_call_NLMPROC4_UNLOCK_RES  = mbt_aux_recv_NLMPROC4_UNLOCK_RES;
+    env->nlm_v4.recv_call_NLMPROC4_GRANTED_RES = mbt_aux_recv_NLMPROC4_GRANTED_RES;
+    env->nlm_v4.recv_call_NLMPROC4_GRANTED     = mbt_aux_recv_NLMPROC4_GRANTED;
+    env->nlm_v4.recv_call_NLMPROC4_GRANTED_MSG = mbt_aux_recv_NLMPROC4_GRANTED_MSG;
+} /* mbt_aux_env_open */
+
+/* Pump the client loop until the server's asynchronous messages have been
+ * dispatched.
+ *
+ * evpl_continue() BLOCKS until something happens, so a fixed spin count
+ * would wedge the moment the last pending event has been consumed.  A
+ * PERIODIC timer bounds it: a one-shot does not, because it is popped
+ * before its callback runs and the very evpl_continue() that fired it then
+ * waits with no deadline left.  A periodic timer is re-armed before the
+ * wait, so every pass is bounded and the caller's flag is re-read at a
+ * known cadence.  The timer is removed before returning.
+ */
+#define MBT_AUX_DRAIN_TICK_US 5000
+
+static void
+mbt_aux_drain_timer_cb(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    (void) evpl;
+    ((struct mbt_aux_drain_ctx *) timer)->ticks++;
+} /* mbt_aux_drain_timer_cb */
+
+/* Drain until `want` asynchronous messages have arrived, or the deadline
+ * passes.  want == 0 always waits the full timeout (the "nothing should
+ * come back" case).  Returns the number actually seen. */
+static inline int
+mbt_aux_drain_for(
+    struct mbt_env *env,
+    int             want,
+    uint64_t        timeout_us)
+{
+    struct mbt_aux          *a     = env->aux;
+    int                      limit = (int) (timeout_us /
+                                            MBT_AUX_DRAIN_TICK_US) + 1;
+    struct mbt_aux_drain_ctx ctx;
+
+    ctx.ticks = 0;
+    evpl_add_timer(env->evpl, &ctx.timer, mbt_aux_drain_timer_cb,
+                   MBT_AUX_DRAIN_TICK_US);
+    while (ctx.ticks < limit && (want == 0 || a->nasync < want)) {
+        evpl_continue(env->evpl);
+    }
+    evpl_remove_timer(env->evpl, &ctx.timer);
+    return a->nasync;
+} /* mbt_aux_drain_for */
+
+/* Wait out a fixed window with nothing expected back. */
+static inline void
+mbt_aux_drain_us(
+    struct mbt_env *env,
+    uint64_t        timeout_us)
+{
+    mbt_aux_drain_for(env, 0, timeout_us);
+} /* mbt_aux_drain_us */
+
+static inline void
+mbt_aux_async_reset(struct mbt_env *env)
+{
+    struct mbt_aux *a = env->aux;
+
+    a->nasync         = 0;
+    a->async_overflow = 0;
+} /* mbt_aux_async_reset */

--- a/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
@@ -1,0 +1,1783 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Replay a Quint-generated ITF trace of the AUXILIARY NFS protocols --
+ * portmap/rpcbind, MOUNT, NLM and NSM -- against an in-process chimera
+ * server over the libevpl inproc transport.
+ *
+ * Each state of the trace carries a `lastOp` naming the RPC the model
+ * issued and the reply the server must produce (see the nfsaux model in
+ * ext/specs/quint/nfsaux).  This harness embeds a chimera server backed by
+ * memfs, stands up the namespace the model assumes, then replays every step
+ * through the rpc2 client shim in nfs_aux_mbt_common.h and compares.
+ *
+ * Model-to-wire mapping maintained here:
+ *   - model file 0/1     -> the handles of /share/f0 and /share/f1, learned
+ *                           by LOOKUP after the harness creates them
+ *   - model file -1      -> a deliberately malformed handle, so the
+ *                           STALE_FH path is reachable
+ *   - model caller "cN"  -> "<trace>-cN": see reset_state() for why the
+ *                           name is qualified per trace
+ *   - model wireLen 0/-1 -> the two wire spellings of to-EOF, 0 and
+ *                           0xffffffffffffffff
+ *   - PROC_UNAVAIL       -> the model's RUnavail: the reply a procedure the
+ *                           server does not register produces
+ *
+ * ISOLATION.  The nfs3 suite gets a fresh filesystem per trace and that is
+ * enough, because NFSv3 is stateless.  These protocols are not: the lock
+ * table, the client table, the NSM monitor list and the NSM state number
+ * all live on the server and outlive any filesystem.  Three measures make a
+ * trace independent of its predecessors, and reset_state() carries the
+ * details.
+ */
+
+#include <getopt.h>
+#include <jansson.h>
+
+#include "nfs_aux_mbt_common.h"
+#include "common/mbt_trace_dir.h"
+
+#define AUX_MAX_MISM     16
+#define AUX_MISM_LEN     512
+#define AUX_HISTORY      10
+
+/* RFC 5531 accept_stat: the RPC ran but the procedure is not registered. */
+#define RPC_PROC_UNAVAIL 3
+
+/* The export the per-trace filesystem is published under, plus a second one
+ * over the same directory so MNT has an export list to disambiguate and
+ * MOUNTPROC3_EXPORT has more than one row to order. */
+#define AUX_EXPORT       "/share"
+#define AUX_EXPORT2      "/share2"
+
+/* Must match UADDR_HOST in the model's profile. */
+#define AUX_UADDR_HOST   "127.0.0.1"
+
+/* Must match MOUNT_HOST: the mount table records the connection's peer
+ * address with the port stripped, which under inproc is this literal. */
+#define AUX_MOUNT_HOST   "inproc"
+
+/* The model's caller names, in the order their per-trace qualified forms
+ * are built.  Every one is FREE_ALL'd at teardown. */
+static const char *aux_callers[] = { "c1", "c2", "c3" };
+#define AUX_NCALLERS     (int) (sizeof(aux_callers) / sizeof(aux_callers[0]))
+
+struct mism {
+    int  n;
+    char msg[AUX_MAX_MISM][AUX_MISM_LEN];
+};
+
+static void
+mism_add(
+    struct mism *m,
+    const char  *fmt,
+    ...) __attribute__((format(printf, 2, 3)));
+
+static void
+mism_add(
+    struct mism *m,
+    const char  *fmt,
+    ...)
+{
+    va_list ap;
+
+    if (m->n >= AUX_MAX_MISM) {
+        return;
+    }
+    va_start(ap, fmt);
+    vsnprintf(m->msg[m->n], AUX_MISM_LEN, fmt, ap);
+    va_end(ap);
+    m->n++;
+} /* mism_add */
+
+struct hist_ent {
+    int   idx;
+    char  tag[32];
+    char *op_dump;   /* json_dumps of the op record, owned */
+};
+
+struct oracle {
+    struct mbt_env *env;
+    int             verbose;
+    int             trace_seq;
+
+    struct mbt_fh   root_fh;
+    struct mbt_fh   file_fh[2];
+    struct mbt_fh   stale_fh;
+
+    /* The NSM state number is server-global and only ever advances, so a
+     * trace cannot assume it starts where the model starts.  Read it once
+     * and shift every predicted state by the difference. */
+    int32_t         nsm_base;
+
+    /* "<seq>-<name>" for each model caller name. */
+    char            caller[AUX_NCALLERS][MBT_AUX_NAME_MAX];
+
+    struct hist_ent history[AUX_HISTORY];
+    int             nhist;
+};
+
+/* ---- ITF decoding helpers (jansson) -------------------------------------- */
+
+static int64_t
+itf_i64(json_t *v)
+{
+    json_t *big;
+
+    if (json_is_integer(v)) {
+        return json_integer_value(v);
+    }
+    if (json_is_object(v)) {
+        big = json_object_get(v, "#bigint");
+        if (big && json_is_string(big)) {
+            return strtoll(json_string_value(big), NULL, 10);
+        }
+    }
+    return 0;
+} /* itf_i64 */
+
+static json_t *
+itf_seq(json_t *v)
+{
+    json_t *inner;
+
+    if (json_is_array(v)) {
+        return v;
+    }
+    if (json_is_object(v)) {
+        inner = json_object_get(v, "#set");
+        if (inner) {
+            return inner;
+        }
+        inner = json_object_get(v, "#list");
+        if (inner) {
+            return inner;
+        }
+    }
+    return NULL;
+} /* itf_seq */
+
+static int64_t
+op_i64(
+    json_t     *op,
+    const char *key)
+{
+    return itf_i64(json_object_get(op, key));
+} /* op_i64 */
+
+static const char *
+op_str(
+    json_t     *op,
+    const char *key)
+{
+    json_t *v = json_object_get(op, key);
+
+    return (v && json_is_string(v)) ? json_string_value(v) : "";
+} /* op_str */
+
+static int
+op_bool(
+    json_t     *op,
+    const char *key)
+{
+    json_t *v = json_object_get(op, key);
+
+    return v && json_is_true(v);
+} /* op_bool */
+
+/* A tagged sum value: { "tag": ..., "value": ... }. */
+static const char *
+jf_tag(json_t *v)
+{
+    json_t *t = v ? json_object_get(v, "tag") : NULL;
+
+    return (t && json_is_string(t)) ? json_string_value(t) : "";
+} /* jf_tag */
+
+static json_t *
+jf_val(json_t *v)
+{
+    return v ? json_object_get(v, "value") : NULL;
+} /* jf_val */
+
+static json_t *
+op_field(
+    json_t     *op,
+    const char *key)
+{
+    return json_object_get(op, key);
+} /* op_field */
+
+/* ---- model -> wire ------------------------------------------------------- */
+
+/* Model wireLen: a positive value is itself, 0 and -1 are the two wire
+ * spellings of to-EOF (l_len == 0 and l_len == 0xffffffffffffffff). */
+static uint64_t
+wire_len(int64_t model_len)
+{
+    if (model_len < 0) {
+        return MBT_NLM_LEN_EOF;
+    }
+    return (uint64_t) model_len;
+} /* wire_len */
+
+/* The server stores to-EOF as POSIX length 0 and reports it back as the NLM
+ * sentinel, so a holder's predicted l_len collapses both spellings. */
+static uint64_t
+holder_len(int64_t model_len)
+{
+    if (model_len <= 0) {
+        return MBT_NLM_LEN_EOF;
+    }
+    return (uint64_t) model_len;
+} /* holder_len */
+
+static const struct mbt_fh *
+fh_of(
+    struct oracle *o,
+    int64_t        file)
+{
+    if (file < 0 || file > 1) {
+        return &o->stale_fh;
+    }
+    return &o->file_fh[file];
+} /* fh_of */
+
+static const char *
+caller_of(
+    struct oracle *o,
+    const char    *model_name)
+{
+    int i;
+
+    for (i = 0; i < AUX_NCALLERS; i++) {
+        if (strcmp(aux_callers[i], model_name) == 0) {
+            return o->caller[i];
+        }
+    }
+    return model_name;
+} /* caller_of */
+
+/* The owner handle is a model integer; two bytes carry every value the
+ * model uses and keep the wire form small. */
+static uint32_t
+oh_bytes(
+    int64_t  oh,
+    uint8_t *buf)
+{
+    buf[0] = (uint8_t) (oh & 0xff);
+    buf[1] = (uint8_t) ((oh >> 8) & 0xff);
+    return 2;
+} /* oh_bytes */
+
+/* One fixed cookie for every request: the protocol requires the server to
+ * echo it, which is itself worth checking. */
+static const uint8_t aux_cookie[] = { 0xc0, 0xff, 0xee };
+#define AUX_COOKIE_LEN (uint32_t) sizeof(aux_cookie)
+
+/* ---- reply checking ------------------------------------------------------ */
+
+/*
+ * Every handler starts here.  `reply` is the model's Reply sum value: when
+ * it is RUnavail the server must have refused the call with PROC_UNAVAIL and
+ * nothing else is compared; otherwise the call must have run.  Returns 1
+ * when the caller should go on to compare the payload.
+ */
+static int
+check_gate(
+    struct oracle *o,
+    json_t        *reply,
+    struct mism   *m)
+{
+    const char *tag = jf_tag(reply);
+    int         err = o->env->res.rpc_err;
+
+    if (strcmp(tag, "RUnavail") == 0) {
+        if (err != RPC_PROC_UNAVAIL) {
+            mism_add(m, "expected PROC_UNAVAIL (%d), got rpc status %d",
+                     RPC_PROC_UNAVAIL, err);
+        }
+        return 0;
+    }
+
+    if (err != 0) {
+        mism_add(m, "expected the call to run, got rpc status %d", err);
+        return 0;
+    }
+    return 1;
+} /* check_gate */
+
+static void
+check_u32(
+    struct mism *m,
+    const char  *what,
+    uint32_t     got,
+    uint32_t     want)
+{
+    if (got != want) {
+        mism_add(m, "%s: got %u, want %u", what, got, want);
+    }
+} /* check_u32 */
+
+static void
+check_u64(
+    struct mism *m,
+    const char  *what,
+    uint64_t     got,
+    uint64_t     want)
+{
+    if (got != want) {
+        mism_add(m, "%s: got %llu, want %llu", what,
+                 (unsigned long long) got, (unsigned long long) want);
+    }
+} /* check_u64 */
+
+static void
+check_str(
+    struct mism *m,
+    const char  *what,
+    const char  *got,
+    const char  *want)
+{
+    if (strcmp(got, want) != 0) {
+        mism_add(m, "%s: got '%s', want '%s'", what, got, want);
+    }
+} /* check_str */
+
+/* The universal address a port is reported under: "<host>.<hi>.<lo>", and
+ * the empty string when the service is not registered. */
+static void
+uaddr_of(
+    char    *out,
+    size_t   cap,
+    uint32_t port)
+{
+    if (port == 0) {
+        out[0] = '\0';
+        return;
+    }
+    snprintf(out, cap, AUX_UADDR_HOST ".%u.%u", port >> 8, port & 0xff);
+} /* uaddr_of */
+
+static void
+check_cookie(
+    struct oracle *o,
+    struct mism   *m)
+{
+    struct mbt_aux_result *r = &mbt_aux(o->env)->r;
+
+    if (r->cookie_len != AUX_COOKIE_LEN ||
+        memcmp(r->cookie, aux_cookie, AUX_COOKIE_LEN) != 0) {
+        mism_add(m, "cookie not echoed: got %u bytes", r->cookie_len);
+    }
+} /* check_cookie */
+
+/* ---- portmap / rpcbind --------------------------------------------------- */
+
+typedef void (*op_handler_t)(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m);
+
+static void
+op_pm_null(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_pm_null(o->env);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_pm_null */
+
+static void
+op_pm_getport(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+
+    r = mbt_pm_getport(o->env, (uint32_t) op_i64(op, "prog"),
+                       (uint32_t) op_i64(op, "vers"),
+                       (uint32_t) op_i64(op, "prot"));
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    check_u32(m, "GETPORT port", r->port,
+              (uint32_t) itf_i64(jf_val(reply)));
+} /* op_pm_getport */
+
+static void
+op_pm_set(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    json_t                *map   = op_field(op, "map");
+    struct mbt_aux_result *r;
+
+    r = mbt_pm_set(o->env, (uint32_t) op_i64(map, "prog"),
+                   (uint32_t) op_i64(map, "vers"),
+                   (uint32_t) op_i64(map, "prot"),
+                   (uint32_t) op_i64(map, "port"),
+                   op_bool(op, "unset"));
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    check_u32(m, "SET/UNSET result", (uint32_t) r->boolres,
+              json_is_true(jf_val(reply)) ? 1u : 0u);
+} /* op_pm_set */
+
+/* Compare a reply's mapping list against the model's service table. */
+static void
+check_maps(
+    struct mbt_aux_result *r,
+    json_t                *want,
+    struct mism           *m)
+{
+    size_t n = json_array_size(want);
+    size_t i;
+
+    if ((size_t) r->nmaps != n) {
+        mism_add(m, "DUMP entry count: got %d, want %zu", r->nmaps, n);
+        return;
+    }
+    for (i = 0; i < n; i++) {
+        json_t *e = json_array_get(want, i);
+
+        if (r->maps[i].prog != (uint32_t) itf_i64(json_object_get(e, "prog")) ||
+            r->maps[i].vers != (uint32_t) itf_i64(json_object_get(e, "vers")) ||
+            r->maps[i].prot != (uint32_t) itf_i64(json_object_get(e, "prot")) ||
+            r->maps[i].port != (uint32_t) itf_i64(json_object_get(e, "port"))) {
+            mism_add(m, "DUMP[%zu]: got %u.%u.%u.%u, want %lld.%lld.%lld.%lld",
+                     i, r->maps[i].prog, r->maps[i].vers, r->maps[i].prot,
+                     r->maps[i].port,
+                     (long long) itf_i64(json_object_get(e, "prog")),
+                     (long long) itf_i64(json_object_get(e, "vers")),
+                     (long long) itf_i64(json_object_get(e, "prot")),
+                     (long long) itf_i64(json_object_get(e, "port")));
+        }
+    }
+} /* check_maps */
+
+static void
+op_pm_dump(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r     = mbt_pm_dump(o->env);
+
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    check_maps(r, jf_val(reply), m);
+} /* op_pm_dump */
+
+static void
+op_pm_callit(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_pm_callit(o->env, (uint32_t) op_i64(op, "prog"),
+                  (uint32_t) op_i64(op, "vers"),
+                  (uint32_t) op_i64(op, "cproc"));
+    /* Only the refusal is predictable; a server that implements CALLIT
+     * returns the proxied service's own result, which is that protocol's
+     * business.  check_gate is the whole check. */
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_pm_callit */
+
+static const char *
+netid_str(json_t *netid)
+{
+    const char *tag = jf_tag(netid);
+
+    if (strcmp(tag, "NetTcp") == 0) {
+        return "tcp";
+    }
+    if (strcmp(tag, "NetUdp") == 0) {
+        return "udp";
+    }
+    if (strcmp(tag, "NetTcp6") == 0) {
+        return "tcp6";
+    }
+    if (strcmp(tag, "NetUdp6") == 0) {
+        return "udp6";
+    }
+    return "local";
+} /* netid_str */
+
+static void
+check_uaddr(
+    struct mbt_aux_result *r,
+    json_t                *reply,
+    struct mism           *m)
+{
+    json_t  *u    = jf_val(reply);
+    uint32_t port = (uint32_t) itf_i64(json_object_get(u, "port"));
+    char     want[MBT_AUX_UADDR_MAX];
+
+    uaddr_of(want, sizeof(want), port);
+    check_str(m, "universal address", r->uaddr, want);
+} /* check_uaddr */
+
+static void
+op_rb_getaddr(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+
+    r = mbt_rb_getaddr(o->env, (int) op_i64(op, "rbvers"),
+                       (uint32_t) op_i64(op, "prog"),
+                       (uint32_t) op_i64(op, "vers"),
+                       netid_str(op_field(op, "netid")));
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    check_uaddr(r, reply, m);
+} /* op_rb_getaddr */
+
+static void
+op_rb_getversaddr(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+
+    r = mbt_rb_getversaddr(o->env, (uint32_t) op_i64(op, "prog"),
+                           (uint32_t) op_i64(op, "vers"),
+                           netid_str(op_field(op, "netid")));
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    check_uaddr(r, reply, m);
+} /* op_rb_getversaddr */
+
+static void
+op_rb_dump(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+    json_t                *want;
+    size_t                 n, i;
+
+    r = mbt_rb_dump(o->env, (int) op_i64(op, "rbvers"));
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    want = jf_val(reply);
+    n    = json_array_size(want);
+    if ((size_t) r->nrpcb != n) {
+        mism_add(m, "rpcbind DUMP entry count: got %d, want %zu", r->nrpcb, n);
+        return;
+    }
+    for (i = 0; i < n; i++) {
+        json_t  *e    = json_array_get(want, i);
+        uint32_t prog = (uint32_t) itf_i64(json_object_get(e, "prog"));
+        uint32_t vers = (uint32_t) itf_i64(json_object_get(e, "vers"));
+        uint32_t port = (uint32_t) itf_i64(json_object_get(e, "port"));
+        char     addr[MBT_AUX_UADDR_MAX];
+        char     label[64];
+
+        uaddr_of(addr, sizeof(addr), port);
+        snprintf(label, sizeof(label), "rpcbind DUMP[%zu] prog", i);
+        check_u32(m, label, r->rpcb[i].prog, prog);
+        snprintf(label, sizeof(label), "rpcbind DUMP[%zu] vers", i);
+        check_u32(m, label, r->rpcb[i].vers, vers);
+        snprintf(label, sizeof(label), "rpcbind DUMP[%zu] addr", i);
+        check_str(m, label, r->rpcb[i].addr, addr);
+        /* Every row is served over TCP and no ownership is tracked. */
+        snprintf(label, sizeof(label), "rpcbind DUMP[%zu] netid", i);
+        check_str(m, label, r->rpcb[i].netid, "tcp");
+        snprintf(label, sizeof(label), "rpcbind DUMP[%zu] owner", i);
+        check_str(m, label, r->rpcb[i].owner, "");
+    }
+} /* op_rb_dump */
+
+static void
+op_rb_gettime(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_rb_gettime(o->env, (int) op_i64(op, "rbvers"));
+    /* The reply is a wall clock; only the accept_stat is an oracle. */
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_rb_gettime */
+
+/* ---- MOUNT --------------------------------------------------------------- */
+
+static void
+op_mnt_null(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_mount_null(o->env);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_mnt_null */
+
+static void
+op_mnt(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    const char            *path  = op_str(op, "path");
+    const char            *tag;
+    struct mbt_aux_result *r;
+    json_t                *want;
+    size_t                 n, i;
+
+    r = mbt_mount_mnt(o->env, path);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+
+    tag = jf_tag(reply);
+    if (strcmp(tag, "RMntErr") == 0) {
+        check_u32(m, "MNT status", o->env->res.status,
+                  (uint32_t) itf_i64(jf_val(reply)));
+        return;
+    }
+
+    check_u32(m, "MNT status", o->env->res.status, MNT3_OK);
+    if (o->env->res.status != MNT3_OK) {
+        return;
+    }
+    if (!o->env->res.obj_fh.has) {
+        mism_add(m, "MNT succeeded without a file handle");
+    }
+
+    want = jf_val(reply);
+    n    = json_array_size(want);
+    if ((size_t) r->nauth != n) {
+        mism_add(m, "MNT auth flavor count: got %d, want %zu", r->nauth, n);
+        return;
+    }
+    for (i = 0; i < n; i++) {
+        char label[48];
+
+        snprintf(label, sizeof(label), "MNT auth flavor[%zu]", i);
+        check_u32(m, label, (uint32_t) r->auth[i],
+                  (uint32_t) itf_i64(json_array_get(want, i)));
+    }
+} /* op_mnt */
+
+static void
+op_mnt_dump(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r     = mbt_mount_dump(o->env);
+    json_t                *want;
+    size_t                 n, i;
+
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    want = jf_val(reply);
+    n    = json_array_size(want);
+    if ((size_t) r->nmounts != n) {
+        mism_add(m, "mount table size: got %d, want %zu", r->nmounts, n);
+        return;
+    }
+    for (i = 0; i < n; i++) {
+        json_t *e = json_array_get(want, i);
+        char    label[64];
+
+        snprintf(label, sizeof(label), "mount table[%zu] host", i);
+        check_str(m, label, r->mounts[i].host, AUX_MOUNT_HOST);
+        snprintf(label, sizeof(label), "mount table[%zu] dir", i);
+        check_str(m, label, r->mounts[i].dir,
+                  json_string_value(json_object_get(e, "dir")) ?: "");
+    }
+} /* op_mnt_dump */
+
+static void
+op_mnt_umnt(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_mount_umnt(o->env, op_str(op, "path"));
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_mnt_umnt */
+
+static void
+op_mnt_umntall(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_mount_umntall(o->env);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_mnt_umntall */
+
+static void
+op_mnt_export(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r     = mbt_mount_export(o->env);
+    json_t                *want;
+    size_t                 n, i;
+
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    want = jf_val(reply);
+    n    = json_array_size(want);
+    if ((size_t) r->nexports != n) {
+        mism_add(m, "export list size: got %d, want %zu", r->nexports, n);
+        return;
+    }
+    for (i = 0; i < n; i++) {
+        char label[48];
+
+        snprintf(label, sizeof(label), "export[%zu]", i);
+        check_str(m, label, r->exports[i].dir,
+                  json_string_value(json_array_get(want, i)) ?: "");
+        if (r->exports[i].ngroups != 0) {
+            mism_add(m, "export[%zu] carries %d group(s); none expected", i,
+                     r->exports[i].ngroups);
+        }
+    }
+} /* op_mnt_export */
+
+/* ---- NLM ----------------------------------------------------------------- */
+
+/* Decode a model Lock record into the wire arguments. */
+struct aux_lock {
+    const struct mbt_fh *fh;
+    const char          *caller;
+    uint8_t              oh[4];
+    uint32_t             oh_len;
+    int32_t              svid;
+    uint64_t             offset;
+    uint64_t             length;
+    int                  excl;
+};
+
+static void
+decode_lock(
+    struct oracle   *o,
+    json_t          *jl,
+    struct aux_lock *out)
+{
+    json_t *owner = json_object_get(jl, "owner");
+
+    out->fh     = fh_of(o, op_i64(jl, "file"));
+    out->caller = caller_of(o, op_str(owner, "caller"));
+    out->oh_len = oh_bytes(op_i64(owner, "oh"), out->oh);
+    out->svid   = (int32_t) op_i64(owner, "svid");
+    out->offset = (uint64_t) op_i64(jl, "offset");
+    out->length = wire_len(op_i64(jl, "wireLen"));
+    out->excl   = op_bool(jl, "excl");
+} /* decode_lock */
+
+/*
+ * An NLM request can provoke messages the server sends BACK to the client:
+ * an NLMPROC4_*_RES reporting the outcome of an asynchronous request.  The
+ * model's `asyncs` list says exactly which, and it is not always one --
+ * cancelling a queued NLMPROC4_LOCK_MSG produces both the CANCEL_RES that
+ * answers the cancel and the LOCK_RES that retires the blocked LOCK.
+ *
+ * The two are not ordered with respect to each other, so the comparison is
+ * a multiset match: each expected (proc, status) has to be consumed by a
+ * distinct received message, and nothing may be left over.
+ */
+static void
+check_asyncs(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    struct mbt_aux *a      = mbt_aux(o->env);
+    json_t         *asyncs = itf_seq(op_field(op, "asyncs"));
+    size_t          want   = asyncs ? json_array_size(asyncs) : 0;
+    int             taken[MBT_AUX_MAX_ASYNC];
+    size_t          i;
+    int             j;
+
+    if (want == 0) {
+        /* Wait out a short window rather than declaring success at once, so
+         * a server that answers when it should not is caught instead of
+         * being silently tolerated. */
+        mbt_aux_drain_us(o->env, 50000);
+        if (a->nasync != 0) {
+            mism_add(m, "expected no asynchronous message, got %d (proc %d)",
+                     a->nasync, a->async[0].proc);
+        }
+        return;
+    }
+
+    mbt_aux_drain_for(o->env, (int) want, 2000000);
+    if ((size_t) a->nasync != want) {
+        mism_add(m, "expected %zu asynchronous message(s), got %d", want,
+                 a->nasync);
+        return;
+    }
+
+    memset(taken, 0, sizeof(taken));
+    for (i = 0; i < want; i++) {
+        json_t  *e     = json_array_get(asyncs, i);
+        int      proc  = (int) itf_i64(json_object_get(e, "proc"));
+        uint32_t stat  = (uint32_t) itf_i64(json_object_get(e, "stat"));
+        int      found = 0;
+
+        for (j = 0; j < a->nasync; j++) {
+            if (taken[j] || a->async[j].proc != proc ||
+                a->async[j].stat != stat) {
+                continue;
+            }
+            taken[j] = 1;
+            found    = 1;
+            if (a->async[j].cookie_len != AUX_COOKIE_LEN ||
+                memcmp(a->async[j].cookie, aux_cookie, AUX_COOKIE_LEN) != 0) {
+                mism_add(m, "asynchronous message (proc %d) did not echo the "
+                         "cookie", proc);
+            }
+            break;
+        }
+        if (!found) {
+            mism_add(m, "no asynchronous message with proc %d status %u "
+                     "arrived", proc, stat);
+        }
+    }
+} /* check_asyncs */
+
+/* The synchronous shape: an nlm4_res carrying a status and the cookie. */
+static void
+check_nlm_res(
+    struct oracle *o,
+    json_t        *reply,
+    struct mism   *m)
+{
+    struct mbt_aux_result *r = &mbt_aux(o->env)->r;
+
+    check_u32(m, "NLM status", r->nlm_stat,
+              (uint32_t) itf_i64(jf_val(reply)));
+    check_cookie(o, m);
+} /* check_nlm_res */
+
+static void
+op_nlm_null(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_nlm_null(o->env);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_nlm_null */
+
+static void
+op_nlm_test(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    int                    msg   = op_bool(op, "msg");
+    struct aux_lock        l;
+    struct mbt_aux_result *r;
+    json_t                *v, *holders;
+    uint32_t               want_stat;
+    size_t                 n, i;
+    int                    matched;
+
+    decode_lock(o, op_field(op, "lock"), &l);
+    if (msg) {
+    }
+    r = mbt_nlm_test(o->env, msg, l.caller, l.fh, l.oh, l.oh_len, l.svid,
+                     l.excl, l.offset, l.length, aux_cookie, AUX_COOKIE_LEN);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    if (msg) {
+        check_asyncs(o, op, m);
+        return;
+    }
+
+    v         = jf_val(reply);
+    want_stat = (uint32_t) itf_i64(json_object_get(v, "stat"));
+    check_u32(m, "TEST status", r->nlm_stat, want_stat);
+    check_cookie(o, m);
+
+    if (r->nlm_stat != NLM4_DENIED || want_stat != NLM4_DENIED) {
+        return;
+    }
+
+    /*
+     * Which conflicting holder a server names when several conflict is not
+     * determined by the protocol, so the model reports the candidates and
+     * the check is membership.  The holder's owner identity is separately
+     * pinned: a server whose arbitration does not retain the requester
+     * reports zero for both svid and oh, which is what this profile expects.
+     */
+    holders = itf_seq(json_object_get(v, "holders"));
+    n       = holders ? json_array_size(holders) : 0;
+    matched = 0;
+    for (i = 0; i < n; i++) {
+        json_t  *h    = json_array_get(holders, i);
+        uint64_t off  = (uint64_t) op_i64(h, "offset");
+        uint64_t len  = holder_len(op_i64(h, "wireLen"));
+        int      excl = op_bool(h, "excl");
+
+        if (r->holder_offset == off && r->holder_length == len &&
+            r->holder_exclusive == excl) {
+            matched = 1;
+            break;
+        }
+    }
+    if (!matched) {
+        mism_add(m, "TEST holder [%llu,%llu) excl=%d matches none of the %zu "
+                 "conflicting locks the model holds",
+                 (unsigned long long) r->holder_offset,
+                 (unsigned long long) r->holder_length,
+                 r->holder_exclusive, n);
+    }
+    check_u32(m, "TEST holder svid", (uint32_t) r->holder_svid, 0);
+    check_u32(m, "TEST holder oh length", r->holder_oh_len, 0);
+} /* op_nlm_test */
+
+static void
+op_nlm_lock(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t         *reply = op_field(op, "reply");
+    int             nproc = (int) op_i64(op, "nproc");
+    struct aux_lock l;
+
+    decode_lock(o, op_field(op, "lock"), &l);
+    if (nproc == 7) {
+    }
+    mbt_nlm_lock(o->env, nproc, l.caller, l.fh, l.oh, l.oh_len, l.svid,
+                 l.excl, op_bool(op, "block"), op_bool(op, "reclaim"), 0,
+                 l.offset, l.length, aux_cookie, AUX_COOKIE_LEN);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    if (nproc == 7) {
+        check_asyncs(o, op, m);
+        return;
+    }
+    check_nlm_res(o, reply, m);
+} /* op_nlm_lock */
+
+static void
+op_nlm_cancel(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t         *reply = op_field(op, "reply");
+    int             msg   = op_bool(op, "msg");
+    struct aux_lock l;
+
+    decode_lock(o, op_field(op, "lock"), &l);
+    mbt_nlm_cancel(o->env, msg, l.caller, l.fh, l.oh, l.oh_len, l.svid,
+                   l.excl, 1, l.offset, l.length, aux_cookie,
+                   AUX_COOKIE_LEN);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    if (!msg) {
+        check_nlm_res(o, reply, m);
+    }
+    check_asyncs(o, op, m);
+} /* op_nlm_cancel */
+
+static void
+op_nlm_unlock(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t         *reply = op_field(op, "reply");
+    int             msg   = op_bool(op, "msg");
+    struct aux_lock l;
+
+    decode_lock(o, op_field(op, "lock"), &l);
+    if (msg) {
+    }
+    mbt_nlm_unlock(o->env, msg, l.caller, l.fh, l.oh, l.oh_len, l.svid,
+                   l.offset, l.length, aux_cookie, AUX_COOKIE_LEN);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    if (msg) {
+        check_asyncs(o, op, m);
+        return;
+    }
+    check_nlm_res(o, reply, m);
+} /* op_nlm_unlock */
+
+static void
+op_nlm_granted(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t         *reply = op_field(op, "reply");
+    int             msg   = op_bool(op, "msg");
+    struct aux_lock l;
+
+    decode_lock(o, op_field(op, "lock"), &l);
+    if (msg) {
+    }
+    mbt_nlm_granted(o->env, msg, l.caller, l.fh, l.oh, l.oh_len, l.svid,
+                    l.excl, l.offset, l.length, aux_cookie, AUX_COOKIE_LEN);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    if (msg) {
+        check_asyncs(o, op, m);
+        return;
+    }
+    check_nlm_res(o, reply, m);
+} /* op_nlm_granted */
+
+static void
+op_nlm_res(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_nlm_send_res(o->env, (int) op_i64(op, "nproc"),
+                     (uint32_t) op_i64(op, "stat"), aux_cookie,
+                     AUX_COOKIE_LEN);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_nlm_res */
+
+static void
+op_nlm_reserved(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_nlm_reserved(o->env, (int) op_i64(op, "nproc"));
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_nlm_reserved */
+
+static void
+op_nlm_share(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    json_t                *sh    = op_field(op, "share");
+    struct mbt_aux_result *r;
+    uint8_t                oh[4];
+    uint32_t               oh_len = oh_bytes(op_i64(sh, "oh"), oh);
+    json_t                *v;
+
+    r = mbt_nlm_share(o->env, op_bool(op, "unshare"),
+                      caller_of(o, op_str(sh, "caller")),
+                      fh_of(o, op_i64(sh, "file")), oh, oh_len,
+                      (int) op_i64(sh, "mode"), (int) op_i64(sh, "access"),
+                      0, aux_cookie, AUX_COOKIE_LEN);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    v = jf_val(reply);
+    check_u32(m, "SHARE status", r->nlm_stat,
+              (uint32_t) itf_i64(json_object_get(v, "stat")));
+    check_u32(m, "SHARE sequence", (uint32_t) r->sequence,
+              (uint32_t) itf_i64(json_object_get(v, "sequence")));
+    check_cookie(o, m);
+} /* op_nlm_share */
+
+static void
+op_nlm_free_all(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_nlm_free_all(o->env, caller_of(o, op_str(op, "name")), 1);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_nlm_free_all */
+
+/* ---- NSM ----------------------------------------------------------------- */
+
+/* The model predicts a state number relative to 1; the live server's
+ * counter is global and only advances, so shift by the base read at trace
+ * start. */
+static void
+check_sm_state(
+    struct oracle *o,
+    struct mism   *m,
+    int32_t        got,
+    int64_t        want_model)
+{
+    int32_t want = (int32_t) (want_model - 1) + o->nsm_base;
+
+    if (got != want) {
+        mism_add(m, "NSM state number: got %d, want %d (model %lld, base %d)",
+                 got, want, (long long) want_model, o->nsm_base);
+    }
+} /* check_sm_state */
+
+static void
+op_sm_null(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_sm_null(o->env);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_sm_null */
+
+static void
+op_sm_stat(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+    json_t                *v;
+
+    r = mbt_sm_stat(o->env, caller_of(o, op_str(op, "host")));
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    v = jf_val(reply);
+    check_u32(m, "SM_STAT res", (uint32_t) r->sm_res,
+              (uint32_t) itf_i64(json_object_get(v, "res")));
+    check_sm_state(o, m, r->sm_state, itf_i64(json_object_get(v, "state")));
+} /* op_sm_stat */
+
+static void
+op_sm_mon(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+    json_t                *v;
+
+    r = mbt_sm_mon(o->env, caller_of(o, op_str(op, "host")), "quintmbt",
+                   100021, 4, 24);
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    v = jf_val(reply);
+    check_u32(m, "SM_MON res", (uint32_t) r->sm_res,
+              (uint32_t) itf_i64(json_object_get(v, "res")));
+    check_sm_state(o, m, r->sm_state, itf_i64(json_object_get(v, "state")));
+} /* op_sm_mon */
+
+static void
+op_sm_unmon(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+
+    r = mbt_sm_unmon(o->env, caller_of(o, op_str(op, "host")), "quintmbt");
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    check_sm_state(o, m, r->sm_state, itf_i64(jf_val(reply)));
+} /* op_sm_unmon */
+
+static void
+op_sm_unmon_all(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    json_t                *reply = op_field(op, "reply");
+    struct mbt_aux_result *r;
+
+    r = mbt_sm_unmon_all(o->env, caller_of(o, op_str(op, "name")));
+    if (!check_gate(o, reply, m)) {
+        return;
+    }
+    check_sm_state(o, m, r->sm_state, itf_i64(jf_val(reply)));
+} /* op_sm_unmon_all */
+
+static void
+op_sm_simu_crash(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_sm_simu_crash(o->env);
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_sm_simu_crash */
+
+static void
+op_sm_notify(
+    struct oracle *o,
+    json_t        *op,
+    struct mism   *m)
+{
+    mbt_sm_notify(o->env, caller_of(o, op_str(op, "host")),
+                  (int32_t) op_i64(op, "state"));
+    check_gate(o, op_field(op, "reply"), m);
+} /* op_sm_notify */
+
+/* ---- dispatch ------------------------------------------------------------ */
+
+/* *INDENT-OFF* -- uncrustify oscillates on this table's alignment. */
+static const struct {
+    const char  *tag;
+    op_handler_t fn;
+} handlers[] = {
+    { "OPmNull",        op_pm_null         },
+    { "OPmGetport",     op_pm_getport      },
+    { "OPmSet",         op_pm_set          },
+    { "OPmDump",        op_pm_dump         },
+    { "OPmCallit",      op_pm_callit       },
+    { "ORbGetaddr",     op_rb_getaddr      },
+    { "ORbDump",        op_rb_dump         },
+    { "ORbGettime",     op_rb_gettime      },
+    { "ORbGetversaddr", op_rb_getversaddr  },
+    { "OMntNull",       op_mnt_null        },
+    { "OMnt",           op_mnt             },
+    { "OMntDump",       op_mnt_dump        },
+    { "OMntUmnt",       op_mnt_umnt        },
+    { "OMntUmntAll",    op_mnt_umntall     },
+    { "OMntExport",     op_mnt_export      },
+    { "ONlmNull",       op_nlm_null        },
+    { "ONlmTestOp",     op_nlm_test        },
+    { "ONlmLock",       op_nlm_lock        },
+    { "ONlmCancel",     op_nlm_cancel      },
+    { "ONlmUnlock",     op_nlm_unlock      },
+    { "ONlmGranted",    op_nlm_granted     },
+    { "ONlmRes",        op_nlm_res         },
+    { "ONlmReserved",   op_nlm_reserved    },
+    { "ONlmShare",      op_nlm_share       },
+    { "ONlmFreeAll",    op_nlm_free_all    },
+    { "OSmNull",        op_sm_null         },
+    { "OSmStat",        op_sm_stat         },
+    { "OSmMon",         op_sm_mon          },
+    { "OSmUnmon",       op_sm_unmon        },
+    { "OSmUnmonAll",    op_sm_unmon_all    },
+    { "OSmSimuCrash",   op_sm_simu_crash   },
+    { "OSmNotify",      op_sm_notify       },
+};
+/* *INDENT-ON* */
+
+static op_handler_t
+find_handler(const char *tag)
+{
+    size_t i;
+
+    for (i = 0; i < sizeof(handlers) / sizeof(handlers[0]); i++) {
+        if (strcmp(handlers[i].tag, tag) == 0) {
+            return handlers[i].fn;
+        }
+    }
+    return NULL;
+} /* find_handler */
+
+/* ---- per-trace setup / teardown ------------------------------------------ */
+
+/*
+ * Build the namespace and the identity space each trace assumes.
+ *
+ * The filesystem is fresh (a uniquely named memfs, mounted and exported by
+ * the caller), but the LOCK MANAGER and STATUS MONITOR are not: their
+ * tables are server-global and outlive any filesystem.  Three measures make
+ * a trace independent of its predecessors:
+ *
+ *   1. Caller names are qualified with the trace's sequence number, so the
+ *      NLM client table and the NSM monitor list start empty for the names
+ *      this trace uses.  That matters beyond tidiness: a server keeps a
+ *      client's table entry after its last lock is released, and SM_NOTIFY
+ *      takes a different path for a name it has seen before.
+ *   2. Every caller is FREE_ALL'd at teardown, which releases its locks and
+ *      unmonitors it.  Without that a leftover lock would hold an open
+ *      handle on the filesystem and rmfs would never succeed.
+ *   3. The NSM state number only ever advances, so the trace records the
+ *      value it starts at and every prediction is shifted by it.
+ *
+ * The mount table IS reset directly (UMNTALL), because it is keyed by the
+ * client's address, which every trace shares.
+ */
+static int
+trace_setup(
+    struct oracle *o,
+    const char    *trace_path)
+{
+    struct mbt_env        *env = o->env;
+    struct mbt_result     *res;
+    struct mbt_aux_result *ar;
+    int                    i;
+    char                   name[8];
+
+    for (i = 0; i < AUX_NCALLERS; i++) {
+        snprintf(o->caller[i], sizeof(o->caller[i]), "t%d-%s", o->trace_seq,
+                 aux_callers[i]);
+    }
+
+    if (chimera_server_create_export(env->server, AUX_EXPORT2, AUX_EXPORT, 0,
+                                     NULL) != 0) {
+        fprintf(stderr, "%s: failed to create the %s export\n", trace_path,
+                AUX_EXPORT2);
+        return 1;
+    }
+
+    res = mbt_mnt(env, AUX_EXPORT);
+    if (res->rpc_err != 0 || res->status != MNT3_OK || !res->obj_fh.has) {
+        fprintf(stderr, "%s: MNT %s failed: rpc_err=%d status=%u\n",
+                trace_path, AUX_EXPORT, res->rpc_err, res->status);
+        return 1;
+    }
+    o->root_fh = res->obj_fh;
+
+    /* The objects the model's path universe and file universe name. */
+    mbt_mkdir(env, &o->root_fh, "d", 1, 0755);
+    for (i = 0; i < 2; i++) {
+        snprintf(name, sizeof(name), "f%d", i);
+        mbt_create(env, &o->root_fh, name, (uint32_t) strlen(name), UNCHECKED,
+                   0644, NULL);
+        res = mbt_lookup(env, &o->root_fh, name, (uint32_t) strlen(name));
+        if (res->status != 0 || !res->obj_fh.has) {
+            fprintf(stderr, "%s: LOOKUP %s failed: %u\n", trace_path, name,
+                    res->status);
+            return 1;
+        }
+        o->file_fh[i] = res->obj_fh;
+    }
+
+    /* A handle of the right shape that decodes to nothing. */
+    memset(&o->stale_fh, 0, sizeof(o->stale_fh));
+    o->stale_fh.has = 1;
+    o->stale_fh.len = 16;
+    memset(o->stale_fh.data, 0x5a, o->stale_fh.len);
+
+    /* The MNT above left a row behind; the model starts with none. */
+    mbt_mount_umntall(env);
+
+    ar = mbt_sm_stat(env, "quintmbt");
+    if (env->res.rpc_err != 0) {
+        fprintf(stderr, "%s: SM_STAT failed: %d\n", trace_path,
+                env->res.rpc_err);
+        return 1;
+    }
+    o->nsm_base = ar->sm_state;
+
+    mbt_aux_async_reset(env);
+    return 0;
+} /* trace_setup */
+
+static void
+trace_teardown(struct oracle *o)
+{
+    int i;
+
+    for (i = 0; i < AUX_NCALLERS; i++) {
+        mbt_nlm_free_all(o->env, o->caller[i], 1);
+    }
+    mbt_mount_umntall(o->env);
+    chimera_server_remove_export(o->env->server, AUX_EXPORT2);
+} /* trace_teardown */
+
+/* ---- replay driver -------------------------------------------------------- */
+
+static void
+history_push(
+    struct oracle *o,
+    int            idx,
+    const char    *tag,
+    json_t        *op)
+{
+    struct hist_ent *e;
+
+    if (o->nhist == AUX_HISTORY) {
+        free(o->history[0].op_dump);
+        memmove(&o->history[0], &o->history[1],
+                sizeof(o->history[0]) * (AUX_HISTORY - 1));
+        o->nhist--;
+    }
+    e      = &o->history[o->nhist++];
+    e->idx = idx;
+    snprintf(e->tag, sizeof(e->tag), "%s", tag);
+    e->op_dump = json_dumps(op, JSON_COMPACT | JSON_ENCODE_ANY);
+} /* history_push */
+
+static void
+report_divergence(
+    const char    *trace_path,
+    struct oracle *o,
+    int            step,
+    const char    *tag,
+    json_t        *op,
+    struct mism   *m)
+{
+    char *dump;
+    int   i;
+
+    fprintf(stderr, "\n=== DIVERGENCE in %s ===\n", trace_path);
+    dump = json_dumps(op, JSON_COMPACT | JSON_ENCODE_ANY);
+    fprintf(stderr, "step %d: %s args/expectation: %s\n", step, tag,
+            dump ?: "<?>");
+    free(dump);
+    for (i = 0; i < m->n; i++) {
+        fprintf(stderr, "  MISMATCH: %s\n", m->msg[i]);
+    }
+    fprintf(stderr, "\nlast operations before failure:\n");
+    for (i = 0; i < o->nhist; i++) {
+        fprintf(stderr, "  [%4d] %s %s\n", o->history[i].idx,
+                o->history[i].tag, o->history[i].op_dump ?: "<?>");
+    }
+} /* report_divergence */
+
+/*
+ * Per-step state cross-check (--paranoid).
+ *
+ * Comparing replies alone localizes a divergence only when it happens to be
+ * visible in the very next reply.  A lock the server did not grant (or did
+ * not release) is invisible until something later collides with it, by which
+ * point the trace has moved on and the report names the wrong step.
+ *
+ * This walks the model's own `held` list -- the ITF carries it -- and asks
+ * the server, with a TEST from an owner that appears nowhere in the trace,
+ * whether each file's ranges are free.  The predicted answer is computed
+ * here from the model's held set with the same rule the model uses, so a
+ * mismatch pins the exact step at which the two lock tables parted.
+ *
+ * It costs an RPC per probe range per step, so it is off by default and
+ * exists for narrowing a divergence rather than for the routine run.
+ */
+static const uint64_t paranoid_offsets[] = { 0, 8, 16 };
+static const uint64_t paranoid_lengths[] = { 8, 16, MBT_NLM_LEN_EOF };
+
+static int
+model_conflicts(
+    json_t  *held,
+    int64_t  file,
+    uint64_t off,
+    uint64_t len)
+{
+    size_t n = held ? json_array_size(held) : 0;
+    size_t i;
+
+    /* The probe is exclusive, so any overlapping lock conflicts.  Lengths
+     * are compared in the POSIX convention the model stores: 0 (and the
+     * model's -1 spelling) mean to-EOF. */
+    for (i = 0; i < n; i++) {
+        json_t  *l = json_array_get(held, i);
+        int64_t  hlen;
+        uint64_t hoff, hend, pend;
+
+        if (op_i64(l, "file") != file) {
+            continue;
+        }
+        hoff = (uint64_t) op_i64(l, "offset");
+        hlen = op_i64(l, "wireLen");
+        hend = (hlen <= 0) ? UINT64_MAX : hoff + (uint64_t) hlen;
+        pend = (len == MBT_NLM_LEN_EOF) ? UINT64_MAX : off + len;
+        if (hoff < pend && off < hend) {
+            return 1;
+        }
+    }
+    return 0;
+} /* model_conflicts */
+
+static void
+check_state(
+    struct oracle *o,
+    json_t        *state,
+    struct mism   *m)
+{
+    static const uint8_t probe_oh[] = { 0xff, 0xff };
+    json_t              *held       = NULL;
+    const char          *k;
+    json_t              *v;
+    size_t               fi, oi, li;
+
+    json_object_foreach(state, k, v)
+    {
+        const char *base = strrchr(k, ':');
+
+        if (strcmp(base ? base + 1 : k, "held") == 0) {
+            held = itf_seq(v);
+        }
+    }
+
+    for (fi = 0; fi < 2; fi++) {
+        for (oi = 0; oi < sizeof(paranoid_offsets) / sizeof(uint64_t); oi++) {
+            for (li = 0; li < sizeof(paranoid_lengths) / sizeof(uint64_t);
+                 li++) {
+                uint64_t               off  = paranoid_offsets[oi];
+                uint64_t               len  = paranoid_lengths[li];
+                int                    want = model_conflicts(held, (int64_t) fi, off, len);
+                struct mbt_aux_result *r;
+
+                r = mbt_nlm_test(o->env, 0, "probe-owner", &o->file_fh[fi],
+                                 probe_oh, sizeof(probe_oh), 0x7fff, 1, off,
+                                 len, aux_cookie, AUX_COOKIE_LEN);
+                if ((r->nlm_stat == NLM4_DENIED) != want) {
+                    mism_add(m, "state check: f%zu [%llu,%llu) is %s on the "
+                             "server but %s in the model", fi,
+                             (unsigned long long) off,
+                             (unsigned long long) len,
+                             r->nlm_stat == NLM4_DENIED ? "held" : "free",
+                             want ? "held" : "free");
+                }
+            }
+        }
+    }
+} /* check_state */
+
+/* Each state's lastOp key is module-qualified by the instance name. */
+static json_t *
+state_lastop(json_t *state)
+{
+    const char *k;
+    json_t     *v;
+
+    json_object_foreach(state, k, v)
+    {
+        const char *base = strrchr(k, ':');
+
+        if (strcmp(base ? base + 1 : k, "lastOp") == 0) {
+            return v;
+        }
+    }
+    return NULL;
+} /* state_lastop */
+
+static int paranoid;
+
+static int
+run_trace(
+    struct mbt_env *env,
+    const char     *trace_path,
+    const char     *fsname,
+    int             trace_seq,
+    int             verbose,
+    int             dry_run)
+{
+    json_error_t   jerr;
+    json_t        *root;
+    json_t        *states;
+    json_t        *state;
+    json_t        *last_op;
+    json_t        *op;
+    const char    *tag;
+    op_handler_t   fn;
+    struct oracle *o;
+    size_t         idx, nstates;
+    int            failed = 0;
+    struct mism    m;
+
+    root = json_load_file(trace_path, 0, &jerr);
+    if (!root) {
+        fprintf(stderr, "%s: JSON parse error: %s (line %d)\n", trace_path,
+                jerr.text, jerr.line);
+        return 1;
+    }
+    states = json_object_get(root, "states");
+    if (!states || !json_is_array(states) ||
+        !json_object_get(root, "vars")) {
+        fprintf(stderr, "%s: not an ITF trace\n", trace_path);
+        json_decref(root);
+        return 1;
+    }
+    nstates = json_array_size(states);
+
+    if (dry_run) {
+        printf("%s: %zu steps, format OK\n", trace_path, nstates - 1);
+        json_decref(root);
+        return 0;
+    }
+
+    /* Backstop for a server deadlock: with everything in one process a hung
+     * reply spins in mbt_call_wait forever; SIGALRM's default disposition
+     * kills the test with a nonzero status. */
+    alarm(180);
+
+    o = calloc(1, sizeof(*o));
+    mbt_env_fs_setup(env, fsname);
+
+    o->env       = env;
+    o->verbose   = verbose;
+    o->trace_seq = trace_seq;
+
+    if (trace_setup(o, trace_path)) {
+        failed = 1;
+        goto out;
+    }
+
+    for (idx = 1; idx < nstates; idx++) {
+        state   = json_array_get(states, idx);
+        last_op = state_lastop(state);
+        if (!last_op) {
+            fprintf(stderr, "%s: state %zu has no lastOp\n", trace_path, idx);
+            failed = 1;
+            goto out;
+        }
+        tag = jf_tag(last_op);
+        op  = jf_val(last_op);
+        fn  = find_handler(tag);
+        if (!fn) {
+            fprintf(stderr, "%s: step %zu: no handler for %s\n", trace_path,
+                    idx, tag);
+            failed = 1;
+            goto out;
+        }
+
+        memset(&m, 0, sizeof(m));
+        /* The asynchronous log is cleared once per step, here rather than in
+         * each handler, so every op is judged only on what its own call
+         * provoked. */
+        mbt_aux_async_reset(env);
+        fn(o, op, &m);
+        if (!m.n && paranoid) {
+            check_state(o, state, &m);
+        }
+        history_push(o, (int) idx, tag, op);
+        if (verbose) {
+            printf("  [%4zu] %s\n", idx, tag);
+        }
+        if (m.n) {
+            report_divergence(trace_path, o, (int) idx, tag, op, &m);
+            failed = 1;
+            goto out;
+        }
+    }
+
+    printf("%s: %zu steps replayed\n", trace_path, nstates - 1);
+
+ out:
+    trace_teardown(o);
+    mbt_env_fs_teardown(env, fsname);
+    while (o->nhist) {
+        free(o->history[--o->nhist].op_dump);
+    }
+    free(o);
+    json_decref(root);
+    alarm(0);
+    return failed;
+} /* run_trace */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    static struct option long_options[] = {
+        { "trace",          required_argument,          0,
+          't'                                                                   },
+        { "trace-dir",      required_argument,          0,
+          'D'                                                                                             },
+        { "exclude-prefix", required_argument,          0,
+          'X'                                                                                                                      },
+        { "dry-run",        no_argument,                0,
+          'n'                                                                                                                                               },
+        { "verbose",        no_argument,                0,
+          'v'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        },
+        { "paranoid",       no_argument,                0,
+          'p'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 },
+        { "backend",        required_argument,          0,
+          'B'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          },
+        { 0,                0,                          0,                         0 },
+    };
+    char               **traces;
+    int                  ntraces  = 0;
+    int                  dry_run  = 0;
+    int                  verbose  = 0;
+    const char          *backend  = "memfs";
+    int                  failures = 0;
+    int                  c, i;
+    struct mbt_env       env;
+    struct mbt_env_opts  opts;
+
+    traces = mbt_collect_traces(argc, argv, &ntraces);
+
+    while ((c = getopt_long(argc, argv, "t:D:X:nvpB:", long_options,
+                            NULL)) != -1) {
+        switch (c) {
+            case 't':
+            case 'D':
+            case 'X':
+                break;   /* handled by mbt_collect_traces */
+            case 'n':
+                dry_run = 1;
+                break;
+            case 'v':
+                verbose = 1;
+                break;
+            case 'p':
+                paranoid = 1;
+                break;
+            case 'B':
+                backend = optarg;
+                break;
+            default:
+                fprintf(stderr,
+                        "usage: %s [--trace FILE ...] [--trace-dir DIR] "
+                        "[--backend memfs|diskfs|cairn] [--dry-run] "
+                        "[--verbose] [--paranoid]\n", argv[0]);
+                mbt_free_traces(traces, ntraces);
+                return 2;
+        } /* switch */
+    }
+
+    if (ntraces == 0) {
+        fprintf(stderr, "%s: at least one --trace or --trace-dir is required\n",
+                argv[0]);
+        mbt_free_traces(traces, ntraces);
+        return 2;
+    }
+
+    if (!dry_run) {
+        memset(&opts, 0, sizeof(opts));
+        opts.module = backend;
+        /* The universal addresses rpcbind reports are built from this rather
+         * than from the connection's local address, which under inproc is a
+         * service name rather than an IP. */
+        opts.portmap_hostname = AUX_UADDR_HOST;
+        /* Exact attribute comparison cannot tolerate a stale cache, and the
+         * per-trace namespace setup re-creates the same names each time. */
+        opts.disable_caches = 1;
+        mbt_aux_env_open(&env, &opts);
+    }
+
+    for (i = 0; i < ntraces; i++) {
+        char fsname[32];
+
+        snprintf(fsname, sizeof(fsname), "fs_%d", i);
+        failures += run_trace(dry_run ? NULL : &env, traces[i], fsname, i,
+                              verbose, dry_run);
+    }
+
+    if (!dry_run) {
+        mbt_env_stop(&env);
+    }
+
+    mbt_free_traces(traces, ntraces);
+    return failures ? 1 : 0;
+} /* main */

--- a/src/server/nfs/tests/quint/nfs_aux_probe.c
+++ b/src/server/nfs/tests/quint/nfs_aux_probe.c
@@ -1,0 +1,785 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Ground-truth probe for the auxiliary NFS protocols (portmap/rpcbind,
+ * MOUNT, NLM, NSM).
+ *
+ * The model in ext/specs/quint/nfsaux is written against RFC 1833 / RFC
+ * 1813 Appendix I+II and gated down to what chimera implements.  Two kinds
+ * of fact go into that gating, and neither is derivable from the RFCs:
+ *
+ *   - which procedures chimera registers at all (an unregistered one is
+ *     answered PROC_UNAVAIL by the rpc2 layer, accept_stat 3), and
+ *   - the handful of constants the replies carry (the portmap service
+ *     table, the universal-address host, the MOUNT auth flavors, the NSM
+ *     state number a fresh non-persistent server starts at).
+ *
+ * This probe pins both against the live in-process server, with no trace
+ * corpus involved, so a change on either side turns this test red at the
+ * source instead of showing up as a mass divergence in the replay.
+ *
+ * Run with --dump to print everything it observes rather than asserting;
+ * that is the mode used when (re)deriving the model's constants.
+ */
+
+#include <getopt.h>
+
+#include "nfs_aux_mbt_common.h"
+
+#define PROBE_EXPORT     "/share"
+#define PROBE_EXPORT2    "/share2"
+#define PROBE_UADDR_HOST "127.0.0.1"
+#define PROBE_CALLER_A   "quint-a"
+#define PROBE_CALLER_B   "quint-b"
+
+/* RFC 5531 accept_stat carried back to the caller as a positive status. */
+#define RPC_PROC_UNAVAIL 3
+
+static int failures;
+static int dump;
+
+static void
+fail(
+    const char *fmt,
+    ...) __attribute__((format(printf, 1, 2)));
+
+static void
+fail(
+    const char *fmt,
+    ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    fprintf(stderr, "FAIL: ");
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+    failures++;
+} /* fail */
+
+static void
+check_eq(
+    const char *what,
+    long        got,
+    long        want)
+{
+    if (dump) {
+        printf("  %-42s %ld\n", what, got);
+        return;
+    }
+    if (got != want) {
+        fail("%s: got %ld, want %ld", what, got, want);
+    }
+} /* check_eq */
+
+static void
+check_u64(
+    const char        *what,
+    unsigned long long got,
+    unsigned long long want)
+{
+    if (dump) {
+        printf("  %-42s %llu\n", what, got);
+        return;
+    }
+    if (got != want) {
+        fail("%s: got %llu, want %llu", what, got, want);
+    }
+} /* check_u64 */
+
+static void
+check_str(
+    const char *what,
+    const char *got,
+    const char *want)
+{
+    if (dump) {
+        printf("  %-42s '%s'\n", what, got);
+        return;
+    }
+    if (strcmp(got, want) != 0) {
+        fail("%s: got '%s', want '%s'", what, got, want);
+    }
+} /* check_str */
+
+/* ---------------------------------------------------------------------- */
+
+static const struct {
+    uint32_t prog, vers, prot, port;
+} expect_services[] = {
+    { 100000, 2, 6, 111   },
+    { 100000, 3, 6, 111   },
+    { 100000, 4, 6, 111   },
+    { 100003, 3, 6, 2049  },
+    { 100003, 4, 6, 2049  },
+    { 100005, 3, 6, 20048 },
+    { 100021, 4, 6, 32803 },
+    { 100024, 1, 6, 32765 },
+};
+
+#define NEXPECT_SERVICES (int) (sizeof(expect_services) / \
+                                sizeof(expect_services[0]))
+
+static void
+probe_portmap(struct mbt_env *env)
+{
+    struct mbt_aux_result *r;
+    char                   label[96];
+    int                    i;
+
+    printf("portmap/rpcbind:\n");
+
+    /* NULL carries no reply body; the accept_stat is the whole check. */
+    mbt_pm_null(env);
+    check_eq("PMAPPROC_NULL rpc status", env->res.rpc_err, 0);
+
+    for (i = 0; i < NEXPECT_SERVICES; i++) {
+        r = mbt_pm_getport(env, expect_services[i].prog,
+                           expect_services[i].vers, expect_services[i].prot);
+        snprintf(label, sizeof(label), "GETPORT %u.%u.%u",
+                 expect_services[i].prog, expect_services[i].vers,
+                 expect_services[i].prot);
+        check_eq(label, r->port, expect_services[i].port);
+    }
+
+    /* Exact-match semantics: a served program at an unserved version, and
+     * a served (prog, vers) over an unserved transport, are both 0. */
+    r = mbt_pm_getport(env, 100003, 2, 6);
+    check_eq("GETPORT 100003.2.6 (unserved vers)", r->port, 0);
+    r = mbt_pm_getport(env, 100003, 3, 17);
+    check_eq("GETPORT 100003.3.17 (udp)", r->port, 0);
+    r = mbt_pm_getport(env, 300000, 1, 6);
+    check_eq("GETPORT 300000.1.6 (unknown prog)", r->port, 0);
+
+    r = mbt_pm_dump(env);
+    check_eq("PMAPPROC_DUMP entries", r->nmaps, NEXPECT_SERVICES);
+    for (i = 0; i < r->nmaps && i < NEXPECT_SERVICES; i++) {
+        snprintf(label, sizeof(label), "DUMP[%d] prog.vers.prot.port", i);
+        if (dump) {
+            printf("  %-42s %u.%u.%u.%u\n", label, r->maps[i].prog,
+                   r->maps[i].vers, r->maps[i].prot, r->maps[i].port);
+            continue;
+        }
+        if (r->maps[i].prog != expect_services[i].prog ||
+            r->maps[i].vers != expect_services[i].vers ||
+            r->maps[i].prot != expect_services[i].prot ||
+            r->maps[i].port != expect_services[i].port) {
+            fail("DUMP[%d]: got %u.%u.%u.%u, want %u.%u.%u.%u", i,
+                 r->maps[i].prog, r->maps[i].vers, r->maps[i].prot,
+                 r->maps[i].port, expect_services[i].prog,
+                 expect_services[i].vers, expect_services[i].prot,
+                 expect_services[i].port);
+        }
+    }
+
+    /* rpcbind GETADDR: the port is encoded as the last two components of
+     * the universal address; the host half comes from server.portmap_hostname
+     * because the harness sets it (the inproc local address is not an IP). */
+    r = mbt_rb_getaddr(env, 3, 100003, 3, "tcp");
+    check_str("rpcbproc_getaddr 100003.3 tcp", r->uaddr,
+              PROBE_UADDR_HOST ".8.1");
+    r = mbt_rb_getaddr(env, 4, 100005, 3, "tcp");
+    check_str("RPCBPROC_GETADDR 100005.3 tcp", r->uaddr,
+              PROBE_UADDR_HOST ".78.80");
+    r = mbt_rb_getaddr(env, 4, 100021, 4, "tcp");
+    check_str("RPCBPROC_GETADDR 100021.4 tcp", r->uaddr,
+              PROBE_UADDR_HOST ".128.35");
+    r = mbt_rb_getaddr(env, 3, 100003, 3, "udp");
+    check_str("rpcbproc_getaddr 100003.3 udp", r->uaddr, "");
+    r = mbt_rb_getaddr(env, 4, 100003, 3, "tcp6");
+    check_str("RPCBPROC_GETADDR 100003.3 tcp6", r->uaddr, "");
+
+    r = mbt_rb_dump(env, 3);
+    check_eq("rpcbproc_dump entries", r->nrpcb, NEXPECT_SERVICES);
+    if (r->nrpcb > 0) {
+        check_str("rpcbproc_dump[0] netid", r->rpcb[0].netid, "tcp");
+        check_str("rpcbproc_dump[0] addr", r->rpcb[0].addr,
+                  PROBE_UADDR_HOST ".0.111");
+        check_str("rpcbproc_dump[0] owner", r->rpcb[0].owner, "");
+    }
+    r = mbt_rb_dump(env, 4);
+    check_eq("RPCBPROC_DUMP entries", r->nrpcb, NEXPECT_SERVICES);
+
+    /* Everything chimera does not register.  These are what the model's
+     * IMPLEMENTED gate encodes. */
+    mbt_pm_set(env, 100003, 3, 6, 2049, 0);
+    check_eq("PMAPPROC_SET accept_stat", env->res.rpc_err, RPC_PROC_UNAVAIL);
+    mbt_pm_set(env, 100003, 3, 6, 2049, 1);
+    check_eq("PMAPPROC_UNSET accept_stat", env->res.rpc_err, RPC_PROC_UNAVAIL);
+    mbt_pm_callit(env, 100003, 3, 0);
+    check_eq("PMAPPROC_CALLIT accept_stat", env->res.rpc_err,
+             RPC_PROC_UNAVAIL);
+    mbt_rb_gettime(env, 3);
+    check_eq("rpcbproc_gettime accept_stat", env->res.rpc_err,
+             RPC_PROC_UNAVAIL);
+    mbt_rb_gettime(env, 4);
+    check_eq("RPCBPROC_GETTIME accept_stat", env->res.rpc_err,
+             RPC_PROC_UNAVAIL);
+    mbt_rb_getversaddr(env, 100003, 3, "tcp");
+    check_eq("RPCBPROC_GETVERSADDR accept_stat", env->res.rpc_err,
+             RPC_PROC_UNAVAIL);
+} /* probe_portmap */
+
+/* ---------------------------------------------------------------------- */
+
+static struct mbt_fh root_fh;
+static struct mbt_fh file_fh[2];
+
+static void
+probe_mount(struct mbt_env *env)
+{
+    struct mbt_aux_result *r;
+    int                    i;
+
+    printf("mount:\n");
+
+    mbt_mount_null(env);
+    check_eq("MOUNTPROC3_NULL rpc status", env->res.rpc_err, 0);
+
+    r = mbt_mount_mnt(env, PROBE_EXPORT);
+    check_eq("MNT /share status", env->res.status, MNT3_OK);
+    check_eq("MNT /share auth flavor count", r->nauth, 2);
+    if (r->nauth == 2) {
+        check_eq("MNT /share auth[0]", r->auth[0], 0);   /* AUTH_NONE */
+        check_eq("MNT /share auth[1]", r->auth[1], 1);   /* AUTH_SYS  */
+    }
+    root_fh = env->res.obj_fh;
+
+    mbt_mount_mnt(env, PROBE_EXPORT2);
+    check_eq("MNT /share2 status", env->res.status, MNT3_OK);
+
+    /* No export matches -> NOENT (chimera maps the lookup failure itself). */
+    mbt_mount_mnt(env, "/nope");
+    check_eq("MNT /nope status", env->res.status, MNT3ERR_NOENT);
+
+    /* Export matches, path under it does not exist. */
+    mbt_mount_mnt(env, "/share/nope");
+    check_eq("MNT /share/nope status", env->res.status, MNT3ERR_NOENT);
+
+    /* Export matches only as a string prefix, not at a component boundary. */
+    mbt_mount_mnt(env, "/shareXX");
+    check_eq("MNT /shareXX status", env->res.status, MNT3ERR_NOENT);
+
+    /* Leading slash is optional (missing_leading_slash in the resolver). */
+    mbt_mount_mnt(env, "share");
+    check_eq("MNT share (no leading /) status", env->res.status, MNT3_OK);
+
+    /* A path whose parent component is a regular file: the walk got as far
+     * as f0 and could not descend. */
+    mbt_mount_mnt(env, "/share/f0/x");
+    check_eq("MNT /share/f0/x status", env->res.status, MNT3ERR_NOTDIR);
+
+    /* MNT of a regular file succeeds: the object is not type-checked. */
+    mbt_mount_mnt(env, "/share/f0");
+    check_eq("MNT /share/f0 status", env->res.status, MNT3_OK);
+
+    /* The mount table records the client-requested path -- including for a
+     * MNT that then failed, because the row goes in as soon as an export
+     * matches -- most recent first, and never twice for one path.  Of the
+     * eight MNTs above, /nope and /shareXX matched no export and left
+     * nothing; the other six each left one row. */
+    r = mbt_mount_dump(env);
+    check_eq("mount table size", r->nmounts, 6);
+    for (i = 0; i < r->nmounts; i++) {
+        check_str("mount table host", r->mounts[i].host, "inproc");
+    }
+    if (r->nmounts == 6) {
+        check_str("mount table[0]", r->mounts[0].dir, "/share/f0");
+        check_str("mount table[1]", r->mounts[1].dir, "/share/f0/x");
+        check_str("mount table[2]", r->mounts[2].dir, "share");
+        check_str("mount table[3]", r->mounts[3].dir, "/share/nope");
+        check_str("mount table[4]", r->mounts[4].dir, "/share2");
+        check_str("mount table[5]", r->mounts[5].dir, "/share");
+    }
+
+    /* Exports are reported most recently created first, with no group
+     * restriction. */
+    r = mbt_mount_export(env);
+    check_eq("export count", r->nexports, 2);
+    if (r->nexports == 2) {
+        check_str("export[0]", r->exports[0].dir, PROBE_EXPORT2);
+        check_str("export[1]", r->exports[1].dir, PROBE_EXPORT);
+        check_eq("export[0] group count", r->exports[0].ngroups, 0);
+    }
+
+    mbt_mount_umnt(env, PROBE_EXPORT2);
+    r = mbt_mount_dump(env);
+    check_eq("mount table size after UMNT /share2", r->nmounts, 5);
+
+    mbt_mount_umntall(env);
+    r = mbt_mount_dump(env);
+    check_eq("rmtab entries after UMNTALL", r->nmounts, 0);
+
+} /* probe_mount */
+
+/* ---------------------------------------------------------------------- */
+
+/* The export root handle, before anything else needs it. */
+static void
+probe_root_handle(struct mbt_env *env)
+{
+    struct mbt_result *res = mbt_mnt(env, PROBE_EXPORT);
+
+    if (res->rpc_err != 0 || res->status != MNT3_OK || !res->obj_fh.has) {
+        fprintf(stderr, "probe: MNT %s failed: rpc_err=%d status=%u\n",
+                PROBE_EXPORT, res->rpc_err, res->status);
+        exit(1);
+    }
+    root_fh = res->obj_fh;
+    mbt_mount_umntall(env);
+} /* probe_root_handle */
+
+static void
+probe_setup_files(struct mbt_env *env)
+{
+    struct mbt_result *res;
+    int                i;
+    char               name[8];
+
+    for (i = 0; i < 2; i++) {
+        snprintf(name, sizeof(name), "f%d", i);
+        res = mbt_create(env, &root_fh, name, (uint32_t) strlen(name),
+                         UNCHECKED, 420, NULL);
+        if (res->status != 0 && res->status != 17) {
+            fprintf(stderr, "probe: CREATE %s failed: %u\n", name,
+                    res->status);
+            exit(1);
+        }
+        res = mbt_lookup(env, &root_fh, name, (uint32_t) strlen(name));
+        if (res->status != 0 || !res->obj_fh.has) {
+            fprintf(stderr, "probe: LOOKUP %s failed: %u\n", name,
+                    res->status);
+            exit(1);
+        }
+        file_fh[i] = res->obj_fh;
+    }
+} /* probe_setup_files */
+
+/* ---------------------------------------------------------------------- */
+
+static const uint8_t oh_a[] = { 0xa0, 0xa1 };
+static const uint8_t oh_b[] = { 0xb0, 0xb1 };
+static const uint8_t ck[]   = { 0xc0, 0xff, 0xee };
+
+static void
+probe_nlm(struct mbt_env *env)
+{
+    struct mbt_aux_result *r;
+    struct mbt_fh          bogus;
+
+    printf("nlm:\n");
+
+    mbt_nlm_null(env);
+    check_eq("NLMPROC4_NULL rpc status", env->res.rpc_err, 0);
+
+    /* An unparseable file handle is STALE_FH, not a crash. */
+    memset(&bogus, 0, sizeof(bogus));
+    bogus.has = 1;
+    bogus.len = 8;
+    memset(bogus.data, 0x5a, 8);
+    r = mbt_nlm_test(env, 0, PROBE_CALLER_A, &bogus, oh_a, sizeof(oh_a), 1, 1,
+                     0, 16, ck, sizeof(ck));
+    check_eq("TEST on a bogus fh", r->nlm_stat, NLM4_STALE_FH);
+    check_eq("TEST cookie echoed", r->cookie_len, sizeof(ck));
+
+    /* No claims on the file yet. */
+    r = mbt_nlm_test(env, 0, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                     1, 1, 0, 16, ck, sizeof(ck));
+    check_eq("TEST on an unlocked file", r->nlm_stat, NLM4_GRANTED);
+
+    /* Exclusive lock, then the same owner's identical re-LOCK (idempotent),
+     * then a different owner's conflicting request. */
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                     1, 1, 0, 0, 0, 0, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [0,16) as A", r->nlm_stat, NLM4_GRANTED);
+
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                     1, 1, 0, 0, 0, 0, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [0,16) again as A", r->nlm_stat, NLM4_GRANTED);
+
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b),
+                     2, 1, 0, 0, 0, 8, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [8,24) as B (overlaps)", r->nlm_stat, NLM4_DENIED);
+
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b),
+                     2, 1, 0, 0, 0, 32, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [32,48) as B (disjoint)", r->nlm_stat, NLM4_GRANTED);
+
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b),
+                     2, 0, 0, 0, 0, 64, 16, ck, sizeof(ck));
+    check_eq("LOCK shared [64,80) as B", r->nlm_stat, NLM4_GRANTED);
+
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                     1, 0, 0, 0, 0, 64, 16, ck, sizeof(ck));
+    check_eq("LOCK shared [64,80) as A (shared/shared)", r->nlm_stat,
+             NLM4_GRANTED);
+
+    /* A already holds [64,80) shared, so this names a range it holds: the
+     * request is answered as an idempotent retry WITHOUT re-evaluating the
+     * mode, so the upgrade silently does not happen.  (The third-party case
+     * below, where the requester holds nothing, does conflict.) */
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                     1, 1, 0, 0, 0, 64, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [64,80) as A over its own shared", r->nlm_stat,
+             NLM4_GRANTED);
+
+    /* TEST reports the conflicting holder's range and mode. */
+    r = mbt_nlm_test(env, 0, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b),
+                     2, 1, 0, 16, ck, sizeof(ck));
+    check_eq("TEST excl [0,16) as B", r->nlm_stat, NLM4_DENIED);
+    check_eq("TEST holder exclusive", r->holder_exclusive, 1);
+    check_eq("TEST holder svid", r->holder_svid, 0);
+    check_eq("TEST holder oh len", r->holder_oh_len, 0);
+    check_u64("TEST holder offset", r->holder_offset, 0);
+    check_u64("TEST holder length", r->holder_length, 16);
+
+    /* UNLOCK is always GRANTED, present or not. */
+    r = mbt_nlm_unlock(env, 0, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                       1, 0, 16, ck, sizeof(ck));
+    check_eq("UNLOCK [0,16) as A", r->nlm_stat, NLM4_GRANTED);
+    r = mbt_nlm_unlock(env, 0, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                       1, 0, 16, ck, sizeof(ck));
+    check_eq("UNLOCK [0,16) as A again", r->nlm_stat, NLM4_GRANTED);
+    r = mbt_nlm_unlock(env, 0, "no-such-host", &file_fh[0], oh_a,
+                       sizeof(oh_a), 1, 0, 16, ck, sizeof(ck));
+    check_eq("UNLOCK by an unknown caller", r->nlm_stat, NLM4_GRANTED);
+
+    /* B can now take the range A released. */
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b),
+                     2, 1, 0, 0, 0, 0, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [0,16) as B after A unlocked", r->nlm_stat,
+             NLM4_GRANTED);
+
+    /* CANCEL always answers GRANTED. */
+    r = mbt_nlm_cancel(env, 0, PROBE_CALLER_A, &file_fh[0], oh_a,
+                       sizeof(oh_a), 1, 1, 0, 0, 16, ck, sizeof(ck));
+    check_eq("CANCEL with nothing pending", r->nlm_stat, NLM4_GRANTED);
+
+    /* The server's own GRANTED receiver. */
+    r = mbt_nlm_granted(env, 0, PROBE_CALLER_A, &file_fh[0], oh_a,
+                        sizeof(oh_a), 1, 1, 0, 16, ck, sizeof(ck));
+    check_eq("GRANTED (server-side receipt)", r->nlm_stat, NLM4_GRANTED);
+
+    /* The DOS share half is accepted without enforcement. */
+    r = mbt_nlm_share(env, 0, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                      3, 3, 0, ck, sizeof(ck));
+    check_eq("SHARE stat", r->nlm_stat, NLM4_GRANTED);
+    check_eq("SHARE sequence", r->sequence, 0);
+    r = mbt_nlm_share(env, 1, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                      3, 3, 0, ck, sizeof(ck));
+    check_eq("UNSHARE stat", r->nlm_stat, NLM4_GRANTED);
+
+    /* Reserved slots are registered and ack. */
+    mbt_nlm_reserved(env, 16);
+    check_eq("RESERVED_16 accept_stat", env->res.rpc_err, 0);
+    mbt_nlm_reserved(env, 19);
+    check_eq("RESERVED_19 accept_stat", env->res.rpc_err, 0);
+
+    /* The *_RES direction acks. */
+    mbt_nlm_send_res(env, 11, NLM4_GRANTED, ck, sizeof(ck));
+    check_eq("TEST_RES accept_stat", env->res.rpc_err, 0);
+    mbt_nlm_send_res(env, 12, NLM4_GRANTED, ck, sizeof(ck));
+    check_eq("LOCK_RES accept_stat", env->res.rpc_err, 0);
+    mbt_nlm_send_res(env, 15, NLM4_GRANTED, ck, sizeof(ck));
+    check_eq("GRANTED_RES accept_stat", env->res.rpc_err, 0);
+
+    /* The asynchronous half: a *_MSG is acked with a void reply and the
+     * result comes back as a *_RES call on this connection. */
+    mbt_aux_async_reset(env);
+    mbt_nlm_test(env, 1, PROBE_CALLER_B, &file_fh[1], oh_b, sizeof(oh_b), 2,
+                 1, 0, 16, ck, sizeof(ck));
+    check_eq("TEST_MSG accept_stat", env->res.rpc_err, 0);
+    mbt_aux_drain_for(env, 1, 2000000);
+    check_eq("TEST_MSG async replies", mbt_aux(env)->nasync, 1);
+    if (mbt_aux(env)->nasync == 1) {
+        check_eq("TEST_MSG async proc", mbt_aux(env)->async[0].proc, 11);
+        check_eq("TEST_MSG async stat", mbt_aux(env)->async[0].stat,
+                 NLM4_GRANTED);
+    }
+
+    mbt_aux_async_reset(env);
+    mbt_nlm_lock(env, 7, PROBE_CALLER_B, &file_fh[1], oh_b, sizeof(oh_b), 2,
+                 1, 0, 0, 0, 0, 16, ck, sizeof(ck));
+    check_eq("LOCK_MSG accept_stat", env->res.rpc_err, 0);
+    mbt_aux_drain_for(env, 1, 2000000);
+    check_eq("LOCK_MSG async replies", mbt_aux(env)->nasync, 1);
+    if (mbt_aux(env)->nasync == 1) {
+        check_eq("LOCK_MSG async proc", mbt_aux(env)->async[0].proc, 12);
+        check_eq("LOCK_MSG async stat", mbt_aux(env)->async[0].stat,
+                 NLM4_GRANTED);
+    }
+
+    mbt_aux_async_reset(env);
+    mbt_nlm_unlock(env, 1, PROBE_CALLER_B, &file_fh[1], oh_b, sizeof(oh_b), 2,
+                   0, 16, ck, sizeof(ck));
+    mbt_aux_drain_for(env, 1, 2000000);
+    check_eq("UNLOCK_MSG async replies", mbt_aux(env)->nasync, 1);
+    if (mbt_aux(env)->nasync == 1) {
+        check_eq("UNLOCK_MSG async proc", mbt_aux(env)->async[0].proc, 14);
+    }
+
+    mbt_aux_async_reset(env);
+    mbt_nlm_cancel(env, 1, PROBE_CALLER_B, &file_fh[1], oh_b, sizeof(oh_b), 2,
+                   1, 1, 0, 16, ck, sizeof(ck));
+    mbt_aux_drain_for(env, 1, 2000000);
+    check_eq("CANCEL_MSG async replies", mbt_aux(env)->nasync, 1);
+    if (mbt_aux(env)->nasync == 1) {
+        check_eq("CANCEL_MSG async proc", mbt_aux(env)->async[0].proc, 13);
+    }
+
+    mbt_aux_async_reset(env);
+    mbt_nlm_granted(env, 1, PROBE_CALLER_B, &file_fh[1], oh_b, sizeof(oh_b),
+                    2, 1, 0, 16, ck, sizeof(ck));
+    check_eq("GRANTED_MSG accept_stat", env->res.rpc_err, 0);
+    mbt_aux_drain_us(env, 200000);
+    check_eq("GRANTED_MSG async replies", mbt_aux(env)->nasync, 0);
+
+    /* A third owner taking an exclusive lock over B's shared range: the
+     * requester holds nothing of its own, so the idempotency short-circuit
+     * cannot apply and the claim core decides. */
+    r = mbt_nlm_lock(env, 2, "quint-c", &file_fh[0], oh_a, sizeof(oh_a), 3, 1,
+                     0, 0, 0, 64, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [64,80) as C over B's shared", r->nlm_stat,
+             NLM4_DENIED);
+
+    /* Same owner handle, different svid: a distinct lock owner, so it
+     * conflicts rather than coalescing. */
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b),
+                     99, 1, 0, 0, 0, 32, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [32,48) as B svid 99 over B svid 2", r->nlm_stat,
+             NLM4_DENIED);
+
+    /* A blocking LOCK on a range another owner holds: queued, answered with
+     * the RFC 1813 interim NLM4_BLOCKED. */
+    mbt_aux_async_reset(env);
+    r = mbt_nlm_lock(env, 2, "quint-d", &file_fh[0], oh_a, sizeof(oh_a), 4, 1,
+                     1 /* block */, 0, 0, 32, 16, ck, sizeof(ck));
+    check_eq("blocking LOCK over a held range", r->nlm_stat, NLM4_BLOCKED);
+    /* Releasing the blocker should hand the queued lock its grant
+     * out-of-band, via an NLM_GRANTED callback. */
+    mbt_nlm_unlock(env, 0, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b), 2,
+                   32, 16, ck, sizeof(ck));
+    /* The deferred grant IS made -- see the TEST below -- but it is
+     * delivered as an out-of-band NLMPROC4_GRANTED addressed to the
+     * client's own lock manager, which this harness is not, so nothing
+     * arrives here.  That is what the model's
+     * NLM_GRANT_CALLBACK_OBSERVABLE = false records. */
+    mbt_aux_drain_for(env, 1, 500000);
+    check_eq("async messages after the blocker left", mbt_aux(env)->nasync, 0);
+    r = mbt_nlm_test(env, 0, "quint-e", &file_fh[0], oh_a, sizeof(oh_a), 5, 1,
+                     32, 16, ck, sizeof(ck));
+    check_eq("TEST [32,48) after the blocker left (d was granted)",
+             r->nlm_stat, NLM4_DENIED);
+    mbt_nlm_unlock(env, 0, "quint-d", &file_fh[0], oh_a, sizeof(oh_a), 4, 32,
+                   16, ck, sizeof(ck));
+
+    /* NM_LOCK: like LOCK but the holder is not monitored. */
+    r = mbt_nlm_lock(env, 22, PROBE_CALLER_A, &file_fh[1], oh_a, sizeof(oh_a),
+                     1, 1, 0, 0, 0, 128, 16, ck, sizeof(ck));
+    check_eq("NM_LOCK excl [128,144) as A", r->nlm_stat, NLM4_GRANTED);
+
+    /*
+     * A blocking request queued behind a lock that FREE_ALL removes: does
+     * releasing the blocker that way promote the waiter, the way releasing
+     * it with UNLOCK does?
+     */
+    mbt_nlm_free_all(env, "quint-w1", 1);
+    mbt_nlm_free_all(env, "quint-w2", 1);
+    r = mbt_nlm_lock(env, 2, "quint-w1", &file_fh[0], oh_a, sizeof(oh_a), 1,
+                     1, 0, 0, 0, 1024, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [1024,1040) as w1", r->nlm_stat, NLM4_GRANTED);
+    r = mbt_nlm_lock(env, 2, "quint-w2", &file_fh[0], oh_b, sizeof(oh_b), 2,
+                     1, 1 /* block */, 0, 0, 1024, 16, ck, sizeof(ck));
+    check_eq("blocking LOCK [1024,1040) as w2", r->nlm_stat, NLM4_BLOCKED);
+    mbt_nlm_free_all(env, "quint-w1", 1);
+    mbt_aux_drain_us(env, 200000);
+    r = mbt_nlm_test(env, 0, "quint-w3", &file_fh[0], oh_a, sizeof(oh_a), 3,
+                     1, 1024, 16, ck, sizeof(ck));
+    check_eq("TEST [1024,1040) after FREE_ALL of the blocker (promoted)",
+             r->nlm_stat, NLM4_DENIED);
+    mbt_nlm_free_all(env, "quint-w2", 1);
+
+    /* The trace shape that first exposed a divergence: the waiter spans
+     * TWO of the blocker's locks, and the blocker also has a queued request
+     * of its own on the same file for FREE_ALL to cancel. */
+    r = mbt_nlm_lock(env, 2, "quint-w1", &file_fh[1], oh_a, sizeof(oh_a), 1,
+                     1, 0, 0, 0, 8, 8, ck, sizeof(ck));
+    check_eq("LOCK excl f1 [8,16) as w1", r->nlm_stat, NLM4_GRANTED);
+    r = mbt_nlm_lock(env, 2, "quint-w1", &file_fh[1], oh_a, sizeof(oh_a), 1,
+                     1, 0, 0, 0, 16, 8, ck, sizeof(ck));
+    check_eq("LOCK excl f1 [16,24) as w1", r->nlm_stat, NLM4_GRANTED);
+    r = mbt_nlm_lock(env, 2, "quint-w2", &file_fh[1], oh_b, sizeof(oh_b), 2,
+                     1, 1, 0, 0, 8, 16, ck, sizeof(ck));
+    check_eq("blocking LOCK f1 [8,24) as w2 (spans both)", r->nlm_stat,
+             NLM4_BLOCKED);
+    r = mbt_nlm_lock(env, 2, "quint-w1", &file_fh[1], oh_b, sizeof(oh_b), 9,
+                     1, 1, 0, 0, 8, 8, ck, sizeof(ck));
+    check_eq("blocking LOCK f1 [8,16) as w1/other-owner", r->nlm_stat,
+             NLM4_BLOCKED);
+    mbt_nlm_free_all(env, "quint-w1", 1);
+    mbt_aux_drain_us(env, 200000);
+    check_eq("TEST f1 [16,24) after FREE_ALL of both blockers (promoted)",
+             mbt_nlm_test(env, 0, "quint-w3", &file_fh[1], oh_a, sizeof(oh_a),
+                          3, 1, 16, 8, ck, sizeof(ck))->nlm_stat,
+             NLM4_DENIED);
+    mbt_nlm_free_all(env, "quint-w2", 1);
+
+    /* The same shape, but the blocker leaves via UNLOCK rather than
+     * FREE_ALL -- the case the replay corpus already covers. */
+    r = mbt_nlm_lock(env, 2, "quint-w1", &file_fh[0], oh_a, sizeof(oh_a), 1,
+                     1, 0, 0, 0, 2048, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [2048,2064) as w1", r->nlm_stat, NLM4_GRANTED);
+    r = mbt_nlm_lock(env, 2, "quint-w2", &file_fh[0], oh_b, sizeof(oh_b), 2,
+                     1, 1, 0, 0, 2048, 16, ck, sizeof(ck));
+    check_eq("blocking LOCK [2048,2064) as w2", r->nlm_stat, NLM4_BLOCKED);
+    mbt_nlm_unlock(env, 0, "quint-w1", &file_fh[0], oh_a, sizeof(oh_a), 1,
+                   2048, 16, ck, sizeof(ck));
+    mbt_aux_drain_us(env, 200000);
+    r = mbt_nlm_test(env, 0, "quint-w3", &file_fh[0], oh_a, sizeof(oh_a), 3,
+                     1, 2048, 16, ck, sizeof(ck));
+    check_eq("TEST [2048,2064) after UNLOCK of the blocker (promoted)",
+             r->nlm_stat, NLM4_DENIED);
+    mbt_nlm_free_all(env, "quint-w2", 1);
+
+    /* FREE_ALL drops every lock the named client holds. */
+    mbt_nlm_free_all(env, PROBE_CALLER_B, 1);
+    check_eq("FREE_ALL accept_stat", env->res.rpc_err, 0);
+    r = mbt_nlm_test(env, 0, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                     1, 1, 0, 16, ck, sizeof(ck));
+    check_eq("TEST [0,16) after FREE_ALL of B", r->nlm_stat, NLM4_GRANTED);
+} /* probe_nlm */
+
+/* ---------------------------------------------------------------------- */
+
+static void
+probe_nsm(struct mbt_env *env)
+{
+    struct mbt_aux_result *r;
+
+    printf("nsm:\n");
+
+    mbt_sm_null(env);
+    check_eq("SM_NULL rpc status", env->res.rpc_err, 0);
+
+    r = mbt_sm_stat(env, "somehost");
+    check_eq("SM_STAT res_stat", r->sm_res, 0);        /* STAT_SUCC */
+    /* A server whose lock state cannot survive a restart starts at 1. */
+    check_eq("SM_STAT state", r->sm_state, 1);
+
+    r = mbt_sm_mon(env, "somehost", "me", 100021, 4, 24);
+    check_eq("SM_MON res_stat", r->sm_res, 0);
+    check_eq("SM_MON state matches SM_STAT", r->sm_state, r->sm_state);
+
+    r = mbt_sm_unmon(env, "somehost", "me");
+    check_eq("SM_UNMON state", r->sm_state, 1);
+    r = mbt_sm_unmon_all(env, "me");
+    check_eq("SM_UNMON_ALL state", r->sm_state, 1);
+
+    /* SM_NOTIFY for a host that holds locks releases them. */
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_A, &file_fh[0], oh_a, sizeof(oh_a),
+                     1, 1, 0, 0, 0, 256, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [256,272) as A (for SM_NOTIFY)", r->nlm_stat,
+             NLM4_GRANTED);
+    mbt_sm_notify(env, PROBE_CALLER_A, 7);
+    check_eq("SM_NOTIFY accept_stat", env->res.rpc_err, 0);
+    r = mbt_nlm_test(env, 0, PROBE_CALLER_B, &file_fh[0], oh_b, sizeof(oh_b),
+                     2, 1, 256, 16, ck, sizeof(ck));
+    check_eq("TEST [256,272) after SM_NOTIFY of A", r->nlm_stat,
+             NLM4_GRANTED);
+
+    /* SM_NOTIFY naming a host with no NLM client falls back to matching
+     * monitors by the notify's source address.  Under inproc every peer
+     * address is the same string, so the fallback matches every monitored
+     * host -- pin whether that releases unrelated locks. */
+    r = mbt_nlm_lock(env, 2, PROBE_CALLER_B, &file_fh[1], oh_b, sizeof(oh_b),
+                     2, 1, 0, 0, 0, 512, 16, ck, sizeof(ck));
+    check_eq("LOCK excl [512,528) as B (for the fallback)", r->nlm_stat,
+             NLM4_GRANTED);
+    mbt_sm_notify(env, "a-host-that-never-locked", 9);
+    r = mbt_nlm_test(env, 0, "quint-e", &file_fh[1], oh_a, sizeof(oh_a), 5, 1,
+                     512, 16, ck, sizeof(ck));
+    check_eq("TEST [512,528) after an unknown-host SM_NOTIFY (released)",
+             r->nlm_stat, NLM4_GRANTED);
+
+    /* SM_SIMU_CRASH bumps the state number, keeping it odd.  With monitored
+     * hosts present it also spawns the reboot-notify worker, which under
+     * inproc resolves and calls back into this very server. */
+    mbt_sm_simu_crash(env);
+    check_eq("SM_SIMU_CRASH accept_stat", env->res.rpc_err, 0);
+    r = mbt_sm_stat(env, "somehost");
+    check_eq("SM_STAT state after SIMU_CRASH", r->sm_state, 3);
+    mbt_sm_simu_crash(env);
+    r = mbt_sm_stat(env, "somehost");
+    check_eq("SM_STAT state after a second SIMU_CRASH", r->sm_state, 5);
+} /* probe_nsm */
+
+/* ---------------------------------------------------------------------- */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    /* *INDENT-OFF* -- uncrustify oscillates on this table's alignment. */
+    static struct option long_options[] = {
+        { "dump", no_argument, 0, 'd' },
+        { 0,      0,           0, 0   },
+    };
+    /* *INDENT-ON* */
+    struct mbt_env      env;
+    struct mbt_env_opts opts;
+    int                 c;
+
+    while ((c = getopt_long(argc, argv, "d", long_options, NULL)) != -1) {
+        switch (c) {
+            case 'd':
+                dump = 1;
+                break;
+            default:
+                fprintf(stderr, "usage: %s [--dump]\n", argv[0]);
+                return 2;
+        } /* switch */
+    }
+
+    memset(&opts, 0, sizeof(opts));
+    opts.portmap_hostname = PROBE_UADDR_HOST;
+    opts.disable_caches   = 1;
+
+    /* A hung reply spins forever inside mbt_call_wait with everything in one
+     * process; SIGALRM's default disposition turns that into a test failure. */
+    alarm(180);
+
+    mbt_aux_env_open(&env, &opts);
+    mbt_env_fs_setup(&env, "fs0");
+    if (chimera_server_create_export(env.server, PROBE_EXPORT2, "/share", 0,
+                                     NULL) != 0) {
+        fprintf(stderr, "probe: failed to create the %s export\n",
+                PROBE_EXPORT2);
+        return 1;
+    }
+
+    probe_portmap(&env);
+    /* MOUNT resolution is probed against a namespace that exists, so the
+     * objects have to be created first -- which needs the export root
+     * handle, hence the bare MNT here. */
+    probe_root_handle(&env);
+    probe_setup_files(&env);
+    probe_mount(&env);
+    probe_nlm(&env);
+    probe_nsm(&env);
+
+    chimera_server_remove_export(env.server, PROBE_EXPORT2);
+    mbt_env_fs_teardown(&env, "fs0");
+    mbt_env_stop(&env);
+    alarm(0);
+
+    if (failures) {
+        fprintf(stderr, "\n%d aux probe expectation(s) failed\n", failures);
+        return 1;
+    }
+    printf("\nnfs aux probe: all expectations hold\n");
+    return 0;
+} /* main */


### PR DESCRIPTION
Consumes the new `nfsaux` corpus from chimera-nas/specs#5 and replays it against
an in-process chimera server, the way the NFSv3 and NFSv4 suites already do —
covering the four RPC protocols that surround NFSv3: portmap/rpcbind (100000
v2/v3/v4), MOUNT (100005 v3), NLM (100021 v4) and NSM (100024 v1).

Rebased onto main; `ext/specs` points at specs `main` (`49eca48`) — the
`9829b7c` main already carried, plus chimera-nas/specs#5, which is merged.

### Three server fixes, first two commits

Every one is reachable from the wire by an ordinary conforming client.

1. **`nfs: wrap the portmap DUMP results so a client can decode them`** — for a
   procedure returning a bare recursive type, xdrzcc emits an asymmetric codec:
   the marshaller writes the RFC 1833 chain, the generated *client*
   unmarshaller reads a single bare body and consumes no booleans, so every
   reply fails to decode. Wrapping the chain in a one-field struct makes the two
   agree; the wire encoding is byte-for-byte unchanged. `mount.x` already
   carries the same wrapper for `MOUNTPROC3_DUMP`, added for exactly this
   reason.
2. **`nlm: fix three faults in the asynchronous half of the protocol`**
   - every `send_call_NLMPROC4_*_RES` passed a NULL reply callback; the
     generated dispatcher invokes it unconditionally, so the server took a
     SIGSEGV the moment a client acknowledged the call — which every conforming
     client does;
   - `nlm4_send_res()` had no arm for the `_MSG` procedures and a silent
     `default: rc = 0`, so a `LOCK_MSG` that failed on a stale handle or an
     allocation failure sent *nothing* and left the client waiting forever;
   - `CANCEL_MSG` acknowledged and replied GRANTED without cancelling, on a
     comment that stopped being true when blocking locks started queueing in the
     claim core — a client that gave up on a blocking LOCK left it queued, to be
     granted later against a range nobody wanted.

   Plus the grant engine's shutdown callback, which read the `nlm_grant_ctx`
   that `evpl_thread_function` actually hands it as the `nlm_granter` passed to
   `evpl_thread_create`, and aborted in `evpl_core_epoll_remove()`. Tearing down
   a server that had ever served a blocking lock crashed.

### The suite, third commit

Two ctests, neither binding a port, needing a netns, or spawning a daemon:

- `mbtaux/probe_memfs` — ground truth with no corpus involved: which procedures
  the server registers and the constants their replies carry. Neither is
  derivable from the RFCs, so pinning them here means a change on either side
  goes red at the source instead of as a mass divergence in the replay.
- `mbtaux/batch_memfs` — 42 traces replayed back to back, ~25 s.

`nfs3_mbt_common.h` grows the auxiliary services behind an opt-in flag, so the
existing suites pay nothing. The NLM connection also *exports* NLM_V4, because
the asynchronous half of that protocol is answered by the server calling
`NLMPROC4_*_RES` back on the same connection — a client that does not serve the
program cannot see its own results.

Isolation needed more than the NFSv3 suite's fresh-filesystem-per-trace: the
lock table, the client table, the monitor list and the NSM state number are all
server-global. Caller names are qualified per trace, every caller is `FREE_ALL`'d
at teardown (a leftover lock holds an open handle and `rmfs` would never
succeed), and the NSM state number — which only ever rises — is read at trace
start and every prediction shifted by it.

`--paranoid` is on for the batch. Comparing replies alone does not merely
*mislocate* a lock-table divergence, it can miss one outright: a lock the server
failed to grant or release is invisible until some later operation happens to
collide with it, and nothing guarantees one does. The flag probes each file's
ranges against the model's own lock set after every step, and it is what caught
the release-ordering behaviour the model now encodes (a client's locks are
released one at a time with a queue pump after each, so a narrow waiter
satisfied by a partial release beats a wider one).

### Coverage

Line coverage of the eight files these protocols live in, `ctest -L
"nfs3_mbt|nfs4_mbt"` before vs. the same plus `nfsaux_mbt`, one clang Coverage
build and one fixed object set:

| file | lines | before | after |
|---|---|---|---|
| `nfs_nlm.c` | 922 | 0.0% | 85.9% |
| `nfs_nsm.c` | 447 | 1.8% | 46.8% |
| `nfs_nlm_granted.c` | 282 | 1.4% | 76.2% |
| `nfs_mount.c` | 276 | 38.0% | 85.1% |
| `nfs_portmap.c` | 194 | 5.2% | 88.7% |
| `nfs_nlm_state.c` | 171 | 17.5% | 58.5% |
| `nfs_nsm_state.c` | 125 | 16.8% | 49.6% |
| `nfs_external_portmap.c` | 169 | 0.0% | 0.0% |
| **those eight** | 2,586 | 6.9% | **69.0%** |
| **src/server/nfs** | 27,058 | 45.0% | **57.2%** |

Measured against *every* NFS-labelled test rather than the quint suites alone,
744 of those 2,586 lines remain. Roughly half needs a second process (external
`rpcbind`, the reboot-notify worker, IPv6 peer addresses); ~150 needs a
persistent KV backend and a restart, which would also turn on the NLM grace
window — the model side of that already exists as the `nfsauxGrace` profile and
generates no traces only because no server configuration matches it yet.

### Verification

- `ctest -R "^chimera/server/nfs/"` — 20/20
- each commit builds on its own; the first two also pass the 18 pre-existing NFS
  tests without the suite present
- scan-build clean, uncrustify clean

