### PR TITLE
nfs4: drive the model corpus to zero divergences

### DIFF
--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -1375,7 +1375,7 @@ chimera_nfs4_set_changeinfo(
      * when the backend filled the change attribute (native counter, or its
      * ctime fallback) in both snapshots: not every backend populates the
      * rename/link pre/post directory attrs, and reading an unset field is
-     * uninitialized memory -- which a self-rename (RFC 7530 §10.4.5: a
+     * uninitialized memory -- which a self-rename (RFC 7530 §16.27.4: a
      * no-op) would then report as a spurious change, failing pynfs
      * RNM18/19/20.  Without both, report a non-atomic, no-change cinfo. */
     uint64_t change_mask = CHIMERA_VFS_ATTR_CHANGE | CHIMERA_VFS_ATTR_CTIME;

--- a/src/server/nfs/nfs4_proc_allocate.c
+++ b/src/server/nfs/nfs4_proc_allocate.c
@@ -67,6 +67,72 @@ chimera_nfs4_allocate_open_callback(
                          req);
 } /* chimera_nfs4_allocate_open_callback */
 
+static void
+chimera_nfs4_allocate_typecheck_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request  *req = private_data;
+    struct ALLOCATE4res *res = &req->res_compound.resarray[req->index].opallocate;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->ar_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->ar_status);
+        return;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        !S_ISREG(attr->va_mode)) {
+        res->ar_status = chimera_nfs4_data_nonreg_status(attr->va_mode);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->ar_status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED,
+                        chimera_nfs4_allocate_open_callback,
+                        req);
+} /* chimera_nfs4_allocate_typecheck_complete */
+
+/*
+ * The current filehandle of a special-stateid ALLOCATE is not guaranteed to be
+ * a regular file: nothing has OPENed it, so no earlier op rejected the type.
+ * RFC 7862 §11.2: ALLOCATE operates on a regular file, so a
+ * directory cfh is NFS4ERR_ISDIR rather than a backend-level success.
+ */
+static void
+chimera_nfs4_allocate_typecheck_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request  *req = private_data;
+    struct ALLOCATE4res *res = &req->res_compound.resarray[req->index].opallocate;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->ar_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->ar_status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        CHIMERA_VFS_ATTR_MODE,
+                        chimera_nfs4_allocate_typecheck_complete,
+                        req);
+} /* chimera_nfs4_allocate_typecheck_open_callback */
+
 void
 chimera_nfs4_allocate(
     struct chimera_server_nfs_thread *thread,
@@ -118,8 +184,9 @@ chimera_nfs4_allocate(
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,
-                            CHIMERA_VFS_OPEN_INFERRED,
-                            chimera_nfs4_allocate_open_callback,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH |
+                            CHIMERA_VFS_OPEN_NOFOLLOW,
+                            chimera_nfs4_allocate_typecheck_open_callback,
                             req);
         return;
     }

--- a/src/server/nfs/nfs4_proc_copy.c
+++ b/src/server/nfs/nfs4_proc_copy.c
@@ -487,6 +487,18 @@ chimera_nfs4_copy(
         return;
     }
 
+    /* RFC 7862 §15.2.3: COPY moves data between two files.  Naming one file
+     * as both source and destination is NFS4ERR_INVAL whatever the ranges --
+     * the overlap qualifier belongs to CLONE (§15.13.3), not here.  The Linux
+     * client knows it: nfs4_copy_file_range() refuses when the two inodes
+     * match rather than send a COPY the server has to reject. */
+    if (req->saved_fhlen == req->fhlen &&
+        memcmp(req->saved_fh, req->fh, req->fhlen) == 0) {
+        res->cr_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->cr_status);
+        return;
+    }
+
     chimera_nfs4_resolve_current_stateid(req, &args->ca_src_stateid);
     chimera_nfs4_resolve_current_stateid(req, &args->ca_dst_stateid);
 

--- a/src/server/nfs/nfs4_proc_copy.c
+++ b/src/server/nfs/nfs4_proc_copy.c
@@ -5,25 +5,37 @@
 #include "nfs4_procs.h"
 #include "nfs4_status.h"
 #include "nfs4_state.h"
+#include "nfs4_session.h"
+#include "nfs4_stateid.h"
+#include "vfs/vfs_release.h"
 #include "vfs/vfs_procs.h"
 
 #define CHIMERA_NFS4_COPY_IO_SIZE (128 * 1024)
 #define CHIMERA_NFS4_COPY_IOV_MAX 256
 
 struct nfs4_copy_state_refs {
-    void               *src_state;
-    uint8_t             src_type;
-    void               *dst_state;
-    uint8_t             dst_type;
-    struct nfs_request *req;
-    uint64_t            src_offset;
-    uint64_t            dst_offset;
-    uint64_t            remaining;
-    uint64_t            copied;
-    uint32_t            rw_count;
-    uint32_t            rw_eof;
-    int                 rw_niov;
-    struct evpl_iovec   rw_iov[CHIMERA_NFS4_COPY_IOV_MAX];
+    void                           *src_state;
+    uint8_t                         src_type;
+    void                           *dst_state;
+    uint8_t                         dst_type;
+    /* Handles opened by COPY itself for a special stateid, which names no
+     * state-table entry; released with the refs. */
+    struct chimera_vfs_open_handle *src_own;
+    struct chimera_vfs_open_handle *dst_own;
+    struct chimera_vfs_open_handle *src_handle;
+    struct chimera_vfs_open_handle *dst_handle;
+    uint8_t                         src_special;
+    uint8_t                         dst_special;
+    uint64_t                        req_count; /* ca_count as sent; 0 means "to EOF" */
+    struct nfs_request             *req;
+    uint64_t                        src_offset;
+    uint64_t                        dst_offset;
+    uint64_t                        remaining;
+    uint64_t                        copied;
+    uint32_t                        rw_count;
+    uint32_t                        rw_eof;
+    int                             rw_niov;
+    struct evpl_iovec               rw_iov[CHIMERA_NFS4_COPY_IOV_MAX];
 };
 
 /* Returns NULL for any state type that carries no open handle -- a delegation
@@ -33,6 +45,9 @@ chimera_nfs4_copy_state_handle(
     void   *state,
     uint8_t state_type)
 {
+    if (!state) {
+        return NULL;
+    }
     switch (state_type) {
         case NFS4_SLOT_TYPE_OPEN:
             return ((struct nfs_open_state *) state)->handle;
@@ -57,6 +72,12 @@ chimera_nfs4_copy_release_refs(
     if (refs->dst_state) {
         nfs_state_table_release(table, refs->dst_state, refs->dst_type,
                                 req->thread->vfs_thread);
+    }
+    if (refs->src_own) {
+        chimera_vfs_release(req->thread->vfs_thread, refs->src_own);
+    }
+    if (refs->dst_own) {
+        chimera_vfs_release(req->thread->vfs_thread, refs->dst_own);
     }
     free(refs);
 } /* chimera_nfs4_copy_release_refs */
@@ -236,6 +257,217 @@ chimera_nfs4_copy_complete(
     chimera_nfs4_compound_complete(req, res->cr_status);
 } /* chimera_nfs4_copy_complete */
 
+static void
+chimera_nfs4_copy_fail(
+    struct nfs4_copy_state_refs *refs,
+    nfsstat4                     status);
+
+static void
+chimera_nfs4_copy_start(
+    struct nfs4_copy_state_refs *refs);
+
+/* The source range must lie inside the source file: RFC 7862 §15.2.3 makes a
+ * COPY whose ca_src_offset + ca_count runs past the end of the source
+ * NFS4ERR_INVAL rather than a short copy.  ca_count == 0 means "to EOF", so
+ * only an offset past the end is out of range there.  The size is not known
+ * until the handle is open, hence the extra round trip. */
+static void
+chimera_nfs4_copy_srcattr_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs4_copy_state_refs *refs = private_data;
+    struct nfs_request          *req  = refs->req;
+    nfsstat4                     status;
+    uint64_t                     size;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_copy_fail(refs,
+                               chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    size = (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) ? attr->va_size : 0;
+
+    if (refs->req_count == 0) {
+        if (refs->src_offset > size) {
+            chimera_nfs4_copy_fail(refs, NFS4ERR_INVAL);
+            return;
+        }
+        refs->remaining = size - refs->src_offset;
+    } else {
+        if (refs->src_offset > size ||
+            refs->req_count > size - refs->src_offset) {
+            chimera_nfs4_copy_fail(refs, NFS4ERR_INVAL);
+            return;
+        }
+        refs->remaining = refs->req_count;
+    }
+
+    /* Share reservations are checked here, after the range: an out-of-range
+     * COPY is an argument error the server can answer without consulting any
+     * state, so it reports NFS4ERR_INVAL rather than masking it behind a
+     * conflict.  A special stateid names no open, so the deny modes held by
+     * any owner of any client still have to be honored explicitly -- exactly
+     * as READ, SEEK and DEALLOCATE do -- or the anonymous stateid would be a
+     * way around them. */
+    if (refs->src_special) {
+        status = nfs4_clients_check_io_denied(
+            &req->thread->shared->nfs4_shared_clients,
+            req->saved_fh, req->saved_fhlen, OPEN4_SHARE_ACCESS_READ);
+        if (status != NFS4_OK) {
+            chimera_nfs4_copy_fail(refs, status);
+            return;
+        }
+    }
+
+    if (refs->dst_special) {
+        status = nfs4_clients_check_io_denied(
+            &req->thread->shared->nfs4_shared_clients,
+            req->fh, req->fhlen, OPEN4_SHARE_ACCESS_WRITE);
+        if (status != NFS4_OK) {
+            chimera_nfs4_copy_fail(refs, status);
+            return;
+        }
+    }
+
+    chimera_nfs4_copy_start(refs);
+} /* chimera_nfs4_copy_srcattr_complete */
+
+/* Start the transfer once both endpoints have a usable handle. */
+static void
+chimera_nfs4_copy_begin(struct nfs4_copy_state_refs *refs)
+{
+    struct nfs_request             *req  = refs->req;
+    struct COPY4args               *args =
+        &req->args_compound->argarray[req->index].opcopy;
+    struct COPY4res                *res =
+        &req->res_compound.resarray[req->index].opcopy;
+    struct chimera_vfs_open_handle *src_handle;
+    struct chimera_vfs_open_handle *dst_handle;
+
+    src_handle = refs->src_own
+        ? refs->src_own
+        : chimera_nfs4_copy_state_handle(refs->src_state, refs->src_type);
+    dst_handle = refs->dst_own
+        ? refs->dst_own
+        : chimera_nfs4_copy_state_handle(refs->dst_state, refs->dst_type);
+
+    if (!src_handle || !dst_handle) {
+        chimera_nfs4_copy_release_refs(req, refs);
+        res->cr_status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->cr_status);
+        return;
+    }
+
+    refs->src_offset = args->ca_src_offset;
+    refs->dst_offset = args->ca_dst_offset;
+    refs->req_count  = args->ca_count;
+    refs->src_handle = src_handle;
+    refs->dst_handle = dst_handle;
+
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        src_handle,
+                        CHIMERA_VFS_ATTR_SIZE,
+                        chimera_nfs4_copy_srcattr_complete,
+                        refs);
+} /* chimera_nfs4_copy_begin */
+
+static void
+chimera_nfs4_copy_start(struct nfs4_copy_state_refs *refs)
+{
+    struct nfs_request             *req        = refs->req;
+    struct chimera_vfs_open_handle *src_handle = refs->src_handle;
+    struct chimera_vfs_open_handle *dst_handle = refs->dst_handle;
+
+    req->nfs_state_ref = refs;
+
+    if (src_handle->vfs_module == dst_handle->vfs_module &&
+        (dst_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE)) {
+        chimera_vfs_copy_range(req->thread->vfs_thread, &req->cred,
+                               src_handle,
+                               refs->src_offset,
+                               dst_handle,
+                               refs->dst_offset,
+                               refs->remaining,
+                               0,
+                               0,
+                               0,
+                               chimera_nfs4_copy_complete,
+                               req);
+    } else {
+        chimera_nfs4_copy_rw_step(refs);
+    }
+} /* chimera_nfs4_copy_start */
+
+static void
+chimera_nfs4_copy_fail(
+    struct nfs4_copy_state_refs *refs,
+    nfsstat4                     status)
+{
+    struct nfs_request *req = refs->req;
+    struct COPY4res    *res = &req->res_compound.resarray[req->index].opcopy;
+
+    chimera_nfs4_copy_release_refs(req, refs);
+    res->cr_status = status;
+    chimera_nfs4_compound_complete(req, res->cr_status);
+} /* chimera_nfs4_copy_fail */
+
+static void
+chimera_nfs4_copy_dst_open_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs4_copy_state_refs *refs = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_copy_fail(refs,
+                               chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    refs->dst_own = handle;
+    chimera_nfs4_copy_begin(refs);
+} /* chimera_nfs4_copy_dst_open_complete */
+
+static void
+chimera_nfs4_copy_open_dst(struct nfs4_copy_state_refs *refs)
+{
+    struct nfs_request *req = refs->req;
+
+    chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED,
+                        chimera_nfs4_copy_dst_open_complete,
+                        refs);
+} /* chimera_nfs4_copy_open_dst */
+
+static void
+chimera_nfs4_copy_src_open_complete(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs4_copy_state_refs *refs = private_data;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_nfs4_copy_fail(refs,
+                               chimera_nfs4_errno_to_nfsstat4(error_code));
+        return;
+    }
+
+    refs->src_own = handle;
+
+    if (refs->dst_special) {
+        chimera_nfs4_copy_open_dst(refs);
+    } else {
+        chimera_nfs4_copy_begin(refs);
+    }
+} /* chimera_nfs4_copy_src_open_complete */
+
 void
 chimera_nfs4_copy(
     struct chimera_server_nfs_thread *thread,
@@ -243,13 +475,11 @@ chimera_nfs4_copy(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct COPY4args               *args  = &argop->opcopy;
-    struct COPY4res                *res   = &resop->opcopy;
-    struct nfs_state_table         *table = &thread->shared->nfs4_state_table;
-    struct nfs4_copy_state_refs    *refs;
-    struct chimera_vfs_open_handle *src_handle;
-    struct chimera_vfs_open_handle *dst_handle;
-    nfsstat4                        status;
+    struct COPY4args            *args  = &argop->opcopy;
+    struct COPY4res             *res   = &resop->opcopy;
+    struct nfs_state_table      *table = &thread->shared->nfs4_state_table;
+    struct nfs4_copy_state_refs *refs;
+    nfsstat4                     status;
 
     if (req->saved_fhlen == 0 || req->fhlen == 0) {
         res->cr_status = NFS4ERR_NOFILEHANDLE;
@@ -263,70 +493,61 @@ chimera_nfs4_copy(
     refs = calloc(1, sizeof(*refs));
     chimera_nfs_abort_if(refs == NULL, "copy state refs OOM");
 
-    status = nfs_state_table_acquire(table, &args->ca_src_stateid, 0,
-                                     &refs->src_state, &refs->src_type);
-    if (status != NFS4_OK) {
-        free(refs);
-        res->cr_status = status;
-        chimera_nfs4_compound_complete(req, res->cr_status);
-        return;
+    refs->req         = req;
+    refs->src_special = nfs4_stateid_is_special(&args->ca_src_stateid);
+    refs->dst_special = nfs4_stateid_is_special(&args->ca_dst_stateid);
+
+    /* RFC 7862 §15.2.3 asks only that ca_src_stateid be READ-valid and
+     * ca_dst_stateid WRITE-valid, and RFC 8881 §8.2.3 makes the anonymous
+     * and READ-bypass stateids exactly that.  Neither names a state-table
+     * entry, so open the filehandle the compound supplied -- the saved FH
+     * for the source, the current FH for the destination -- the same way
+     * READ, SEEK and DEALLOCATE do, rather than rejecting the operation.
+     *
+     * The share-reservation checks those ops perform apply here too: a
+     * special-stateid COPY reads the source and writes the destination, so
+     * a conflicting deny held by any owner of any client makes it
+     * NFS4ERR_LOCKED. */
+    if (!refs->src_special) {
+        status = nfs_state_table_acquire(table, &args->ca_src_stateid, 0,
+                                         &refs->src_state, &refs->src_type);
+        if (status != NFS4_OK) {
+            chimera_nfs4_copy_fail(refs, status);
+            return;
+        }
     }
 
-    status = nfs_state_table_acquire(table, &args->ca_dst_stateid, 0,
-                                     &refs->dst_state, &refs->dst_type);
-    if (status != NFS4_OK) {
-        nfs_state_table_release(table, refs->src_state, refs->src_type,
-                                thread->vfs_thread);
-        free(refs);
-        res->cr_status = status;
-        chimera_nfs4_compound_complete(req, res->cr_status);
-        return;
+    if (!refs->dst_special) {
+        status = nfs_state_table_acquire(table, &args->ca_dst_stateid, 0,
+                                         &refs->dst_state, &refs->dst_type);
+        if (status != NFS4_OK) {
+            chimera_nfs4_copy_fail(refs, status);
+            return;
+        }
+
+        /* The destination stateid must name a write-capable open of the
+        * current filehandle (the saved filehandle is the source -- RFC 7862
+        * §15.2).  Without this the write would target whatever handle the
+        * stateid carries, rather than the object the compound named. */
+        status = nfs_state_check_write_for_fh(refs->dst_state, refs->dst_type,
+                                              req->fh, req->fhlen);
+        if (status != NFS4_OK) {
+            chimera_nfs4_copy_fail(refs, status);
+            return;
+        }
     }
 
-    /* The destination stateid must name a write-capable open of the current
-     * filehandle (the saved filehandle is the source -- RFC 7862 sec 15.2).
-     * Without this the write would target whatever handle the stateid carries,
-     * rather than the object the compound named. */
-    status = nfs_state_check_write_for_fh(refs->dst_state, refs->dst_type,
-                                          req->fh, req->fhlen);
-    if (status != NFS4_OK) {
-        chimera_nfs4_copy_release_refs(req, refs);
-        res->cr_status = status;
-        chimera_nfs4_compound_complete(req, res->cr_status);
-        return;
-    }
-
-    src_handle = chimera_nfs4_copy_state_handle(refs->src_state, refs->src_type);
-    dst_handle = chimera_nfs4_copy_state_handle(refs->dst_state, refs->dst_type);
-
-    if (!src_handle || !dst_handle) {
-        chimera_nfs4_copy_release_refs(req, refs);
-        res->cr_status = NFS4ERR_BAD_STATEID;
-        chimera_nfs4_compound_complete(req, res->cr_status);
-        return;
-    }
-
-    refs->req        = req;
-    refs->src_offset = args->ca_src_offset;
-    refs->dst_offset = args->ca_dst_offset;
-    refs->remaining  = args->ca_count ? args->ca_count : UINT64_MAX;
-
-    req->nfs_state_ref = refs;
-
-    if (src_handle->vfs_module == dst_handle->vfs_module &&
-        (dst_handle->vfs_module->capabilities & CHIMERA_VFS_CAP_COPY_RANGE)) {
-        chimera_vfs_copy_range(thread->vfs_thread, &req->cred,
-                               src_handle,
-                               refs->src_offset,
-                               dst_handle,
-                               refs->dst_offset,
-                               refs->remaining,
-                               0,
-                               0,
-                               0,
-                               chimera_nfs4_copy_complete,
-                               req);
+    if (refs->src_special) {
+        chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
+                            req->saved_fh,
+                            req->saved_fhlen,
+                            CHIMERA_VFS_OPEN_INFERRED |
+                            CHIMERA_VFS_OPEN_READ_ONLY,
+                            chimera_nfs4_copy_src_open_complete,
+                            refs);
+    } else if (refs->dst_special) {
+        chimera_nfs4_copy_open_dst(refs);
     } else {
-        chimera_nfs4_copy_rw_step(refs);
+        chimera_nfs4_copy_begin(refs);
     }
 } /* chimera_nfs4_copy */

--- a/src/server/nfs/nfs4_proc_deallocate.c
+++ b/src/server/nfs/nfs4_proc_deallocate.c
@@ -69,6 +69,72 @@ chimera_nfs4_deallocate_open_callback(
                          req);
 } /* chimera_nfs4_deallocate_open_callback */
 
+static void
+chimera_nfs4_deallocate_typecheck_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request    *req = private_data;
+    struct DEALLOCATE4res *res = &req->res_compound.resarray[req->index].opdeallocate;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->dr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->dr_status);
+        return;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        !S_ISREG(attr->va_mode)) {
+        res->dr_status = chimera_nfs4_data_nonreg_status(attr->va_mode);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->dr_status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED,
+                        chimera_nfs4_deallocate_open_callback,
+                        req);
+} /* chimera_nfs4_deallocate_typecheck_complete */
+
+/*
+ * The current filehandle of a special-stateid DEALLOCATE is not guaranteed to be
+ * a regular file: nothing has OPENed it, so no earlier op rejected the type.
+ * RFC 7862 §11.9: DEALLOCATE operates on a regular file, so a
+ * directory cfh is NFS4ERR_ISDIR rather than a backend-level success.
+ */
+static void
+chimera_nfs4_deallocate_typecheck_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request    *req = private_data;
+    struct DEALLOCATE4res *res = &req->res_compound.resarray[req->index].opdeallocate;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->dr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->dr_status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        CHIMERA_VFS_ATTR_MODE,
+                        chimera_nfs4_deallocate_typecheck_complete,
+                        req);
+} /* chimera_nfs4_deallocate_typecheck_open_callback */
+
 void
 chimera_nfs4_deallocate(
     struct chimera_server_nfs_thread *thread,
@@ -120,8 +186,9 @@ chimera_nfs4_deallocate(
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,
-                            CHIMERA_VFS_OPEN_INFERRED,
-                            chimera_nfs4_deallocate_open_callback,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH |
+                            CHIMERA_VFS_OPEN_NOFOLLOW,
+                            chimera_nfs4_deallocate_typecheck_open_callback,
                             req);
         return;
     }

--- a/src/server/nfs/nfs4_proc_link.c
+++ b/src/server/nfs/nfs4_proc_link.c
@@ -108,7 +108,7 @@ chimera_nfs4_link(
         return;
     }
 
-    /* RFC 7530 §10.4.5 (hard link to a delegated file must recall the
+    /* RFC 8881 §18.9.4 (hard link to a delegated file must recall the
      * delegation) is now enforced centrally by chimera_vfs_link_at(), which
      * recalls any caching lease on the SAVEFH source before linking. */
     chimera_vfs_open_fh(thread->vfs_thread,

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -437,6 +437,36 @@ chimera_nfs4_lock(
             nfs_open_owner_get(oo);
             req->lock_4_0_open_owner = oo;
             req->lock_4_0_lock_owner = lock_owner;
+        } else if (!created) {
+            /* 4.1+ has neither lock seqids nor an open_to_lock_owner replay
+             * cache, so the arm above does not apply to it -- but the stateid
+             * identity rule does.  RFC 8881 9.1.4.2: a stateid's "other" is
+             * stable for the life of the state, and a (lock-owner, file) pair
+             * has exactly one lock stateid.  A new_lock_owner LOCK naming a
+             * lock-owner that already has one must therefore re-establish
+             * that stateid, not mint a second one for the same pair.
+             *
+             * It matters most after LOCKU: 4.1 keeps a lock stateid alive
+             * with no ranges until FREE_STATEID (RFC 8881 18.12), so a client
+             * that unlocks every range and then locks again must get the same
+             * "other" back with its seqid continuing.  Until now it got a
+             * fresh stateid whose seqid restarted at 1, orphaning the old
+             * one.  The reuse was only ever wired into the 4.0 path. */
+            struct nfs_lock_state *ls;
+
+            pthread_mutex_lock(&lock_owner->lock);
+            for (ls = lock_owner->states; ls; ls = ls->next_in_owner) {
+                if (ls->open_state &&
+                    ls->open_state->fh_len == req->fhlen &&
+                    memcmp(ls->open_state->fh, req->fh, req->fhlen) == 0) {
+                    have_reuse  = true;
+                    reuse_shard = ls->shard;
+                    reuse_slot  = ls->slot_idx;
+                    reuse_gen   = ls->generation;
+                    break;
+                }
+            }
+            pthread_mutex_unlock(&lock_owner->lock);
         }
         /* Re-establish an emptied stateid in place: re-acquire it by its slot
          * (the lookup checks shard/slot/generation, not the stateid seqid) and
@@ -461,6 +491,14 @@ chimera_nfs4_lock(
                 req->nfs_state_type = NFS4_SLOT_TYPE_LOCK;
                 nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                                         thread->vfs_thread);
+                if (req->minorversion != 0) {
+                    /* 4.1+ transfers no owner ref onto the request (only the
+                     * 4.0 arm above does), and the create path below -- which
+                     * normally drops this borrow -- is skipped when the
+                     * stateid is reused.  Drop it here: the reused state
+                     * carries its own pin on the owner. */
+                    nfs_lock_owner_put(lock_owner);
+                }
             } else {
                 have_reuse = false;
             }

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -510,7 +510,7 @@ chimera_nfs4_open_nonreg_status(
 } /* chimera_nfs4_open_nonreg_status */
 
 static void
-chimera_nfs4_open_complete(
+chimera_nfs4_open_finish(
     struct nfs_request *req,
     nfsstat4            status)
 {
@@ -548,6 +548,123 @@ chimera_nfs4_open_complete(
     }
 
     chimera_nfs4_compound_complete(req, status);
+} /* chimera_nfs4_open_finish */
+
+/*
+ * Tear the open state this OPEN just installed back down.  Used when the
+ * deferred truncate fails: the OPEN reports the error, so it must not leave a
+ * stateid behind that the client was never told about.
+ */
+static void
+chimera_nfs4_open_unwind_state(struct nfs_request *req)
+{
+    struct nfs_state_table *table = &req->thread->shared->nfs4_state_table;
+    struct OPEN4res        *res   =
+        &req->res_compound.resarray[req->index].opopen;
+    void                   *state_void;
+    uint8_t                 state_type;
+
+    if (nfs_state_table_acquire(table, &res->resok4.stateid,
+                                NFS4_SLOT_TYPE_OPEN,
+                                &state_void, &state_type) != NFS4_OK) {
+        return;
+    }
+
+    nfs_open_state_destroy(state_void, table, req->thread->vfs_thread);
+    nfs_state_table_release(table, state_void, NFS4_SLOT_TYPE_OPEN,
+                            req->thread->vfs_thread);
+} /* chimera_nfs4_open_unwind_state */
+
+static void
+chimera_nfs4_open_trunc_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct nfs_request     *req   = private_data;
+    struct nfs_state_table *table = &req->thread->shared->nfs4_state_table;
+    struct OPEN4res        *res   =
+        &req->res_compound.resarray[req->index].opopen;
+
+    (void) pre_attr;
+    (void) set_attr;
+    (void) post_attr;
+
+    nfs_state_table_release(table, req->nfs_state_ref, NFS4_SLOT_TYPE_OPEN,
+                            req->thread->vfs_thread);
+    req->nfs_state_ref = NULL;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_open_unwind_state(req);
+        chimera_nfs4_open_finish(req, res->status);
+        return;
+    }
+
+    chimera_nfs4_open_finish(req, NFS4_OK);
+} /* chimera_nfs4_open_trunc_complete */
+
+/*
+ * Every OPEN outcome funnels through here, including the one that parks on the
+ * 4.0 CB_NULL probe -- so this is the one place that sees "the OPEN has
+ * succeeded and its share reservation is held".  An UNCHECKED4 truncate of an
+ * existing file is applied here rather than as part of the open, so an OPEN
+ * that fails (share reservation, type, permission) leaves the file's contents
+ * alone.
+ *
+ * The truncate runs through the just-installed open state's handle and the
+ * descriptor-originated fsetattr, so it is authorized by the access this OPEN
+ * was granted rather than re-checked against the file's mode -- the ftruncate
+ * rule, and the same grant the client would use for a WRITE.
+ */
+static void
+chimera_nfs4_open_complete(
+    struct nfs_request *req,
+    nfsstat4            status)
+{
+    struct nfs_state_table *table = &req->thread->shared->nfs4_state_table;
+    struct OPEN4res        *res   =
+        &req->res_compound.resarray[req->index].opopen;
+    struct nfs_open_state  *open_state;
+    void                   *state_void;
+    uint8_t                 state_type;
+
+    if (status == NFS4_OK && req->open_trunc_pending) {
+        req->open_trunc_pending = false;
+
+        if (nfs_state_table_acquire(table, &res->resok4.stateid,
+                                    NFS4_SLOT_TYPE_OPEN,
+                                    &state_void, &state_type) == NFS4_OK) {
+            open_state          = state_void;
+            req->nfs_state_ref  = state_void;
+            req->nfs_state_type = NFS4_SLOT_TYPE_OPEN;
+
+            memset(&req->open_trunc_attr, 0, sizeof(req->open_trunc_attr));
+            req->open_trunc_attr.va_set_mask = CHIMERA_VFS_ATTR_SIZE;
+            req->open_trunc_attr.va_req_mask = CHIMERA_VFS_ATTR_SIZE;
+            req->open_trunc_attr.va_size     = 0;
+
+            chimera_vfs_fsetattr(req->thread->vfs_thread, &req->cred,
+                                 open_state->handle,
+                                 &req->open_trunc_attr,
+                                 0,
+                                 0,
+                                 chimera_nfs4_open_trunc_complete,
+                                 req);
+            return;
+        }
+        /* The state was reaped before the truncate could run (a lease sweep
+         * racing this OPEN); the stateid is already dead, so report it as
+         * such rather than truncating on its behalf. */
+        res->status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_open_finish(req, res->status);
+        return;
+    }
+
+    req->open_trunc_pending = false;
+    chimera_nfs4_open_finish(req, status);
 } /* chimera_nfs4_open_complete */
 
 /*
@@ -867,15 +984,22 @@ chimera_nfs4_open_unchecked_lookup_complete(
         }
 
         /* RFC 7530 OPEN/UNCHECKED recreate: create attrs are ignored for an
-         * existing object, except size=0 truncates the file. */
+         * existing object, except size=0 truncates the file.
+         *
+         * The truncate is deliberately NOT handed to the open below.  That
+         * call opens and applies attributes in one step, while the share
+         * reservation is not admitted until chimera_nfs4_open_acquire_share()
+         * runs on the completion -- so an OPEN destined to fail
+         * NFS4ERR_SHARE_DENIED emptied the file on its way to failing.  A
+         * failed OPEN must leave the object alone; note it here and let
+         * chimera_nfs4_open_complete() apply it once the reservation is
+         * actually held. */
         if ((ctx->attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) &&
             ctx->attr->va_size == 0) {
-            ctx->attr->va_set_mask = CHIMERA_VFS_ATTR_SIZE;
-            ctx->attr->va_req_mask = CHIMERA_VFS_ATTR_SIZE;
-        } else {
-            ctx->attr->va_set_mask = 0;
-            ctx->attr->va_req_mask = 0;
+            req->open_trunc_pending = true;
         }
+        ctx->attr->va_set_mask = 0;
+        ctx->attr->va_req_mask = 0;
     } else if (error_code != CHIMERA_VFS_ENOENT) {
         res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
         chimera_vfs_release(req->thread->vfs_thread, parent_handle);
@@ -1265,6 +1389,8 @@ chimera_nfs4_open(
 {
     struct OPEN4args *args = &argop->opopen;
     struct OPEN4res  *res  = &resop->opopen;
+
+    req->open_trunc_pending = false;
 
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -94,7 +94,7 @@ chimera_nfs4_open_acquire_share(
         /* The conflict is a breakable holder -- an NFSv4 delegation being
          * recalled (try_acquire already kicked the break).  Tell the client to
          * retry; by the next attempt the delegation's DELEGRETURN should have
-         * released the claim and the SHARE will be granted (RFC 7530 §10.4.5
+         * released the claim and the SHARE will be granted (RFC 7530 §10.2
          * recommends NFS4ERR_DELAY while a recall is outstanding). */
         chimera_vfs_state_put(vfs_state, file_state);
         return NFS4ERR_DELAY;

--- a/src/server/nfs/nfs4_proc_remove.c
+++ b/src/server/nfs/nfs4_proc_remove.c
@@ -165,7 +165,7 @@ nfs4_remove_lookup_complete(
     struct nfs4_remove_ctx *ctx = private_data;
     struct nfs_request     *req = ctx->req;
 
-    /* RFC 7530 §10.4.5: a REMOVE of a delegated file must recall the
+    /* RFC 7530 §10.4.4: a REMOVE of a delegated file must recall the
      * delegation first.  We looked the target up to learn its FH; if a caching
      * lease is held, kick the recall and tell the client to retry
      * (NFS4ERR_DELAY).  The retry finds no lease and the remove proceeds. */
@@ -214,7 +214,7 @@ chimera_nfs4_remove_open_callback(
     ctx->parent_handle = parent_handle;
 
     /* Look the victim up first when delegations OR pNFS are in play: the FH lets
-     * us recall a delegation (RFC 7530 §10.4.5) before the remove, and the pNFS
+     * us recall a delegation (RFC 7530 §10.4.4) before the remove, and the pNFS
      * attrs let us delete its data-server backing file afterwards.  Skip the
      * extra LOOKUP entirely otherwise (have_layout stays 0). */
     if (chimera_server_config_get_nfs4_delegations(req->thread->shared->config) ||

--- a/src/server/nfs/nfs4_proc_rename.c
+++ b/src/server/nfs/nfs4_proc_rename.c
@@ -99,7 +99,7 @@ chimera_nfs4_rename_delay(struct nfs_request *req)
     chimera_nfs4_compound_complete(req, NFS4ERR_DELAY);
 } /* chimera_nfs4_rename_delay */
 
-/* RFC 7530 §10.4.5: a RENAME must recall a delegation on the file being
+/* RFC 7530 §10.4.4: a RENAME must recall a delegation on the file being
  * renamed over (the target name), if one exists, before proceeding. */
 static void
 chimera_nfs4_rename_recall_target(

--- a/src/server/nfs/nfs4_proc_seek.c
+++ b/src/server/nfs/nfs4_proc_seek.c
@@ -67,6 +67,73 @@ chimera_nfs4_seek_open_callback(
                      req);
 } /* chimera_nfs4_seek_open_callback */
 
+static void
+chimera_nfs4_seek_typecheck_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct SEEK4res    *res = &req->res_compound.resarray[req->index].opseek;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->sa_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->sa_status);
+        return;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+        !S_ISREG(attr->va_mode)) {
+        res->sa_status = chimera_nfs4_data_nonreg_status(attr->va_mode);
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle = NULL;
+        chimera_nfs4_compound_complete(req, res->sa_status);
+        return;
+    }
+
+    chimera_vfs_release(req->thread->vfs_thread, req->handle);
+    req->handle = NULL;
+
+    chimera_vfs_open_fh(req->thread->vfs_thread, &req->cred,
+                        req->fh,
+                        req->fhlen,
+                        CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_READ_ONLY,
+                        chimera_nfs4_seek_open_callback,
+                        req);
+} /* chimera_nfs4_seek_typecheck_complete */
+
+/*
+ * The current filehandle of a special-stateid SEEK is not guaranteed to be
+ * a regular file: nothing has OPENed it, so no earlier op rejected the type.
+ * RFC 7862 §15.11.3 lists NFS4ERR_ISDIR for SEEK on a
+ * directory; without this the offset check below runs first and reports
+ * NFS4ERR_NXIO instead.
+ */
+static void
+chimera_nfs4_seek_typecheck_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct SEEK4res    *res = &req->res_compound.resarray[req->index].opseek;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        res->sa_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->sa_status);
+        return;
+    }
+
+    req->handle = handle;
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred,
+                        handle,
+                        CHIMERA_VFS_ATTR_MODE,
+                        chimera_nfs4_seek_typecheck_complete,
+                        req);
+} /* chimera_nfs4_seek_typecheck_open_callback */
+
 void
 chimera_nfs4_seek(
     struct chimera_server_nfs_thread *thread,
@@ -130,8 +197,9 @@ chimera_nfs4_seek(
         chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                             req->fh,
                             req->fhlen,
-                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_READ_ONLY,
-                            chimera_nfs4_seek_open_callback,
+                            CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH |
+                            CHIMERA_VFS_OPEN_NOFOLLOW,
+                            chimera_nfs4_seek_typecheck_open_callback,
                             req);
         return;
     }

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1048,7 +1048,7 @@ nfs4_clients_check_io_denied(
 /* Cross-client analogue of nfs_client_has_open_state_for_fh: true if ANY
  * client holds this file open.  A removed-but-open file keeps its filehandle
  * valid until the last CLOSE regardless of which client opened it (RFC 7530
- * §16.2.5), so PUTFH must consult every client's open state, not just the one
+ * §16.26.5), so PUTFH must consult every client's open state, not just the one
  * bound to the querying connection. */
 SYMBOL_EXPORT bool
 nfs4_clients_have_open_state(

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -919,7 +919,7 @@ nfs_client_check_io_denied(
 
 /* True if `client` holds any open state keyed by `fh` (i.e. it has this file
  * open).  Used to keep a filehandle valid after its last link is removed
- * while an open still references the inode (RFC 7530 §16.2.5). */
+ * while an open still references the inode (RFC 7530 §16.26.5). */
 SYMBOL_EXPORT bool
 nfs_client_has_open_state_for_fh(
     struct nfs_client *client,

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -593,6 +593,19 @@ nfs_state_owner_client(
     } // switch
 } /* nfs_state_owner_client */
 
+/*
+ * A stateid belongs to the client that created it, so it designates no state
+ * for any other client and using it from one is NFS4ERR_BAD_STATEID -- RFC
+ * 8881 15.1.5.2 defines that error as "a stateid does not properly designate
+ * any valid state", which is exactly this case.  NFS4ERR_ACCESS would be
+ * wrong twice over: it claims the caller lacks permission on the object, and
+ * it sends the client into permission recovery when the state-recovery path
+ * (RFC 8881 8.2.4 / 8.4) is the one that applies.
+ *
+ * `client` is NULL on 4.0, where a COMPOUND carries no identity of its own:
+ * the stateid is the only client binding, so there is nothing to compare it
+ * against and the check does not apply.
+ */
 static inline nfsstat4
 nfs_state_check_client(
     void              *state,
@@ -602,7 +615,7 @@ nfs_state_check_client(
     struct nfs_client *owner = nfs_state_owner_client(state, type);
 
     if (!owner) {
-        return NFS4ERR_ACCESS;
+        return NFS4ERR_BAD_STATEID;
     }
 
     if (!client) {
@@ -610,7 +623,7 @@ nfs_state_check_client(
     }
 
     if (owner != client) {
-        return NFS4ERR_ACCESS;
+        return NFS4ERR_BAD_STATEID;
     }
 
     return NFS4_OK;

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -173,6 +173,12 @@ struct nfs_request {
      * owner seqid + caches the reply iff this is non-NULL and the status
      * is in nfs4_seqid_should_advance(). */
     struct nfs_open_owner            *open_4_0_owner;
+    /* An OPEN/UNCHECKED of an existing file asked for size 0.  The truncate
+     * is held back until the share reservation is granted (see
+     * chimera_nfs4_open_complete) so a denied OPEN cannot destroy the
+     * file's contents. */
+    bool                              open_trunc_pending;
+    struct chimera_vfs_attrs          open_trunc_attr;
     /* Per-owner seqid bookkeeping for the 4.0 LOCK flow.  For
      * new_lock_owner=true both open_owner (open_seqid) and lock_owner
      * (lock_seqid) advance; for new_lock_owner=false only the lock_owner

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 add_test(NAME chimera/server/nfs/mbtaux/probe_memfs
     COMMAND $<TARGET_FILE:nfs_aux_probe>)
 set_tests_properties(chimera/server/nfs/mbtaux/probe_memfs PROPERTIES
-    LABELS "nfsaux_mbt;memfs"
+    LABELS "quint;nfsaux_mbt;memfs"
     TIMEOUT 120)
 
 # Delegation policy probe: pins the deterministic grant/recall behavior the
@@ -172,7 +172,7 @@ add_test(NAME chimera/server/nfs/mbtaux/batch_memfs
     COMMAND $<TARGET_FILE:nfs_aux_mbt_replay> --paranoid
             --trace-dir ${SPECS_BUNDLE_DIR}/nfsaux)
 set_tests_properties(chimera/server/nfs/mbtaux/batch_memfs PROPERTIES
-    LABELS "nfsaux_mbt;memfs"
+    LABELS "quint;nfsaux_mbt;memfs"
     TIMEOUT 600)
 
 # SKIP_RETURN_CODE 77 still applies to NFS4: a trace whose capability profile

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -263,6 +263,17 @@ mbt_env_open_opts(
 
     env->module = (opts && opts->module) ? opts->module : "memfs";
 
+    /* Deliberately NOT raising common.umount_timeout_ms here.
+     *
+     * chimera_vfs_umount already purges the mount's cached opens and dispatches
+     * their closes immediately -- it never waits out the open cache's idle
+     * sweep (see chimera_vfs_open_cache_purge_by_mount).  So the only thing it
+     * can be waiting on is a handle with opencnt > 0, i.e. one that is still
+     * genuinely open.  The harness closes every open the trace left behind
+     * (v4_close_dangling_opens) before tearing the filesystem down, so it
+     * should never have to wait at all.  A longer timeout would just hide a
+     * leaked handle behind a slower test. */
+
     if (opts) {
         if (opts->nfs4_delegations) {
             chimera_server_config_set_nfs4_delegations(config, 1);
@@ -462,6 +473,27 @@ mbt_env_fs_setup(
     struct mbt_env *env,
     const char     *fsname)
 {
+    char path[80];
+
+    snprintf(path, sizeof(path), "/%s", fsname);
+
+    /* Mount and export under the *filesystem's own* name rather than a shared
+     * "share", and check every call.
+     *
+     * A trace that diverges stops mid-replay, and from that point the model's
+     * view of the server is by definition wrong -- so the dangling-open sweep,
+     * which closes what the model believes is open, cannot close what the
+     * server actually has.  The leftover handle keeps the filesystem
+     * referenced, umount reports EBUSY and (correctly) leaves the mount
+     * registered.  With one shared mount name that poisoned the entire rest of
+     * the batch: every later trace mounted its own filesystem under the same
+     * name, silently got the stuck one instead, and reported its predecessor's
+     * leftovers as divergences.  One genuine failure turned into dozens of
+     * phantom ones.
+     *
+     * Per-trace names make a stuck mount inert: it keeps its own name, the
+     * next trace's mount cannot collide with it, and the batch goes on
+     * reporting only real divergences. */
     if (mbt_module_is_passthrough(env->module)) {
         char dir[300];
         int  mrc;
@@ -475,7 +507,7 @@ mbt_env_fs_setup(
                     env->module, dir, strerror(errno));
             exit(1);
         }
-        mrc = chimera_server_mount(env->server, "share", env->module, dir,
+        mrc = chimera_server_mount(env->server, path + 1, env->module, dir,
                                    NULL);
         if (mrc == CHIMERA_VFS_ENOTSUP) {
             /* The backing filesystem cannot produce file handles
@@ -500,11 +532,15 @@ mbt_env_fs_setup(
                     fsname);
             exit(1);
         }
-        chimera_server_mount(env->server, "share", env->module, fsname, NULL);
+        if (chimera_server_mount(env->server, path + 1, env->module, fsname,
+                                 NULL) != 0) {
+            fprintf(stderr, "failed to mount %s filesystem %s\n", env->module,
+                    fsname);
+            exit(1);
+        }
     }
-    if (chimera_server_create_export(env->server, "/share", "/share", 0,
-                                     NULL) != 0) {
-        fprintf(stderr, "failed to create /share export\n");
+    if (chimera_server_create_export(env->server, path, path, 0, NULL) != 0) {
+        fprintf(stderr, "failed to create %s export\n", path);
         exit(1);
     }
 } /* mbt_env_fs_setup */
@@ -516,10 +552,38 @@ mbt_env_fs_teardown(
     struct mbt_env *env,
     const char     *fsname)
 {
-    int tries = 0;
+    int  tries = 0;
+    int  rc;
 
-    chimera_server_remove_export(env->server, "/share");
-    chimera_server_unmount(env->server, "share");
+    char path[80];
+
+    snprintf(path, sizeof(path), "/%s", fsname);
+
+    chimera_server_remove_export(env->server, path);
+
+    /* The unmount status was previously discarded, and that is what made a
+     * batch run nondeterministic.  Every trace mounts its filesystem under the
+     * same name, so an unmount that reports EBUSY -- which also leaves the
+     * mount in the table -- means the next trace gets its predecessor's
+     * filesystem and reports the leftovers as divergences, attributed to
+     * whichever trace happened to follow a slow drain.  Across five identical
+     * runs that produced 0, 16, 42, 42 and 48 divergences.
+     *
+     * umount blocks until the mount is genuinely idle (it purges the cached
+     * opens and issues the backend closes itself), so a failure here is a real
+     * leak, not a timing hiccup to retry around: something still holds a
+     * reference after the configured 30s.  Fail loudly -- a hard stop is
+     * debuggable, a corpus silently replayed against the wrong filesystem is
+     * not. */
+    rc = chimera_server_unmount(env->server, path + 1);
+    if (rc != 0) {
+        fprintf(stderr,
+                "warning: unmount of %s returned %d -- a handle is still "
+                "open, most likely because a diverging trace stopped before "
+                "the model knew what to close.  The mount keeps its own name, "
+                "so later traces are unaffected.\n", fsname, rc);
+        return;
+    }
 
     /* Passthrough backends have no filesystem to remove; the unmounted host
      * dir is intentionally left in place (its inode must not be reused
@@ -534,12 +598,19 @@ mbt_env_fs_teardown(
      * the just-closed opens (v4_close_dangling_opens) draining on the server's
      * async close thread, so the fs can stay busy for a short window; retry
      * until it drains rather than leaking the filesystem (which would slow a
-     * long corpus quadratically).  5s ceiling, matching the SMB harness. */
+     * long corpus quadratically).
+     *
+     * Giving up here used to be a warning that carried on with the filesystem
+     * still alive, which is how a slow drain turned into unexplained
+     * divergences in some *later* trace.  A leaked fs makes every subsequent
+     * result unreliable, so fail loudly instead: a hard stop is debuggable, a
+     * corrupted corpus is not. */
     while (chimera_server_rmfs(env->server, env->module, fsname) != 0) {
-        if (++tries >= 5000) {
-            fprintf(stderr, "warning: rmfs %s still failed after %d retries\n",
+        if (++tries >= 30000) {
+            fprintf(stderr,
+                    "fatal: rmfs %s never drained after %d retries\n",
                     fsname, tries);
-            break;
+            exit(1);
         }
         usleep(1000);
     }

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -469,13 +469,14 @@ mbt_env_open_opts(
  * is never reused mid-run, so cached FHs likewise cannot collide across
  * traces.  The whole session_dir is reaped at process exit. */
 static inline void
-mbt_env_fs_setup(
+mbt_env_fs_setup_as(
     struct mbt_env *env,
-    const char     *fsname)
+    const char     *fsname,
+    const char     *mntname)
 {
     char path[80];
 
-    snprintf(path, sizeof(path), "/%s", fsname);
+    snprintf(path, sizeof(path), "/%s", mntname);
 
     /* Mount and export under the *filesystem's own* name rather than a shared
      * "share", and check every call.
@@ -543,21 +544,32 @@ mbt_env_fs_setup(
         fprintf(stderr, "failed to create %s export\n", path);
         exit(1);
     }
+} /* mbt_env_fs_setup_as */
+
+/* The common case: mount and export the filesystem under its own name, so a
+ * batch gets one mount per trace. */
+static inline void
+mbt_env_fs_setup(
+    struct mbt_env *env,
+    const char     *fsname)
+{
+    mbt_env_fs_setup_as(env, fsname, fsname);
 } /* mbt_env_fs_setup */
 
 /* Tear the per-trace filesystem back down.  Order matters: rmfs is EBUSY while
  * the fs still has a mount, so unmount (and drop the export) first. */
 static inline void
-mbt_env_fs_teardown(
+mbt_env_fs_teardown_as(
     struct mbt_env *env,
-    const char     *fsname)
+    const char     *fsname,
+    const char     *mntname)
 {
     int  tries = 0;
     int  rc;
 
     char path[80];
 
-    snprintf(path, sizeof(path), "/%s", fsname);
+    snprintf(path, sizeof(path), "/%s", mntname);
 
     chimera_server_remove_export(env->server, path);
 
@@ -614,6 +626,14 @@ mbt_env_fs_teardown(
         }
         usleep(1000);
     }
+} /* mbt_env_fs_teardown_as */
+
+static inline void
+mbt_env_fs_teardown(
+    struct mbt_env *env,
+    const char     *fsname)
+{
+    mbt_env_fs_teardown_as(env, fsname, fsname);
 } /* mbt_env_fs_teardown */
 
 /* Backward-compatible one-shot setup used by the single-trace probes: open the

--- a/src/server/nfs/tests/quint/nfs3_mbt_probe.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_probe.c
@@ -121,7 +121,7 @@ main(
 
     printf("backend: %s\n", backend);
 
-    res = mbt_mnt(env, "/share");
+    res = mbt_mnt(env, "/fs0");
     if (res->rpc_err || res->status != MNT3_OK) {
         fprintf(stderr, "MNT /share failed: %u\n", res->status);
         return 1;

--- a/src/server/nfs/tests/quint/nfs3_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_replay.c
@@ -1599,11 +1599,15 @@ run_trace(
     o->fileid_known = calloc(MBT_MAX_FIDS, sizeof(*o->fileid_known));
     o->scratch      = malloc(MBT_MAX_DATA);
 
-    struct mbt_result *res = mbt_mnt(env, "/share");
+    char               mntpath[80];
+
+    snprintf(mntpath, sizeof(mntpath), "/%s", fsname);
+
+    struct mbt_result *res = mbt_mnt(env, mntpath);
 
     if (res->rpc_err != 0 || res->status != MNT3_OK || !res->obj_fh.has) {
-        fprintf(stderr, "%s: MNT /share failed: rpc_err=%d status=%u\n",
-                trace_path, res->rpc_err, res->status);
+        fprintf(stderr, "%s: MNT %s failed: rpc_err=%d status=%u\n",
+                trace_path, mntpath, res->rpc_err, res->status);
         failed = 1;
         goto out;
     }

--- a/src/server/nfs/tests/quint/nfs4_deleg_probe.c
+++ b/src/server/nfs/tests/quint/nfs4_deleg_probe.c
@@ -521,8 +521,8 @@ main(void)
         memset(&ops, 0, sizeof(ops));
         ops[0].argop                 = OP_PUTROOTFH;
         ops[1].argop                 = OP_LOOKUP;
-        ops[1].oplookup.objname.data = "share";
-        ops[1].oplookup.objname.len  = 5;
+        ops[1].oplookup.objname.data = "fs0";
+        ops[1].oplookup.objname.len  = 3;
         ops[2].argop                 = OP_GETFH;
         /* minorversion 0 compound: reuse pc_compound without SEQUENCE but
          * with minorversion 1 is invalid; send raw. */
@@ -882,7 +882,7 @@ main(void)
 
         /* M0: FH identity -- the NFS3 MOUNT root vs the NFS4 export
          * root, and a file's handle via both protocols. */
-        r3 = mbt_mnt(env, "/share");
+        r3 = mbt_mnt(env, "/fs0");
         expect("NFS3 MOUNT of the shared export",
                r3->status == MNT3_OK && r3->obj_fh.has, "mnt");
         root3 = r3->obj_fh;

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -248,7 +248,6 @@ enum v4_dev {
     DEV_ACCESS_NO_EXECUTE,        /* D4-2 */
     DEV_SYMLINK_MODE_0755,        /* D4-4 */
     DEV_LOOKUPP_SYMLINK,          /* D4-7 */
-    DEV_COPY_SPECIAL_STATEID,     /* D4-14 */
     DEV_COARSE_TYPE_ERR,          /* D4-15 */
     DEV_READLINK_DIR_INVAL,       /* D4-16 */
     DEV_COUNT,
@@ -259,7 +258,6 @@ static const char *v4_dev_ids[DEV_COUNT] = {
     "D4-2-access-no-execute",
     "D4-4-symlink-mode-0755",
     "D4-7-lookupp-symlink",
-    "D4-14-copy-special-stateid",
     "D4-15-coarse-type-error",
     "D4-16-readlink-dir-inval",
 };
@@ -921,41 +919,66 @@ v4_expand_name(
     /* *INDENT-OFF* */
     struct { const char *tag; const char *bytes; uint32_t len; } map[] = {
         /* --- rejected by chimera_nfs4_validate_name ------------------ */
-        { "NEMPTY",  "",                                          0                             },
-        { "NDOT",    ".",                                         1                             },
-        { "NDOTDOT", "..",                                        2                             },
-        { "NSLASH",  "a/b",                                       3                             },
-        { "NNUL",    "a\0b",                                      3                             },
+        { "NEMPTY",  "",                                          0
+        },
+        { "NDOT",    ".",                                         1
+        },
+        { "NDOTDOT", "..",                                        2
+        },
+        { "NSLASH",  "a/b",                                       3
+        },
+        { "NNUL",    "a\0b",                                      3
+        },
         /* --- rejected by chimera_nfs4_utf8_valid, one per branch ----- */
-        { "NUTF8",   "\x80",                                      1                             }, /* stray continuation */
-        { "NUTF8B",  "\xC0" "\x80",                               2                             }, /* overlong 2-byte    */
-        { "NUTF8C",  "\xE0" "\x80" "\x80",                        3                             }, /* overlong 3-byte    */
-        { "NUSUR",   "\xED" "\xA0" "\x80",                        3                             }, /* surrogate U+D800   */
-        { "NUNCH",   "\xEF" "\xBF" "\xBF",                        3                             }, /* non-char U+FFFF    */
-        { "NU4OV",   "\xF0" "\x8F" "\xBF" "\xBF",                 4                             }, /* overlong 4-byte    */
-        { "NU4HI",   "\xF4" "\x90" "\x80" "\x80",                 4                             }, /* above U+10FFFF     */
-        { "NUF5",    "\xF5" "\x80" "\x80" "\x80",                 4                             }, /* c > 0xF4           */
-        { "NUTRUNC", "\xE6" "\x97",                               2                             }, /* truncated 3-byte   */
-        { "NUBADC",  "\xC3" "A",                                  2                             }, /* bad continuation   */
+        { "NUTF8",   "\x80",                                      1
+        },                                                                                         /* stray continuation */
+        { "NUTF8B",  "\xC0" "\x80",                               2
+        },                                                                                         /* overlong 2-byte    */
+        { "NUTF8C",  "\xE0" "\x80" "\x80",                        3
+        },                                                                                         /* overlong 3-byte    */
+        { "NUSUR",   "\xED" "\xA0" "\x80",                        3
+        },                                                                                         /* surrogate U+D800   */
+        { "NUNCH",   "\xEF" "\xBF" "\xBF",                        3
+        },                                                                                         /* non-char U+FFFF    */
+        { "NU4OV",   "\xF0" "\x8F" "\xBF" "\xBF",                 4
+        },                                                                                         /* overlong 4-byte    */
+        { "NU4HI",   "\xF4" "\x90" "\x80" "\x80",                 4
+        },                                                                                         /* above U+10FFFF     */
+        { "NUF5",    "\xF5" "\x80" "\x80" "\x80",                 4
+        },                                                                                         /* c > 0xF4           */
+        { "NUTRUNC", "\xE6" "\x97",                               2
+        },                                                                                         /* truncated 3-byte   */
+        { "NUBADC",  "\xC3" "A",                                  2
+        },                                                                                         /* bad continuation   */
         /* --- multi-character names.  Every sentinel above is a single
          * character, so the validator's loop (for i < len, with the inner
          * continuation-byte while) only ever ran one iteration and never a
          * transition between widths.  These do. --- */
-        { "NUMIXB",  "a" "\xC3" "\xA9" "\x80",                    4                             }, /* ok,ok,stray cont  */
-        { "NUMIXT",  "a" "\xE6" "\x97",                           3                             }, /* ok, then truncated*/
-        { "NUMIXS",  "\xC3" "\xA9" "\xED" "\xA0" "\x80",          5                             }, /* ok, surrogate */
+        { "NUMIXB",  "a" "\xC3" "\xA9" "\x80",                    4
+        },                                                                                         /* ok,ok,stray cont  */
+        { "NUMIXT",  "a" "\xE6" "\x97",                           3
+        },                                                                                         /* ok, then truncated*/
+        { "NUMIXS",  "\xC3" "\xA9" "\xED" "\xA0" "\x80",          5
+        },                                                                                         /* ok, surrogate */
         /* --- ACCEPTED: the multi-byte success paths, which every name
          * the model generated until now (pure ASCII) skipped entirely --- */
         { "NUMIX",   "a" "\xC3" "\xA9" "\xE6" "\x97" "\xA5"
           "\xF0" "\x9D" "\x84" "\x9E",  10 },            /* 1+2+3+4 widths  */
-        { "NUREP",   "\xC3" "\xA9" "\xC3" "\xA9" "\xC3" "\xA9",   6                             }, /* loop x3 */
-        { "NU2",     "\xC3" "\xA9",                               2                             }, /* U+00E9  e-acute    */
-        { "NU3",     "\xE6" "\x97" "\xA5",                        3                             }, /* U+65E5  CJK        */
-        { "NU4",     "\xF0" "\x9D" "\x84" "\x9E",                 4                             }, /* U+1D11E clef       */
-        { "NU3E",    "\xE0" "\xA0" "\x80",                        3                             }, /* U+0800  3-byte min */
-        { "NU3S",    "\xED" "\x9F" "\xBF",                        3                             }, /* U+D7FF just below
+        { "NUREP",   "\xC3" "\xA9" "\xC3" "\xA9" "\xC3" "\xA9",   6
+        },                                                                                         /* loop x3 */
+        { "NU2",     "\xC3" "\xA9",                               2
+        },                                                                                         /* U+00E9  e-acute    */
+        { "NU3",     "\xE6" "\x97" "\xA5",                        3
+        },                                                                                         /* U+65E5  CJK        */
+        { "NU4",     "\xF0" "\x9D" "\x84" "\x9E",                 4
+        },                                                                                         /* U+1D11E clef       */
+        { "NU3E",    "\xE0" "\xA0" "\x80",                        3
+        },                                                                                         /* U+0800  3-byte min */
+        { "NU3S",    "\xED" "\x9F" "\xBF",                        3
+        },                                                                                         /* U+D7FF just below
                                                                                                     * the surrogates    */
-        { "NU4M",    "\xF4" "\x8F" "\xBF" "\xBF",                 4                             }, /* U+10FFFF max       */
+        { "NU4M",    "\xF4" "\x8F" "\xBF" "\xBF",                 4
+        },                                                                                         /* U+10FFFF max       */
     };
     /* *INDENT-ON* */
     unsigned i;
@@ -2773,22 +2796,6 @@ classify_status_mismatch(
     * silently miss each new op the generator learns to aim at a symlink. */
     if (est == NFS4ERR_NOTDIR && ast == V4_ERR_SYMLINK) {
         o->dev_hits[DEV_LOOKUPP_SYMLINK]++;
-        o->status_dev = ast;
-        return;
-    }
-    /* D4-14: chimera's COPY has no special-stateid path at all --
-     * chimera_nfs4_copy_state_handle() resolves the anonymous/bypass stateid
-     * to a NULL handle and the op answers NFS4ERR_BAD_STATEID.  RFC 7862
-     * §15.2.3 (R-42-43) only requires ca_src_stateid to be READ-valid and
-     * ca_dst_stateid WRITE-valid, and RFC 5661 §8.2.3 makes the anonymous
-     * stateid exactly that (subject to share reservations), so the model is
-     * right and this is a chimera gap, not RFC discretion.  Accepted here so
-     * the corpus keeps running past COPY; retire once COPY learns to open the
-     * FH on the fly the way SEEK and DEALLOCATE do.  Narrow on purpose: a
-     * BAD_STATEID the model itself predicted still compares normally. */
-    if (strcmp(tag, "SCopy") == 0 && ast == NFS4ERR_BAD_STATEID &&
-        est != NFS4ERR_BAD_STATEID) {
-        o->dev_hits[DEV_COPY_SPECIAL_STATEID]++;
         o->status_dev = ast;
         return;
     }

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -207,6 +207,40 @@ jf_val(json_t *v)
     return json_object_get(v, "value");
 } /* jf_val */
 
+
+/* Every attribute chimera advertises as supported, minus the two write-only
+ * *_SET attributes and RDATTR_ERROR (meaningful only inside READDIR).  Shared
+ * by RGetattrWide, RReaddir and the wide VERIFY/NVERIFY variants: asking for
+ * the server's whole attribute vocabulary is what drives
+ * chimera_nfs4_marshall_attrs, which each of those three ops compiles its own
+ * static copy of. */
+static void
+v4_wide_attr_mask(uint32_t *m)
+{
+    m[0] = (1U << FATTR4_SUPPORTED_ATTRS) |
+        (1U << FATTR4_TYPE) | (1U << FATTR4_FH_EXPIRE_TYPE) |
+        (1U << FATTR4_CHANGE) | (1U << FATTR4_SIZE) |
+        (1U << FATTR4_LINK_SUPPORT) | (1U << FATTR4_SYMLINK_SUPPORT) |
+        (1U << FATTR4_NAMED_ATTR) | (1U << FATTR4_FSID) |
+        (1U << FATTR4_UNIQUE_HANDLES) | (1U << FATTR4_LEASE_TIME) |
+        (1U << FATTR4_ACL) | (1U << FATTR4_ACLSUPPORT) |
+        (1U << FATTR4_ARCHIVE) | (1U << FATTR4_CANSETTIME) |
+        (1U << FATTR4_CASE_INSENSITIVE) | (1U << FATTR4_CASE_PRESERVING) |
+        (1U << FATTR4_CHOWN_RESTRICTED) | (1U << FATTR4_FILEHANDLE) |
+        (1U << FATTR4_FILEID) | (1U << FATTR4_FILES_AVAIL) |
+        (1U << FATTR4_FILES_FREE) | (1U << FATTR4_FILES_TOTAL) |
+        (1U << FATTR4_MAXNAME) | (1U << FATTR4_MAXREAD) |
+        (1U << FATTR4_MAXWRITE);
+    m[1] = (1U << (FATTR4_MODE - 32)) |
+        (1U << (FATTR4_NUMLINKS - 32)) | (1U << (FATTR4_OWNER - 32)) |
+        (1U << (FATTR4_OWNER_GROUP - 32)) | (1U << (FATTR4_RAWDEV - 32)) |
+        (1U << (FATTR4_SPACE_AVAIL - 32)) | (1U << (FATTR4_SPACE_FREE - 32)) |
+        (1U << (FATTR4_SPACE_TOTAL - 32)) | (1U << (FATTR4_SPACE_USED - 32)) |
+        (1U << (FATTR4_TIME_ACCESS - 32)) |
+        (1U << (FATTR4_TIME_METADATA - 32)) |
+        (1U << (FATTR4_TIME_MODIFY - 32));
+} /* v4_wide_attr_mask */
+
 /* ---- known-deviation registry (see DEVIATIONS-NFS4.md) ------------------- */
 
 enum v4_dev {
@@ -214,6 +248,9 @@ enum v4_dev {
     DEV_ACCESS_NO_EXECUTE,        /* D4-2 */
     DEV_SYMLINK_MODE_0755,        /* D4-4 */
     DEV_LOOKUPP_SYMLINK,          /* D4-7 */
+    DEV_COPY_SPECIAL_STATEID,     /* D4-14 */
+    DEV_COARSE_TYPE_ERR,          /* D4-15 */
+    DEV_READLINK_DIR_INVAL,       /* D4-16 */
     DEV_COUNT,
 };
 
@@ -222,7 +259,12 @@ static const char *v4_dev_ids[DEV_COUNT] = {
     "D4-2-access-no-execute",
     "D4-4-symlink-mode-0755",
     "D4-7-lookupp-symlink",
+    "D4-14-copy-special-stateid",
+    "D4-15-coarse-type-error",
+    "D4-16-readlink-dir-inval",
 };
+
+#define E_WRONG_TYPE 10083
 
 /* ---- per-op reply summary ------------------------------------------------ */
 
@@ -829,14 +871,122 @@ struct v4_argscratch {
     char              owner[64];
     uint8_t           verf[8];
     uint32_t          bitmap[2];
-    uint8_t           blob[16];
+    uint8_t           blob[64];
     uint32_t          attr_req[2];
     struct evpl_iovec wiov;
     int               wiov_used;
     char              xval[64];
     uint32_t          ia_hint;               /* IO_ADVISE request hint */
     uint8_t           ws_pattern[V4_BLOCK_SIZE]; /* WRITE_SAME ADB pattern */
+    /* Materialized component names.  Two, because RENAME carries two at once. */
+    char              nbuf[2][300];
 };
+
+
+/*
+ * Materialize a model component name onto the wire.
+ *
+ * Ordinary names travel as themselves.  The hostile sentinels expand to byte
+ * strings a JSON trace cannot carry literally -- an embedded NUL, invalid
+ * UTF-8, 256 bytes -- which is the same abstract-sentinel trick the POSIX
+ * suite uses for its ENAMETOOLONG cases.  Kept in lockstep with nameStatus()
+ * in nfs4_ops.qnt, which predicts what chimera_nfs4_validate_name() answers
+ * for each (nfs4_procs.h):
+ *
+ *   NEMPTY  ""                  -> NFS4ERR_INVAL        (len == 0)
+ *   NLONG   256 * 'x'           -> NFS4ERR_NAMETOOLONG  (len > 255)
+ *   NDOT    "."                 -> NFS4ERR_BADNAME
+ *   NDOTDOT ".."                -> NFS4ERR_BADNAME
+ *   NSLASH  "a/b"               -> NFS4ERR_BADCHAR      (path separator)
+ *   NNUL    "a\0b"              -> NFS4ERR_BADCHAR      (embedded NUL)
+ *   NUTF8   "\x80"              -> NFS4ERR_INVAL        (stray continuation)
+ *   NUTF8B  "\xC0\x80"          -> NFS4ERR_INVAL        (overlong 2-byte)
+ *   NUTF8C  "\xE0\x80\x80"      -> NFS4ERR_INVAL        (overlong 3-byte)
+ */
+static void
+v4_expand_name(
+    const char  *sname,
+    char        *buf,
+    const char **out,
+    uint32_t    *outlen)
+{
+    /* Adjacent string literals, not one literal: a C hex escape is greedy, so
+     * "\xE6\x97\xA5" would parse as a single overlong escape. */
+    /* *INDENT-OFF* */
+    struct { const char *tag; const char *bytes; uint32_t len; } map[] = {
+        /* --- rejected by chimera_nfs4_validate_name ------------------ */
+        { "NEMPTY",  "",                             0 },
+        { "NDOT",    ".",                            1 },
+        { "NDOTDOT", "..",                           2 },
+        { "NSLASH",  "a/b",                          3 },
+        { "NNUL",    "a\0b",                         3 },
+        /* --- rejected by chimera_nfs4_utf8_valid, one per branch ----- */
+        { "NUTF8",   "\x80",                         1 },  /* stray continuation */
+        { "NUTF8B",  "\xC0" "\x80",                  2 },  /* overlong 2-byte    */
+        { "NUTF8C",  "\xE0" "\x80" "\x80",           3 },  /* overlong 3-byte    */
+        { "NUSUR",   "\xED" "\xA0" "\x80",           3 },  /* surrogate U+D800   */
+        { "NUNCH",   "\xEF" "\xBF" "\xBF",           3 },  /* non-char U+FFFF    */
+        { "NU4OV",   "\xF0" "\x8F" "\xBF" "\xBF",    4 },  /* overlong 4-byte    */
+        { "NU4HI",   "\xF4" "\x90" "\x80" "\x80",    4 },  /* above U+10FFFF     */
+        { "NUF5",    "\xF5" "\x80" "\x80" "\x80",    4 },  /* c > 0xF4           */
+        { "NUTRUNC", "\xE6" "\x97",                  2 },  /* truncated 3-byte   */
+        { "NUBADC",  "\xC3" "A",                     2 },  /* bad continuation   */
+        /* --- multi-character names.  Every sentinel above is a single
+         * character, so the validator's loop (for i < len, with the inner
+         * continuation-byte while) only ever ran one iteration and never a
+         * transition between widths.  These do. --- */
+        { "NUMIXB",  "a" "\xC3" "\xA9" "\x80",     4 },  /* ok,ok,stray cont  */
+        { "NUMIXT",  "a" "\xE6" "\x97",             3 },  /* ok, then truncated*/
+        { "NUMIXS",  "\xC3" "\xA9" "\xED" "\xA0" "\x80", 5 }, /* ok, surrogate */
+        /* --- ACCEPTED: the multi-byte success paths, which every name
+         * the model generated until now (pure ASCII) skipped entirely --- */
+        { "NUMIX",   "a" "\xC3" "\xA9" "\xE6" "\x97" "\xA5"
+                     "\xF0" "\x9D" "\x84" "\x9E",  10 }, /* 1+2+3+4 widths  */
+        { "NUREP",   "\xC3" "\xA9" "\xC3" "\xA9" "\xC3" "\xA9", 6 }, /* loop x3 */
+        { "NU2",     "\xC3" "\xA9",                  2 },  /* U+00E9  e-acute    */
+        { "NU3",     "\xE6" "\x97" "\xA5",           3 },  /* U+65E5  CJK        */
+        { "NU4",     "\xF0" "\x9D" "\x84" "\x9E",    4 },  /* U+1D11E clef       */
+        { "NU3E",    "\xE0" "\xA0" "\x80",           3 },  /* U+0800  3-byte min */
+        { "NU3S",    "\xED" "\x9F" "\xBF",           3 },  /* U+D7FF just below
+                                                            * the surrogates    */
+        { "NU4M",    "\xF4" "\x8F" "\xBF" "\xBF",    4 },  /* U+10FFFF max       */
+    };
+    /* *INDENT-ON* */
+    unsigned i;
+
+    if (strcmp(sname, "NLONG") == 0) {
+        memset(buf, 'x', 256);
+        *out    = buf;
+        *outlen = 256;
+        return;
+    }
+    for (i = 0; i < sizeof(map) / sizeof(map[0]); i++) {
+        if (strcmp(sname, map[i].tag) == 0) {
+            memcpy(buf, map[i].bytes, map[i].len);
+            *out    = buf;
+            *outlen = map[i].len;
+            return;
+        }
+    }
+    *out    = sname;
+    *outlen = (uint32_t) strlen(sname);
+} /* v4_expand_name */
+
+
+/* Compare a server-returned directory entry against a model name.  Model names
+ * may be sentinels (see v4_expand_name), so the expected side has to be
+ * materialized before comparing -- the server returns the real bytes, e.g. the
+ * two bytes of U+00E9 rather than the string "NU2". */
+static int
+v4_name_eq(const char *wire, const char *model_name)
+{
+    char        buf[300];
+    const char *want;
+    uint32_t    wantlen;
+
+    v4_expand_name(model_name, buf, &want, &wantlen);
+    return strlen(wire) == wantlen && memcmp(wire, want, wantlen) == 0;
+} /* v4_name_eq */
 
 static void
 pack_be32(
@@ -886,6 +1036,63 @@ pack_fattr(
     f->attr_vals.data = s->blob;
     f->attr_vals.len  = len;
 } /* pack_fattr */
+
+/*
+ * SETATTR carrying every writable attribute chimera accepts except SIZE and
+ * ACL: mode, owner, owner_group and both settable times.  Values are packed in
+ * ascending attribute-bit order (RFC 7530 §5) -- MODE(33), OWNER(36),
+ * OWNER_GROUP(37), TIME_ACCESS_SET(40), TIME_MODIFY_SET(42).
+ *
+ * The model treats this as exactly a mode-only SETATTR, so the extra
+ * attributes must not move anything it tracks: owner and group are "0", the
+ * identity the harness already runs as, and both times use
+ * SET_TO_SERVER_TIME4 (discriminant 0, no nfstime4 body).  The point is
+ * SETATTR's own copy of chimera_nfs4_unmarshall_attrs, which a mode/size-only
+ * model leaves largely unexecuted.
+ */
+static void
+pack_fattr_wide(
+    struct fattr4        *f,
+    struct v4_argscratch *s,
+    int                   mode)
+{
+    uint32_t len = 0;
+    int      i;
+
+    s->bitmap[0] = 0;
+    s->bitmap[1] = (1U << (FATTR4_MODE - 32)) |
+        (1U << (FATTR4_OWNER - 32)) |
+        (1U << (FATTR4_OWNER_GROUP - 32)) |
+        (1U << (FATTR4_TIME_ACCESS_SET - 32)) |
+        (1U << (FATTR4_TIME_MODIFY_SET - 32));
+
+    pack_be32(s->blob + len, (uint32_t) mode);
+    len += 4;
+
+    /* owner, then owner_group: utf8str_mixed, length-prefixed and padded to a
+     * 4-byte boundary.  chimera converts the text with strtoul(). */
+    for (i = 0; i < 2; i++) {
+        pack_be32(s->blob + len, 1);
+        len         += 4;
+        s->blob[len] = '0';
+        s->blob[len + 1] = 0;
+        s->blob[len + 2] = 0;
+        s->blob[len + 3] = 0;
+        len         += 4;
+    }
+
+    /* settime4 x2: SET_TO_SERVER_TIME4 carries no timestamp. */
+    pack_be32(s->blob + len, 0);
+    len += 4;
+    pack_be32(s->blob + len, 0);
+    len += 4;
+
+    f->num_attrmask   = 2;
+    f->attrmask       = s->bitmap;
+    f->attr_vals.data = s->blob;
+    f->attr_vals.len  = len;
+} /* pack_fattr_wide */
+
 
 static void
 set_stateid(
@@ -1028,8 +1235,16 @@ encode_op(
     }
     if (strcmp(tag, "RLookup") == 0) {
         a->argop                 = OP_LOOKUP;
-        a->oplookup.objname.data = (void *) json_string_value(v);
-        a->oplookup.objname.len  = (uint32_t) strlen(json_string_value(v));
+        v4_expand_name(json_string_value(v), s->nbuf[0],
+                       (const char **) &a->oplookup.objname.data,
+                       &a->oplookup.objname.len);
+        return 0;
+    }
+    if (strcmp(tag, "RSecinfo") == 0) {
+        a->argop                  = OP_SECINFO;
+        v4_expand_name(json_string_value(v), s->nbuf[0],
+                       (const char **) &a->opsecinfo.name.data,
+                       &a->opsecinfo.name.len);
         return 0;
     }
     if (strcmp(tag, "RLookupp") == 0) {
@@ -1042,6 +1257,16 @@ encode_op(
             (1U << FATTR4_SIZE);
         s->attr_req[1] = (1U << (FATTR4_MODE - 32)) |
             (1U << (FATTR4_NUMLINKS - 32));
+        a->opgetattr.attr_request     = s->attr_req;
+        a->opgetattr.num_attr_request = 2;
+        return 0;
+    }
+    if (strcmp(tag, "RGetattrWide") == 0) {
+        /* See v4_wide_attr_mask: the model predicts the status and nothing
+         * else (SGetattrWide has no comparator arm), so this exists purely to
+         * run chimera's attribute marshaller over its whole vocabulary. */
+        a->argop = OP_GETATTR;
+        v4_wide_attr_mask(s->attr_req);
         a->opgetattr.attr_request     = s->attr_req;
         a->opgetattr.num_attr_request = 2;
         return 0;
@@ -1061,9 +1286,13 @@ encode_op(
         memset(a->opreaddir.cookieverf, 0, sizeof(a->opreaddir.cookieverf));
         a->opreaddir.dircount         = 65536;
         a->opreaddir.maxcount         = 1048576;
-        s->attr_req[0]                = 1U << FATTR4_FILEID;
+        /* Ask for the server's whole attribute vocabulary, not just FILEID:
+         * READDIR compiles its own copy of chimera_nfs4_marshall_attrs and
+         * marshals it per directory entry, and the harness compares only
+         * names and eof -- so this is free coverage of that copy. */
+        v4_wide_attr_mask(s->attr_req);
         a->opreaddir.attr_request     = s->attr_req;
-        a->opreaddir.num_attr_request = 1;
+        a->opreaddir.num_attr_request = 2;
         return 0;
     }
     if (strcmp(tag, "RCreate") == 0) {
@@ -1080,29 +1309,40 @@ encode_op(
             a->opcreate.objtype.devdata.specdata1 = 0;
             a->opcreate.objtype.devdata.specdata2 = 0;
         }
-        a->opcreate.objname.data = (void *) jf_str(v, "name");
-        a->opcreate.objname.len  = (uint32_t) strlen(jf_str(v, "name"));
+        v4_expand_name(jf_str(v, "name"), s->nbuf[0],
+                       (const char **) &a->opcreate.objname.data,
+                       &a->opcreate.objname.len);
         pack_fattr(&a->opcreate.createattrs, s, (int) jf_i64(v, "mode"), -1);
         return 0;
     }
     if (strcmp(tag, "RRemove") == 0) {
         a->argop                = OP_REMOVE;
-        a->opremove.target.data = (void *) json_string_value(v);
-        a->opremove.target.len  = (uint32_t) strlen(json_string_value(v));
+        v4_expand_name(json_string_value(v), s->nbuf[0],
+                       (const char **) &a->opremove.target.data,
+                       &a->opremove.target.len);
         return 0;
     }
     if (strcmp(tag, "RRename") == 0) {
         a->argop                 = OP_RENAME;
-        a->oprename.oldname.data = (void *) jf_str(v, "oldname");
-        a->oprename.oldname.len  = (uint32_t) strlen(jf_str(v, "oldname"));
-        a->oprename.newname.data = (void *) jf_str(v, "newname");
-        a->oprename.newname.len  = (uint32_t) strlen(jf_str(v, "newname"));
+        v4_expand_name(jf_str(v, "oldname"), s->nbuf[0],
+                       (const char **) &a->oprename.oldname.data,
+                       &a->oprename.oldname.len);
+        v4_expand_name(jf_str(v, "newname"), s->nbuf[1],
+                       (const char **) &a->oprename.newname.data,
+                       &a->oprename.newname.len);
         return 0;
     }
     if (strcmp(tag, "RLink") == 0) {
         a->argop               = OP_LINK;
-        a->oplink.newname.data = (void *) json_string_value(v);
-        a->oplink.newname.len  = (uint32_t) strlen(json_string_value(v));
+        v4_expand_name(json_string_value(v), s->nbuf[0],
+                       (const char **) &a->oplink.newname.data,
+                       &a->oplink.newname.len);
+        return 0;
+    }
+    if (strcmp(tag, "RSetattrWide") == 0) {
+        a->argop = OP_SETATTR;
+        memset(&a->opsetattr.stateid, 0, sizeof(a->opsetattr.stateid));
+        pack_fattr_wide(&a->opsetattr.obj_attributes, s, (int) itf_i64(v));
         return 0;
     }
     if (strcmp(tag, "RSetattr") == 0) {
@@ -1117,6 +1357,32 @@ encode_op(
         pack_fattr(&a->opsetattr.obj_attributes, s,
                    mode < 0 ? -1 : (int) mode,
                    size_blk < 0 ? -1 : size_blk * V4_BLOCK_SIZE);
+        return 0;
+    }
+    if (strcmp(tag, "RVerifyWide") == 0 ||
+        strcmp(tag, "RNverifyWide") == 0) {
+        int            nv = tag[1] == 'N';
+        struct fattr4 *f  = nv ? &a->opnverify.obj_attributes
+                               : &a->opverify.obj_attributes;
+
+        /* Wide mask, empty value blob.  chimera marshals every requested
+         * attribute before comparing, so this exercises VERIFY's own copy of
+         * chimera_nfs4_marshall_attrs; the length guard
+         * (out_len == attr_vals.len) then makes the comparison differ
+         * deterministically, which is what lets the model predict the answer
+         * without knowing a single attribute value. */
+        a->argop = nv ? OP_NVERIFY : OP_VERIFY;
+        v4_wide_attr_mask(s->bitmap);
+        /* VERIFY's own supported set omits FATTR4_RAWDEV, though GETATTR
+         * marshals it happily -- an asymmetry in chimera, recorded as an open
+         * finding in DEVIATIONS-NFS4.md.  Requesting it here would answer
+         * NFS4ERR_ATTRNOTSUPP before the marshaller ever runs, defeating the
+         * point of the op, so drop the bit until chimera is fixed. */
+        s->bitmap[1] &= ~(1U << (FATTR4_RAWDEV - 32));
+        f->attrmask       = s->bitmap;
+        f->num_attrmask   = 2;
+        f->attr_vals.data = s->blob;
+        f->attr_vals.len  = 0;
         return 0;
     }
     if (strcmp(tag, "RVerifySize") == 0 ||
@@ -1249,6 +1515,20 @@ encode_op(
         memcpy(a->opdestroy_session.dsa_sessionid, o->sess[sess], 16);
         return 0;
     }
+    if (strcmp(tag, "RBindConnToSession") == 0) {
+        int64_t sess = jf_i64(v, "sess");
+
+        if (sess < 0 || sess >= V4_MAX_SESS || !o->sess_known[sess]) {
+            mism_add(m, "model session %" PRId64 " unknown", sess);
+            return -1;
+        }
+        a->argop = OP_BIND_CONN_TO_SESSION;
+        memcpy(a->opbind_conn_to_session.bctsa_sessid, o->sess[sess], 16);
+        a->opbind_conn_to_session.bctsa_dir =
+            (uint32_t) jf_i64(v, "dir");
+        a->opbind_conn_to_session.bctsa_use_conn_in_rdma_mode = 0;
+        return 0;
+    }
     if (strcmp(tag, "RDestroyClientid") == 0) {
         if (wire_clientid(o, itf_i64(v), &cid, m) < 0) {
             return -1;
@@ -1318,8 +1598,9 @@ encode_op(
             const char *name = json_string_value(jf_val(claim));
 
             a->opopen.claim.claim     = CLAIM_NULL;
-            a->opopen.claim.file.data = (void *) name;
-            a->opopen.claim.file.len  = (uint32_t) strlen(name);
+            v4_expand_name(name, s->nbuf[0],
+                           (const char **) &a->opopen.claim.file.data,
+                           &a->opopen.claim.file.len);
         } else {
             a->opopen.claim.claim = CLAIM_FH;
         }
@@ -1894,6 +2175,9 @@ decode_resop(
         case OP_LOOKUP:
             st = rop->oplookup.status;
             break;
+        case OP_SECINFO:
+            st = rop->opsecinfo.status;
+            break;
         case OP_LOOKUPP:
             st = rop->oplookupp.status;
             break;
@@ -2056,6 +2340,9 @@ decode_resop(
                 memcpy(r->sessionid,
                        rop->opcreate_session.csr_resok4.csr_sessionid, 16);
             }
+            break;
+        case OP_BIND_CONN_TO_SESSION:
+            st = rop->opbind_conn_to_session.bctsr_status;
             break;
         case OP_DESTROY_SESSION:
             st = rop->opdestroy_session.dsr_status;
@@ -2385,6 +2672,20 @@ check_deleg(
 #define SPARSE_TAG(t) (strcmp(t, "SAllocate") == 0 || \
                        strcmp(t, "SDeallocate") == 0 || \
                        strcmp(t, "SSeek") == 0)
+/* Ops that run the shared regular-file type gate (see D4-15). */
+/* ...of which these four now answer the per-type split directly
+ * (chimera_nfs4_data_nonreg_status), so their symlink arm must match
+ * exactly rather than fall through the D4-15 acceptance. */
+#define DATAGATE_TAG(t) (strcmp(t, "SRead") == 0 || \
+                         strcmp(t, "SWrite") == 0 || \
+                         strcmp(t, "SCommit") == 0 || \
+                         strcmp(t, "SLockt") == 0)
+#define TYPEGATE_TAG(t) (strcmp(t, "SRead") == 0 || \
+                         strcmp(t, "SWrite") == 0 || \
+                         strcmp(t, "SCommit") == 0 || \
+                         strcmp(t, "SLockt") == 0 || \
+                         strcmp(t, "SSetattr") == 0 || \
+                         SPARSE_TAG(t))
 #define XATTR_TAG(t)  (strcmp(t, "SGetxattr") == 0 || \
                        strcmp(t, "SSetxattr") == 0 || \
                        strcmp(t, "SListxattrs") == 0 || \
@@ -2452,9 +2753,66 @@ classify_status_mismatch(
                       tag, est, ast);
         return;
     }
-    if ((strcmp(tag, "SLookupp") == 0 || strcmp(tag, "SReaddir") == 0) &&
-        est == NFS4ERR_NOTDIR && ast == V4_ERR_SYMLINK) {
+    /* D4-7: wherever a path operation meets a symlink where a directory was
+     * required, chimera answers the more specific NFS4ERR_SYMLINK and the
+     * model predicts the generic NFS4ERR_NOTDIR.  RFC 7530 Table 7 lists both
+     * for every op that can hit it -- LOOKUPP and READDIR on a symlink cfh,
+     * and OPEN/CREATE/REMOVE/RENAME/LINK on a symlink *parent* -- so either is
+     * conformant.  Matched on the (NOTDIR, SYMLINK) status pair rather than an
+     * op list: the pair itself is the deviation, and enumerating tags would
+     * silently miss each new op the generator learns to aim at a symlink. */
+    if (est == NFS4ERR_NOTDIR && ast == V4_ERR_SYMLINK) {
         o->dev_hits[DEV_LOOKUPP_SYMLINK]++;
+        o->status_dev = ast;
+        return;
+    }
+    /* D4-14: chimera's COPY has no special-stateid path at all --
+     * chimera_nfs4_copy_state_handle() resolves the anonymous/bypass stateid
+     * to a NULL handle and the op answers NFS4ERR_BAD_STATEID.  RFC 7862
+     * §15.2.3 (R-42-43) only requires ca_src_stateid to be READ-valid and
+     * ca_dst_stateid WRITE-valid, and RFC 5661 §8.2.3 makes the anonymous
+     * stateid exactly that (subject to share reservations), so the model is
+     * right and this is a chimera gap, not RFC discretion.  Accepted here so
+     * the corpus keeps running past COPY; retire once COPY learns to open the
+     * FH on the fly the way SEEK and DEALLOCATE do.  Narrow on purpose: a
+     * BAD_STATEID the model itself predicted still compares normally. */
+    if (strcmp(tag, "SCopy") == 0 && ast == NFS4ERR_BAD_STATEID &&
+        est != NFS4ERR_BAD_STATEID) {
+        o->dev_hits[DEV_COPY_SPECIAL_STATEID]++;
+        o->status_dev = ast;
+        return;
+    }
+    /* D4-15: chimera answers the coarse 4.0-style type error on every
+     * data-path and size-setting op -- NFS4ERR_ISDIR for a directory,
+     * NFS4ERR_INVAL for every other non-regular object, in all minor
+     * versions -- where the model predicts the per-type split (SYMLINK for a
+     * symlink; WRONG_TYPE for a special file, and for a directory on a 4.1+
+     * SETATTR(size)).  Both are conformant: RFC 7530 Table 7 lists SYMLINK
+     * *and* INVAL for READ/WRITE/COMMIT on a symlink cfh (R-CORE-91/96/97),
+     * and RFC 8881 15.1.2.9 makes WRONG_TYPE the more specific successor of
+     * INVAL (R-ATTR-25 marks the exact choice server-specific).  The model
+     * stays RFC-first and reconciles here, exactly as D4-7 does. */
+    /* D4-16: READLINK on a *directory* answers NFS4ERR_INVAL where the model
+     * predicts NFS4ERR_ISDIR.  Here the model is right and chimera is not --
+     * RFC 7530 §16.25.4/.5 Table 7 (rfc-notes R-CORE-86) and RFC 8881
+     * §18.24.3 both make a directory cfh ISDIR, with INVAL reserved for the
+     * other non-symlink types.  It is registered rather than fixed because
+     * pynfs RDLK2d (st_readlink.testDir) asserts INVAL for a directory, so the
+     * RFC-correct answer fails the legacy suite: chimera stays bug-compatible
+     * with pynfs on purpose and the model tolerates it here.  Retire this row
+     * and restore the split in nfs4_proc_readlink.c if pynfs is corrected. */
+    if (strcmp(tag, "SReadlink") == 0 && est == NFS4ERR_ISDIR &&
+        ast == NFS4ERR_INVAL) {
+        o->dev_hits[DEV_READLINK_DIR_INVAL]++;
+        o->status_dev = ast;
+        return;
+    }
+    if (TYPEGATE_TAG(tag) &&
+        (est == V4_ERR_SYMLINK || est == E_WRONG_TYPE) &&
+        !(DATAGATE_TAG(tag) && est == V4_ERR_SYMLINK) &&
+        (ast == NFS4ERR_INVAL ||
+         (ast == NFS4ERR_ISDIR && strcmp(tag, "SSetattr") == 0))) {
+        o->dev_hits[DEV_COARSE_TYPE_ERR]++;
         o->status_dev = ast;
         return;
     }
@@ -2581,7 +2939,7 @@ check_result(
             int found = 0;
 
             for (j = 0; j < r->nnames; j++) {
-                if (strcmp(r->names[j], json_string_value(jn)) == 0) {
+                if (v4_name_eq(r->names[j], json_string_value(jn))) {
                     found = 1;
                     break;
                 }
@@ -2596,7 +2954,7 @@ check_result(
 
             json_array_foreach(names, i, jn)
             {
-                if (strcmp(r->names[j], json_string_value(jn)) == 0) {
+                if (v4_name_eq(r->names[j], json_string_value(jn))) {
                     found = 1;
                     break;
                 }
@@ -3061,6 +3419,7 @@ run_compound(
     struct COMPOUND4args args;
     struct v4_ctx        ctx = { .cur = -1, .saved = -1, .abort = 0 };
     char                 tagbuf[32];
+    char                 tagexp[300];
     json_t              *op;
     json_t              *seq_req = NULL;
     json_t              *seq_exp = NULL;
@@ -3100,10 +3459,28 @@ run_compound(
         }
     }
 
-    snprintf(tagbuf, sizeof(tagbuf), "t%" PRId64, jf_i64(lab, "tag"));
     memset(&args, 0, sizeof(args));
-    args.tag.data     = tagbuf;
-    args.tag.len      = (uint32_t) strlen(tagbuf);
+    {
+        /* The model may override the wire tag with a sentinel (see runTagged
+         * in nfs4.qnt): chimera validates the COMPOUND tag as a utf8str_cs
+         * before running any operation, so a malformed one fails the whole
+         * compound with an empty result array.  "" means use the default
+         * identity tag. */
+        const char *tn = jf_str(lab, "tagName");
+
+        if (tn && tn[0]) {
+            const char *tb;
+            uint32_t    tl;
+
+            v4_expand_name(tn, tagexp, &tb, &tl);
+            args.tag.data = (void *) tb;
+            args.tag.len  = tl;
+        } else {
+            snprintf(tagbuf, sizeof(tagbuf), "t%" PRId64, jf_i64(lab, "tag"));
+            args.tag.data = tagbuf;
+            args.tag.len  = (uint32_t) strlen(tagbuf);
+        }
+    }
     args.minorversion = (uint32_t) o->minor;
     args.argarray     = argarray;
     args.num_argarray = (uint32_t) nops;
@@ -3200,6 +3577,11 @@ run_compound(
             ctx.cur = itf_i64(jf_val(json_array_get(ops, i)));
         } else if (strcmp(eop, "RPutrootfh") == 0) {
             ctx.cur = 0;
+        } else if (strcmp(eop, "RSecinfo") == 0) {
+            /* SECINFO consumes the current filehandle (RFC 7530 16.31.3), so
+             * drop the tracked cfh exactly as the model does -- any following
+             * op is expected to answer NFS4ERR_NOFILEHANDLE. */
+            ctx.cur = -1;
         } else if (strcmp(eop, "RSavefh") == 0) {
             ctx.saved = ctx.cur;
         } else if (strcmp(eop, "RRestorefh") == 0) {

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -4038,8 +4038,11 @@ run_trace(
         memset(argarray, 0, sizeof(argarray));
         argarray[0].argop                 = OP_PUTROOTFH;
         argarray[1].argop                 = OP_LOOKUP;
-        argarray[1].oplookup.objname.data = "share";
-        argarray[1].oplookup.objname.len  = 5;
+        /* The export is named after this trace's filesystem (see
+         * mbt_env_fs_setup), so a mount left stuck by an earlier diverging
+         * trace cannot be picked up here by mistake. */
+        argarray[1].oplookup.objname.data = (void *) fsname;
+        argarray[1].oplookup.objname.len  = (uint32_t) strlen(fsname);
         argarray[2].argop                 = OP_GETFH;
         args.minorversion                 = 0;
         args.argarray                     = argarray;

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -304,6 +304,7 @@ struct v4_res {
     uint8_t         confirm[8];
     uint32_t        sequenceid, flags; /* EXCHANGE_ID */
     uint8_t         sessionid[16];    /* CREATE_SESSION */
+    uint32_t        fore_slots;       /* CREATE_SESSION: ca_maxrequests */
 
     int             has_sid;          /* OPEN/LOCK/LOCKU/... result stateid */
     struct stateid4 sid;
@@ -407,6 +408,11 @@ struct oracle {
     uint8_t                sess[V4_MAX_SESS][16];
     uint8_t                sess_known[V4_MAX_SESS];
     int                    sess_client[V4_MAX_SESS]; /* model sess -> client */
+
+    /* Fore-channel slots the server granted, and a private sequence id on
+     * the retry slot (see the DELAY retry in run_compound). */
+    uint32_t               sess_slots[V4_MAX_SESS];
+    uint32_t               retry_seq[V4_MAX_SESS];
 
     uint8_t                sid_other[V4_MAX_SIDS][12];
     uint8_t                sid_known[V4_MAX_SIDS];
@@ -915,41 +921,41 @@ v4_expand_name(
     /* *INDENT-OFF* */
     struct { const char *tag; const char *bytes; uint32_t len; } map[] = {
         /* --- rejected by chimera_nfs4_validate_name ------------------ */
-        { "NEMPTY",  "",                             0 },
-        { "NDOT",    ".",                            1 },
-        { "NDOTDOT", "..",                           2 },
-        { "NSLASH",  "a/b",                          3 },
-        { "NNUL",    "a\0b",                         3 },
+        { "NEMPTY",  "",                                          0                             },
+        { "NDOT",    ".",                                         1                             },
+        { "NDOTDOT", "..",                                        2                             },
+        { "NSLASH",  "a/b",                                       3                             },
+        { "NNUL",    "a\0b",                                      3                             },
         /* --- rejected by chimera_nfs4_utf8_valid, one per branch ----- */
-        { "NUTF8",   "\x80",                         1 },  /* stray continuation */
-        { "NUTF8B",  "\xC0" "\x80",                  2 },  /* overlong 2-byte    */
-        { "NUTF8C",  "\xE0" "\x80" "\x80",           3 },  /* overlong 3-byte    */
-        { "NUSUR",   "\xED" "\xA0" "\x80",           3 },  /* surrogate U+D800   */
-        { "NUNCH",   "\xEF" "\xBF" "\xBF",           3 },  /* non-char U+FFFF    */
-        { "NU4OV",   "\xF0" "\x8F" "\xBF" "\xBF",    4 },  /* overlong 4-byte    */
-        { "NU4HI",   "\xF4" "\x90" "\x80" "\x80",    4 },  /* above U+10FFFF     */
-        { "NUF5",    "\xF5" "\x80" "\x80" "\x80",    4 },  /* c > 0xF4           */
-        { "NUTRUNC", "\xE6" "\x97",                  2 },  /* truncated 3-byte   */
-        { "NUBADC",  "\xC3" "A",                     2 },  /* bad continuation   */
+        { "NUTF8",   "\x80",                                      1                             }, /* stray continuation */
+        { "NUTF8B",  "\xC0" "\x80",                               2                             }, /* overlong 2-byte    */
+        { "NUTF8C",  "\xE0" "\x80" "\x80",                        3                             }, /* overlong 3-byte    */
+        { "NUSUR",   "\xED" "\xA0" "\x80",                        3                             }, /* surrogate U+D800   */
+        { "NUNCH",   "\xEF" "\xBF" "\xBF",                        3                             }, /* non-char U+FFFF    */
+        { "NU4OV",   "\xF0" "\x8F" "\xBF" "\xBF",                 4                             }, /* overlong 4-byte    */
+        { "NU4HI",   "\xF4" "\x90" "\x80" "\x80",                 4                             }, /* above U+10FFFF     */
+        { "NUF5",    "\xF5" "\x80" "\x80" "\x80",                 4                             }, /* c > 0xF4           */
+        { "NUTRUNC", "\xE6" "\x97",                               2                             }, /* truncated 3-byte   */
+        { "NUBADC",  "\xC3" "A",                                  2                             }, /* bad continuation   */
         /* --- multi-character names.  Every sentinel above is a single
          * character, so the validator's loop (for i < len, with the inner
          * continuation-byte while) only ever ran one iteration and never a
          * transition between widths.  These do. --- */
-        { "NUMIXB",  "a" "\xC3" "\xA9" "\x80",     4 },  /* ok,ok,stray cont  */
-        { "NUMIXT",  "a" "\xE6" "\x97",             3 },  /* ok, then truncated*/
-        { "NUMIXS",  "\xC3" "\xA9" "\xED" "\xA0" "\x80", 5 }, /* ok, surrogate */
+        { "NUMIXB",  "a" "\xC3" "\xA9" "\x80",                    4                             }, /* ok,ok,stray cont  */
+        { "NUMIXT",  "a" "\xE6" "\x97",                           3                             }, /* ok, then truncated*/
+        { "NUMIXS",  "\xC3" "\xA9" "\xED" "\xA0" "\x80",          5                             }, /* ok, surrogate */
         /* --- ACCEPTED: the multi-byte success paths, which every name
          * the model generated until now (pure ASCII) skipped entirely --- */
         { "NUMIX",   "a" "\xC3" "\xA9" "\xE6" "\x97" "\xA5"
-                     "\xF0" "\x9D" "\x84" "\x9E",  10 }, /* 1+2+3+4 widths  */
-        { "NUREP",   "\xC3" "\xA9" "\xC3" "\xA9" "\xC3" "\xA9", 6 }, /* loop x3 */
-        { "NU2",     "\xC3" "\xA9",                  2 },  /* U+00E9  e-acute    */
-        { "NU3",     "\xE6" "\x97" "\xA5",           3 },  /* U+65E5  CJK        */
-        { "NU4",     "\xF0" "\x9D" "\x84" "\x9E",    4 },  /* U+1D11E clef       */
-        { "NU3E",    "\xE0" "\xA0" "\x80",           3 },  /* U+0800  3-byte min */
-        { "NU3S",    "\xED" "\x9F" "\xBF",           3 },  /* U+D7FF just below
-                                                            * the surrogates    */
-        { "NU4M",    "\xF4" "\x8F" "\xBF" "\xBF",    4 },  /* U+10FFFF max       */
+          "\xF0" "\x9D" "\x84" "\x9E",  10 },            /* 1+2+3+4 widths  */
+        { "NUREP",   "\xC3" "\xA9" "\xC3" "\xA9" "\xC3" "\xA9",   6                             }, /* loop x3 */
+        { "NU2",     "\xC3" "\xA9",                               2                             }, /* U+00E9  e-acute    */
+        { "NU3",     "\xE6" "\x97" "\xA5",                        3                             }, /* U+65E5  CJK        */
+        { "NU4",     "\xF0" "\x9D" "\x84" "\x9E",                 4                             }, /* U+1D11E clef       */
+        { "NU3E",    "\xE0" "\xA0" "\x80",                        3                             }, /* U+0800  3-byte min */
+        { "NU3S",    "\xED" "\x9F" "\xBF",                        3                             }, /* U+D7FF just below
+                                                                                                    * the surrogates    */
+        { "NU4M",    "\xF4" "\x8F" "\xBF" "\xBF",                 4                             }, /* U+10FFFF max       */
     };
     /* *INDENT-ON* */
     unsigned i;
@@ -978,7 +984,9 @@ v4_expand_name(
  * materialized before comparing -- the server returns the real bytes, e.g. the
  * two bytes of U+00E9 rather than the string "NU2". */
 static int
-v4_name_eq(const char *wire, const char *model_name)
+v4_name_eq(
+    const char *wire,
+    const char *model_name)
 {
     char        buf[300];
     const char *want;
@@ -1073,12 +1081,12 @@ pack_fattr_wide(
      * 4-byte boundary.  chimera converts the text with strtoul(). */
     for (i = 0; i < 2; i++) {
         pack_be32(s->blob + len, 1);
-        len         += 4;
-        s->blob[len] = '0';
+        len             += 4;
+        s->blob[len]     = '0';
         s->blob[len + 1] = 0;
         s->blob[len + 2] = 0;
         s->blob[len + 3] = 0;
-        len         += 4;
+        len             += 4;
     }
 
     /* settime4 x2: SET_TO_SERVER_TIME4 carries no timestamp. */
@@ -1234,14 +1242,14 @@ encode_op(
         return 0;
     }
     if (strcmp(tag, "RLookup") == 0) {
-        a->argop                 = OP_LOOKUP;
+        a->argop = OP_LOOKUP;
         v4_expand_name(json_string_value(v), s->nbuf[0],
                        (const char **) &a->oplookup.objname.data,
                        &a->oplookup.objname.len);
         return 0;
     }
     if (strcmp(tag, "RSecinfo") == 0) {
-        a->argop                  = OP_SECINFO;
+        a->argop = OP_SECINFO;
         v4_expand_name(json_string_value(v), s->nbuf[0],
                        (const char **) &a->opsecinfo.name.data,
                        &a->opsecinfo.name.len);
@@ -1284,8 +1292,8 @@ encode_op(
         a->argop            = OP_READDIR;
         a->opreaddir.cookie = 0;
         memset(a->opreaddir.cookieverf, 0, sizeof(a->opreaddir.cookieverf));
-        a->opreaddir.dircount         = 65536;
-        a->opreaddir.maxcount         = 1048576;
+        a->opreaddir.dircount = 65536;
+        a->opreaddir.maxcount = 1048576;
         /* Ask for the server's whole attribute vocabulary, not just FILEID:
          * READDIR compiles its own copy of chimera_nfs4_marshall_attrs and
          * marshals it per directory entry, and the harness compares only
@@ -1316,14 +1324,14 @@ encode_op(
         return 0;
     }
     if (strcmp(tag, "RRemove") == 0) {
-        a->argop                = OP_REMOVE;
+        a->argop = OP_REMOVE;
         v4_expand_name(json_string_value(v), s->nbuf[0],
                        (const char **) &a->opremove.target.data,
                        &a->opremove.target.len);
         return 0;
     }
     if (strcmp(tag, "RRename") == 0) {
-        a->argop                 = OP_RENAME;
+        a->argop = OP_RENAME;
         v4_expand_name(jf_str(v, "oldname"), s->nbuf[0],
                        (const char **) &a->oprename.oldname.data,
                        &a->oprename.oldname.len);
@@ -1333,7 +1341,7 @@ encode_op(
         return 0;
     }
     if (strcmp(tag, "RLink") == 0) {
-        a->argop               = OP_LINK;
+        a->argop = OP_LINK;
         v4_expand_name(json_string_value(v), s->nbuf[0],
                        (const char **) &a->oplink.newname.data,
                        &a->oplink.newname.len);
@@ -1378,7 +1386,7 @@ encode_op(
          * finding in DEVIATIONS-NFS4.md.  Requesting it here would answer
          * NFS4ERR_ATTRNOTSUPP before the marshaller ever runs, defeating the
          * point of the op, so drop the bit until chimera is fixed. */
-        s->bitmap[1] &= ~(1U << (FATTR4_RAWDEV - 32));
+        s->bitmap[1]     &= ~(1U << (FATTR4_RAWDEV - 32));
         f->attrmask       = s->bitmap;
         f->num_attrmask   = 2;
         f->attr_vals.data = s->blob;
@@ -1597,7 +1605,7 @@ encode_op(
         if (strcmp(jf_tag(claim), "OCNull") == 0) {
             const char *name = json_string_value(jf_val(claim));
 
-            a->opopen.claim.claim     = CLAIM_NULL;
+            a->opopen.claim.claim = CLAIM_NULL;
             v4_expand_name(name, s->nbuf[0],
                            (const char **) &a->opopen.claim.file.data,
                            &a->opopen.claim.file.len);
@@ -2339,6 +2347,8 @@ decode_resop(
             if (st == NFS4_OK) {
                 memcpy(r->sessionid,
                        rop->opcreate_session.csr_resok4.csr_sessionid, 16);
+                r->fore_slots = rop->opcreate_session.csr_resok4.
+                    csr_fore_chan_attrs.ca_maxrequests;
             }
             break;
         case OP_BIND_CONN_TO_SESSION:
@@ -2669,9 +2679,9 @@ check_deleg(
               "deleg.stateid");
 } /* check_deleg */
 
-#define SPARSE_TAG(t) (strcmp(t, "SAllocate") == 0 || \
-                       strcmp(t, "SDeallocate") == 0 || \
-                       strcmp(t, "SSeek") == 0)
+#define SPARSE_TAG(t)   (strcmp(t, "SAllocate") == 0 || \
+                         strcmp(t, "SDeallocate") == 0 || \
+                         strcmp(t, "SSeek") == 0)
 /* Ops that run the shared regular-file type gate (see D4-15). */
 /* ...of which these four now answer the per-type split directly
  * (chimera_nfs4_data_nonreg_status), so their symlink arm must match
@@ -2686,14 +2696,14 @@ check_deleg(
                          strcmp(t, "SLockt") == 0 || \
                          strcmp(t, "SSetattr") == 0 || \
                          SPARSE_TAG(t))
-#define XATTR_TAG(t)  (strcmp(t, "SGetxattr") == 0 || \
-                       strcmp(t, "SSetxattr") == 0 || \
-                       strcmp(t, "SListxattrs") == 0 || \
-                       strcmp(t, "SRemovexattr") == 0)
-#define PNFS_TAG(t)   (strcmp(t, "SLayoutget") == 0 || \
-                       strcmp(t, "SLayoutreturn") == 0 || \
-                       strcmp(t, "SLayoutcommit") == 0 || \
-                       strcmp(t, "SGetdeviceinfo") == 0)
+#define XATTR_TAG(t)    (strcmp(t, "SGetxattr") == 0 || \
+                         strcmp(t, "SSetxattr") == 0 || \
+                         strcmp(t, "SListxattrs") == 0 || \
+                         strcmp(t, "SRemovexattr") == 0)
+#define PNFS_TAG(t)     (strcmp(t, "SLayoutget") == 0 || \
+                         strcmp(t, "SLayoutreturn") == 0 || \
+                         strcmp(t, "SLayoutcommit") == 0 || \
+                         strcmp(t, "SGetdeviceinfo") == 0)
 
 /* Divergence in status: capability reconciliation or mismatch.  Mirrors
  * Replayer.classify_status_mismatch. */
@@ -2754,13 +2764,13 @@ classify_status_mismatch(
         return;
     }
     /* D4-7: wherever a path operation meets a symlink where a directory was
-     * required, chimera answers the more specific NFS4ERR_SYMLINK and the
-     * model predicts the generic NFS4ERR_NOTDIR.  RFC 7530 Table 7 lists both
-     * for every op that can hit it -- LOOKUPP and READDIR on a symlink cfh,
-     * and OPEN/CREATE/REMOVE/RENAME/LINK on a symlink *parent* -- so either is
-     * conformant.  Matched on the (NOTDIR, SYMLINK) status pair rather than an
-     * op list: the pair itself is the deviation, and enumerating tags would
-     * silently miss each new op the generator learns to aim at a symlink. */
+    * required, chimera answers the more specific NFS4ERR_SYMLINK and the
+    * model predicts the generic NFS4ERR_NOTDIR.  RFC 7530 Table 7 lists both
+    * for every op that can hit it -- LOOKUPP and READDIR on a symlink cfh,
+    * and OPEN/CREATE/REMOVE/RENAME/LINK on a symlink *parent* -- so either is
+    * conformant.  Matched on the (NOTDIR, SYMLINK) status pair rather than an
+    * op list: the pair itself is the deviation, and enumerating tags would
+    * silently miss each new op the generator learns to aim at a symlink. */
     if (est == NFS4ERR_NOTDIR && ast == V4_ERR_SYMLINK) {
         o->dev_hits[DEV_LOOKUPP_SYMLINK]++;
         o->status_dev = ast;
@@ -2793,14 +2803,14 @@ classify_status_mismatch(
      * INVAL (R-ATTR-25 marks the exact choice server-specific).  The model
      * stays RFC-first and reconciles here, exactly as D4-7 does. */
     /* D4-16: READLINK on a *directory* answers NFS4ERR_INVAL where the model
-     * predicts NFS4ERR_ISDIR.  Here the model is right and chimera is not --
-     * RFC 7530 §16.25.4/.5 Table 7 (rfc-notes R-CORE-86) and RFC 8881
-     * §18.24.3 both make a directory cfh ISDIR, with INVAL reserved for the
-     * other non-symlink types.  It is registered rather than fixed because
-     * pynfs RDLK2d (st_readlink.testDir) asserts INVAL for a directory, so the
-     * RFC-correct answer fails the legacy suite: chimera stays bug-compatible
-     * with pynfs on purpose and the model tolerates it here.  Retire this row
-     * and restore the split in nfs4_proc_readlink.c if pynfs is corrected. */
+    * predicts NFS4ERR_ISDIR.  Here the model is right and chimera is not --
+    * RFC 7530 §16.25.4/.5 Table 7 (rfc-notes R-CORE-86) and RFC 8881
+    * §18.24.3 both make a directory cfh ISDIR, with INVAL reserved for the
+    * other non-symlink types.  It is registered rather than fixed because
+    * pynfs RDLK2d (st_readlink.testDir) asserts INVAL for a directory, so the
+    * RFC-correct answer fails the legacy suite: chimera stays bug-compatible
+    * with pynfs on purpose and the model tolerates it here.  Retire this row
+    * and restore the split in nfs4_proc_readlink.c if pynfs is corrected. */
     if (strcmp(tag, "SReadlink") == 0 && est == NFS4ERR_ISDIR &&
         ast == NFS4ERR_INVAL) {
         o->dev_hits[DEV_READLINK_DIR_INVAL]++;
@@ -3036,6 +3046,10 @@ check_result(
         if (sess >= 0 && sess < V4_MAX_SESS) {
             memcpy(o->sess[sess], r->sessionid, 16);
             o->sess_known[sess] = 1;
+            o->sess_slots[sess] = r->fore_slots;
+            /* A brand-new session's slots are all unused, and an unused
+             * slot's first request must carry sequence id 1. */
+            o->retry_seq[sess] = 0;
             if (req && strcmp(jf_tag(req), "RCreateSession") == 0) {
                 o->sess_client[sess] =
                     (int) jf_i64(jf_val(req), "client");
@@ -3415,7 +3429,8 @@ run_compound(
     struct nfs_argop4    argarray[V4_MAX_OPS];
     struct v4_argscratch scratch[V4_MAX_OPS];
     struct v4_reply      rep;
-    struct v4_call_ctx   cctx = { .o = o, .rep = &rep };
+    struct v4_reply      first = { 0 };
+    struct v4_call_ctx   cctx  = { .o = o, .rep = &rep };
     struct COMPOUND4args args;
     struct v4_ctx        ctx = { .cur = -1, .saved = -1, .abort = 0 };
     char                 tagbuf[32];
@@ -3426,6 +3441,9 @@ run_compound(
     size_t               i;
     int                  attempt;
     int                  n;
+    uint32_t             retry_slot = 0;
+    int                  retry_sess = 0;
+    int                  has_seq    = 0;
 
     o->status_dev              = 0;
     o->cur_open_clientid_known = 0;
@@ -3488,10 +3506,46 @@ run_compound(
     struct evpl_rpc2_conn *conn =
         conn_for(o, compound_client(o, ops, results));
 
+    /* A 4.1+ compound leads with SEQUENCE.  Pick the session's highest
+     * granted slot for DELAY retries: the model only ever drives slot 0, so
+     * anything above it is ours to use.  Slot 0 means "no safe retry slot"
+     * (a 4.0 compound, or a session that granted a single slot). */
+    if (nops > 0 && strcmp(jf_tag(json_array_get(ops, 0)), "RSequence") == 0) {
+        int64_t rsess = jf_i64(jf_val(json_array_get(ops, 0)), "sess");
+
+        has_seq = 1;
+        if (rsess >= 0 && rsess < V4_MAX_SESS && o->sess_known[rsess] &&
+            o->sess_slots[rsess] >= 2) {
+            retry_sess = (int) rsess;
+            retry_slot = o->sess_slots[rsess] - 1;
+        }
+    }
+
     /* Send; retry when the server reports transient DELAY the model did
-     * not predict. */
+     * not predict.
+     *
+     * A 4.1+ retry may not reuse the model's (slot, sequence id).  That pair
+     * names a slot in the session reply cache, and RFC 8881 2.10.6.2 reserves
+     * reusing it for retransmitting a request whose reply was lost -- so the
+     * server answers a verbatim resend from the cache, which is exactly what
+     * it is required to do.  Resending the same compound therefore replays
+     * the cached DELAY forever instead of re-running the operation: the retry
+     * loop could never make progress, and every DELAY became a divergence
+     * after the retry budget ran out.
+     *
+     * Retry on a slot the model never uses, with a sequence id of our own, so
+     * the retry actually executes and the model's slot keeps the sequence the
+     * trace assigned it.  The model's slot still holds the first attempt's
+     * reply on the server, so the reply-cache bookkeeping below records that
+     * one rather than the retry's. */
     for (attempt = 0; attempt < V4_RETRY_DELAY_MAX; attempt++) {
         int unexpected_delay = 0;
+
+        if (attempt > 0 && has_seq && retry_slot > 0) {
+            argarray[0].opsequence.sa_slotid     = retry_slot;
+            argarray[0].opsequence.sa_sequenceid = ++o->retry_seq[retry_sess];
+            argarray[0].opsequence.sa_cachethis  = 0;
+        }
 
         memset(&rep, 0, sizeof(rep));
         o->arena_used = 0;
@@ -3517,7 +3571,16 @@ run_compound(
                 unexpected_delay = 1;
             }
         }
+        if (attempt == 0) {
+            first = rep;
+        }
         if (!unexpected_delay) {
+            break;
+        }
+        if (has_seq && retry_slot == 0) {
+            /* A 4.1+ compound with nowhere safe to retry: resending it
+             * verbatim would only replay the cached reply.  A 4.0 compound
+             * has no reply cache, so resending it re-runs the work. */
             break;
         }
         usleep(100000);
@@ -3615,7 +3678,7 @@ run_compound(
 
     /* Record the reply summary for future SEQUENCE replays of this
      * slot. */
-    if (seq_req && rep.nres > 0 && rep.res[0].status == NFS4_OK) {
+    if (seq_req && first.nres > 0 && first.res[0].status == NFS4_OK) {
         int64_t sess = jf_i64(seq_req, "sess");
         int64_t slot = jf_i64(seq_req, "slot");
 
@@ -3623,12 +3686,14 @@ run_compound(
             slot < V4_MAX_SLOTS) {
             struct v4_cached *c = &o->cache[sess][slot];
 
+            /* The first attempt is what the server cached against the
+             * model's slot: a retry runs on a different one. */
             c->valid  = 1;
-            c->status = rep.status;
-            c->nres   = rep.nres;
-            for (n = 0; n < rep.nres; n++) {
-                c->op[n].status = rep.res[n].status;
-                c->op[n].fnv    = rep.res[n].fnv;
+            c->status = first.status;
+            c->nres   = first.nres;
+            for (n = 0; n < first.nres; n++) {
+                c->op[n].status = first.res[n].status;
+                c->op[n].fnv    = first.res[n].fnv;
             }
         }
     }
@@ -4036,8 +4101,8 @@ run_trace(
         memset(&rep, 0, sizeof(rep));
         memset(&args, 0, sizeof(args));
         memset(argarray, 0, sizeof(argarray));
-        argarray[0].argop                 = OP_PUTROOTFH;
-        argarray[1].argop                 = OP_LOOKUP;
+        argarray[0].argop = OP_PUTROOTFH;
+        argarray[1].argop = OP_LOOKUP;
         /* The export is named after this trace's filesystem (see
          * mbt_env_fs_setup), so a mount left stuck by an earlier diverging
          * trace cannot be picked up here by mistake. */

--- a/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
@@ -1620,7 +1620,11 @@ run_trace(
     alarm(180);
 
     o = calloc(1, sizeof(*o));
-    mbt_env_fs_setup(env, fsname);
+    /* The aux harness asserts against a fixed "/share" export -- its MNT
+     * cases include deliberate near-misses like "/shareXX" -- so it mounts
+     * under that name rather than the per-trace one the batch replayers
+     * use.  The filesystem itself is still per-trace. */
+    mbt_env_fs_setup_as(env, fsname, "share");
 
     o->env       = env;
     o->verbose   = verbose;
@@ -1673,7 +1677,7 @@ run_trace(
 
  out:
     trace_teardown(o);
-    mbt_env_fs_teardown(env, fsname);
+    mbt_env_fs_teardown_as(env, fsname, "share");
     while (o->nhist) {
         free(o->history[--o->nhist].op_dump);
     }

--- a/src/server/nfs/tests/quint/nfs_aux_probe.c
+++ b/src/server/nfs/tests/quint/nfs_aux_probe.c
@@ -753,14 +753,18 @@ main(
     alarm(180);
 
     mbt_aux_env_open(&env, &opts);
-    mbt_env_fs_setup(&env, "fs0");
+    /* The aux harness asserts against a fixed "/share" export -- its MNT
+     * cases include deliberate near-misses like "/shareXX" -- so it mounts
+     * under that name rather than the per-trace one the batch replayers
+     * use.  The filesystem itself is still per-trace. */
+    mbt_env_fs_setup_as(&env, "fs0", "share");
     if (chimera_server_create_export(env.server, PROBE_EXPORT2, "/share", 0,
                                      NULL) != 0) {
         fprintf(stderr, "probe: failed to create the %s export\n",
                 PROBE_EXPORT2);
         /* Unwind what mbt_aux_env_open built; returning straight out leaks the
          * environment's READ scratch buffer. */
-        mbt_env_fs_teardown(&env, "fs0");
+        mbt_env_fs_teardown_as(&env, "fs0", "share");
         mbt_env_stop(&env);
         return 1;
     }
@@ -776,7 +780,7 @@ main(
     probe_nsm(&env);
 
     chimera_server_remove_export(env.server, PROBE_EXPORT2);
-    mbt_env_fs_teardown(&env, "fs0");
+    mbt_env_fs_teardown_as(&env, "fs0", "share");
     mbt_env_stop(&env);
     alarm(0);
 

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -4988,6 +4988,17 @@ cairn_link_at(
      * pre-link value. */
     cairn_map_attrs(fs, &request->link_at.r_dir_pre_attr, parent_inode);
 
+    /* Re-entering the namespace re-takes the reference that stands for it:
+     * refcnt holds one reference for the inode's presence in the namespace
+     * plus one per open handle, and cairn_remove_at drops the namespace one
+     * as nlink reaches 0.  An inode unlinked while open and then linked again
+     * would otherwise have that same reference dropped twice, removing the
+     * inode while open handles still refer to it.  (cairn has no
+     * create_unlinked, so nlink 0 here always means "lost its last name".) */
+    if (target_inode->nlink == 0) {
+        target_inode->refcnt++;
+    }
+
     target_inode->nlink++;
     target_inode->ctime = now;
     target_inode->change++;

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -177,7 +177,14 @@ struct memfs_inode {
     struct memfs_fs           *fs;
     uint64_t                   inum;
     uint32_t                   gen;
+    /* refcnt counts the references that keep this inode alive: one for its
+     * presence in the namespace, plus one per open handle.  link_ref records
+     * whether the namespace reference is currently held, which nlink alone
+     * cannot tell: an inode with nlink 0 either lost its last name (reference
+     * already dropped) or was born anonymous via create_unlinked and is
+     * waiting to be linked (reference still held). */
     uint32_t                   refcnt;
+    uint8_t                    link_ref;
     uint64_t                   size;
     uint64_t                   space_used;
     uint64_t                   alloc_size;   /* SMB AllocationSize reservation */
@@ -795,6 +802,7 @@ memfs_inode_alloc(
 
     inode->gen++;
     inode->refcnt         = 1;
+    inode->link_ref       = 1;
     inode->mode           = 0;
     inode->change         = 0;
     inode->dos_attributes = 0;
@@ -1311,6 +1319,7 @@ memfs_fs_create(
     inode->space_used = 4096;
     inode->gen        = 1;
     inode->refcnt     = 1;
+    inode->link_ref   = 1;
     inode->uid        = 0;
     inode->gid        = 0;
     inode->nlink      = 2;
@@ -3187,6 +3196,7 @@ memfs_remove_at(
     memfs_map_attrs(fs, &request->remove_at.r_removed_attr, inode, request->fh);
 
     if (inode->nlink == 0) {
+        inode->link_ref = 0;
         --inode->refcnt;
 
         if (inode->refcnt == 0) {
@@ -6002,6 +6012,7 @@ memfs_rename_at(
             }
             int existing_freed = 0;
             if (existing_inode->nlink == 0) {
+                existing_inode->link_ref = 0;
                 --existing_inode->refcnt;
                 if (existing_inode->refcnt == 0) {
                     memfs_inode_free(thread, existing_inode);
@@ -6222,8 +6233,11 @@ memfs_link_at(
 
         if (existing_inode) {
             existing_inode->nlink--;
-            if (existing_inode->nlink == 0 && --existing_inode->refcnt == 0) {
-                memfs_inode_free(thread, existing_inode);
+            if (existing_inode->nlink == 0) {
+                existing_inode->link_ref = 0;
+                if (--existing_inode->refcnt == 0) {
+                    memfs_inode_free(thread, existing_inode);
+                }
             }
             pthread_mutex_unlock(&existing_inode->lock);
         }
@@ -6239,6 +6253,18 @@ memfs_link_at(
                                 request->link_at.namelen);
 
     rb_tree_insert(&parent_inode->dir.dirents, hash, dirent);
+
+    /* Re-entering the namespace re-takes the reference that stands for it.
+     * Without this an inode that was unlinked while open (its namespace
+     * reference dropped, kept alive by the open) and then linked again would
+     * have the same reference dropped a second time by the next unlink,
+     * freeing the inode out from under handles that still point at it.
+     * A create_unlinked inode has never given the reference up, so link_ref
+     * is still set and nothing is taken here. */
+    if (!inode->link_ref) {
+        inode->link_ref = 1;
+        inode->refcnt++;
+    }
 
     inode->nlink++;
 

--- a/src/vfs/vfs_proc_umount.c
+++ b/src/vfs/vfs_proc_umount.c
@@ -234,14 +234,31 @@ chimera_vfs_umount_progress(struct chimera_vfs_request *request)
         return;
     }
 
-    /* Someone else still holds a handle.  Wait for them to drop it. */
+    /* Someone else still holds a handle.  Wait for them to drop it.
+     *
+     * Note what reaching here means: the sweeps above already pulled every
+     * *unreferenced* handle off pending_close and dispatched its close, so a
+     * non-zero count is handles with opencnt > 0 -- genuinely still open by
+     * someone.  Waiting cannot help unless that someone is about to close
+     * them, so say so rather than silently polling: a caller that unmounts
+     * after closing its own opens is looking at a leak. */
     wait = request->umount.wait;
 
     if (!wait) {
+        chimera_vfs_info(
+            "umount %s: %lu handle(s) still open after purging the cache; "
+            "waiting up to %lu ms for the holder(s) to close them",
+            request->umount.mount->path, referenced,
+            vfs->umount_timeout_us / 1000);
         wait                 = calloc(1, sizeof(*wait));
         wait->request        = request;
         request->umount.wait = wait;
     } else if (wait->waited_us >= vfs->umount_timeout_us) {
+        chimera_vfs_error(
+            "umount %s: giving up with %lu handle(s) still open after %lu ms "
+            "-- the mount stays registered and callers will see EBUSY",
+            request->umount.mount->path, referenced,
+            wait->waited_us / 1000);
         chimera_vfs_umount_wait_stop(request);
         chimera_vfs_umount_abandon(request);
         return;


### PR DESCRIPTION
Replaying the generated NFSv4 corpus against the server left 34
deterministic divergences.  This takes them to zero.  Each one was
resolved by working out what the RFC requires and fixing whichever side
was wrong -- in several cases that was the model, in several the server,
and twice it was a genuine bug the corpus had cornered.

chimera-nas/specs#6 and #10 are merged; the submodule moves to ab180e2, the specs
main commit whose trace bundle is published to GHCR.  Every commit here
pins that same SHA rather than the intermediate ones, because the bundle
is keyed by the push commit and the macOS build has no quint to fall back
on -- pinning an ancestor would leave those commits unbuildable there.

### Server fixes

- **SEEK/ALLOCATE/DEALLOCATE on a non-regular filehandle.** These reached
  the backend with a directory or symlink current filehandle. They now
  type-check first, per the valid-error tables.

- **A lock-owner's existing stateid is reused on 4.1+**, as 4.0 already
  did. The reuse lookup sat inside a `minorversion == 0` branch, so a
  4.1 client re-locking through the same owner got a fresh stateid.

- **COPY** gained a special-stateid path, source-range validation
  (RFC 7862 15.2.3) and a same-file check. The deny checks had to move
  after the range rule: an out-of-range COPY is INVAL regardless of who
  holds the file open.

- **A foreign stateid is BAD_STATEID, not ACCESS** (RFC 8881 15.1.5.2),
  on READ, WRITE and SETATTR.

- **OPEN no longer truncates when it goes on to fail.** An OPEN carrying
  `size = 0` that was then refused for a share conflict had already
  destroyed the file's contents. The truncate is now deferred until the
  open has actually succeeded, and unwound if the later setattr fails.
  This was the most damaging bug here: a rejected OPEN silently emptied
  a file the caller had no right to modify.

- **`memfs`/`cairn` re-take the namespace reference when a link comes
  back.** `refcnt` holds one reference for an inode's presence in the
  namespace plus one per open handle, and `remove_at` drops the namespace
  one as `nlink` reaches 0 -- which is what keeps an unlinked-but-open
  file's filehandle usable until the last CLOSE (RFC 7530 16.26.5).
  `link_at` bumped `nlink` without taking that reference back, so the
  next unlink dropped it a second time and freed an inode that open
  handles still pointed at. The corpus reaches this by unlinking a file
  while open, linking it again, and unlinking it again; freeing a live
  inode is also a plausible source of the intermittent heap corruption
  seen at teardown, though that is unconfirmed. `nlink` alone cannot say
  whether the reference is held -- an inode at `nlink` 0 either lost its
  last name or was born anonymous via `create_unlinked` and is waiting to
  be linked, which is how S3 PUT and multipart upload build objects -- so
  memfs gets an explicit flag and cairn, which has no `create_unlinked`,
  needs only the `nlink` test.

### Harness

- Each trace gets its own mount, so one stuck filesystem cannot be
  inherited by every later trace in the batch and reported as its
  divergences -- five identical runs previously produced 0, 16, 42, 42
  and 48.
- An unexpected NFS4ERR_DELAY is retried on a slot the model does not
  use, so the retry cannot collide with the session reply cache.
- `umount` says what it is waiting on, and why it gave up.

### Known gaps

- The replayer aborts the whole run on an unknown operation rather than
  skipping the trace, so a specs bump that adds an operation takes the
  suite down until the encoder lands. The existing capability-mismatch
  SKIP path would fit.
- Trace generation does not remove outputs a previous specs pin
  produced, so a stale `.itf.json` from an older model is still picked up
  by `--trace-dir` after the bump.

