### PR TITLE
s3/tests: quint model-based test suite for the S3 server

### DIFF
--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -313,11 +313,23 @@ s3_server_notify(
                     chimera_s3_put_recv(evpl, s3_request);
                 }
             } else if (is_complete_mpu) {
-                /* Accumulate the client's part manifest. */
-                chimera_s3_complete_multipart_upload_recv(evpl, s3_request);
+                /* Accumulate the client's part manifest.  A request routing
+                 * already failed (e.g. NoSuchBucket) never reached the
+                 * handler that initializes the accumulation state -- drain
+                 * the body instead of touching it. */
+                if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE) {
+                    s3_server_drain_body(evpl, s3_request);
+                } else {
+                    chimera_s3_complete_multipart_upload_recv(evpl, s3_request);
+                }
             } else if (is_delete_objects) {
-                /* Accumulate the <Delete> document. */
-                chimera_s3_delete_objects_recv(evpl, s3_request);
+                /* Accumulate the <Delete> document (same failed-routing
+                 * guard as above). */
+                if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE) {
+                    s3_server_drain_body(evpl, s3_request);
+                } else {
+                    chimera_s3_delete_objects_recv(evpl, s3_request);
+                }
             } else if (request_type == EVPL_HTTP_REQUEST_TYPE_POST) {
                 /* CreateMultipartUpload: body is empty in practice. */
                 s3_server_drain_body(evpl, s3_request);
@@ -349,13 +361,26 @@ s3_server_notify(
                     chimera_s3_put_recv(evpl, s3_request);
                 }
             } else if (is_complete_mpu) {
-                chimera_s3_complete_multipart_upload_recv(evpl, s3_request);
-                /* Body fully in hand: parse + validate + assemble. */
-                chimera_s3_complete_multipart_upload_body_done(evpl, s3_request);
+                /* A request routing already failed (e.g. NoSuchBucket) must
+                 * keep its error: running the handler here would operate on
+                 * never-initialized body state and overwrite the status
+                 * with a fabricated success. */
+                if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE) {
+                    s3_server_drain_body(evpl, s3_request);
+                } else {
+                    chimera_s3_complete_multipart_upload_recv(evpl, s3_request);
+                    /* Body fully in hand: parse + validate + assemble. */
+                    chimera_s3_complete_multipart_upload_body_done(evpl,
+                                                                   s3_request);
+                }
             } else if (is_delete_objects) {
-                chimera_s3_delete_objects_recv(evpl, s3_request);
-                /* Body fully in hand: parse keys + remove them. */
-                chimera_s3_delete_objects_body_done(evpl, s3_request);
+                if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE) {
+                    s3_server_drain_body(evpl, s3_request);
+                } else {
+                    chimera_s3_delete_objects_recv(evpl, s3_request);
+                    /* Body fully in hand: parse keys + remove them. */
+                    chimera_s3_delete_objects_body_done(evpl, s3_request);
+                }
             } else if (request_type == EVPL_HTTP_REQUEST_TYPE_POST) {
                 s3_server_drain_body(evpl, s3_request);
             }

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -1264,6 +1264,26 @@ chimera_s3_add_cred(
     return chimera_s3_cred_cache_add(shared->cred_cache, access_key, secret_key, pinned);
 } /* chimera_s3_add_cred */
 
+SYMBOL_EXPORT int
+chimera_s3_remove_cred(
+    void       *s3_shared,
+    const char *access_key)
+{
+    struct chimera_server_s3_shared *shared = s3_shared;
+
+    return chimera_s3_cred_cache_remove(shared->cred_cache, access_key);
+} /* chimera_s3_remove_cred */
+
+SYMBOL_EXPORT void
+chimera_s3_advance_cred_clock(
+    void   *s3_shared,
+    int64_t seconds)
+{
+    struct chimera_server_s3_shared *shared = s3_shared;
+
+    chimera_s3_cred_cache_advance(shared->cred_cache, seconds);
+} /* chimera_s3_advance_cred_clock */
+
 static void *
 s3_server_init(
     const struct chimera_server_config *config,

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -698,7 +698,18 @@ s3_server_dispatch(
             urlp++;
         }
 
+        /* Split bucket from key on the first '/' BEFORE the query string: a
+         * legal unencoded '/' in a query value (?delimiter=/, ?prefix=d/)
+         * must not be mistaken for the bucket/key separator.  (Most SDKs
+         * percent-encode query values, which masked this.) */
         slash = strchr(urlp, '/');
+        {
+            const char *query0 = strchr(urlp, '?');
+
+            if (slash && query0 && slash > query0) {
+                slash = NULL;
+            }
+        }
 
         if (slash) {
             s3_request->bucket_name    = urlp;

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -363,6 +363,21 @@ s3_server_notify(
             if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_SEND ||
                 s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE) {
                 s3_server_respond(evpl, s3_request);
+
+                if (request_type == EVPL_HTTP_REQUEST_TYPE_GET &&
+                    s3_request->vfs_state == CHIMERA_S3_VFS_STATE_SEND &&
+                    s3_request->file_left == 0) {
+                    /* A zero-length GET body produces no WANT_DATA
+                     * notification, so nothing else would ever drive the
+                     * send path: run it here.  With nothing left to read it
+                     * finishes immediately, releasing the object handle --
+                     * otherwise the handle leaks and pins the filesystem.
+                     * (Reached when the VFS lookup/open chain completed
+                     * inline -- synchronous backends like memfs -- before
+                     * this RECEIVE_COMPLETE; the opposite ordering runs the
+                     * send path from chimera_s3_get_metadata_done.) */
+                    chimera_s3_get_send(evpl, s3_request);
+                }
             }
             break;
         case EVPL_HTTP_NOTIFY_WANT_DATA:

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -1005,6 +1005,14 @@ s3_server_dispatch(
 
     s3_request->file_left       = s3_request->file_length;
     s3_request->file_cur_offset = s3_request->file_offset;
+
+    /* Requests are recycled without being zeroed, and only the handlers that
+     * serve object bytes (GET/List/Copy/...) set file_real_length.  A handler
+     * that never touches it (PutObject, DeleteObject, UploadPart) would
+     * otherwise inherit the previous request's value and trip the
+     * file_length != file_real_length test in s3_server_respond, turning its
+     * 200/204 into a 206 with a fabricated Content-Range. */
+    s3_request->file_real_length = 0;
     chimera_s3_dump_request(s3_request);
 
     {

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -495,6 +495,12 @@ chimera_s3_dispatch_callback(
     if (error_code) {
         s3_request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         s3_request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        /* This is a VFS completion callback: on an asynchronous backend the
+         * RECEIVE_COMPLETE notification may already have passed, so an error
+         * completed here must answer the request itself or nothing will. */
+        if (s3_request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(evpl, s3_request);
+        }
         return;
     }
 
@@ -525,6 +531,10 @@ chimera_s3_dispatch_callback(
                 s3_request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
                 break;
         } /* switch */
+        if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE &&
+            s3_request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(evpl, s3_request);
+        }
         return;
     }
 
@@ -589,6 +599,14 @@ chimera_s3_dispatch_callback(
             s3_request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
             break;
     } /* switch */
+
+    /* Routing that completed the request in this VFS-callback context (the
+    * unimplemented-method arms above) must answer it: on an asynchronous
+    * backend the RECEIVE_COMPLETE notification may already have passed. */
+    if (s3_request->vfs_state == CHIMERA_S3_VFS_STATE_COMPLETE &&
+        s3_request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+        s3_server_respond(evpl, s3_request);
+    }
 
 } /* chimera_s3_dispatch_callback */
 

--- a/src/server/s3/s3.h
+++ b/src/server/s3/s3.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 struct s3_bucket;
 
 void
@@ -57,5 +59,19 @@ chimera_s3_add_cred(
     const char *access_key,
     const char *secret_key,
     int         pinned);
+
+int
+chimera_s3_remove_cred(
+    void       *s3_shared,
+    const char *access_key);
+
+/* Advance the S3 credential cache's synthetic clock by `seconds` and sweep
+ * expired credentials synchronously.  Test instrumentation: lets a harness
+ * exercise TTL expiry by ticking time deterministically instead of waiting
+ * out the sweeper's wall-clock cadence. */
+void
+chimera_s3_advance_cred_clock(
+    void   *s3_shared,
+    int64_t seconds);
 
 extern struct chimera_server_protocol s3_protocol;

--- a/src/server/s3/s3_bucket.c
+++ b/src/server/s3/s3_bucket.c
@@ -444,6 +444,9 @@ chimera_s3_delete_bucket(
     if (shared->bucket_root_pathlen == 0) {
         request->status    = CHIMERA_S3_STATUS_NOT_IMPLEMENTED;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 

--- a/src/server/s3/s3_cred_cache.h
+++ b/src/server/s3/s3_cred_cache.h
@@ -38,7 +38,23 @@ struct chimera_s3_cred_cache {
     pthread_mutex_t                      expiry_lock;
     pthread_cond_t                       expiry_cond;
     int                                  shutdown;
+    /* Synthetic addition to CLOCK_REALTIME, applied to every expiry
+     * decision (stamping at add, comparing at sweep).  Zero in production;
+     * a test harness advances it -- and runs a sweep synchronously -- via
+     * chimera_s3_cred_cache_advance(), so TTL behavior is exercised by
+     * ticking a clock rather than waiting on one. */
+    int64_t                              clock_offset_sec;
 };
+
+/* The cache's notion of now: the real clock plus the synthetic offset. */
+static inline void
+chimera_s3_cred_cache_now(
+    struct chimera_s3_cred_cache *cache,
+    struct timespec              *ts)
+{
+    clock_gettime(CLOCK_REALTIME, ts);
+    ts->tv_sec += __atomic_load_n(&cache->clock_offset_sec, __ATOMIC_RELAXED);
+} // chimera_s3_cred_cache_now
 
 static inline unsigned int
 chimera_s3_cred_cache_hash(
@@ -79,18 +95,59 @@ chimera_s3_cred_cache_remove_locked(
     call_rcu(&cred->rcu, chimera_s3_cred_cache_rcu_free);
 } // chimera_s3_cred_cache_remove_locked
 
+/* One sweep pass: remove every unpinned cred whose expiration is at or
+ * before the cache's (synthetic-offset-aware) now.  Pure writer
+ * (rcu_assign + call_rcu) under the per-bucket locks; callable from the
+ * expiry thread or synchronously from chimera_s3_cred_cache_advance(). */
+static inline void
+chimera_s3_cred_cache_sweep(struct chimera_s3_cred_cache *cache)
+{
+    struct chimera_s3_cred *cred, *next;
+    struct timespec         ts;
+    int                     i;
+
+    chimera_s3_cred_cache_now(cache, &ts);
+
+    for (i = 0; i < cache->num_buckets; i++) {
+        pthread_mutex_lock(&cache->buckets[i].lock);
+
+        cred = cache->buckets[i].head;
+        while (cred) {
+            next = cred->next;
+            if (!cred->pinned &&
+                (ts.tv_sec > cred->expiration.tv_sec ||
+                 (ts.tv_sec == cred->expiration.tv_sec &&
+                  ts.tv_nsec >= cred->expiration.tv_nsec))) {
+
+                chimera_s3_cred_cache_remove_locked(cache, cred, i);
+            }
+            cred = next;
+        }
+
+        pthread_mutex_unlock(&cache->buckets[i].lock);
+    }
+} // chimera_s3_cred_cache_sweep
+
+/* Advance the cache's synthetic clock and sweep synchronously.  A test
+ * exercises credential expiry by ticking time forward deterministically --
+ * never by waiting out the sweeper thread's cadence. */
+static inline void
+chimera_s3_cred_cache_advance(
+    struct chimera_s3_cred_cache *cache,
+    int64_t                       seconds)
+{
+    __atomic_add_fetch(&cache->clock_offset_sec, seconds, __ATOMIC_RELAXED);
+    chimera_s3_cred_cache_sweep(cache);
+} // chimera_s3_cred_cache_advance
+
 static void *
 chimera_s3_cred_cache_expiry_thread(void *arg)
 {
     struct chimera_s3_cred_cache *cache = arg;
-    struct chimera_s3_cred       *cred, *next;
     struct timespec               ts;
-    int                           i;
 
-    /* Pure writer: sweeps expired creds (rcu_assign + call_rcu) under the
-     * per-bucket locks, never takes an RCU read lock.  Not registered as a
-     * QSBR reader -- a thread parked in cond_timedwait must not sit in the
-     * grace-period quorum. */
+    /* Not registered as a QSBR reader -- a thread parked in cond_timedwait
+     * must not sit in the grace-period quorum. */
     pthread_mutex_lock(&cache->expiry_lock);
 
     while (!cache->shutdown) {
@@ -103,26 +160,7 @@ chimera_s3_cred_cache_expiry_thread(void *arg)
             break;
         }
 
-        clock_gettime(CLOCK_REALTIME, &ts);
-
-        for (i = 0; i < cache->num_buckets; i++) {
-            pthread_mutex_lock(&cache->buckets[i].lock);
-
-            cred = cache->buckets[i].head;
-            while (cred) {
-                next = cred->next;
-                if (!cred->pinned &&
-                    (ts.tv_sec > cred->expiration.tv_sec ||
-                     (ts.tv_sec == cred->expiration.tv_sec &&
-                      ts.tv_nsec >= cred->expiration.tv_nsec))) {
-
-                    chimera_s3_cred_cache_remove_locked(cache, cred, i);
-                }
-                cred = next;
-            }
-
-            pthread_mutex_unlock(&cache->buckets[i].lock);
-        }
+        chimera_s3_cred_cache_sweep(cache);
     }
 
     pthread_mutex_unlock(&cache->expiry_lock);
@@ -215,7 +253,7 @@ chimera_s3_cred_cache_add(
     cred->pinned         = pinned;
 
     if (!pinned) {
-        clock_gettime(CLOCK_REALTIME, &now);
+        chimera_s3_cred_cache_now(cache, &now);
         cred->expiration.tv_sec  = now.tv_sec + cache->ttl;
         cred->expiration.tv_nsec = now.tv_nsec;
     }

--- a/src/server/s3/s3_delete.c
+++ b/src/server/s3/s3_delete.c
@@ -49,6 +49,9 @@ chimera_s3_delete_open_callback(
         request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_vfs_release(thread->vfs, request->dir_handle);
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 
@@ -84,6 +87,9 @@ chimera_s3_get_lookup_callback(
     if (error_code) {
         request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 

--- a/src/server/s3/s3_delete_objects.c
+++ b/src/server/s3/s3_delete_objects.c
@@ -412,8 +412,11 @@ chimera_s3_del_open_cb(
     struct chimera_server_s3_thread *thread  = request->thread;
 
     if (error_code) {
-        /* Parent directory could not be opened: object is effectively gone. */
-        chimera_s3_del_record(request, 1, NULL, NULL);
+        /* The parent existed a moment ago (its lookup succeeded); any
+        * failure to open it is a real error, not an absent object. */
+        chimera_s3_del_record(request, 0, "InternalError",
+                              "We encountered an internal error. "
+                              "Please try again.");
         return;
     }
 
@@ -441,9 +444,16 @@ chimera_s3_del_lookup_cb(
     struct chimera_s3_request       *request = private_data;
     struct chimera_server_s3_thread *thread  = request->thread;
 
-    if (error_code) {
+    if (error_code == CHIMERA_VFS_ENOENT || error_code == CHIMERA_VFS_ENOTDIR) {
         /* Parent path does not exist: object is effectively gone. */
         chimera_s3_del_record(request, 1, NULL, NULL);
+        return;
+    } else if (error_code) {
+        /* Any other lookup failure (ESTALE, EIO, ...) must not masquerade
+         * as a successful delete: the object may well still exist. */
+        chimera_s3_del_record(request, 0, "InternalError",
+                              "We encountered an internal error. "
+                              "Please try again.");
         return;
     }
 

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -168,7 +168,6 @@ struct chimera_s3_request {
             int                           versions;      /* emit ListVersionsResult */
             int                           prefix_len;
             int                           delimiter_len;
-            int                           enumdir_len;   /* prefix up to last delimiter */
             int                           has_start;     /* skip past 'start' (exclusive) */
             int                           start_len;
             int                           marker_len;     /* V1 marker echo */
@@ -180,7 +179,6 @@ struct chimera_s3_request {
             struct chimera_s3_list_entry *entries;
             char                          delimiter[CHIMERA_S3_DELIM_MAX];
             char                          prefix[CHIMERA_S3_KEY_MAX];
-            char                          enumdir[CHIMERA_S3_KEY_MAX];
             char                          start[CHIMERA_S3_KEY_MAX];
             char                          marker[CHIMERA_S3_KEY_MAX];
             char                          ctoken[CHIMERA_S3_KEY_MAX];

--- a/src/server/s3/s3_list.c
+++ b/src/server/s3/s3_list.c
@@ -314,7 +314,6 @@ chimera_s3_list_setup(
     const char                *startafter,
     int                        startafter_len)
 {
-    const char *slash;
     const char *sk  = NULL;
     int         skl = 0;
 
@@ -352,20 +351,6 @@ chimera_s3_list_setup(
     request->list.delimiter[delimiter_len] = '\0';
     request->list.delimiter_len            = delimiter_len;
 
-    /* For the common '/' delimiter we can prune the VFS walk to the directory
-     * containing the prefix and never descend below it. enumdir is the prefix
-     * truncated at its last '/' (the directory whose children we enumerate). */
-    request->list.enumdir[0]  = '\0';
-    request->list.enumdir_len = 0;
-    if (delimiter_len == 1 && delimiter[0] == '/') {
-        slash = rindex(request->list.prefix, '/');
-        if (slash) {
-            int el = slash - request->list.prefix;
-            memcpy(request->list.enumdir, request->list.prefix, el);
-            request->list.enumdir[el] = '\0';
-            request->list.enumdir_len = el;
-        }
-    }
 
     if (marker_len > CHIMERA_S3_KEY_MAX - 1) {
         marker_len = CHIMERA_S3_KEY_MAX - 1;
@@ -502,28 +487,23 @@ chimera_s3_list_filter(
     int                        klen;
     const char                *k = chimera_s3_list_key(path, pathlen, &klen);
 
-    if (request->list.delimiter_len == 1 && request->list.delimiter[0] == '/') {
-        /* Folder-style: only descend ancestors-or-equal of enumdir so we read
-        * exactly one level and roll subdirectories up into CommonPrefixes. */
-        const char *e  = request->list.enumdir;
-        int         el = request->list.enumdir_len;
+    /* Descend any directory that is on the path to the prefix or wholly
+     * inside the prefix subtree.  Delimiter rollup -- '/' included -- is
+     * resolved over FILE keys in the find callback, never from directories:
+     * a directory with no objects under it (an empty husk left behind by
+     * DeleteObject, or a directory created over NFS/SMB) must not surface
+     * as a phantom CommonPrefix, and whether a group appears past a start
+     * key depends on it having a member key past that key.  AWS defines
+     * CommonPrefixes over keys, so the walk must see the keys; the old
+     * one-level '/' pruning could not tell a populated group from an empty
+     * husk. */
+    const char *p  = request->list.prefix;
+    int         pl = request->list.prefix_len;
 
-        if (el >= klen && memcmp(e, k, klen) == 0 &&
-            (el == klen || e[klen] == '/')) {
-            return 0;
-        }
-        return 1;
-    } else {
-        /* Flat or arbitrary-delimiter: descend any directory that is on the
-         * path to the prefix or wholly inside the prefix subtree. */
-        const char *p  = request->list.prefix;
-        int         pl = request->list.prefix_len;
-
-        if (klen >= pl) {
-            return memcmp(k, p, pl) == 0 ? 0 : 1;
-        }
-        return (memcmp(k, p, klen) == 0 && p[klen] == '/') ? 0 : 1;
+    if (klen >= pl) {
+        return memcmp(k, p, pl) == 0 ? 0 : 1;
     }
+    return (memcmp(k, p, klen) == 0 && p[klen] == '/') ? 0 : 1;
 } /* chimera_s3_list_filter */
 
 static int
@@ -557,26 +537,9 @@ chimera_s3_list_find_callback(
     }
 
     if (isdir) {
-        /* Only '/' subdirectories collapse to CommonPrefixes here; other
-         * delimiters are resolved over file keys below, so directories are
-         * pure traversal. */
-        if (!(dl == 1 && request->list.delimiter[0] == '/')) {
-            return 0;
-        }
-        /* The subdirectory itself is the CommonPrefix "<key>/". A directory
-         * shorter than the prefix (e.g. the enumdir we descended through) is
-         * traversal only, not a result. */
-        if (klen < pl || memcmp(k, p, pl) != 0) {
-            return 0;
-        }
-        {
-            char cp[CHIMERA_S3_KEY_MAX + 2];
-            int  n = klen < CHIMERA_S3_KEY_MAX ? klen : CHIMERA_S3_KEY_MAX;
-            memcpy(cp, k, n);
-            cp[n]     = '/';
-            cp[n + 1] = '\0';
-            chimera_s3_list_add_prefix(request, cp, n + 1);
-        }
+        /* Directories are pure traversal: every CommonPrefix is derived
+         * from the file keys rolled up in the branch below (see the descent
+         * filter), so an empty directory contributes nothing. */
         return 0;
     } else {
         /* File key: roll up at the first delimiter past the prefix, else it is
@@ -595,6 +558,35 @@ chimera_s3_list_find_callback(
             if (memcmp(rest + i, request->list.delimiter, dl) == 0) {
                 idx = i;
                 break;
+            }
+        }
+
+        if (request->list.has_start) {
+            /* Exclusive start key, applied per file key: a key at or before
+             * it contributes nothing.  A key past it is a Contents entry --
+             * or keeps its rollup group alive: AWS still lists a
+             * CommonPrefix whose string sorts at or before the start key
+             * while the group has members past it.  The one exception is a
+             * start key naming the group exactly (a continuation token
+             * minted at the group): that group is fully consumed. */
+            const char *st  = request->list.start;
+            int         stl = (int) strlen(st);
+            int         cmpl, c;
+
+            cmpl = klen < stl ? klen : stl;
+            c    = memcmp(k, st, cmpl);
+            if (c == 0) {
+                c = klen - stl;
+            }
+            if (c <= 0) {
+                return 0;
+            }
+            if (idx >= 0) {
+                int elen = pl + idx + dl;
+
+                if (elen == stl && memcmp(k, st, elen) == 0) {
+                    return 0;
+                }
             }
         }
 
@@ -660,11 +652,24 @@ chimera_s3_list_find_complete(
     }
     n = w;
 
-    /* Page window: skip everything at or before the caller's start key. */
+    /* Page window: skip everything at or before the caller's start key --
+     * except a CommonPrefix the start key falls strictly inside, which the
+     * collection phase (above) has already vetted for members past the
+     * start key. */
     start_idx = 0;
     if (request->list.has_start) {
-        while (start_idx < n &&
-               strcmp(ents[start_idx].key, request->list.start) <= 0) {
+        while (start_idx < n) {
+            const char *ek   = ents[start_idx].key;
+            size_t      elen = strlen(ek);
+
+            if (strcmp(ek, request->list.start) > 0) {
+                break;
+            }
+            if (ents[start_idx].is_prefix &&
+                strlen(request->list.start) > elen &&
+                memcmp(request->list.start, ek, elen) == 0) {
+                break;
+            }
             start_idx++;
         }
     }

--- a/src/server/s3/s3_list.c
+++ b/src/server/s3/s3_list.c
@@ -545,9 +545,24 @@ chimera_s3_list_find_callback(
         /* File key: roll up at the first delimiter past the prefix, else it is
          * an object directly under the prefix. */
         const char *rest;
+        const char *base;
         int         restlen, i, idx = -1;
 
         if (klen < pl || memcmp(k, p, pl) != 0) {
+            return 0;
+        }
+
+        /* Internal in-flight artifacts are not objects: on a backend without
+         * CREATE_UNLINKED, multipart parts ("._chimera_mpu_*"), the Complete
+         * scratch file and PutObject temp files are real named files in the
+         * key's directory until they are consumed -- AWS never lists an
+         * in-flight upload's parts as objects. */
+        base = k + klen;
+        while (base > k && base[-1] != '/') {
+            base--;
+        }
+        if ((size_t) (klen - (base - k)) >= strlen("._chimera_") &&
+            memcmp(base, "._chimera_", strlen("._chimera_")) == 0) {
             return 0;
         }
 

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -2911,8 +2911,12 @@ chimera_s3_complete_multipart_upload_body_done(
     int                                 i;
 
     if (request->multipart.body_len == CHIMERA_S3_MP_BODY_OVERFLOW) {
-        request->status    = CHIMERA_S3_STATUS_MALFORMED_XML;
-        request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        free(request->multipart.body_buf);
+        request->multipart.body_buf = NULL;
+        request->multipart.body_len = 0;
+        request->multipart.body_cap = 0;
+        request->status             = CHIMERA_S3_STATUS_MALFORMED_XML;
+        request->vfs_state          = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
         }
@@ -2924,8 +2928,12 @@ chimera_s3_complete_multipart_upload_body_done(
                                          request->multipart.body_len,
                                          &client_parts, &n_client);
     if (err != CHIMERA_S3_STATUS_OK) {
-        request->status    = err;
-        request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        free(request->multipart.body_buf);
+        request->multipart.body_buf = NULL;
+        request->multipart.body_len = 0;
+        request->multipart.body_cap = 0;
+        request->status             = err;
+        request->vfs_state          = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
         }
@@ -3024,8 +3032,12 @@ chimera_s3_complete_multipart_upload_body_done(
         /* Drop our lookup ref; upload remains in the table. */
         free(server_parts);
         chimera_s3_multipart_upload_release(thread, upload);
-        request->status    = err;
-        request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        free(request->multipart.body_buf);
+        request->multipart.body_buf = NULL;
+        request->multipart.body_len = 0;
+        request->multipart.body_cap = 0;
+        request->status             = err;
+        request->vfs_state          = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
         }

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -770,6 +770,9 @@ chimera_s3_upload_part_create_unlinked_callback(
         request->multipart.upload = NULL;
         request->status           = CHIMERA_S3_STATUS_INTERNAL_ERROR;
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 
@@ -801,6 +804,9 @@ chimera_s3_upload_part_create_callback(
         request->multipart.upload = NULL;
         request->status           = CHIMERA_S3_STATUS_INTERNAL_ERROR;
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 
@@ -826,6 +832,9 @@ chimera_s3_upload_part_open_dir_callback(
         request->multipart.upload = NULL;
         request->status           = CHIMERA_S3_STATUS_INTERNAL_ERROR;
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 
@@ -889,6 +898,9 @@ chimera_s3_upload_part_lookup_callback(
         request->multipart.upload = NULL;
         request->status           = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -366,6 +366,9 @@ chimera_s3_put_create_unlinked_callback(
         request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_vfs_release(thread->vfs, request->dir_handle);
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 
@@ -398,6 +401,9 @@ chimera_s3_put_create_callback(
         request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_vfs_release(thread->vfs, request->dir_handle);
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 
@@ -426,6 +432,9 @@ chimera_s3_put_open_dir_callback(
     if (error_code) {
         request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 
@@ -486,6 +495,9 @@ chimera_s3_put_lookup_callback(
     if (error_code) {
         request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
+        if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
+            s3_server_respond(thread->evpl, request);
+        }
         return;
     }
 

--- a/src/server/s3/s3_tagging.c
+++ b/src/server/s3/s3_tagging.c
@@ -580,7 +580,6 @@ chimera_s3_tagging_set_next(
     struct chimera_server_s3_thread *thread = request->thread;
     struct chimera_s3_tagging_ctx   *ctx    = request->tagging;
     struct chimera_s3_tag           *t;
-    char                             name[CHIMERA_S3_TAG_PREFIX_LEN + CHIMERA_S3_TAG_MAX_KEY_LEN + 1];
     int                              namelen;
 
     if (ctx->cur >= ctx->n_tags) {
@@ -590,13 +589,14 @@ chimera_s3_tagging_set_next(
     }
 
     t       = &ctx->tags[ctx->cur];
-    namelen = snprintf(name, sizeof(name), CHIMERA_S3_TAG_PREFIX "%s", t->key);
+    namelen = snprintf(ctx->set_name, sizeof(ctx->set_name),
+                       CHIMERA_S3_TAG_PREFIX "%s", t->key);
 
     chimera_s3_request_get(request);
 
     chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
                           ctx->handle, 0 /* create-or-replace */,
-                          name, namelen,
+                          ctx->set_name, namelen,
                           t->val, strlen(t->val),
                           chimera_s3_tagging_set_cb, request);
 } /* chimera_s3_tagging_set_next */
@@ -1011,7 +1011,6 @@ chimera_s3_tagging_store_set_next(
     struct chimera_server_s3_thread *thread = request->thread;
     struct chimera_s3_tagging_ctx   *ctx    = request->tagging;
     struct chimera_s3_tag           *t;
-    char                             name[CHIMERA_S3_TAG_PREFIX_LEN + CHIMERA_S3_TAG_MAX_KEY_LEN + 1];
     int                              namelen;
 
     if (ctx->cur >= ctx->n_tags) {
@@ -1020,13 +1019,14 @@ chimera_s3_tagging_store_set_next(
     }
 
     t       = &ctx->tags[ctx->cur];
-    namelen = snprintf(name, sizeof(name), CHIMERA_S3_TAG_PREFIX "%s", t->key);
+    namelen = snprintf(ctx->set_name, sizeof(ctx->set_name),
+                       CHIMERA_S3_TAG_PREFIX "%s", t->key);
 
     chimera_s3_request_get(request);
 
     chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
                           ctx->handle, 0,
-                          name, namelen,
+                          ctx->set_name, namelen,
                           t->val, strlen(t->val),
                           chimera_s3_tagging_store_set_cb, request);
 } /* chimera_s3_tagging_store_set_next */

--- a/src/server/s3/s3_tagging.h
+++ b/src/server/s3/s3_tagging.h
@@ -39,6 +39,13 @@ struct chimera_s3_tagging_ctx {
     int                             total;
     /* Which subresource operation is in flight (enum chimera_s3_tagging_op). */
     int                             op;
+    /* The composed xattr name of the set currently in flight.  It must
+     * live here, not on a caller's stack: chimera_vfs_set_xattr keeps the
+     * caller's pointer until the completion callback, and an asynchronous
+     * backend (cairn's delegation thread) reads it after the caller has
+     * returned. */
+    char                            set_name[CHIMERA_S3_TAG_PREFIX_LEN +
+                                             CHIMERA_S3_TAG_MAX_KEY_LEN + 1];
     /* Names returned by list_xattrs (for GET/DELETE), staged here. */
     char                           *names;
     int                             names_len;

--- a/src/server/s3/tests/CMakeLists.txt
+++ b/src/server/s3/tests/CMakeLists.txt
@@ -145,3 +145,6 @@ if(BOTO3_FOUND)
     # in s3_auth.c learns to append the AWS V2 subresource list.
 
 endif()
+
+# S3 model-based tests (quint): in-process replay harness, no python/boto3.
+add_subdirectory(quint)

--- a/src/server/s3/tests/quint/CMakeLists.txt
+++ b/src/server/s3/tests/quint/CMakeLists.txt
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# S3 model-based tests: the Quint specification and its trace generation live
+# in the chimera-nas/specs repo (submodule ext/specs, quint/s3); this
+# directory owns only the C replay harness that drives that corpus against
+# the live chimera server.  The replayer (s3_mbt_replay.c) embeds the chimera
+# server (S3 enabled, memfs backend) in the test process and issues each
+# trace's requests through the libevpl HTTP/1.1 client over the inproc
+# transport, SigV4-signed like any AWS SDK would, failing on any divergence
+# from the model's expected response.  No test binds a port, needs a network
+# namespace or resource lock, or spawns a daemon -- every trace runs fully
+# parallel on any host.
+#
+# The trace corpus is resolved once, at the top level, by
+# cmake/SpecsBundle.cmake into SPECS_BUNDLE_DIR (a fetched prebuilt bundle
+# when the submodule is clean, else an in-tree build of ext/specs).  The
+# replay ctest points --trace-dir at ${SPECS_BUNDLE_DIR}/s3; the pure-C
+# smoke/deviation probe needs no corpus and always runs.
+
+# The C replayer + probe: chimera server + libevpl HTTP client in one process
+# over the inproc transport (see s3_mbt_common.h).  They build regardless of
+# whether a trace corpus is available.  OpenSSL::Crypto is linked directly
+# for the harness's own SigV4 signer (the same library the server verifies
+# with).
+add_executable(s3_mbt_probe s3_mbt_probe.c)
+target_include_directories(s3_mbt_probe PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(s3_mbt_probe chimera_server chimera_metrics OpenSSL::Crypto)
+
+add_executable(s3_mbt_replay s3_mbt_replay.c)
+target_include_directories(s3_mbt_replay PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(s3_mbt_replay chimera_server chimera_metrics OpenSSL::Crypto jansson)
+
+# Smoke + deviation probe: walks the modeled surface once end-to-end and
+# asserts each documented chimera deviation from official AWS S3 behavior
+# (see the deviation registry in s3_mbt_replay.c) still reproduces.  Goes
+# red when chimera is fixed -- the signal to retire a deviation.  Needs no
+# trace corpus.
+add_test(NAME chimera/server/s3/mbt/probe_memfs
+    COMMAND $<TARGET_FILE:s3_mbt_probe>)
+set_tests_properties(chimera/server/s3/mbt/probe_memfs PROPERTIES
+    LABELS "quint;s3_mbt;memfs"
+    TIMEOUT 60)
+
+if(NOT SPECS_BUNDLE_AVAILABLE)
+    message(STATUS "s3 MBT replay ctests skipped (no specs trace corpus)")
+    return()
+endif()
+
+# One batched replay: a single replayer process opens the server + HTTP
+# client once and replays every trace in the corpus back-to-back, standing
+# up a fresh, uniquely-named memfs (mkfs) per trace -- and dropping the
+# bucket-map entries the trace created -- so no server-side state can leak
+# across traces while the per-process server/client init is amortized over
+# the whole corpus.
+add_test(NAME chimera/server/s3/mbt/batch_memfs
+    COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3)
+set_tests_properties(chimera/server/s3/mbt/batch_memfs PROPERTIES
+    LABELS "quint;s3_mbt;memfs"
+    TIMEOUT 300)

--- a/src/server/s3/tests/quint/CMakeLists.txt
+++ b/src/server/s3/tests/quint/CMakeLists.txt
@@ -48,14 +48,43 @@ if(NOT SPECS_BUNDLE_AVAILABLE)
     return()
 endif()
 
-# One batched replay: a single replayer process opens the server + HTTP
-# client once and replays every trace in the corpus back-to-back, standing
-# up a fresh, uniquely-named memfs (mkfs) per trace -- and dropping the
-# bucket-map entries the trace created -- so no server-side state can leak
-# across traces while the per-process server/client init is amortized over
-# the whole corpus.
+# Batched replays: a single replayer process opens the server + HTTP client
+# once and replays every trace in the corpus back-to-back, standing up a
+# fresh, uniquely-named memfs (mkfs) per trace -- and dropping the
+# bucket-map entries and aborting the in-flight uploads the trace created
+# -- so no server-side state can leak across traces while the per-process
+# server/client init is amortized over the whole corpus.
+#
+# stepMultipart traces carry multipart uploads and are replayed separately
+# with a 5 MiB block size: AWS's minimum part size makes every non-empty
+# part legal at that scale, which is the contract the model's EntityTooSmall
+# encoding assumes.  They are excluded from the normal-block-size batches by
+# filename prefix (there is no include-prefix, so the multipart batch
+# excludes every OTHER flavor instead).
 add_test(NAME chimera/server/s3/mbt/batch_memfs
-    COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3)
+    COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+            --exclude-prefix stepMultipart_)
 set_tests_properties(chimera/server/s3/mbt/batch_memfs PROPERTIES
+    LABELS "quint;s3_mbt;memfs"
+    TIMEOUT 300)
+
+add_test(NAME chimera/server/s3/mbt/batch_multipart_memfs
+    COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+            --block-size 5242880
+            --exclude-prefix step_ --exclude-prefix stepData_
+            --exclude-prefix stepList_ --exclude-prefix stepBucket_
+            --exclude-prefix stepTag_)
+set_tests_properties(chimera/server/s3/mbt/batch_multipart_memfs PROPERTIES
+    LABELS "quint;s3_mbt;memfs"
+    TIMEOUT 300)
+
+# The same corpus signed with AWS Signature V2 ("AWS <key>:<hmac-sha1>"),
+# exercising the server's V2 verifier end to end.  Multipart is excluded
+# only for the block-size reason above -- V2 signing itself covers every
+# op (the server's V2 canonical resource carries no subresources).
+add_test(NAME chimera/server/s3/mbt/batch_sigv2_memfs
+    COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+            --sigv2 --exclude-prefix stepMultipart_)
+set_tests_properties(chimera/server/s3/mbt/batch_sigv2_memfs PROPERTIES
     LABELS "quint;s3_mbt;memfs"
     TIMEOUT 300)

--- a/src/server/s3/tests/quint/CMakeLists.txt
+++ b/src/server/s3/tests/quint/CMakeLists.txt
@@ -78,6 +78,60 @@ set_tests_properties(chimera/server/s3/mbt/batch_multipart_memfs PROPERTIES
     LABELS "quint;s3_mbt;memfs"
     TIMEOUT 300)
 
+# The same corpora replayed against the on-disk backends.  The corpus is
+# protocol-level and backend-agnostic, so a divergence here is a genuine
+# backend deviation from the model memfs already satisfies.  Each replay
+# self-provisions its scratch (device image / rocksdb dir) under its own
+# mkdtemp session dir.  Gated on the storage each backend needs.
+#
+# Withheld batches, and why:
+#  - diskfs multipart: PutObject's create_unlinked+link_at publish at
+#    multipart scale intermittently SEGVs -- the link_at completion is
+#    delivered on the diskfs IQ/txn thread and the follow-on getattr races
+#    the owning thread (chimera_s3_put_finish_common -> chimera_vfs_getattr,
+#    ~1-in-2 on stepMultipart_64_0x11_1).  Re-enable when the diskfs
+#    completion threading is settled.
+#  - linux/io_uring (passthrough): need a name_to_handle_at-capable scratch
+#    filesystem ($CHIMERA_MBT_SCRATCH; overlayfs/tmpfs skip 77) and an
+#    io_uring-capable environment, and both exhibit intermittent ESTALE
+#    path lookups for directories that demonstrably exist (deterministic on
+#    e.g. stepList_128_0x1_3 step 13: DeleteObjects' parent lookup ESTALEs,
+#    the object survives on disk).  Until the batch-delete masking fix,
+#    that surfaced as ghost objects "resurrecting" after a reported
+#    <Deleted>; it now surfaces as honest InternalError entries.  With the
+#    caches disabled (S3_MBT_DISABLE_CACHES=1) the failure moves earlier (a
+#    PUT's final getattr loses its attributes), so the fault is in the
+#    passthrough module, not the cache layer.  Run manually with
+#    --backend linux/io_uring; S3_MBT_KEEP_SCRATCH=1 preserves the backing
+#    tree for post-mortem.
+if(HAVE_LIBAIO)
+    add_test(NAME chimera/server/s3/mbt/batch_diskfs
+        COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+                --backend diskfs --exclude-prefix stepMultipart_)
+    set_tests_properties(chimera/server/s3/mbt/batch_diskfs PROPERTIES
+        LABELS "quint;s3_mbt;diskfs"
+        TIMEOUT 300)
+endif()
+
+if(CAIRN_ENABLED)
+    add_test(NAME chimera/server/s3/mbt/batch_cairn
+        COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+                --backend cairn --exclude-prefix stepMultipart_)
+    set_tests_properties(chimera/server/s3/mbt/batch_cairn PROPERTIES
+        LABELS "quint;s3_mbt;cairn"
+        TIMEOUT 300)
+
+    add_test(NAME chimera/server/s3/mbt/batch_multipart_cairn
+        COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+                --backend cairn --block-size 5242880
+                --exclude-prefix step_ --exclude-prefix stepData_
+                --exclude-prefix stepList_ --exclude-prefix stepBucket_
+                --exclude-prefix stepTag_)
+    set_tests_properties(chimera/server/s3/mbt/batch_multipart_cairn PROPERTIES
+        LABELS "quint;s3_mbt;cairn"
+        TIMEOUT 300)
+endif()
+
 # The same corpus signed with AWS Signature V2 ("AWS <key>:<hmac-sha1>"),
 # exercising the server's V2 verifier end to end.  Multipart is excluded
 # only for the block-size reason above -- V2 signing itself covers every

--- a/src/server/s3/tests/quint/s3_mbt_common.h
+++ b/src/server/s3/tests/quint/s3_mbt_common.h
@@ -31,6 +31,9 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/stat.h>
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
@@ -85,6 +88,8 @@ struct s3_mbt_env {
     struct evpl_http_conn     *conn;
     struct evpl_endpoint      *ep;
     char                       session_dir[256];
+    const char                *module;      /* VFS backend under test */
+    char                       pt_root[300]; /* passthrough backing root */
     int                        sigv2; /* sign with SigV2 by default */
     uint8_t                   *body_buf;
     struct s3_mbt_resp         res;
@@ -553,8 +558,18 @@ s3_mbt_call(
 
 /* ---- server + client lifecycle ------------------------------------------ */
 
+/* memfs/diskfs/cairn create named filesystems (mkfs); linux and io_uring are
+ * passthrough backends that mount a host directory and have no mkfs. */
+static inline int
+s3_mbt_module_is_passthrough(const char *module)
+{
+    return strcmp(module, "linux") == 0 || strcmp(module, "io_uring") == 0;
+} /* s3_mbt_module_is_passthrough */
+
 static inline void
-s3_mbt_env_open(struct s3_mbt_env *env)
+s3_mbt_env_open_module(
+    struct s3_mbt_env *env,
+    const char        *module)
 {
     struct chimera_server_config *config;
     struct evpl_thread_config    *tcfg;
@@ -580,6 +595,79 @@ s3_mbt_env_open(struct s3_mbt_env *env)
     chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
     chimera_server_config_set_s3_enabled(config, 1);
     chimera_server_config_set_s3_port(config, S3_MBT_PORT);
+
+    /* Debug aid, mirroring the NFS3 harness's disable_caches option: run
+     * with the VFS attr/name caches off to separate cache-coherence
+     * suspects from backend behavior. */
+    if (getenv("S3_MBT_DISABLE_CACHES")) {
+        chimera_server_config_set_attr_cache_enabled(config, 0);
+        chimera_server_config_set_name_cache_enabled(config, 0);
+    }
+
+    env->module = module ? module : "memfs";
+
+    /* Backend module registration, mirroring nfs3_mbt_common.h: memfs is a
+    * default module; diskfs and cairn are self-provisioned under the
+    * per-process session_dir (1 GiB sparse libaio image / rocksdb dir) so
+    * every replay process is isolated and cleaned up with its temp dir. */
+    if (strcmp(env->module, "diskfs") == 0) {
+        char img[300], cfg[512];
+        int  fd;
+
+        snprintf(img, sizeof(img), "%s/device-0.img", env->session_dir);
+        fd = open(img, O_CREAT | O_TRUNC | O_RDWR, 0644);
+        if (fd < 0 || ftruncate(fd, 1024LL * 1024 * 1024) != 0) {
+            fprintf(stderr, "diskfs device image %s: %s\n", img,
+                    strerror(errno));
+            exit(1);
+        }
+        close(fd);
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"unsafe_async\":true,"
+                 "\"intent_log_size\":67108864,"
+                 "\"devices\":[{\"type\":\"libaio\",\"size\":1,\"path\":\"%s\"}]}",
+                 img);
+        chimera_server_config_add_module(config, "diskfs", NULL, cfg);
+    } else if (strcmp(env->module, "cairn") == 0) {
+        char dir[300], cfg[512];
+
+        snprintf(dir, sizeof(dir), "%s/cairn", env->session_dir);
+        if (mkdir(dir, 0755) != 0 && errno != EEXIST) {
+            fprintf(stderr, "cairn dir %s: %s\n", dir, strerror(errno));
+            exit(1);
+        }
+        snprintf(cfg, sizeof(cfg), "{\"initialize\":true,\"path\":\"%s\"}",
+                 dir);
+        chimera_server_config_add_module(config, "cairn", NULL, cfg);
+    }
+
+    /* Passthrough backends store their trees on a real host filesystem that
+     * must support name_to_handle_at (tmpfs and overlayfs do not).  Root the
+     * backing store at $CHIMERA_MBT_SCRATCH (default: the current directory);
+     * an unsupported filesystem surfaces as an ENOTSUP mount that fs_setup
+     * turns into a clean 77 skip. */
+    if (s3_mbt_module_is_passthrough(env->module)) {
+        const char *scratch = getenv("CHIMERA_MBT_SCRATCH");
+        char       *abs_scratch;
+
+        if (!scratch || !scratch[0]) {
+            scratch = ".";
+        }
+        abs_scratch = realpath(scratch, NULL);
+        if (!abs_scratch) {
+            fprintf(stderr, "realpath(%s) failed: %s\n", scratch,
+                    strerror(errno));
+            exit(1);
+        }
+        snprintf(env->pt_root, sizeof(env->pt_root),
+                 "%s/s3_mbt_pt_XXXXXX", abs_scratch);
+        free(abs_scratch);
+        if (!mkdtemp(env->pt_root)) {
+            fprintf(stderr, "mkdtemp(%s) failed: %s\n", env->pt_root,
+                    strerror(errno));
+            exit(1);
+        }
+    }
 
     env->server = chimera_server_init(config, env->metrics);
 
@@ -609,22 +697,61 @@ s3_mbt_env_open(struct s3_mbt_env *env)
                                          NULL);
 
     env->body_buf = malloc(S3_MBT_BODY_MAX);
+} /* s3_mbt_env_open_module */
+
+static inline void
+s3_mbt_env_open(struct s3_mbt_env *env)
+{
+    s3_mbt_env_open_module(env, "memfs");
 } /* s3_mbt_env_open */
 
-/* Per-trace filesystem: a fresh named memfs mounted at /share (unique fsname
- * => distinct fsid, so no stale cache entry can be hit across traces).
- * Buckets are NOT pre-created -- CreateBucket is part of the modeled surface
- * and traces create what they use. */
+/* Per-trace filesystem mounted at /share.  mkfs backends get a fresh named
+ * filesystem (unique fsname => distinct fsid, so no stale cache entry can be
+ * hit across traces); passthrough backends get a fresh host subdirectory (a
+ * brand-new inode is the passthrough analogue of a fresh fsid).  Buckets are
+ * NOT pre-created -- CreateBucket is part of the modeled surface and traces
+ * create what they use. */
 static inline void
 s3_mbt_env_fs_setup(
     struct s3_mbt_env *env,
     const char        *fsname)
 {
-    if (chimera_server_mkfs(env->server, "memfs", fsname, NULL) != 0) {
-        fprintf(stderr, "failed to create memfs filesystem %s\n", fsname);
+    if (s3_mbt_module_is_passthrough(env->module)) {
+        char dir[340];
+        int  mrc;
+
+        snprintf(dir, sizeof(dir), "%s/%s", env->pt_root, fsname);
+        if (mkdir(dir, 0777) != 0 && errno != EEXIST) {
+            fprintf(stderr, "failed to create %s backing dir %s: %s\n",
+                    env->module, dir, strerror(errno));
+            exit(1);
+        }
+        mrc = chimera_server_mount(env->server, "share", env->module, dir,
+                                   NULL);
+        if (mrc == CHIMERA_VFS_ENOTSUP) {
+            /* The backing filesystem cannot produce file handles
+             * (name_to_handle_at): point CHIMERA_MBT_SCRATCH at an
+             * ext4/xfs/btrfs path to exercise this backend.  _exit() to
+             * bypass evpl's atexit leak-check. */
+            fprintf(stderr, "SKIP: %s backend needs a name_to_handle_at-"
+                    "capable scratch fs; %s is not one (set "
+                    "CHIMERA_MBT_SCRATCH)\n", env->module, dir);
+            _exit(77);
+        }
+        if (mrc != 0) {
+            fprintf(stderr, "mount %s at %s failed: status=%d\n",
+                    env->module, dir, mrc);
+            _exit(1);
+        }
+        return;
+    }
+
+    if (chimera_server_mkfs(env->server, env->module, fsname, NULL) != 0) {
+        fprintf(stderr, "failed to create %s filesystem %s\n", env->module,
+                fsname);
         exit(1);
     }
-    chimera_server_mount(env->server, "share", "memfs", fsname, NULL);
+    chimera_server_mount(env->server, "share", env->module, fsname, NULL);
 } /* s3_mbt_env_fs_setup */
 
 static int
@@ -665,7 +792,14 @@ s3_mbt_env_fs_teardown(
 
     chimera_server_unmount(env->server, "share");
 
-    while (chimera_server_rmfs(env->server, "memfs", fsname) != 0) {
+    /* Passthrough backends have no filesystem to remove; the unmounted host
+     * dir is intentionally left in place (its inode must not be reused
+     * mid-run) and is reaped with the scratch dir. */
+    if (s3_mbt_module_is_passthrough(env->module)) {
+        return;
+    }
+
+    while (chimera_server_rmfs(env->server, env->module, fsname) != 0) {
         if (++tries >= 5000) {
             fprintf(stderr, "warning: rmfs %s still failed after %d retries\n",
                     fsname, tries);
@@ -678,7 +812,7 @@ s3_mbt_env_fs_teardown(
 static inline void
 s3_mbt_env_stop(struct s3_mbt_env *env)
 {
-    char cmd[300];
+    char cmd[340];
 
     evpl_http_client_close(env->agent, env->conn);
     evpl_http_destroy(env->agent);
@@ -692,6 +826,19 @@ s3_mbt_env_stop(struct s3_mbt_env *env)
     snprintf(cmd, sizeof(cmd), "rm -rf %s", env->session_dir);
     if (system(cmd) != 0) {
         fprintf(stderr, "warning: failed to remove %s\n", env->session_dir);
+    }
+    if (env->pt_root[0]) {
+        /* Debug aid: keep the passthrough backing tree for post-mortem
+         * inspection of what the server actually left on disk. */
+        if (getenv("S3_MBT_KEEP_SCRATCH")) {
+            fprintf(stderr, "keeping passthrough scratch %s\n", env->pt_root);
+        } else {
+            snprintf(cmd, sizeof(cmd), "rm -rf %s", env->pt_root);
+            if (system(cmd) != 0) {
+                fprintf(stderr, "warning: failed to remove %s\n",
+                        env->pt_root);
+            }
+        }
     }
 } /* s3_mbt_env_stop */
 

--- a/src/server/s3/tests/quint/s3_mbt_common.h
+++ b/src/server/s3/tests/quint/s3_mbt_common.h
@@ -116,6 +116,8 @@ struct s3_mbt_req {
     const char    *meta;                     /* value for the x-amz-meta-m header */
     const char    *content_sha;              /* x-amz-content-sha256 override
                                               * (aws-chunked: STREAMING-...) */
+    const char    *access_key;               /* credential override */
+    const char    *secret_key;
     enum s3_mbt_auth auth;
     const uint8_t *body;
     size_t         body_len;
@@ -165,9 +167,11 @@ static inline void
 s3_mbt_sign(
     const struct s3_mbt_req *req,
     const char              *access_key,
+    const char              *secret_key,
     char                    *authorization,
     size_t                   authorization_len)
 {
+    char          k0[264];
     char          canonical[4096];
     char          to_sign[512];
     char          cr_hash[65];
@@ -208,7 +212,8 @@ s3_mbt_sign(
              "AWS4-HMAC-SHA256\n%s\n%s\n%s",
              S3_MBT_AMZ_DATE, S3_MBT_SCOPE, cr_hash);
 
-    s3_mbt_hmac256("AWS4" S3_MBT_SECRET_KEY, strlen("AWS4" S3_MBT_SECRET_KEY),
+    snprintf(k0, sizeof(k0), "AWS4%s", secret_key);
+    s3_mbt_hmac256(k0, strlen(k0),
                    S3_MBT_DATESTAMP, strlen(S3_MBT_DATESTAMP), k);
     s3_mbt_hmac256(k, 32, "us-east-1", strlen("us-east-1"), k);
     s3_mbt_hmac256(k, 32, "s3", strlen("s3"), k);
@@ -233,6 +238,8 @@ s3_mbt_sign(
 static inline void
 s3_mbt_sign_v2(
     const struct s3_mbt_req *req,
+    const char              *access_key,
+    const char              *secret_key,
     char                    *authorization,
     size_t                   authorization_len)
 {
@@ -286,11 +293,11 @@ s3_mbt_sign_v2(
         off += snprintf(sts + off, sizeof(sts) - off, "/");
     }
 
-    HMAC(EVP_sha1(), S3_MBT_SECRET_KEY, (int) strlen(S3_MBT_SECRET_KEY),
+    HMAC(EVP_sha1(), secret_key, (int) strlen(secret_key),
          (const unsigned char *) sts, off, sig, &siglen);
     EVP_EncodeBlock(sig_b64, sig, (int) siglen);
 
-    snprintf(authorization, authorization_len, "AWS %s:%s", S3_MBT_ACCESS_KEY,
+    snprintf(authorization, authorization_len, "AWS %s:%s", access_key,
              sig_b64);
 } /* s3_mbt_sign_v2 */
 
@@ -434,6 +441,8 @@ s3_mbt_call(
     }
 
     enum s3_mbt_auth auth = req->auth;
+    const char      *ak   = req->access_key ? req->access_key : S3_MBT_ACCESS_KEY;
+    const char      *sk   = req->secret_key ? req->secret_key : S3_MBT_SECRET_KEY;
 
     if (auth == S3_MBT_AUTH_DEFAULT) {
         auth = env->sigv2 ? S3_MBT_AUTH_V2 : S3_MBT_AUTH_V4;
@@ -473,9 +482,8 @@ s3_mbt_call(
                                          req->content_sha ? req->content_sha
                                                           : S3_MBT_PAYLOAD);
             s3_mbt_sign(req,
-                        auth == S3_MBT_AUTH_V4_BADKEY ? "nosuchaccesskey"
-                                                      : S3_MBT_ACCESS_KEY,
-                        authorization, sizeof(authorization));
+                        auth == S3_MBT_AUTH_V4_BADKEY ? "nosuchaccesskey" : ak,
+                        sk, authorization, sizeof(authorization));
             if (auth == S3_MBT_AUTH_V4_BADSIG) {
                 /* corrupt the last hex digit of the signature */
                 size_t n = strlen(authorization);
@@ -486,7 +494,7 @@ s3_mbt_call(
             break;
         case S3_MBT_AUTH_V2:
         case S3_MBT_AUTH_V2_BADSIG:
-            s3_mbt_sign_v2(req, authorization, sizeof(authorization));
+            s3_mbt_sign_v2(req, ak, sk, authorization, sizeof(authorization));
             if (auth == S3_MBT_AUTH_V2_BADSIG) {
                 /* corrupt the first character of the base64 signature */
                 char *colon = strrchr(authorization, ':');

--- a/src/server/s3/tests/quint/s3_mbt_common.h
+++ b/src/server/s3/tests/quint/s3_mbt_common.h
@@ -1,0 +1,525 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Shared environment for the S3 model-based tests: a chimera server (S3
+ * enabled, memfs backend) and a libevpl HTTP/1.1 client in ONE process,
+ * connected over libevpl's inproc transport.  Nothing binds a TCP port, needs
+ * a network namespace, or spawns a daemon -- every trace runs fully parallel
+ * on any host.
+ *
+ * The client half issues real S3 requests: each call builds the HTTP request
+ * (method, path, query, headers, body), signs it with AWS Signature V4 the
+ * way any AWS SDK would, dispatches it on the client's own evpl loop and
+ * spins evpl_continue() until the response completes.  Responses are captured
+ * whole (status, the headers S3 semantics live in, and the body) into one
+ * result struct reused per call, so the replayer's oracle has a uniform view.
+ *
+ * SigV4 notes: the server verifies the signature over the request exactly as
+ * sent, copies the client's x-amz-content-sha256 into the canonical request
+ * without hashing the payload, and never checks the date for freshness -- so
+ * the harness signs with UNSIGNED-PAYLOAD and a fixed x-amz-date, keeping
+ * every request byte-deterministic.  The Host header is set explicitly (to a
+ * dot-free name, selecting path-style bucket addressing) because SigV4 signs
+ * whatever Host goes on the wire. */
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
+#include "evpl/evpl.h"
+#include "evpl/evpl_http.h"
+#include "server/server.h"
+#include "server/s3/s3.h"
+#include "common/tcp_flavor.h"
+#include "prometheus-c.h"
+
+#define S3_MBT_PORT        5000
+#define S3_MBT_BODY_MAX    (1024 * 1024)
+
+#define S3_MBT_ACCESS_KEY  "quintaccess"
+#define S3_MBT_SECRET_KEY  "quintsecret"
+
+/* Fixed signing date: the server never checks it for freshness, and a fixed
+ * date keeps requests byte-identical run to run. */
+#define S3_MBT_AMZ_DATE    "20260101T000000Z"
+#define S3_MBT_DATESTAMP   "20260101"
+#define S3_MBT_SCOPE       S3_MBT_DATESTAMP "/us-east-1/s3/aws4_request"
+#define S3_MBT_SIGNED_HDRS "host;x-amz-content-sha256;x-amz-date"
+#define S3_MBT_PAYLOAD     "UNSIGNED-PAYLOAD"
+#define S3_MBT_HOST        "localhost"
+
+/* One response, captured whole.  Headers are copied out in the notify
+ * callback -- the request object is freed the moment the terminal callback
+ * returns, so nothing may be read from it afterwards. */
+struct s3_mbt_resp {
+    int      done;
+    int      status;
+    int      has_content_length;
+    int64_t  content_length;
+    char     etag[160];
+    char     content_range[160];
+    char     location[256];
+    char     content_type[128];
+    size_t   body_len;
+    uint8_t *body;              /* borrows env->body_buf */
+};
+
+struct s3_mbt_env {
+    struct chimera_server     *server;
+    struct prometheus_metrics *metrics;
+    struct evpl               *evpl;
+    struct evpl_http_agent    *agent;
+    struct evpl_http_conn     *conn;
+    struct evpl_endpoint      *ep;
+    char                       session_dir[256];
+    uint8_t                   *body_buf;
+    struct s3_mbt_resp         res;
+};
+
+/* One request, declaratively.  query/range/copy_source may be NULL. */
+struct s3_mbt_req {
+    enum evpl_http_request_type method;
+    const char    *path;                     /* "/bucket/key", starts with '/' */
+    const char    *query;                    /* pre-sorted, no leading '?' */
+    const char    *range;                    /* "bytes=0-8191" */
+    const char    *copy_source;              /* "/srcbucket/srckey" */
+    const uint8_t *body;
+    size_t         body_len;
+};
+
+/* ---- crypto helpers (OpenSSL, same library the server verifies with) ---- */
+
+static inline void
+s3_mbt_sha256_hex(
+    const void *data,
+    size_t      len,
+    char       *hex65)
+{
+    unsigned char hash[32];
+    unsigned int  hl  = sizeof(hash);
+    EVP_MD_CTX   *ctx = EVP_MD_CTX_new();
+
+    EVP_DigestInit_ex(ctx, EVP_sha256(), NULL);
+    EVP_DigestUpdate(ctx, data, len);
+    EVP_DigestFinal_ex(ctx, hash, &hl);
+    EVP_MD_CTX_free(ctx);
+
+    for (int i = 0; i < 32; i++) {
+        sprintf(hex65 + i * 2, "%02x", hash[i]);
+    }
+} /* s3_mbt_sha256_hex */
+
+static inline void
+s3_mbt_hmac256(
+    const void   *key,
+    size_t        keylen,
+    const void   *data,
+    size_t        datalen,
+    unsigned char out[32])
+{
+    unsigned int hl = 32;
+
+    HMAC(EVP_sha256(), key, (int) keylen, data, datalen, out, &hl);
+} /* s3_mbt_hmac256 */
+
+/* AWS SigV4 Authorization header for one request as the harness sends it:
+ * fixed signed-header set (host, x-amz-content-sha256, x-amz-date), unsigned
+ * payload.  Any extra headers (Range, x-amz-copy-source) are deliberately
+ * left out of SignedHeaders, which SigV4 permits. */
+static inline void
+s3_mbt_sign(
+    const struct s3_mbt_req *req,
+    char                    *authorization,
+    size_t                   authorization_len)
+{
+    char          canonical[4096];
+    char          to_sign[512];
+    char          cr_hash[65];
+    char          sig_hex[65];
+    unsigned char k[32], sig[32];
+    const char   *method;
+
+    switch (req->method) {
+        case EVPL_HTTP_REQUEST_TYPE_GET:    method = "GET";    break;
+        case EVPL_HTTP_REQUEST_TYPE_HEAD:   method = "HEAD";   break;
+        case EVPL_HTTP_REQUEST_TYPE_PUT:    method = "PUT";    break;
+        case EVPL_HTTP_REQUEST_TYPE_POST:   method = "POST";   break;
+        case EVPL_HTTP_REQUEST_TYPE_DELETE: method = "DELETE"; break;
+        default:
+            fprintf(stderr, "s3_mbt_sign: unsupported method %d\n", req->method);
+            exit(3);
+    } /* switch */
+
+    snprintf(canonical, sizeof(canonical),
+             "%s\n"                          /* method */
+             "%s\n"                          /* canonical URI: the raw path */
+             "%s\n"                          /* canonical query, as sent */
+             "host:%s\n"
+             "x-amz-content-sha256:%s\n"
+             "x-amz-date:%s\n"
+             "\n"
+             "%s\n"
+             "%s",
+             method, req->path, req->query ? req->query : "",
+             S3_MBT_HOST, S3_MBT_PAYLOAD, S3_MBT_AMZ_DATE,
+             S3_MBT_SIGNED_HDRS, S3_MBT_PAYLOAD);
+
+    s3_mbt_sha256_hex(canonical, strlen(canonical), cr_hash);
+
+    snprintf(to_sign, sizeof(to_sign),
+             "AWS4-HMAC-SHA256\n%s\n%s\n%s",
+             S3_MBT_AMZ_DATE, S3_MBT_SCOPE, cr_hash);
+
+    s3_mbt_hmac256("AWS4" S3_MBT_SECRET_KEY, strlen("AWS4" S3_MBT_SECRET_KEY),
+                   S3_MBT_DATESTAMP, strlen(S3_MBT_DATESTAMP), k);
+    s3_mbt_hmac256(k, 32, "us-east-1", strlen("us-east-1"), k);
+    s3_mbt_hmac256(k, 32, "s3", strlen("s3"), k);
+    s3_mbt_hmac256(k, 32, "aws4_request", strlen("aws4_request"), k);
+    s3_mbt_hmac256(k, 32, to_sign, strlen(to_sign), sig);
+
+    for (int i = 0; i < 32; i++) {
+        sprintf(sig_hex + i * 2, "%02x", sig[i]);
+    }
+
+    snprintf(authorization, authorization_len,
+             "AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+             S3_MBT_ACCESS_KEY, S3_MBT_SCOPE, S3_MBT_SIGNED_HDRS, sig_hex);
+} /* s3_mbt_sign */
+
+/* ---- response capture --------------------------------------------------- */
+
+static inline void
+s3_mbt_copy_header(
+    struct evpl_http_request *request,
+    const char               *name,
+    char                     *dst,
+    size_t                    dstlen)
+{
+    const char *v = evpl_http_response_header(request, name);
+
+    if (v) {
+        snprintf(dst, dstlen, "%s", v);
+    } else {
+        dst[0] = '\0';
+    }
+} /* s3_mbt_copy_header */
+
+static inline void
+s3_mbt_drain(
+    struct evpl              *evpl,
+    struct evpl_http_request *request,
+    struct s3_mbt_resp       *res)
+{
+    struct evpl_iovec iov[64];
+    uint64_t          avail;
+    int               niov, i;
+
+    avail = evpl_http_request_get_data_avail(request);
+
+    while (avail > 0) {
+        niov = evpl_http_request_get_datav(evpl, request, iov, (int) avail);
+
+        for (i = 0; i < niov; i++) {
+            if (res->body_len + iov[i].length > S3_MBT_BODY_MAX) {
+                fprintf(stderr, "s3_mbt: response body exceeds %d bytes\n",
+                        S3_MBT_BODY_MAX);
+                exit(3);
+            }
+            memcpy(res->body + res->body_len, iov[i].data, iov[i].length);
+            res->body_len += iov[i].length;
+            evpl_iovec_release(evpl, &iov[i]);
+        }
+
+        avail = evpl_http_request_get_data_avail(request);
+    }
+} /* s3_mbt_drain */
+
+static inline void
+s3_mbt_notify(
+    struct evpl                *evpl,
+    struct evpl_http_agent     *agent,
+    struct evpl_http_request   *request,
+    enum evpl_http_notify_type  notify_type,
+    enum evpl_http_request_type request_type,
+    const char                 *uri,
+    void                       *notify_data,
+    void                       *private_data)
+{
+    struct s3_mbt_resp *res = notify_data;
+    const char         *cl;
+
+    (void) agent;
+    (void) request_type;
+    (void) uri;
+    (void) private_data;
+
+    switch (notify_type) {
+        case EVPL_HTTP_NOTIFY_RESPONSE_HEADERS:
+            res->status = evpl_http_request_status(request);
+            s3_mbt_copy_header(request, "ETag", res->etag, sizeof(res->etag));
+            s3_mbt_copy_header(request, "Content-Range", res->content_range,
+                               sizeof(res->content_range));
+            s3_mbt_copy_header(request, "Location", res->location,
+                               sizeof(res->location));
+            s3_mbt_copy_header(request, "Content-Type", res->content_type,
+                               sizeof(res->content_type));
+            cl = evpl_http_response_header(request, "Content-Length");
+            if (cl) {
+                res->has_content_length = 1;
+                res->content_length     = strtoll(cl, NULL, 10);
+            }
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_DATA:
+            s3_mbt_drain(evpl, request, res);
+            break;
+        case EVPL_HTTP_NOTIFY_RECEIVE_COMPLETE:
+            s3_mbt_drain(evpl, request, res);
+            res->done = 1;
+            break;
+        case EVPL_HTTP_NOTIFY_WANT_DATA:
+        case EVPL_HTTP_NOTIFY_RESPONSE_COMPLETE:
+            break;
+        case EVPL_HTTP_NOTIFY_FAILED:
+            /* A transport failure is never a modeled outcome: the trace is
+             * unusable past this point, so bail loudly. */
+            fprintf(stderr,
+                    "s3_mbt: HTTP request failed at transport level (%d)\n",
+                    evpl_http_request_status(request));
+            exit(3);
+    } /* switch */
+} /* s3_mbt_notify */
+
+/* Issue one signed request and wait for the full response. */
+static inline struct s3_mbt_resp *
+s3_mbt_call(
+    struct s3_mbt_env       *env,
+    const struct s3_mbt_req *req)
+{
+    struct evpl_http_request *request;
+    struct evpl_iovec         iov;
+    char                      url[4096];
+    char                      authorization[512];
+
+    memset(&env->res, 0, sizeof(env->res));
+    env->res.body           = env->body_buf;
+    env->res.content_length = -1;
+
+    if (req->query && req->query[0]) {
+        snprintf(url, sizeof(url), "%s?%s", req->path, req->query);
+    } else {
+        snprintf(url, sizeof(url), "%s", req->path);
+    }
+
+    request = evpl_http_request_create(env->conn, req->method, url);
+
+    if (!request) {
+        fprintf(stderr, "s3_mbt: evpl_http_request_create(%s) failed\n", url);
+        exit(3);
+    }
+
+    s3_mbt_sign(req, authorization, sizeof(authorization));
+
+    evpl_http_request_add_header(request, "Host", S3_MBT_HOST);
+    evpl_http_request_add_header(request, "x-amz-date", S3_MBT_AMZ_DATE);
+    evpl_http_request_add_header(request, "x-amz-content-sha256", S3_MBT_PAYLOAD);
+    evpl_http_request_add_header(request, "Authorization", authorization);
+
+    if (req->range) {
+        evpl_http_request_add_header(request, "Range", req->range);
+    }
+    if (req->copy_source) {
+        evpl_http_request_add_header(request, "x-amz-copy-source",
+                                     req->copy_source);
+    }
+
+    /* Stage the whole request body up front; no WANT_DATA handling needed. */
+    if (req->method == EVPL_HTTP_REQUEST_TYPE_PUT ||
+        req->method == EVPL_HTTP_REQUEST_TYPE_POST) {
+        evpl_http_client_set_request_length(request, req->body_len);
+        if (req->body_len) {
+            evpl_iovec_alloc(env->evpl, req->body_len, 0, 1, 0, &iov);
+            memcpy(evpl_iovec_data(&iov), req->body, req->body_len);
+            evpl_iovec_set_length(&iov, req->body_len);
+            evpl_http_request_add_datav(request, &iov, 1);
+        }
+    }
+
+    evpl_http_request_dispatch(request, s3_mbt_notify, &env->res);
+
+    while (!env->res.done) {
+        evpl_continue(env->evpl);
+    }
+
+    return &env->res;
+} /* s3_mbt_call */
+
+/* ---- server + client lifecycle ------------------------------------------ */
+
+static inline void
+s3_mbt_env_open(struct s3_mbt_env *env)
+{
+    struct chimera_server_config *config;
+    struct evpl_thread_config    *tcfg;
+
+    memset(env, 0, sizeof(*env));
+
+    snprintf(env->session_dir, sizeof(env->session_dir), "/tmp/s3_mbt_XXXXXX");
+    if (!mkdtemp(env->session_dir)) {
+        fprintf(stderr, "mkdtemp(%s) failed\n", env->session_dir);
+        exit(1);
+    }
+
+    env->metrics = prometheus_metrics_create(NULL, NULL, 0);
+
+    /* The VFS releases closed handles on an async sweep thread, so a
+     * filesystem stays busy for a window after the last close.  A fast sweep
+     * keeps the per-trace rmfs recycle from stalling; set before the server's
+     * threads start below. */
+    setenv("CHIMERA_CLOSE_SWEEP_INTERVAL_MS", "10", 0);
+
+    config = chimera_server_config_init();
+    chimera_server_config_set_state_dir(config, env->session_dir);
+    chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
+    chimera_server_config_set_s3_enabled(config, 1);
+    chimera_server_config_set_s3_port(config, S3_MBT_PORT);
+
+    env->server = chimera_server_init(config, env->metrics);
+
+    chimera_server_start(env->server);
+
+    /* Runtime CreateBucket materializes bucket dirs under this VFS path (the
+     * per-trace mount recreates /share, so the root stays valid across the
+     * whole batch), and every request must be signed with a known cred. */
+    chimera_server_set_s3_bucket_root(env->server, "/share");
+    chimera_server_add_s3_cred(env->server, S3_MBT_ACCESS_KEY,
+                               S3_MBT_SECRET_KEY, 1);
+
+    /* Client half: its own evpl loop; the response callbacks run inside
+     * evpl_continue() on this (the only) test thread.  The 1 ms wait bound
+     * matters: the default (-1) parks evpl_continue in the poller, and 0
+     * (pure spin) starves the server's threads -- measured 3x slower on the
+     * SMB harness this pattern comes from. */
+    tcfg = evpl_thread_config_init();
+    evpl_thread_config_set_wait_ms(tcfg, 1);
+    env->evpl  = evpl_create(tcfg);
+    env->agent = evpl_http_init(env->evpl);
+
+    env->ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
+                                                 "127.0.0.1", S3_MBT_PORT);
+    env->conn = evpl_http_client_connect(env->agent, EVPL_STREAM_INPROC,
+                                         env->ep, EVPL_HTTP_VERSION_HTTP1,
+                                         NULL);
+
+    env->body_buf = malloc(S3_MBT_BODY_MAX);
+} /* s3_mbt_env_open */
+
+/* Per-trace filesystem: a fresh named memfs mounted at /share (unique fsname
+ * => distinct fsid, so no stale cache entry can be hit across traces).
+ * Buckets are NOT pre-created -- CreateBucket is part of the modeled surface
+ * and traces create what they use. */
+static inline void
+s3_mbt_env_fs_setup(
+    struct s3_mbt_env *env,
+    const char        *fsname)
+{
+    if (chimera_server_mkfs(env->server, "memfs", fsname, NULL) != 0) {
+        fprintf(stderr, "failed to create memfs filesystem %s\n", fsname);
+        exit(1);
+    }
+    chimera_server_mount(env->server, "share", "memfs", fsname, NULL);
+} /* s3_mbt_env_fs_setup */
+
+static int
+s3_mbt_collect_bucket(
+    const struct s3_bucket *bucket,
+    void                   *data)
+{
+    char (*names)[64] = data;
+    int i;
+
+    for (i = 0; i < 16; i++) {
+        if (names[i][0] == '\0') {
+            snprintf(names[i], sizeof(names[i]), "%s",
+                     chimera_s3_bucket_get_name(bucket));
+            break;
+        }
+    }
+    return 0;
+} /* s3_mbt_collect_bucket */
+
+/* Tear the per-trace filesystem back down: drop the bucket-map entries the
+ * trace created (they point into /share), unmount, then rmfs -- retried,
+ * because the VFS closes handles on an async sweep. */
+static inline void
+s3_mbt_env_fs_teardown(
+    struct s3_mbt_env *env,
+    const char        *fsname)
+{
+    char names[16][64];
+    int  tries = 0;
+    int  i;
+
+    memset(names, 0, sizeof(names));
+    chimera_server_iterate_buckets(env->server, s3_mbt_collect_bucket, names);
+    for (i = 0; i < 16 && names[i][0]; i++) {
+        chimera_server_remove_bucket(env->server, names[i]);
+    }
+
+    chimera_server_unmount(env->server, "share");
+
+    while (chimera_server_rmfs(env->server, "memfs", fsname) != 0) {
+        if (++tries >= 5000) {
+            fprintf(stderr, "warning: rmfs %s still failed after %d retries\n",
+                    fsname, tries);
+            break;
+        }
+        usleep(1000);
+    }
+} /* s3_mbt_env_fs_teardown */
+
+static inline void
+s3_mbt_env_stop(struct s3_mbt_env *env)
+{
+    char cmd[300];
+
+    evpl_http_client_close(env->agent, env->conn);
+    evpl_http_destroy(env->agent);
+    evpl_destroy(env->evpl);
+
+    chimera_server_destroy(env->server);
+    prometheus_metrics_destroy(env->metrics);
+
+    free(env->body_buf);
+
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", env->session_dir);
+    if (system(cmd) != 0) {
+        fprintf(stderr, "warning: failed to remove %s\n", env->session_dir);
+    }
+} /* s3_mbt_env_stop */
+
+/* ---- content expansion --------------------------------------------------- */
+
+/* Block symbol s expands to block_size repetitions of byte 0x40+s, matching
+ * the model's contract (symbols are 1..3, so bytes 'A'..'C'). */
+static inline void
+s3_mbt_expand_blocks(
+    const int *syms,
+    int        nsyms,
+    int        block_size,
+    uint8_t   *out)
+{
+    int i;
+
+    for (i = 0; i < nsyms; i++) {
+        memset(out + (size_t) i * block_size, 0x40 + syms[i], block_size);
+    }
+} /* s3_mbt_expand_blocks */

--- a/src/server/s3/tests/quint/s3_mbt_common.h
+++ b/src/server/s3/tests/quint/s3_mbt_common.h
@@ -43,7 +43,9 @@
 #include "prometheus-c.h"
 
 #define S3_MBT_PORT        5000
-#define S3_MBT_BODY_MAX    (1024 * 1024)
+/* Multipart traces replay with 5 MiB blocks; whole-object GETs of an
+ * assembled upload run tens of MiB. */
+#define S3_MBT_BODY_MAX    (64 * 1024 * 1024)
 
 #define S3_MBT_ACCESS_KEY  "quintaccess"
 #define S3_MBT_SECRET_KEY  "quintsecret"
@@ -69,6 +71,8 @@ struct s3_mbt_resp {
     char     content_range[160];
     char     location[256];
     char     content_type[128];
+    char     meta[64];          /* x-amz-meta-m */
+    char     tag_count[16];     /* x-amz-tagging-count */
     size_t   body_len;
     uint8_t *body;              /* borrows env->body_buf */
 };
@@ -81,17 +85,38 @@ struct s3_mbt_env {
     struct evpl_http_conn     *conn;
     struct evpl_endpoint      *ep;
     char                       session_dir[256];
+    int                        sigv2; /* sign with SigV2 by default */
     uint8_t                   *body_buf;
     struct s3_mbt_resp         res;
 };
 
-/* One request, declaratively.  query/range/copy_source may be NULL. */
+/* How to authenticate one request.  DEFAULT follows the environment (V4, or
+ * V2 when env->sigv2 is set); the explicit modes let the probe exercise the
+ * V2 verifier and each authentication failure path. */
+enum s3_mbt_auth {
+    S3_MBT_AUTH_DEFAULT = 0,
+    S3_MBT_AUTH_V4,
+    S3_MBT_AUTH_V2,
+    S3_MBT_AUTH_NONE,      /* no Authorization header -> 400 MissingSecurityHeader */
+    S3_MBT_AUTH_V4_BADSIG, /* corrupted V4 signature  -> 403 SignatureDoesNotMatch */
+    S3_MBT_AUTH_V4_BADKEY, /* unknown access key      -> 403 InvalidAccessKeyId */
+    S3_MBT_AUTH_V2_BADSIG, /* corrupted V2 signature  -> 403 SignatureDoesNotMatch */
+};
+
+/* One request, declaratively.  Pointer fields may be NULL. */
 struct s3_mbt_req {
     enum evpl_http_request_type method;
     const char    *path;                     /* "/bucket/key", starts with '/' */
     const char    *query;                    /* pre-sorted, no leading '?' */
     const char    *range;                    /* "bytes=0-8191" */
     const char    *copy_source;              /* "/srcbucket/srckey" */
+    const char    *copy_range;               /* x-amz-copy-source-range */
+    const char    *host;                     /* Host override (virtual-host) */
+    const char    *content_type;             /* Content-Type header */
+    const char    *meta;                     /* value for the x-amz-meta-m header */
+    const char    *content_sha;              /* x-amz-content-sha256 override
+                                              * (aws-chunked: STREAMING-...) */
+    enum s3_mbt_auth auth;
     const uint8_t *body;
     size_t         body_len;
 };
@@ -133,11 +158,13 @@ s3_mbt_hmac256(
 
 /* AWS SigV4 Authorization header for one request as the harness sends it:
  * fixed signed-header set (host, x-amz-content-sha256, x-amz-date), unsigned
- * payload.  Any extra headers (Range, x-amz-copy-source) are deliberately
- * left out of SignedHeaders, which SigV4 permits. */
+ * payload (or the aws-chunked STREAMING- marker).  Any extra headers (Range,
+ * x-amz-copy-source, Content-Type, x-amz-meta-*) are deliberately left out
+ * of SignedHeaders, which SigV4 permits. */
 static inline void
 s3_mbt_sign(
     const struct s3_mbt_req *req,
+    const char              *access_key,
     char                    *authorization,
     size_t                   authorization_len)
 {
@@ -170,8 +197,10 @@ s3_mbt_sign(
              "%s\n"
              "%s",
              method, req->path, req->query ? req->query : "",
-             S3_MBT_HOST, S3_MBT_PAYLOAD, S3_MBT_AMZ_DATE,
-             S3_MBT_SIGNED_HDRS, S3_MBT_PAYLOAD);
+             req->host ? req->host : S3_MBT_HOST,
+             req->content_sha ? req->content_sha : S3_MBT_PAYLOAD,
+             S3_MBT_AMZ_DATE, S3_MBT_SIGNED_HDRS,
+             req->content_sha ? req->content_sha : S3_MBT_PAYLOAD);
 
     s3_mbt_sha256_hex(canonical, strlen(canonical), cr_hash);
 
@@ -192,8 +221,78 @@ s3_mbt_sign(
 
     snprintf(authorization, authorization_len,
              "AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
-             S3_MBT_ACCESS_KEY, S3_MBT_SCOPE, S3_MBT_SIGNED_HDRS, sig_hex);
+             access_key, S3_MBT_SCOPE, S3_MBT_SIGNED_HDRS, sig_hex);
 } /* s3_mbt_sign */
+
+/* AWS SigV2 Authorization header ("AWS <key>:<base64 hmac-sha1>").  The
+ * string-to-sign mirrors the server's verifier: Content-MD5 is never sent,
+ * the Date line is empty because x-amz-date is always sent, the
+ * CanonicalizedAmzHeaders are exactly the x-amz-* headers this harness emits
+ * (sorted), and the CanonicalizedResource is the URI path only -- with the
+ * bucket-level trailing-slash quirk the server expects. */
+static inline void
+s3_mbt_sign_v2(
+    const struct s3_mbt_req *req,
+    char                    *authorization,
+    size_t                   authorization_len)
+{
+    char          sts[4096];
+    unsigned char sig[20];
+    unsigned char sig_b64[64];
+    unsigned int  siglen = sizeof(sig);
+    size_t        off    = 0;
+    size_t        plen;
+    const char   *method;
+
+    switch (req->method) {
+        case EVPL_HTTP_REQUEST_TYPE_GET:    method = "GET";    break;
+        case EVPL_HTTP_REQUEST_TYPE_HEAD:   method = "HEAD";   break;
+        case EVPL_HTTP_REQUEST_TYPE_PUT:    method = "PUT";    break;
+        case EVPL_HTTP_REQUEST_TYPE_POST:   method = "POST";   break;
+        case EVPL_HTTP_REQUEST_TYPE_DELETE: method = "DELETE"; break;
+        default:
+            fprintf(stderr, "s3_mbt_sign_v2: unsupported method %d\n",
+                    req->method);
+            exit(3);
+    } /* switch */
+
+    /* METHOD \n Content-MD5 \n Content-Type \n Date(empty; x-amz-date) \n */
+    off += snprintf(sts + off, sizeof(sts) - off, "%s\n\n%s\n\n",
+                    method, req->content_type ? req->content_type : "");
+
+    /* CanonicalizedAmzHeaders: the x-amz-* headers s3_mbt_call sends, in
+     * lexicographic name order (copy-source < date < meta-m). */
+    if (req->copy_source) {
+        off += snprintf(sts + off, sizeof(sts) - off,
+                        "x-amz-copy-source:%s\n", req->copy_source);
+    }
+    if (req->copy_range) {
+        off += snprintf(sts + off, sizeof(sts) - off,
+                        "x-amz-copy-source-range:%s\n", req->copy_range);
+    }
+    off += snprintf(sts + off, sizeof(sts) - off, "x-amz-date:%s\n",
+                    S3_MBT_AMZ_DATE);
+    if (req->meta) {
+        off += snprintf(sts + off, sizeof(sts) - off, "x-amz-meta-m:%s\n",
+                        req->meta);
+    }
+
+    /* CanonicalizedResource: the path, sans query; a bucket-level path
+     * (/bucket, no key) takes a trailing slash. */
+    off += snprintf(sts + off, sizeof(sts) - off, "%s", req->path);
+    plen = strlen(req->path);
+    if (plen > 1 && req->path[plen - 1] != '/' &&
+        strchr(req->path + 1, '/') == NULL) {
+        off += snprintf(sts + off, sizeof(sts) - off, "/");
+    }
+
+    HMAC(EVP_sha1(), S3_MBT_SECRET_KEY, (int) strlen(S3_MBT_SECRET_KEY),
+         (const unsigned char *) sts, off, sig, &siglen);
+    EVP_EncodeBlock(sig_b64, sig, (int) siglen);
+
+    snprintf(authorization, authorization_len, "AWS %s:%s", S3_MBT_ACCESS_KEY,
+             sig_b64);
+} /* s3_mbt_sign_v2 */
 
 /* ---- response capture --------------------------------------------------- */
 
@@ -219,14 +318,19 @@ s3_mbt_drain(
     struct evpl_http_request *request,
     struct s3_mbt_resp       *res)
 {
-    struct evpl_iovec iov[64];
+    struct evpl_iovec iov[256];
     uint64_t          avail;
+    uint64_t          take;
     int               niov, i;
 
     avail = evpl_http_request_get_data_avail(request);
 
     while (avail > 0) {
-        niov = evpl_http_request_get_datav(evpl, request, iov, (int) avail);
+        /* get_datav's last argument is a byte count and it emits as many
+         * iovecs as the ring needs for it -- bound each bite so a
+         * multipart-scale body cannot overrun the scatter array. */
+        take = avail < 256 * 1024 ? avail : 256 * 1024;
+        niov = evpl_http_request_get_datav(evpl, request, iov, (int) take);
 
         for (i = 0; i < niov; i++) {
             if (res->body_len + iov[i].length > S3_MBT_BODY_MAX) {
@@ -272,6 +376,10 @@ s3_mbt_notify(
                                sizeof(res->location));
             s3_mbt_copy_header(request, "Content-Type", res->content_type,
                                sizeof(res->content_type));
+            s3_mbt_copy_header(request, "x-amz-meta-m", res->meta,
+                               sizeof(res->meta));
+            s3_mbt_copy_header(request, "x-amz-tagging-count", res->tag_count,
+                               sizeof(res->tag_count));
             cl = evpl_http_response_header(request, "Content-Length");
             if (cl) {
                 res->has_content_length = 1;
@@ -305,7 +413,6 @@ s3_mbt_call(
     const struct s3_mbt_req *req)
 {
     struct evpl_http_request *request;
-    struct evpl_iovec         iov;
     char                      url[4096];
     char                      authorization[512];
 
@@ -326,13 +433,23 @@ s3_mbt_call(
         exit(3);
     }
 
-    s3_mbt_sign(req, authorization, sizeof(authorization));
+    enum s3_mbt_auth auth = req->auth;
 
-    evpl_http_request_add_header(request, "Host", S3_MBT_HOST);
+    if (auth == S3_MBT_AUTH_DEFAULT) {
+        auth = env->sigv2 ? S3_MBT_AUTH_V2 : S3_MBT_AUTH_V4;
+    }
+
+    evpl_http_request_add_header(request, "Host",
+                                 req->host ? req->host : S3_MBT_HOST);
     evpl_http_request_add_header(request, "x-amz-date", S3_MBT_AMZ_DATE);
-    evpl_http_request_add_header(request, "x-amz-content-sha256", S3_MBT_PAYLOAD);
-    evpl_http_request_add_header(request, "Authorization", authorization);
 
+    if (req->content_type) {
+        evpl_http_request_add_header(request, "Content-Type",
+                                     req->content_type);
+    }
+    if (req->meta) {
+        evpl_http_request_add_header(request, "x-amz-meta-m", req->meta);
+    }
     if (req->range) {
         evpl_http_request_add_header(request, "Range", req->range);
     }
@@ -340,16 +457,80 @@ s3_mbt_call(
         evpl_http_request_add_header(request, "x-amz-copy-source",
                                      req->copy_source);
     }
+    if (req->copy_range) {
+        evpl_http_request_add_header(request, "x-amz-copy-source-range",
+                                     req->copy_range);
+    }
 
-    /* Stage the whole request body up front; no WANT_DATA handling needed. */
+    switch (auth) {
+        case S3_MBT_AUTH_V4:
+        case S3_MBT_AUTH_V4_BADSIG:
+        case S3_MBT_AUTH_V4_BADKEY:
+            /* V2 requests deliberately omit x-amz-content-sha256: the server
+             * canonicalizes every x-amz-* header it receives, so any header
+             * sent must also be in the harness's V2 string-to-sign. */
+            evpl_http_request_add_header(request, "x-amz-content-sha256",
+                                         req->content_sha ? req->content_sha
+                                                          : S3_MBT_PAYLOAD);
+            s3_mbt_sign(req,
+                        auth == S3_MBT_AUTH_V4_BADKEY ? "nosuchaccesskey"
+                                                      : S3_MBT_ACCESS_KEY,
+                        authorization, sizeof(authorization));
+            if (auth == S3_MBT_AUTH_V4_BADSIG) {
+                /* corrupt the last hex digit of the signature */
+                size_t n = strlen(authorization);
+                authorization[n - 1] = authorization[n - 1] == '0' ? '1' : '0';
+            }
+            evpl_http_request_add_header(request, "Authorization",
+                                         authorization);
+            break;
+        case S3_MBT_AUTH_V2:
+        case S3_MBT_AUTH_V2_BADSIG:
+            s3_mbt_sign_v2(req, authorization, sizeof(authorization));
+            if (auth == S3_MBT_AUTH_V2_BADSIG) {
+                /* corrupt the first character of the base64 signature */
+                char *colon = strrchr(authorization, ':');
+                colon[1] = colon[1] == 'A' ? 'B' : 'A';
+            }
+            evpl_http_request_add_header(request, "Authorization",
+                                         authorization);
+            break;
+        case S3_MBT_AUTH_NONE:
+            break;
+        default:
+            fprintf(stderr, "s3_mbt_call: bad auth mode %d\n", auth);
+            exit(3);
+    } /* switch */
+
+    /* Stage the whole request body up front; no WANT_DATA handling needed.
+     * A multipart-scale body (5+ MiB blocks) spans several evpl buffer
+     * slabs, so allocate a scatter list and honor the returned count. */
     if (req->method == EVPL_HTTP_REQUEST_TYPE_PUT ||
         req->method == EVPL_HTTP_REQUEST_TYPE_POST) {
         evpl_http_client_set_request_length(request, req->body_len);
         if (req->body_len) {
-            evpl_iovec_alloc(env->evpl, req->body_len, 0, 1, 0, &iov);
-            memcpy(evpl_iovec_data(&iov), req->body, req->body_len);
-            evpl_iovec_set_length(&iov, req->body_len);
-            evpl_http_request_add_datav(request, &iov, 1);
+            struct evpl_iovec iov[64];
+            int               niov;
+            size_t            off = 0;
+            int               i;
+
+            niov = evpl_iovec_alloc(env->evpl, req->body_len, 0, 64, 0, iov);
+            if (niov <= 0) {
+                fprintf(stderr, "s3_mbt: evpl_iovec_alloc(%zu) failed (%d)\n",
+                        req->body_len, niov);
+                exit(3);
+            }
+            for (i = 0; i < niov; i++) {
+                size_t n = iov[i].length;
+
+                if (n > req->body_len - off) {
+                    n = req->body_len - off;
+                    evpl_iovec_set_length(&iov[i], n);
+                }
+                memcpy(evpl_iovec_data(&iov[i]), req->body + off, n);
+                off += n;
+            }
+            evpl_http_request_add_datav(request, iov, niov);
         }
     }
 
@@ -523,3 +704,35 @@ s3_mbt_expand_blocks(
         memset(out + (size_t) i * block_size, 0x40 + syms[i], block_size);
     }
 } /* s3_mbt_expand_blocks */
+
+/* Frame a payload as aws-chunked (SigV4 streaming upload) content: chunks of
+ * `chunk_size` as "<hex-size>;chunk-signature=<64 zeros>\r\n<data>\r\n",
+ * terminated by the zero-length chunk.  The server decodes the framing and
+ * never verifies the per-chunk signatures, so a fixed dummy signature keeps
+ * the request deterministic.  Returns the framed length. */
+static inline size_t
+s3_mbt_aws_chunkify(
+    const uint8_t *in,
+    size_t         in_len,
+    size_t         chunk_size,
+    uint8_t       *out)
+{
+    static const char dummy_sig[] =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+    size_t            off = 0, pos = 0;
+
+    while (pos < in_len) {
+        size_t n = in_len - pos < chunk_size ? in_len - pos : chunk_size;
+
+        off += sprintf((char *) out + off, "%zx;chunk-signature=%s\r\n", n,
+                       dummy_sig);
+        memcpy(out + off, in + pos, n);
+        off       += n;
+        out[off++] = '\r';
+        out[off++] = '\n';
+        pos       += n;
+    }
+    off += sprintf((char *) out + off, "0;chunk-signature=%s\r\n\r\n",
+                   dummy_sig);
+    return off;
+} /* s3_mbt_aws_chunkify */

--- a/src/server/s3/tests/quint/s3_mbt_probe.c
+++ b/src/server/s3/tests/quint/s3_mbt_probe.c
@@ -602,6 +602,71 @@ main(
         simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/mp");
     }
 
+    /* ---- synthetic clock: credential TTL --------------------------------- */
+
+    /* Credential expiry is driven by ticking the cred cache's synthetic
+     * clock (chimera_server_advance_s3_cred_clock advances it and sweeps
+     * synchronously) -- never by waiting out the sweeper thread's wall
+     * cadence.  The server's default TTL is 3600s. */
+    {
+        struct s3_mbt_req req = { .method     = EVPL_HTTP_REQUEST_TYPE_GET,
+                                  .path       = "/bk0/a",
+                                  .access_key = "tempaccess",
+                                  .secret_key = "tempsecret" };
+
+        CHECK(chimera_server_add_s3_cred(env.server, "tempaccess",
+                                         "tempsecret", 0) == 0,
+              "add unpinned cred failed");
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "unpinned-cred GET: got %d want 200",
+              r->status);
+
+        /* re-adding the same key replaces the entry (fresh TTL stamp) */
+        CHECK(chimera_server_add_s3_cred(env.server, "tempaccess",
+                                         "tempsecret", 0) == 0,
+              "re-add unpinned cred failed");
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "replaced-cred GET: got %d want 200",
+              r->status);
+
+        /* an advance short of the TTL leaves the cred alive... */
+        chimera_server_advance_s3_cred_clock(env.server, 3599);
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "pre-TTL GET: got %d want 200", r->status);
+
+        /* ...and ticking past it sweeps the cred: same request now fails
+         * with an unknown access key */
+        chimera_server_advance_s3_cred_clock(env.server, 2);
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 403 &&
+              body_has(r, "<Code>InvalidAccessKeyId</Code>"),
+              "post-TTL GET: got %d, want 403 InvalidAccessKeyId", r->status);
+
+        /* the pinned harness credential is immune to the clock */
+        r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/a");
+        CHECK(r->status == 200, "pinned cred after advance: got %d want 200",
+              r->status);
+
+        /* a pinned extra credential survives any advance, and explicit
+         * removal (not expiry) is what retires it */
+        CHECK(chimera_server_add_s3_cred(env.server, "tempaccess",
+                                         "tempsecret", 1) == 0,
+              "add pinned cred failed");
+        chimera_server_advance_s3_cred_clock(env.server, 100000);
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "pinned temp cred GET: got %d want 200",
+              r->status);
+
+        CHECK(chimera_server_remove_s3_cred(env.server, "tempaccess") == 0,
+              "remove cred failed");
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 403, "removed-cred GET: got %d want 403",
+              r->status);
+        CHECK(chimera_server_remove_s3_cred(env.server, "tempaccess") == -1,
+              "double remove should report absence");
+    }
+
     /* ---- teardown -------------------------------------------------------- */
 
     s3_mbt_env_fs_teardown(&env, "fs0");

--- a/src/server/s3/tests/quint/s3_mbt_probe.c
+++ b/src/server/s3/tests/quint/s3_mbt_probe.c
@@ -1,0 +1,404 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Ground-truth probe for the S3 MBT harness: brings up the in-process S3
+ * server + HTTP client (s3_mbt_common.h), walks the modeled surface once
+ * end-to-end, and asserts each documented chimera deviation from official
+ * AWS S3 behavior still reproduces.  Goes red when chimera is fixed -- the
+ * signal to retire the corresponding entry in s3_mbt_replay.c's deviation
+ * registry (and flip the model expectation if one was encoded there) -- or
+ * if a deviation's shape drifts.  Needs no trace corpus. */
+
+#include "s3_mbt_common.h"
+
+static int failures;
+
+#define CHECK(cond, ...)                                \
+        do {                                            \
+            if (!(cond)) {                              \
+                fprintf(stderr, "FAIL(line %d): ", __LINE__); \
+                fprintf(stderr, __VA_ARGS__);           \
+                fprintf(stderr, "\n");                  \
+                failures++;                             \
+            }                                           \
+        } while (0)
+
+#define BS 8192
+
+static struct s3_mbt_resp *
+simple(
+    struct s3_mbt_env          *env,
+    enum evpl_http_request_type method,
+    const char                 *path)
+{
+    struct s3_mbt_req req = { .method = method, .path = path };
+
+    return s3_mbt_call(env, &req);
+} /* simple */
+
+static struct s3_mbt_resp *
+put_blocks(
+    struct s3_mbt_env *env,
+    const char        *path,
+    const int         *syms,
+    int                nsyms)
+{
+    static uint8_t    body[4 * BS];
+    struct s3_mbt_req req = { .method   = EVPL_HTTP_REQUEST_TYPE_PUT,
+                              .path     = path,                      .body = body,
+                              .body_len = (size_t) nsyms * BS };
+
+    s3_mbt_expand_blocks(syms, nsyms, BS, body);
+    return s3_mbt_call(env, &req);
+} /* put_blocks */
+
+static int
+body_is_blocks(
+    const struct s3_mbt_resp *res,
+    const int                *syms,
+    int                       nsyms)
+{
+    static uint8_t want[4 * BS];
+
+    if (res->body_len != (size_t) nsyms * BS) {
+        return 0;
+    }
+    s3_mbt_expand_blocks(syms, nsyms, BS, want);
+    return memcmp(res->body, want, res->body_len) == 0;
+} /* body_is_blocks */
+
+static int
+body_has(
+    const struct s3_mbt_resp *res,
+    const char               *needle)
+{
+    /* Response bodies here are small XML documents; NUL-terminate a copy. */
+    static char tmp[65536];
+    size_t      n = res->body_len < sizeof(tmp) - 1 ? res->body_len
+                                                    : sizeof(tmp) - 1;
+
+    memcpy(tmp, res->body, n);
+    tmp[n] = '\0';
+    return strstr(tmp, needle) != NULL;
+} /* body_has */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct s3_mbt_env   env;
+    struct s3_mbt_resp *r;
+    char                etag_a[160];
+    int                 s1[]   = { 1 };
+    int                 s12[]  = { 1, 2 };
+    int                 s123[] = { 1, 2, 3 };
+    int                 s23[]  = { 2, 3 };
+    int                 s3[]   = { 3 };
+
+    (void) argc;
+    (void) argv;
+
+    alarm(120);
+
+    s3_mbt_env_open(&env);
+    s3_mbt_env_fs_setup(&env, "fs0");
+
+    /* ---- bucket lifecycle ---------------------------------------------- */
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_HEAD, "/bk0");
+    CHECK(r->status == 404, "HEAD missing bucket: got %d want 404", r->status);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_PUT, "/bk0");
+    CHECK(r->status == 200, "CreateBucket: got %d want 200", r->status);
+    CHECK(strcmp(r->location, "/bk0") == 0,
+          "CreateBucket Location: got '%s' want '/bk0'", r->location);
+
+    /* idempotent re-create (us-east-1 semantics) */
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_PUT, "/bk0");
+    CHECK(r->status == 200, "re-CreateBucket: got %d want 200", r->status);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_HEAD, "/bk0");
+    CHECK(r->status == 200, "HeadBucket: got %d want 200", r->status);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/");
+    CHECK(r->status == 200, "ListBuckets: got %d want 200", r->status);
+    CHECK(body_has(r, "<Name>bk0</Name>"), "ListBuckets lacks bk0");
+
+    /* ---- object core ---------------------------------------------------- */
+
+    r = put_blocks(&env, "/bk0/a", s12, 2);
+    CHECK(r->status == 200, "PutObject: got %d want 200", r->status);
+    CHECK(r->etag[0] == '"', "PutObject ETag missing/unquoted: '%s'", r->etag);
+    snprintf(etag_a, sizeof(etag_a), "%s", r->etag);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/a");
+    CHECK(r->status == 200, "GetObject: got %d want 200", r->status);
+    CHECK(body_is_blocks(r, s12, 2), "GetObject body mismatch");
+    CHECK(strcmp(r->etag, etag_a) == 0,
+          "GetObject ETag: got '%s' want '%s'", r->etag, etag_a);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_HEAD, "/bk0/a");
+    CHECK(r->status == 200, "HeadObject: got %d want 200", r->status);
+    CHECK(r->has_content_length && r->content_length == 2 * BS,
+          "HeadObject Content-Length: got %" PRId64 " want %d",
+          r->content_length, 2 * BS);
+    CHECK(r->body_len == 0, "HeadObject returned a body");
+    CHECK(strcmp(r->etag, etag_a) == 0, "HeadObject ETag mismatch");
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/b");
+    CHECK(r->status == 404, "GetObject missing: got %d want 404", r->status);
+    CHECK(body_has(r, "<Code>NoSuchKey</Code>"),
+          "GetObject missing: body lacks NoSuchKey");
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/nosuch/a");
+    CHECK(r->status == 404, "GetObject missing bucket: got %d want 404",
+          r->status);
+    CHECK(body_has(r, "<Code>NoSuchBucket</Code>"),
+          "GetObject missing bucket: body lacks NoSuchBucket");
+
+    /* overwrite changes content (and, with it, the reported ETag stays
+     * self-consistent on every later read) */
+    r = put_blocks(&env, "/bk0/a", s123, 3);
+    CHECK(r->status == 200, "PutObject overwrite: got %d want 200", r->status);
+    snprintf(etag_a, sizeof(etag_a), "%s", r->etag);
+
+    /* ---- ranges ---------------------------------------------------------- */
+
+    {
+        struct s3_mbt_req req = { .method = EVPL_HTTP_REQUEST_TYPE_GET,
+                                  .path   = "/bk0/a",                  .range = "bytes=0-8191" };
+        char              want_cr[128];
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 206, "ranged GET: got %d want 206", r->status);
+        CHECK(body_is_blocks(r, s1, 1), "ranged GET body mismatch");
+        snprintf(want_cr, sizeof(want_cr), "bytes 0-%d/%d", BS - 1, 3 * BS);
+        CHECK(strcmp(r->content_range, want_cr) == 0,
+              "ranged GET Content-Range: got '%s' want '%s'",
+              r->content_range, want_cr);
+
+        req.range = "bytes=8192-";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 206, "open-ended GET: got %d want 206", r->status);
+        CHECK(body_is_blocks(r, s23, 2), "open-ended GET body mismatch");
+
+        req.range = "bytes=-8192";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 206, "suffix GET: got %d want 206", r->status);
+        CHECK(body_is_blocks(r, s3, 1), "suffix GET body mismatch");
+
+        /* a closed range overrunning EOF is clamped */
+        req.range = "bytes=16384-999999";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 206, "clamped GET: got %d want 206", r->status);
+        CHECK(body_is_blocks(r, s3, 1), "clamped GET body mismatch");
+
+        /* start at/past EOF: unsatisfiable */
+        req.range = "bytes=24576-24577";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 416, "past-EOF GET: got %d want 416", r->status);
+        snprintf(want_cr, sizeof(want_cr), "bytes */%d", 3 * BS);
+        CHECK(strcmp(r->content_range, want_cr) == 0,
+              "416 Content-Range: got '%s' want '%s'",
+              r->content_range, want_cr);
+
+        /* DEVIATION range-full-200: a Range resolving to the entire object
+         * (bytes=0- here) is 206 Partial Content on AWS; chimera collapses
+         * it to a plain 200. */
+        req.range = "bytes=0-";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200,
+              "deviation range-full-200 no longer reproduces: got %d "
+              "(fixed? retire it in s3_mbt_replay.c)", r->status);
+        CHECK(body_is_blocks(r, s123, 3), "full-range GET body mismatch");
+    }
+
+    /* ---- zero-length object ---------------------------------------------- */
+
+    /* the GET of an empty object must still run the send path to completion
+     * and release its handle -- a leak here pins the filesystem (see the
+     * RECEIVE_COMPLETE handler in s3.c) */
+    r = put_blocks(&env, "/bk0/empty", s1, 0);
+    CHECK(r->status == 200, "put empty: got %d want 200", r->status);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/empty");
+    CHECK(r->status == 200, "get empty: got %d want 200", r->status);
+    CHECK(r->body_len == 0, "get empty returned %zu bytes", r->body_len);
+    CHECK(r->has_content_length && r->content_length == 0,
+          "get empty Content-Length: got %" PRId64, r->content_length);
+
+    simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/empty");
+
+    /* ---- listing --------------------------------------------------------- */
+
+    r = put_blocks(&env, "/bk0/b", s1, 1);
+    CHECK(r->status == 200, "put b: got %d", r->status);
+    r = put_blocks(&env, "/bk0/d/a", s1, 1);
+    CHECK(r->status == 200, "put d/a: got %d", r->status);
+
+    {
+        /* deliberately UNENCODED delimiter: a legal '/' in a query value
+         * must not corrupt the bucket/key split (s3.c guards the split
+         * against scanning past the '?') */
+        struct s3_mbt_req req = { .method = EVPL_HTTP_REQUEST_TYPE_GET,
+                                  .path   = "/bk0",
+                                  .query  = "delimiter=/&list-type=2" };
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "ListObjectsV2: got %d want 200", r->status);
+        CHECK(body_has(r, "<Key>a</Key>"), "list lacks key a");
+        CHECK(body_has(r, "<Key>b</Key>"), "list lacks key b");
+        CHECK(!body_has(r, "<Key>d/a</Key>"), "delimited list leaked d/a");
+        CHECK(body_has(r, "<Prefix>d/</Prefix>"), "list lacks CommonPrefix d/");
+        CHECK(body_has(r, "<KeyCount>3</KeyCount>"),
+              "list KeyCount != 3");
+        CHECK(body_has(r, "<IsTruncated>false</IsTruncated>"),
+              "list should not be truncated");
+
+        /* percent-encoded, the way the AWS SDKs send it */
+        req.query = "list-type=2&prefix=d%2F";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "prefixed list: got %d want 200", r->status);
+        CHECK(body_has(r, "<Key>d/a</Key>"), "prefixed list lacks d/a");
+        CHECK(!body_has(r, "<Key>a</Key>") || body_has(r, "<Key>d/a</Key>"),
+              "prefixed list shape");
+
+        /* start-after inside a rolled-up group: the group's CommonPrefix
+         * string ("d/") sorts at or before start-after ("d/a"), but member
+         * keys past start-after keep it in the listing (AWS semantics; the
+         * naive skip-entries-at-or-below-start drops it). */
+        r = put_blocks(&env, "/bk0/d/b", s1, 1);
+        CHECK(r->status == 200, "put d/b: got %d", r->status);
+
+        req.query = "delimiter=%2F&list-type=2&start-after=d%2Fa";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "start-after list: got %d want 200",
+              r->status);
+        CHECK(body_has(r, "<Prefix>d/</Prefix>"),
+              "start-after-in-group list dropped CommonPrefix d/");
+        CHECK(body_has(r, "<KeyCount>1</KeyCount>"),
+              "start-after-in-group list KeyCount != 1");
+
+        /* ...and once no member remains past start-after, the group is gone
+         * -- even though the backing directory still exists. */
+        req.query = "delimiter=%2F&list-type=2&start-after=d%2Fb";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "start-after-past list: got %d want 200",
+              r->status);
+        CHECK(!body_has(r, "<Prefix>d/</Prefix>"),
+              "consumed group d/ still listed after start-after=d/b");
+        CHECK(body_has(r, "<KeyCount>0</KeyCount>"),
+              "start-after-past list KeyCount != 0");
+    }
+
+    /* ---- copy ------------------------------------------------------------ */
+
+    {
+        struct s3_mbt_req req = { .method      = EVPL_HTTP_REQUEST_TYPE_PUT,
+                                  .path        = "/bk0/c",
+                                  .copy_source = "/bk0/a" };
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "CopyObject: got %d want 200", r->status);
+        CHECK(body_has(r, "<CopyObjectResult"), "copy body lacks result");
+        CHECK(body_has(r, "<ETag>"), "copy body lacks ETag");
+
+        r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/c");
+        CHECK(r->status == 200 && body_is_blocks(r, s123, 3),
+              "copied object mismatch");
+
+        /* missing source key */
+        req.path        = "/bk0/x";
+        req.copy_source = "/bk0/nosuchkey";
+        r               = s3_mbt_call(&env, &req);
+        CHECK(r->status == 404, "copy missing src: got %d want 404", r->status);
+        CHECK(body_has(r, "<Code>NoSuchKey</Code>"),
+              "copy missing src: body lacks NoSuchKey");
+
+        /* DEVIATION copy-self-200: copying an object onto itself with no
+         * metadata directive is 400 InvalidRequest on AWS; chimera performs
+         * the copy and returns 200. */
+        req.path        = "/bk0/a";
+        req.copy_source = "/bk0/a";
+        r               = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200,
+              "deviation copy-self-200 no longer reproduces: got %d "
+              "(fixed? retire it in s3_mbt_replay.c)", r->status);
+    }
+
+    /* ---- delete ---------------------------------------------------------- */
+
+    /* DEVIATION delete-object-200: AWS DeleteObject returns 204 No Content;
+     * chimera returns 200 with an empty body. */
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/c");
+    CHECK(r->status == 200,
+          "deviation delete-object-200 no longer reproduces: got %d "
+          "(fixed? retire it in s3_mbt_replay.c)", r->status);
+    CHECK(r->body_len == 0, "DeleteObject returned a body");
+
+    /* DEVIATION delete-object-missing-404: AWS DeleteObject is idempotent
+     * (204 for a missing key); chimera returns 404 NoSuchKey. */
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/c");
+    CHECK(r->status == 404,
+          "deviation delete-object-missing-404 no longer reproduces: got %d "
+          "(fixed? retire it in s3_mbt_replay.c)", r->status);
+
+    /* DEVIATION delete-bucket-nonempty-500: AWS answers DELETE on a
+     * non-empty bucket with 409 BucketNotEmpty; chimera maps its internal
+     * BUCKET_NOT_EMPTY through the default 500 InternalError. */
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0");
+    CHECK(r->status == 500,
+          "deviation delete-bucket-nonempty-500 no longer reproduces: got %d "
+          "(fixed? retire it in s3_mbt_replay.c)", r->status);
+    CHECK(body_has(r, "<Code>InternalError</Code>"),
+          "non-empty DeleteBucket: body lacks InternalError");
+
+    /* drain the bucket, then it deletes cleanly */
+    simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/a");
+    simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/b");
+    simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/d/a");
+    simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/d/b");
+
+    /* the key-path directory "d" still exists on the filesystem, but with no
+     * objects under it, it must NOT surface as a phantom CommonPrefix -- AWS
+     * defines CommonPrefixes over keys, not directories */
+    {
+        struct s3_mbt_req req = { .method = EVPL_HTTP_REQUEST_TYPE_GET,
+                                  .path   = "/bk0",
+                                  .query  = "delimiter=%2F&list-type=2" };
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "post-drain list: got %d want 200", r->status);
+        CHECK(!body_has(r, "<Prefix>d/</Prefix>"),
+              "empty key-path dir d/ listed as phantom CommonPrefix");
+        CHECK(body_has(r, "<KeyCount>0</KeyCount>"),
+              "post-drain list KeyCount != 0");
+    }
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0");
+    CHECK(r->status == 204, "DeleteBucket: got %d want 204", r->status);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_HEAD, "/bk0");
+    CHECK(r->status == 404, "HeadBucket after delete: got %d want 404",
+          r->status);
+
+    r = simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0");
+    CHECK(r->status == 404, "DeleteBucket missing: got %d want 404", r->status);
+    CHECK(body_has(r, "<Code>NoSuchBucket</Code>"),
+          "DeleteBucket missing: body lacks NoSuchBucket");
+
+    /* ---- teardown -------------------------------------------------------- */
+
+    s3_mbt_env_fs_teardown(&env, "fs0");
+    s3_mbt_env_stop(&env);
+
+    if (failures) {
+        fprintf(stderr, "%d probe failure(s)\n", failures);
+        return 1;
+    }
+
+    printf("s3_mbt_probe: all checks passed\n");
+    return 0;
+} /* main */

--- a/src/server/s3/tests/quint/s3_mbt_probe.c
+++ b/src/server/s3/tests/quint/s3_mbt_probe.c
@@ -389,6 +389,219 @@ main(
     CHECK(body_has(r, "<Code>NoSuchBucket</Code>"),
           "DeleteBucket missing: body lacks NoSuchBucket");
 
+    /* ---- authentication -------------------------------------------------- */
+
+    {
+        struct s3_mbt_req req = { .method = EVPL_HTTP_REQUEST_TYPE_GET,
+                                  .path   = "/bk0/a" };
+
+        /* recreate state: bucket + object for the auth round-trips */
+        simple(&env, EVPL_HTTP_REQUEST_TYPE_PUT, "/bk0");
+        put_blocks(&env, "/bk0/a", s12, 2);
+
+        req.auth = S3_MBT_AUTH_NONE;
+        r        = s3_mbt_call(&env, &req);
+        CHECK(r->status == 400, "no-auth GET: got %d want 400", r->status);
+        CHECK(body_has(r, "<Code>MissingSecurityHeader</Code>"),
+              "no-auth GET: body lacks MissingSecurityHeader");
+
+        req.auth = S3_MBT_AUTH_V4_BADSIG;
+        r        = s3_mbt_call(&env, &req);
+        CHECK(r->status == 403, "bad-sig GET: got %d want 403", r->status);
+        CHECK(body_has(r, "<Code>SignatureDoesNotMatch</Code>"),
+              "bad-sig GET: body lacks SignatureDoesNotMatch");
+
+        req.auth = S3_MBT_AUTH_V4_BADKEY;
+        r        = s3_mbt_call(&env, &req);
+        CHECK(r->status == 403, "bad-key GET: got %d want 403", r->status);
+        CHECK(body_has(r, "<Code>InvalidAccessKeyId</Code>"),
+              "bad-key GET: body lacks InvalidAccessKeyId");
+
+        /* SigV2 round-trip: GET, ranged GET, PUT, and a bad V2 signature */
+        req.auth = S3_MBT_AUTH_V2;
+        r        = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200 && body_is_blocks(r, s12, 2),
+              "V2 GET failed (%d)", r->status);
+
+        req.range = "bytes=8192-";
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 206, "V2 ranged GET: got %d want 206", r->status);
+        req.range = NULL;
+
+        req.auth = S3_MBT_AUTH_V2_BADSIG;
+        r        = s3_mbt_call(&env, &req);
+        CHECK(r->status == 403, "V2 bad-sig GET: got %d want 403", r->status);
+    }
+
+    {
+        struct s3_mbt_req req = { .method       = EVPL_HTTP_REQUEST_TYPE_PUT,
+                                  .path         = "/bk0/v2put",
+                                  .auth         = S3_MBT_AUTH_V2,
+                                  .content_type = "text/plain" };
+        static uint8_t    pb[BS];
+
+        s3_mbt_expand_blocks(s1, 1, BS, pb);
+        req.body     = pb;
+        req.body_len = BS;
+        r            = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "V2 PUT: got %d want 200", r->status);
+
+        r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/v2put");
+        CHECK(r->status == 200 && body_is_blocks(r, s1, 1),
+              "V2-put object GET failed");
+        CHECK(strcmp(r->content_type, "text/plain") == 0,
+              "stored Content-Type not echoed: '%s'", r->content_type);
+        simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/v2put");
+    }
+
+    /* ---- virtual-host addressing ----------------------------------------- */
+
+    {
+        struct s3_mbt_req req = { .method = EVPL_HTTP_REQUEST_TYPE_GET,
+                                  .path   = "/a",
+                                  .host   = "bk0.chimera" };
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200 && body_is_blocks(r, s12, 2),
+              "virtual-host GET failed (%d)", r->status);
+    }
+
+    /* ---- aws-chunked upload ---------------------------------------------- */
+
+    {
+        static uint8_t    raw[2 * BS];
+        static uint8_t    framed[2 * BS + 512];
+        struct s3_mbt_req req = { .method      = EVPL_HTTP_REQUEST_TYPE_PUT,
+                                  .path        = "/bk0/chunked",
+                                  .content_sha =
+                                      "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" };
+
+        s3_mbt_expand_blocks(s23, 2, BS, raw);
+        req.body     = framed;
+        req.body_len = s3_mbt_aws_chunkify(raw, sizeof(raw), 5000, framed);
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "aws-chunked PUT: got %d want 200", r->status);
+
+        r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/chunked");
+        CHECK(r->status == 200 && body_is_blocks(r, s23, 2),
+              "aws-chunked object GET failed (%d, %zu bytes)", r->status,
+              r->body_len);
+        simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/chunked");
+    }
+
+    /* ---- tagging ---------------------------------------------------------- */
+
+    {
+        struct s3_mbt_req req = { .method = EVPL_HTTP_REQUEST_TYPE_PUT,
+                                  .path   = "/bk0/a",                  .query = "tagging=" };
+        static const char tags[] =
+            "<Tagging><TagSet><Tag><Key>tk1</Key><Value>tv1</Value></Tag>"
+            "</TagSet></Tagging>";
+
+        req.body     = (const uint8_t *) tags;
+        req.body_len = sizeof(tags) - 1;
+        r            = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "PutObjectTagging: got %d want 200",
+              r->status);
+
+        req.method   = EVPL_HTTP_REQUEST_TYPE_GET;
+        req.body     = NULL;
+        req.body_len = 0;
+        r            = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200 && body_has(r, "<Key>tk1</Key>"),
+              "GetObjectTagging lacks tk1 (%d)", r->status);
+
+        r = simple(&env, EVPL_HTTP_REQUEST_TYPE_HEAD, "/bk0/a");
+        CHECK(strcmp(r->tag_count, "1") == 0,
+              "x-amz-tagging-count '%s', want 1", r->tag_count);
+
+        req.method = EVPL_HTTP_REQUEST_TYPE_DELETE;
+        r          = s3_mbt_call(&env, &req);
+        CHECK(r->status == 204, "DeleteObjectTagging: got %d want 204",
+              r->status);
+
+        /* bucket-level: no tags stored -> 404 NoSuchTagSet */
+        req.method = EVPL_HTTP_REQUEST_TYPE_GET;
+        req.path   = "/bk0";
+        r          = s3_mbt_call(&env, &req);
+        CHECK(r->status == 404 && body_has(r, "<Code>NoSuchTagSet</Code>"),
+              "empty GetBucketTagging: got %d, want 404 NoSuchTagSet",
+              r->status);
+    }
+
+    /* ---- multipart smoke -------------------------------------------------- */
+
+    {
+        struct s3_mbt_req req = { .method = EVPL_HTTP_REQUEST_TYPE_POST,
+                                  .path   = "/bk0/mp",                  .query = "uploads=" };
+        char              uploadid[64];
+        char              etag1[160], etag2[160];
+        char              q[128];
+        char              cbody[1024];
+        static uint8_t    pb[BS];
+
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "CreateMultipartUpload: got %d", r->status);
+        CHECK(body_has(r, "<UploadId>"), "initiate lacks UploadId");
+        {
+            const char *b = strstr((const char *) r->body, "<UploadId>");
+
+            memcpy(uploadid, b + 10, 32);
+            uploadid[32] = '\0';
+        }
+
+        s3_mbt_expand_blocks(s3, 1, BS, pb);
+        req.method   = EVPL_HTTP_REQUEST_TYPE_PUT;
+        req.body     = pb;
+        req.body_len = BS;
+
+        snprintf(q, sizeof(q), "partNumber=1&uploadId=%s", uploadid);
+        req.query = q;
+        r         = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200 && r->etag[0] == '"',
+              "UploadPart 1: got %d etag '%s'", r->status, r->etag);
+        snprintf(etag1, sizeof(etag1), "%s", r->etag);
+
+        snprintf(q, sizeof(q), "partNumber=2&uploadId=%s", uploadid);
+        r = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200, "UploadPart 2: got %d", r->status);
+        snprintf(etag2, sizeof(etag2), "%s", r->etag);
+
+        /* a NON-final part under the 5 MiB minimum fails the Complete */
+        snprintf(cbody, sizeof(cbody),
+                 "<CompleteMultipartUpload>"
+                 "<Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>"
+                 "<Part><PartNumber>2</PartNumber><ETag>%s</ETag></Part>"
+                 "</CompleteMultipartUpload>", etag1, etag2);
+        snprintf(q, sizeof(q), "uploadId=%s", uploadid);
+        req.method   = EVPL_HTTP_REQUEST_TYPE_POST;
+        req.query    = q;
+        req.body     = (const uint8_t *) cbody;
+        req.body_len = strlen(cbody);
+        r            = s3_mbt_call(&env, &req);
+        CHECK(r->status == 400 && body_has(r, "<Code>EntityTooSmall</Code>"),
+              "undersized non-final part: got %d, want 400 EntityTooSmall",
+              r->status);
+
+        /* an ascending SUBSET manifest is legal: complete with part 1 only
+         * (any size is fine for the final part), orphaning part 2 */
+        snprintf(cbody, sizeof(cbody),
+                 "<CompleteMultipartUpload>"
+                 "<Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>"
+                 "</CompleteMultipartUpload>", etag1);
+        req.body_len = strlen(cbody);
+        r            = s3_mbt_call(&env, &req);
+        CHECK(r->status == 200 && body_has(r, "-1\"</ETag>"),
+              "CompleteMultipartUpload: got %d (want 200, ETag ...-1)",
+              r->status);
+
+        r = simple(&env, EVPL_HTTP_REQUEST_TYPE_GET, "/bk0/mp");
+        CHECK(r->status == 200 && body_is_blocks(r, s3, 1),
+              "assembled object GET failed (%d)", r->status);
+        simple(&env, EVPL_HTTP_REQUEST_TYPE_DELETE, "/bk0/mp");
+    }
+
     /* ---- teardown -------------------------------------------------------- */
 
     s3_mbt_env_fs_teardown(&env, "fs0");

--- a/src/server/s3/tests/quint/s3_mbt_replay.c
+++ b/src/server/s3/tests/quint/s3_mbt_replay.c
@@ -1432,7 +1432,7 @@ op_list_objects(
                         enc);
     }
     if (mode == 3) {
-        off += snprintf(query + off, sizeof(query) - off, "&versions=");
+        snprintf(query + off, sizeof(query) - off, "&versions=");
     }
 
     req.path  = path;
@@ -1749,6 +1749,11 @@ parse_tagset(
             !xml_text_after(cur, "Value", vtext, sizeof(vtext))) {
             mism_add(m, "tagging: malformed <Tag> block");
             break;
+        }
+        if (n < max) {
+            /* an unexpected tag key still fills its slot (with a sentinel
+            * no model tag id uses), so every returned index is defined */
+            ids[n] = -1;
         }
         if (strncmp(ktext, "tk", 2) != 0) {
             mism_add(m, "tagging: unexpected tag key '%s'", ktext);
@@ -2644,12 +2649,14 @@ main(
                         "usage: %s [--trace f.itf.json | --trace-dir dir]\n"
                         "          [--exclude-prefix p] [--block-size n]\n"
                         "          [--sigv2] [--verbose] [--dry-run]\n", argv[0]);
+                mbt_free_traces(traces, ntraces);
                 return 2;
         } /* switch */
     }
 
     if (ntraces == 0) {
         fprintf(stderr, "no traces given (--trace / --trace-dir)\n");
+        mbt_free_traces(traces, ntraces);
         return 2;
     }
 

--- a/src/server/s3/tests/quint/s3_mbt_replay.c
+++ b/src/server/s3/tests/quint/s3_mbt_replay.c
@@ -1,0 +1,1450 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/* Replay Quint-generated S3 traces (ITF JSON) against the in-process chimera
+ * S3 server over HTTP, comparing every response against the model's
+ * expectation.
+ *
+ * Model-to-wire mapping:
+ *  - model bucket names are wire bucket names (path-style addressing);
+ *  - a model key (a list of path components) joins with '/' into the wire
+ *    key;
+ *  - content block symbol s at index i is block_size bytes of 0x40+s at
+ *    offset i * block_size; range requests scale block units by block_size;
+ *  - the model's `status` is the HTTP status line, its `err` the <Code> of
+ *    the XML error body;
+ *  - ETag values are not predicted; the harness learns an object's ETag at
+ *    its last write (Put/Copy) and requires every later read (Get, Head,
+ *    ListObjects <Contents>) to report the same value until the object is
+ *    rewritten or deleted.
+ *
+ * Divergence policy (mirrors nfs3_mbt_replay.c): the model always encodes
+ * the official AWS behavior.  A known, documented divergence of chimera is
+ * listed in the deviation registry below and tolerated -- tolerating skips
+ * the response-shape checks that assume the official status, but still
+ * performs the state bookkeeping (ETag learn/forget) that keeps the replay
+ * in sync.  Anything else is a divergence: the trace fails with a report of
+ * the step, the mismatches, and recent history. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <jansson.h>
+
+#include "s3_mbt_common.h"
+#include "common/mbt_trace_dir.h"
+
+#define MBT_MAX_MISM   16
+#define MBT_MISM_LEN   512
+#define MBT_MAX_KEYLEN 160
+#define MBT_MAX_ETAGS  256
+#define MBT_HIST       10
+
+/* ---- mismatch accumulator ------------------------------------------------ */
+
+struct mism {
+    int  count;
+    char msg[MBT_MAX_MISM][MBT_MISM_LEN];
+};
+
+__attribute__((format(printf, 2, 3)))
+static void
+mism_add(
+    struct mism *m,
+    const char  *fmt,
+    ...)
+{
+    va_list ap;
+
+    if (m->count >= MBT_MAX_MISM) {
+        return;
+    }
+    va_start(ap, fmt);
+    vsnprintf(m->msg[m->count], MBT_MISM_LEN, fmt, ap);
+    va_end(ap);
+    m->count++;
+} /* mism_add */
+
+/* ---- ITF decoding -------------------------------------------------------- */
+
+/* Quint ints arrive as {"#bigint":"N"} (or a bare integer for small models). */
+static int64_t
+itf_i64(json_t *v)
+{
+    json_t *big;
+
+    if (json_is_integer(v)) {
+        return json_integer_value(v);
+    }
+    big = json_object_get(v, "#bigint");
+    if (big && json_is_string(big)) {
+        return strtoll(json_string_value(big), NULL, 10);
+    }
+    fprintf(stderr, "malformed ITF integer\n");
+    exit(2);
+} /* itf_i64 */
+
+static json_t *
+op_field(
+    json_t     *op,
+    const char *name)
+{
+    json_t *v = json_object_get(op, name);
+
+    if (!v) {
+        fprintf(stderr, "op lacks field '%s'\n", name);
+        exit(2);
+    }
+    return v;
+} /* op_field */
+
+static int64_t
+op_i64(
+    json_t     *op,
+    const char *name)
+{
+    return itf_i64(op_field(op, name));
+} /* op_i64 */
+
+static const char *
+op_str(
+    json_t     *op,
+    const char *name)
+{
+    json_t *v = op_field(op, name);
+
+    if (!json_is_string(v)) {
+        fprintf(stderr, "op field '%s' is not a string\n", name);
+        exit(2);
+    }
+    return json_string_value(v);
+} /* op_str */
+
+static int
+op_bool(
+    json_t     *op,
+    const char *name)
+{
+    json_t *v = op_field(op, name);
+
+    if (!json_is_boolean(v)) {
+        fprintf(stderr, "op field '%s' is not a bool\n", name);
+        exit(2);
+    }
+    return json_is_true(v);
+} /* op_bool */
+
+/* The tag of a sum-type field, e.g. op["range"] = {"tag":"RFrom",...}. */
+static const char *
+op_tag(
+    json_t     *op,
+    const char *name)
+{
+    json_t *v   = op_field(op, name);
+    json_t *tag = json_object_get(v, "tag");
+
+    if (!tag || !json_is_string(tag)) {
+        fprintf(stderr, "op field '%s' is not a sum value\n", name);
+        exit(2);
+    }
+    return json_string_value(tag);
+} /* op_tag */
+
+/* A model key (JSON array of component strings) joined with '/'.  The empty
+ * key (the start-after sentinel) renders as "". */
+static void
+key_str(
+    json_t *karr,
+    char   *out,
+    size_t  outlen)
+{
+    size_t i, n = json_array_size(karr);
+    size_t off = 0;
+
+    out[0] = '\0';
+    for (i = 0; i < n; i++) {
+        off += snprintf(out + off, outlen - off, "%s%s", i ? "/" : "",
+                        json_string_value(json_array_get(karr, i)));
+    }
+} /* key_str */
+
+/* A model prefix record ({comps, slash}) rendered as its wire string. */
+static void
+prefix_str(
+    json_t *pfx,
+    char   *out,
+    size_t  outlen)
+{
+    json_t *comps = op_field(pfx, "comps");
+    size_t  off   = 0;
+    size_t  i, n = json_array_size(comps);
+
+    out[0] = '\0';
+    for (i = 0; i < n; i++) {
+        off += snprintf(out + off, outlen - off, "%s/",
+                        json_string_value(json_array_get(comps, i)));
+    }
+    /* comps render "d/e/"; a bare prefix drops the trailing slash */
+    if (!op_bool(pfx, "slash") && off > 0) {
+        out[off - 1] = '\0';
+    }
+} /* prefix_str */
+
+/* Content blocks (JSON array of block symbols) into an int array. */
+static int
+blocks_of(
+    json_t *arr,
+    int    *syms,
+    int     max)
+{
+    int i, n = (int) json_array_size(arr);
+
+    if (n > max) {
+        fprintf(stderr, "trace has %d blocks, harness limit %d\n", n, max);
+        exit(2);
+    }
+    for (i = 0; i < n; i++) {
+        syms[i] = (int) itf_i64(json_array_get(arr, i));
+    }
+    return n;
+} /* blocks_of */
+
+/* Model post-state lookup: the size in blocks of (bucket, key) in the ITF
+ * `bkts` map, or -1 if absent.  bkts = {#map:[[name, {#map:[[comps, blocks]]}]]} */
+static int
+model_size_blocks(
+    json_t     *post_bkts,
+    const char *bucket,
+    const char *key)
+{
+    json_t *outer = json_object_get(post_bkts, "#map");
+    size_t  i, j;
+
+    for (i = 0; i < json_array_size(outer); i++) {
+        json_t *pair = json_array_get(outer, i);
+
+        if (strcmp(json_string_value(json_array_get(pair, 0)), bucket) != 0) {
+            continue;
+        }
+        json_t *inner = json_object_get(json_array_get(pair, 1), "#map");
+        for (j = 0; j < json_array_size(inner); j++) {
+            json_t *kv = json_array_get(inner, j);
+            char    kstr[MBT_MAX_KEYLEN];
+
+            key_str(json_array_get(kv, 0), kstr, sizeof(kstr));
+            if (strcmp(kstr, key) == 0) {
+                return (int) json_array_size(json_array_get(kv, 1));
+            }
+        }
+    }
+    return -1;
+} /* model_size_blocks */
+
+/* ---- deviation registry -------------------------------------------------- */
+
+/* Documented divergences of chimera from official AWS S3 behavior, verified
+ * by s3_mbt_probe.c (which goes red when one stops reproducing -- the signal
+ * to retire its entry here).  A status divergence listed here is tolerated;
+ * everything else fails the trace.  `pred`, when set, must also hold for the
+ * entry to apply. */
+struct deviation {
+    const char *id;
+    const char *op_tag;
+    unsigned    expected;
+    unsigned    actual;
+    int         (*pred)(
+        json_t *op);
+};
+
+/* range-full-200 applies only when the requested range resolves to the whole
+ * object (the model's returned data spans block 0 through the full size). */
+static int
+dev_range_is_full(json_t *op)
+{
+    return op_i64(op, "first") == 0 &&
+           (int64_t) json_array_size(op_field(op, "data")) ==
+           op_i64(op, "total");
+} /* dev_range_is_full */
+
+/* copy-self-200 applies only to a copy of an object onto itself. */
+static int
+dev_copy_is_self(json_t *op)
+{
+    char sk[MBT_MAX_KEYLEN], dk[MBT_MAX_KEYLEN];
+
+    key_str(op_field(op, "srcKey"), sk, sizeof(sk));
+    key_str(op_field(op, "dstKey"), dk, sizeof(dk));
+    return strcmp(op_str(op, "srcBucket"), op_str(op, "dstBucket")) == 0 &&
+           strcmp(sk, dk) == 0;
+} /* dev_copy_is_self */
+
+static const struct deviation known_deviations[] = {
+    /* AWS DeleteObject returns 204 No Content; chimera returns 200 for an
+     * existing key... */
+    { "delete-object-200",          "ODeleteObject",            204,    200, NULL              },
+    /* ...and 404 NoSuchKey for a missing one (AWS is idempotent). */
+    { "delete-object-missing-404",  "ODeleteObject",            204,    404, NULL              },
+    /* AWS answers DELETE on a non-empty bucket with 409 BucketNotEmpty;
+     * chimera maps BUCKET_NOT_EMPTY through its default 500 InternalError. */
+    { "delete-bucket-nonempty-500", "ODeleteBucket",            409,    500, NULL              },
+    /* AWS rejects a copy of an object onto itself (no metadata directive)
+     * with 400 InvalidRequest; chimera performs it and returns 200. */
+    { "copy-self-200",              "OCopyObject",              400,    200, dev_copy_is_self  },
+    /* AWS returns 206 for every satisfiable Range, including one resolving
+    * to the whole object; chimera collapses whole-object ranges to 200. */
+    { "range-full-200",             "OGetObject",               206,    200, dev_range_is_full },
+};
+
+static const struct deviation *
+reconcile(
+    const char *tag,
+    json_t     *op,
+    unsigned    expected,
+    unsigned    actual)
+{
+    size_t i;
+
+    for (i = 0; i < sizeof(known_deviations) / sizeof(known_deviations[0]);
+         i++) {
+        const struct deviation *d = &known_deviations[i];
+
+        if (strcmp(d->op_tag, tag) == 0 && d->expected == expected &&
+            d->actual == actual && (!d->pred || d->pred(op))) {
+            return d;
+        }
+    }
+    return NULL;
+} /* reconcile */
+
+/* ---- oracle -------------------------------------------------------------- */
+
+struct etag_ent {
+    int  used;
+    char bucket[80];
+    char key[MBT_MAX_KEYLEN];
+    char etag[160];
+};
+
+struct hist_ent {
+    int  idx;
+    char tag[32];
+    int  status;
+    char op_dump[512];
+};
+
+struct oracle {
+    struct s3_mbt_env *env;
+    int                block_size;
+    int                verbose;
+    struct etag_ent    etags[MBT_MAX_ETAGS];
+    struct hist_ent    history[MBT_HIST];
+    int                hist_len;
+    uint8_t           *expect_buf;   /* expected-body scratch */
+    char              *xml_buf;      /* NUL-terminated response body copy */
+};
+
+static struct etag_ent *
+etag_find(
+    struct oracle *o,
+    const char    *bucket,
+    const char    *key)
+{
+    int i;
+
+    for (i = 0; i < MBT_MAX_ETAGS; i++) {
+        if (o->etags[i].used && strcmp(o->etags[i].bucket, bucket) == 0 &&
+            strcmp(o->etags[i].key, key) == 0) {
+            return &o->etags[i];
+        }
+    }
+    return NULL;
+} /* etag_find */
+
+static void
+etag_learn(
+    struct oracle *o,
+    const char    *bucket,
+    const char    *key,
+    const char    *etag)
+{
+    struct etag_ent *e = etag_find(o, bucket, key);
+    int              i;
+
+    if (!e) {
+        for (i = 0; i < MBT_MAX_ETAGS; i++) {
+            if (!o->etags[i].used) {
+                e = &o->etags[i];
+                break;
+            }
+        }
+        if (!e) {
+            fprintf(stderr, "harness limit: more than %d live ETags; raise "
+                    "MBT_MAX_ETAGS\n", MBT_MAX_ETAGS);
+            exit(3);
+        }
+        e->used = 1;
+        snprintf(e->bucket, sizeof(e->bucket), "%s", bucket);
+        snprintf(e->key, sizeof(e->key), "%s", key);
+    }
+    snprintf(e->etag, sizeof(e->etag), "%s", etag);
+} /* etag_learn */
+
+static void
+etag_forget(
+    struct oracle *o,
+    const char    *bucket,
+    const char    *key)
+{
+    struct etag_ent *e = etag_find(o, bucket, key);
+
+    if (e) {
+        e->used = 0;
+    }
+} /* etag_forget */
+
+/* An ETag reported for (bucket, key) must be well-formed (quoted) and match
+ * the one learned at the object's last write. */
+static void
+etag_check(
+    struct oracle *o,
+    const char    *bucket,
+    const char    *key,
+    const char    *etag,
+    const char    *what,
+    struct mism   *m)
+{
+    struct etag_ent *e;
+    size_t           n = strlen(etag);
+
+    if (n < 2 || etag[0] != '"' || etag[n - 1] != '"') {
+        mism_add(m, "%s: ETag '%s' for %s/%s is not a quoted string",
+                 what, etag, bucket, key);
+        return;
+    }
+    e = etag_find(o, bucket, key);
+    if (!e) {
+        /* first sighting (e.g. the write's own response): learn */
+        etag_learn(o, bucket, key, etag);
+        return;
+    }
+    if (strcmp(e->etag, etag) != 0) {
+        mism_add(m, "%s: ETag for %s/%s changed without a write: learned %s, "
+                 "got %s", what, bucket, key, e->etag, etag);
+    }
+} /* etag_check */
+
+/* ---- status comparison --------------------------------------------------- */
+
+enum st_result {
+    ST_MATCH,
+    ST_TOLERATED,
+    ST_MISMATCH,
+};
+
+static enum st_result
+check_status(
+    struct oracle *o,
+    const char    *tag,
+    json_t        *op,
+    unsigned       expected,
+    unsigned       actual,
+    struct mism   *m)
+{
+    const struct deviation *d;
+
+    if (expected == actual) {
+        return ST_MATCH;
+    }
+    d = reconcile(tag, op, expected, actual);
+    if (d) {
+        if (o->verbose) {
+            fprintf(stderr, "  (deviation %s: %s expected %u, got %u)\n",
+                    d->id, tag, expected, actual);
+        }
+        return ST_TOLERATED;
+    }
+    mism_add(m, "status: expected %u, got %u", expected, actual);
+    return ST_MISMATCH;
+} /* check_status */
+
+/* ---- XML response parsing ------------------------------------------------ */
+
+/* NUL-terminate the response body into o->xml_buf and return it. */
+static const char *
+resp_xml(
+    struct oracle            *o,
+    const struct s3_mbt_resp *res)
+{
+    memcpy(o->xml_buf, res->body, res->body_len);
+    o->xml_buf[res->body_len] = '\0';
+    if (strlen(o->xml_buf) != res->body_len) {
+        /* an embedded NUL would silently truncate every check */
+        fprintf(stderr, "response body contains NUL\n");
+        exit(3);
+    }
+    return o->xml_buf;
+} /* resp_xml */
+
+/* Extract the text of the first <elem> after `from` (a scan cursor into an
+ * XML document); returns the position after the element, or NULL if absent.
+ * Real XML parsing is not needed: the harness's keys and bucket names are
+ * [a-z/] only and the server pretty-prints one element per line. */
+static const char *
+xml_text_after(
+    const char *from,
+    const char *elem,
+    char       *out,
+    size_t      outlen)
+{
+    char        open_tag[64], close_tag[64];
+    const char *s, *e;
+    size_t      n;
+
+    snprintf(open_tag, sizeof(open_tag), "<%s>", elem);
+    snprintf(close_tag, sizeof(close_tag), "</%s>", elem);
+
+    s = strstr(from, open_tag);
+    if (!s) {
+        return NULL;
+    }
+    s += strlen(open_tag);
+    e  = strstr(s, close_tag);
+    if (!e) {
+        return NULL;
+    }
+    n = (size_t) (e - s);
+    if (n >= outlen) {
+        n = outlen - 1;
+    }
+    memcpy(out, s, n);
+    out[n] = '\0';
+    return e + strlen(close_tag);
+} /* xml_text_after */
+
+/* The <Code> of an XML error body ("" if none). */
+static void
+resp_error_code(
+    struct oracle            *o,
+    const struct s3_mbt_resp *res,
+    char                     *out,
+    size_t                    outlen)
+{
+    out[0] = '\0';
+    xml_text_after(resp_xml(o, res), "Code", out, outlen);
+} /* resp_error_code */
+
+/* Compare the XML error body's <Code> against the model's err field.  Only
+ * meaningful when expected == actual (a tolerated deviation's body carries
+ * the server's own code, not the model's). */
+static void
+check_error_code(
+    struct oracle            *o,
+    const struct s3_mbt_resp *res,
+    json_t                   *op,
+    struct mism              *m)
+{
+    const char *want = op_str(op, "err");
+    char        got[64];
+
+    resp_error_code(o, res, got, sizeof(got));
+    if (strcmp(want, got) != 0) {
+        mism_add(m, "error <Code>: expected '%s', got '%s'", want, got);
+    }
+} /* check_error_code */
+
+/* ---- request/response helpers ------------------------------------------- */
+
+static void
+build_path(
+    json_t     *op,
+    const char *bucket_field,
+    const char *key_field,
+    char       *out,
+    size_t      outlen)
+{
+    char key[MBT_MAX_KEYLEN];
+
+    if (key_field) {
+        key_str(op_field(op, key_field), key, sizeof(key));
+        snprintf(out, outlen, "/%s/%s", op_str(op, bucket_field), key);
+    } else {
+        snprintf(out, outlen, "/%s", op_str(op, bucket_field));
+    }
+} /* build_path */
+
+/* Expected body for a block list; returns the byte length. */
+static size_t
+expect_body(
+    struct oracle            *o,
+    json_t                   *data,
+    struct mism              *m,
+    const struct s3_mbt_resp *res,
+    const char               *what)
+{
+    int    syms[64];
+    int    n   = blocks_of(data, syms, 64);
+    size_t len = (size_t) n * o->block_size;
+
+    s3_mbt_expand_blocks(syms, n, o->block_size, o->expect_buf);
+
+    if (res->body_len != len) {
+        mism_add(m, "%s: body length %zu, expected %zu", what, res->body_len,
+                 len);
+    } else if (len && memcmp(res->body, o->expect_buf, len) != 0) {
+        size_t i;
+
+        for (i = 0; i < len && res->body[i] == o->expect_buf[i]; i++) {
+        }
+        mism_add(m, "%s: body differs at offset %zu (got 0x%02x, expected "
+                 "0x%02x)", what, i, res->body[i], o->expect_buf[i]);
+    }
+    return len;
+} /* expect_body */
+
+/* ---- per-op handlers ----------------------------------------------------- */
+
+typedef void (*op_handler_t)(
+    struct oracle *,
+    json_t *op,
+    json_t *post_bkts,
+    struct mism *);
+
+static void
+op_create_bucket(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[128];
+    char                want_loc[144];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_PUT };
+    struct s3_mbt_resp *res;
+
+    (void) post_bkts;
+    build_path(op, "bucket", NULL, path, sizeof(path));
+    req.path = path;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OCreateBucket", op, (unsigned) op_i64(op, "status"),
+                     (unsigned) res->status, m) != ST_MATCH) {
+        return;
+    }
+    snprintf(want_loc, sizeof(want_loc), "%s", path);
+    if (strcmp(res->location, want_loc) != 0) {
+        mism_add(m, "CreateBucket Location: expected '%s', got '%s'",
+                 want_loc, res->location);
+    }
+} /* op_create_bucket */
+
+static void
+op_head_bucket(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[128];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_HEAD };
+    struct s3_mbt_resp *res;
+
+    (void) post_bkts;
+    build_path(op, "bucket", NULL, path, sizeof(path));
+    req.path = path;
+
+    res = s3_mbt_call(o->env, &req);
+
+    check_status(o, "OHeadBucket", op, (unsigned) op_i64(op, "status"),
+                 (unsigned) res->status, m);
+    if (res->body_len != 0) {
+        mism_add(m, "HeadBucket returned a body (%zu bytes)", res->body_len);
+    }
+} /* op_head_bucket */
+
+static void
+op_delete_bucket(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[128];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_DELETE };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+
+    (void) post_bkts;
+    build_path(op, "bucket", NULL, path, sizeof(path));
+    req.path = path;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "ODeleteBucket", op, expected,
+                     (unsigned) res->status, m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 204) {
+        check_error_code(o, res, op, m);
+    }
+} /* op_delete_bucket */
+
+static void
+op_list_buckets(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_GET,
+                                .path   = "/" };
+    struct s3_mbt_resp *res;
+    json_t             *want = json_object_get(op_field(op, "buckets"), "#set");
+    const char         *cur;
+    char                name[80];
+    char                got[16][80];
+    int                 ngot = 0;
+    size_t              i;
+    int                 j;
+
+    (void) post_bkts;
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OListBuckets", op, (unsigned) op_i64(op, "status"),
+                     (unsigned) res->status, m) != ST_MATCH) {
+        return;
+    }
+
+    /* Collect every <Bucket><Name>; compared as a set -- AWS documents no
+     * ordering contract for ListBuckets (and the server iterates a hash). */
+    cur = resp_xml(o, res);
+    while ((cur = strstr(cur, "<Bucket>")) != NULL) {
+        cur = xml_text_after(cur, "Name", name, sizeof(name));
+        if (!cur) {
+            break;
+        }
+        if (ngot < 16) {
+            snprintf(got[ngot], sizeof(got[ngot]), "%s", name);
+        }
+        ngot++;
+    }
+
+    if ((size_t) ngot != json_array_size(want)) {
+        mism_add(m, "ListBuckets: %d buckets, expected %zu", ngot,
+                 json_array_size(want));
+        return;
+    }
+    for (i = 0; i < json_array_size(want); i++) {
+        const char *w     = json_string_value(json_array_get(want, i));
+        int         found = 0;
+
+        for (j = 0; j < ngot; j++) {
+            if (strcmp(got[j], w) == 0) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            mism_add(m, "ListBuckets: bucket '%s' missing from response", w);
+        }
+    }
+} /* op_list_buckets */
+
+static void
+op_put_object(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                bucket[80], key[MBT_MAX_KEYLEN];
+    int                 syms[64];
+    int                 n;
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_PUT };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    enum st_result      st;
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    key_str(op_field(op, "key"), key, sizeof(key));
+    build_path(op, "bucket", "key", path, sizeof(path));
+
+    n = blocks_of(op_field(op, "data"), syms, 64);
+    s3_mbt_expand_blocks(syms, n, o->block_size, o->expect_buf);
+
+    req.path     = path;
+    req.body     = o->expect_buf;
+    req.body_len = (size_t) n * o->block_size;
+
+    res = s3_mbt_call(o->env, &req);
+
+    st = check_status(o, "OPutObject", op, expected, (unsigned) res->status, m);
+
+    /* A successful write (whatever its exact 2xx shape) re-keys the ETag. */
+    if (res->status >= 200 && res->status < 300 && expected == 200) {
+        etag_forget(o, bucket, key);
+        etag_check(o, bucket, key, res->etag, "PutObject", m);
+    }
+    if (st == ST_MATCH && expected == 404) {
+        check_error_code(o, res, op, m);
+    }
+} /* op_put_object */
+
+static void
+op_get_object(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                bucket[80], key[MBT_MAX_KEYLEN];
+    char                range_hdr[80];
+    char                want_cr[96];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_GET };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    const char         *rtag     = op_tag(op, "range");
+    json_t             *rval     = json_object_get(op_field(op, "range"), "value");
+    int64_t             bs       = o->block_size;
+    enum st_result      st;
+    size_t              got_len;
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    key_str(op_field(op, "key"), key, sizeof(key));
+    build_path(op, "bucket", "key", path, sizeof(path));
+    req.path = path;
+
+    if (strcmp(rtag, "RClosed") == 0) {
+        snprintf(range_hdr, sizeof(range_hdr),
+                 "bytes=%" PRId64 "-%" PRId64,
+                 itf_i64(json_object_get(rval, "first")) * bs,
+                 (itf_i64(json_object_get(rval, "last")) + 1) * bs - 1);
+        req.range = range_hdr;
+    } else if (strcmp(rtag, "RFrom") == 0) {
+        snprintf(range_hdr, sizeof(range_hdr), "bytes=%" PRId64 "-",
+                 itf_i64(rval) * bs);
+        req.range = range_hdr;
+    } else if (strcmp(rtag, "RSuffix") == 0) {
+        snprintf(range_hdr, sizeof(range_hdr), "bytes=-%" PRId64,
+                 itf_i64(rval) * bs);
+        req.range = range_hdr;
+    }
+
+    res = s3_mbt_call(o->env, &req);
+
+    st = check_status(o, "OGetObject", op, expected, (unsigned) res->status, m);
+    if (st == ST_MISMATCH) {
+        return;
+    }
+
+    if (expected == 200 || expected == 206) {
+        got_len = expect_body(o, op_field(op, "data"), m, res, "GetObject");
+        if (res->has_content_length &&
+            res->content_length != (int64_t) got_len) {
+            mism_add(m, "GetObject Content-Length %" PRId64 ", body %zu",
+                     res->content_length, got_len);
+        }
+        etag_check(o, bucket, key, res->etag, "GetObject", m);
+        /* On a tolerated whole-object 200 (range-full-200) there is no
+        * Content-Range; only an exact 206 must carry the right one. */
+        if (st == ST_MATCH && expected == 206) {
+            snprintf(want_cr, sizeof(want_cr),
+                     "bytes %" PRId64 "-%" PRId64 "/%" PRId64,
+                     op_i64(op, "first") * bs,
+                     op_i64(op, "first") * bs + (int64_t) got_len - 1,
+                     op_i64(op, "total") * bs);
+            if (strcmp(res->content_range, want_cr) != 0) {
+                mism_add(m, "GetObject Content-Range: expected '%s', got '%s'",
+                         want_cr, res->content_range);
+            }
+        }
+    } else if (expected == 416 && st == ST_MATCH) {
+        snprintf(want_cr, sizeof(want_cr), "bytes */%" PRId64,
+                 op_i64(op, "total") * bs);
+        if (strcmp(res->content_range, want_cr) != 0) {
+            mism_add(m, "416 Content-Range: expected '%s', got '%s'",
+                     want_cr, res->content_range);
+        }
+        check_error_code(o, res, op, m);
+    } else if (expected == 404 && st == ST_MATCH) {
+        check_error_code(o, res, op, m);
+    }
+} /* op_get_object */
+
+static void
+op_head_object(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                bucket[80], key[MBT_MAX_KEYLEN];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_HEAD };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    key_str(op_field(op, "key"), key, sizeof(key));
+    build_path(op, "bucket", "key", path, sizeof(path));
+    req.path = path;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OHeadObject", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (res->body_len != 0) {
+        mism_add(m, "HeadObject returned a body (%zu bytes)", res->body_len);
+    }
+    if (expected == 200) {
+        int64_t want = op_i64(op, "sizeBlocks") * o->block_size;
+
+        if (!res->has_content_length || res->content_length != want) {
+            mism_add(m, "HeadObject Content-Length: expected %" PRId64
+                     ", got %" PRId64, want,
+                     res->has_content_length ? res->content_length : -1);
+        }
+        etag_check(o, bucket, key, res->etag, "HeadObject", m);
+    }
+} /* op_head_object */
+
+static void
+op_delete_object(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                bucket[80], key[MBT_MAX_KEYLEN];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_DELETE };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    enum st_result      st;
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    key_str(op_field(op, "key"), key, sizeof(key));
+    build_path(op, "bucket", "key", path, sizeof(path));
+    req.path = path;
+
+    res = s3_mbt_call(o->env, &req);
+
+    st = check_status(o, "ODeleteObject", op, expected, (unsigned) res->status,
+                      m);
+
+    /* The object is gone (or never was) whenever the bucket existed --
+     * whichever of 204/200/404 came back; drop the learned ETag. */
+    if (expected == 204) {
+        etag_forget(o, bucket, key);
+    }
+    if (st == ST_MATCH && expected == 404) {
+        check_error_code(o, res, op, m);
+    }
+} /* op_delete_object */
+
+static void
+op_copy_object(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                src[MBT_MAX_KEYLEN + 96];
+    char                sb[80], db[80], sk[MBT_MAX_KEYLEN], dk[MBT_MAX_KEYLEN];
+    char                etag[160];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_PUT };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    enum st_result      st;
+
+    (void) post_bkts;
+    snprintf(sb, sizeof(sb), "%s", op_str(op, "srcBucket"));
+    snprintf(db, sizeof(db), "%s", op_str(op, "dstBucket"));
+    key_str(op_field(op, "srcKey"), sk, sizeof(sk));
+    key_str(op_field(op, "dstKey"), dk, sizeof(dk));
+
+    build_path(op, "dstBucket", "dstKey", path, sizeof(path));
+    snprintf(src, sizeof(src), "/%s/%s", sb, sk);
+
+    req.path        = path;
+    req.copy_source = src;
+
+    res = s3_mbt_call(o->env, &req);
+
+    st = check_status(o, "OCopyObject", op, expected, (unsigned) res->status,
+                      m);
+
+    if (res->status == 200 && (expected == 200 || st == ST_TOLERATED)) {
+        /* the destination was (re)written: its ETag is whatever
+         * <CopyObjectResult><ETag> reports */
+        etag_forget(o, db, dk);
+        if (xml_text_after(resp_xml(o, res), "ETag", etag, sizeof(etag))) {
+            etag_check(o, db, dk, etag, "CopyObject", m);
+        } else if (st == ST_MATCH) {
+            mism_add(m, "CopyObject: response lacks <ETag>");
+        }
+        if (st == ST_MATCH &&
+            !strstr(o->xml_buf, "<CopyObjectResult")) {
+            mism_add(m, "CopyObject: response lacks <CopyObjectResult>");
+        }
+    }
+    if (st == ST_MATCH && (expected == 404 || expected == 400)) {
+        check_error_code(o, res, op, m);
+    }
+} /* op_copy_object */
+
+/* Percent-encode a query value the way the AWS SDKs do.  Harness values
+ * are [a-z/] only, so '/' -> %2F is the whole alphabet. */
+static void
+qenc(
+    const char *src,
+    char       *dst,
+    size_t      dstlen)
+{
+    size_t off = 0;
+
+    for (; *src && off + 4 < dstlen; src++) {
+        if (*src == '/') {
+            off += snprintf(dst + off, dstlen - off, "%%2F");
+        } else {
+            dst[off++] = *src;
+        }
+    }
+    dst[off] = '\0';
+} /* qenc */
+
+static void
+op_list_objects(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[128];
+    char                query[512];
+    char                pfx[MBT_MAX_KEYLEN], sa[MBT_MAX_KEYLEN];
+    char                bucket[80];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_GET };
+    struct s3_mbt_resp *res;
+    unsigned            expected  = (unsigned) op_i64(op, "status");
+    int                 delim     = op_bool(op, "delim");
+    json_t             *want_keys = op_field(op, "keys");
+    json_t             *want_pfxs = op_field(op, "prefixes");
+    size_t              off       = 0;
+    const char         *cur;
+    int                 nkeys = 0, npfx = 0;
+    char                text[MBT_MAX_KEYLEN];
+    char                itrunc[16], kcount[16];
+
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    build_path(op, "bucket", NULL, path, sizeof(path));
+    prefix_str(op_field(op, "prefix"), pfx, sizeof(pfx));
+    key_str(op_field(op, "startAfter"), sa, sizeof(sa));
+
+    /* params in byte order, values percent-encoded the way the SDKs send
+     * them, matching the harness's sign-what-you-send contract */
+    if (delim) {
+        off += snprintf(query + off, sizeof(query) - off, "delimiter=%%2F&");
+    }
+    off += snprintf(query + off, sizeof(query) - off, "list-type=2&max-keys=%"
+                    PRId64, op_i64(op, "maxKeys"));
+    if (pfx[0]) {
+        char enc[2 * MBT_MAX_KEYLEN];
+
+        qenc(pfx, enc, sizeof(enc));
+        off += snprintf(query + off, sizeof(query) - off, "&prefix=%s", enc);
+    }
+    if (sa[0]) {
+        char enc[2 * MBT_MAX_KEYLEN];
+
+        qenc(sa, enc, sizeof(enc));
+        off += snprintf(query + off, sizeof(query) - off, "&start-after=%s",
+                        enc);
+    }
+
+    req.path  = path;
+    req.query = query;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OListObjects", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected == 404) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+
+    /* Walk the <Contents> blocks in order: keys, sizes, ETags. */
+    cur = resp_xml(o, res);
+    while ((cur = strstr(cur, "<Contents>")) != NULL) {
+        const char *blk_end = strstr(cur, "</Contents>");
+        const char *p;
+        char        size_txt[32];
+        char        etag_txt[160];
+
+        p = xml_text_after(cur, "Key", text, sizeof(text));
+        if (!p || (blk_end && p > blk_end + strlen("</Contents>"))) {
+            mism_add(m, "ListObjects: malformed <Contents> block");
+            break;
+        }
+        if (nkeys < (int) json_array_size(want_keys)) {
+            char want[MBT_MAX_KEYLEN];
+
+            key_str(json_array_get(want_keys, nkeys), want, sizeof(want));
+            if (strcmp(want, text) != 0) {
+                mism_add(m, "ListObjects: key[%d] = '%s', expected '%s'",
+                         nkeys, text, want);
+            }
+        }
+        /* every listed object's Size and ETag must agree with the model
+         * post-state / the ETag learned at its last write */
+        if (xml_text_after(cur, "Size", size_txt, sizeof(size_txt))) {
+            int mb = model_size_blocks(post_bkts, bucket, text);
+
+            if (mb >= 0 &&
+                strtoll(size_txt, NULL, 10) !=
+                (int64_t) mb * o->block_size) {
+                mism_add(m, "ListObjects: %s Size %s, model %d blocks", text,
+                         size_txt, mb);
+            }
+        }
+        if (xml_text_after(cur, "ETag", etag_txt, sizeof(etag_txt))) {
+            etag_check(o, bucket, text, etag_txt, "ListObjects", m);
+        }
+        nkeys++;
+        cur += strlen("<Contents>");
+    }
+
+    /* Then the <CommonPrefixes> blocks, in order. */
+    cur = resp_xml(o, res);
+    while ((cur = strstr(cur, "<CommonPrefixes>")) != NULL) {
+        if (!xml_text_after(cur, "Prefix", text, sizeof(text))) {
+            mism_add(m, "ListObjects: malformed <CommonPrefixes> block");
+            break;
+        }
+        if (npfx < (int) json_array_size(want_pfxs)) {
+            char want[MBT_MAX_KEYLEN];
+
+            key_str(json_array_get(want_pfxs, npfx), want, sizeof(want));
+            /* a common prefix always renders with a trailing slash */
+            strncat(want, "/", sizeof(want) - strlen(want) - 1);
+            if (strcmp(want, text) != 0) {
+                mism_add(m, "ListObjects: prefix[%d] = '%s', expected '%s'",
+                         npfx, text, want);
+            }
+        }
+        npfx++;
+        cur += strlen("<CommonPrefixes>");
+    }
+
+    if (nkeys != (int) json_array_size(want_keys)) {
+        mism_add(m, "ListObjects: %d keys, expected %zu", nkeys,
+                 json_array_size(want_keys));
+    }
+    if (npfx != (int) json_array_size(want_pfxs)) {
+        mism_add(m, "ListObjects: %d common prefixes, expected %zu", npfx,
+                 json_array_size(want_pfxs));
+    }
+
+    /* IsTruncated and KeyCount (v2 counts both sections). */
+    itrunc[0] = '\0';
+    xml_text_after(o->xml_buf, "IsTruncated", itrunc, sizeof(itrunc));
+    if (strcmp(itrunc, op_bool(op, "truncated") ? "true" : "false") != 0) {
+        mism_add(m, "ListObjects: IsTruncated '%s', expected '%s'", itrunc,
+                 op_bool(op, "truncated") ? "true" : "false");
+    }
+    kcount[0] = '\0';
+    if (xml_text_after(o->xml_buf, "KeyCount", kcount, sizeof(kcount))) {
+        int want = (int) (json_array_size(want_keys) +
+                          json_array_size(want_pfxs));
+
+        if (atoi(kcount) != want) {
+            mism_add(m, "ListObjects: KeyCount %s, expected %d", kcount, want);
+        }
+    } else {
+        mism_add(m, "ListObjects: response lacks <KeyCount>");
+    }
+} /* op_list_objects */
+
+/* ---- dispatch ------------------------------------------------------------ */
+
+static const struct {
+    const char  *tag;
+    op_handler_t fn;
+} handlers[] = {
+    { "OCreateBucket", op_create_bucket       },
+    { "OHeadBucket",   op_head_bucket         },
+    { "ODeleteBucket", op_delete_bucket       },
+    { "OListBuckets",  op_list_buckets        },
+    { "OPutObject",    op_put_object          },
+    { "OGetObject",    op_get_object          },
+    { "OHeadObject",   op_head_object         },
+    { "ODeleteObject", op_delete_object       },
+    { "OCopyObject",   op_copy_object         },
+    { "OListObjects",  op_list_objects        },
+};
+
+static op_handler_t
+find_handler(const char *tag)
+{
+    size_t i;
+
+    for (i = 0; i < sizeof(handlers) / sizeof(handlers[0]); i++) {
+        if (strcmp(handlers[i].tag, tag) == 0) {
+            return handlers[i].fn;
+        }
+    }
+    return NULL;
+} /* find_handler */
+
+/* ---- history + divergence report ---------------------------------------- */
+
+static void
+history_push(
+    struct oracle *o,
+    int            idx,
+    const char    *tag,
+    int            status,
+    json_t        *op)
+{
+    struct hist_ent *h;
+    char            *dump;
+
+    if (o->hist_len == MBT_HIST) {
+        memmove(&o->history[0], &o->history[1],
+                sizeof(o->history[0]) * (MBT_HIST - 1));
+        o->hist_len--;
+    }
+    h         = &o->history[o->hist_len++];
+    h->idx    = idx;
+    h->status = status;
+    snprintf(h->tag, sizeof(h->tag), "%s", tag);
+    dump = json_dumps(op, JSON_COMPACT | JSON_SORT_KEYS);
+    snprintf(h->op_dump, sizeof(h->op_dump), "%s", dump ? dump : "?");
+    free(dump);
+} /* history_push */
+
+static void
+report_divergence(
+    struct oracle *o,
+    const char    *trace_path,
+    int            idx,
+    const char    *tag,
+    json_t        *op,
+    struct mism   *m)
+{
+    char *dump = json_dumps(op, JSON_COMPACT | JSON_SORT_KEYS);
+    int   i;
+
+    fprintf(stderr, "\n=== DIVERGENCE in %s ===\n", trace_path);
+    fprintf(stderr, "step %d: %s %s\n", idx, tag, dump ? dump : "?");
+    free(dump);
+
+    for (i = 0; i < m->count; i++) {
+        fprintf(stderr, "  MISMATCH: %s\n", m->msg[i]);
+    }
+
+    fprintf(stderr, "last %d ops:\n", o->hist_len);
+    for (i = 0; i < o->hist_len; i++) {
+        fprintf(stderr, "  [%d] %s -> %d  %s\n", o->history[i].idx,
+                o->history[i].tag, o->history[i].status,
+                o->history[i].op_dump);
+    }
+} /* report_divergence */
+
+/* ---- trace driver -------------------------------------------------------- */
+
+static int
+run_trace(
+    struct s3_mbt_env *env,
+    const char        *trace_path,
+    const char        *fsname,
+    int                block_size,
+    int                verbose,
+    int                dry_run)
+{
+    json_error_t   jerr;
+    json_t        *trace, *states;
+    struct oracle *o;
+    int            rc = 0;
+    size_t         idx, nstates;
+
+    trace = json_load_file(trace_path, 0, &jerr);
+    if (!trace) {
+        fprintf(stderr, "%s: JSON parse error: %s (line %d)\n", trace_path,
+                jerr.text, jerr.line);
+        return 1;
+    }
+
+    states = json_object_get(trace, "states");
+    if (!states || !json_is_array(states) ||
+        !json_object_get(trace, "vars")) {
+        fprintf(stderr, "%s: not an ITF trace\n", trace_path);
+        json_decref(trace);
+        return 1;
+    }
+    nstates = json_array_size(states);
+
+    if (dry_run) {
+        printf("%s: %zu steps\n", trace_path, nstates - 1);
+        json_decref(trace);
+        return 0;
+    }
+
+    /* Everything runs in one process, so a request the server never answers
+     * would spin in s3_mbt_call forever; SIGALRM's default disposition kills
+     * the test with the trace name already printed. */
+    alarm(120);
+
+    if (verbose) {
+        printf("%s: %zu steps\n", trace_path, nstates - 1);
+    }
+
+    s3_mbt_env_fs_setup(env, fsname);
+
+    o             = calloc(1, sizeof(*o));
+    o->env        = env;
+    o->block_size = block_size;
+    o->verbose    = verbose;
+    o->expect_buf = malloc((size_t) 64 * block_size);
+    o->xml_buf    = malloc(S3_MBT_BODY_MAX + 1);
+
+    for (idx = 1; idx < nstates; idx++) {
+        json_t      *state     = json_array_get(states, idx);
+        json_t      *last_op   = json_object_get(state, "lastOp");
+        json_t      *post_bkts = json_object_get(state, "bkts");
+        const char  *tag;
+        json_t      *op;
+        op_handler_t fn;
+        struct mism  m;
+
+        if (!last_op || !post_bkts) {
+            fprintf(stderr, "%s: state %zu lacks lastOp/bkts\n", trace_path,
+                    idx);
+            rc = 1;
+            break;
+        }
+        tag = json_string_value(json_object_get(last_op, "tag"));
+        op  = json_object_get(last_op, "value");
+
+        fn = find_handler(tag);
+        if (!fn) {
+            fprintf(stderr, "%s: state %zu has unknown op '%s'\n", trace_path,
+                    idx, tag);
+            rc = 1;
+            break;
+        }
+
+        memset(&m, 0, sizeof(m));
+        fn(o, op, post_bkts, &m);
+        history_push(o, (int) idx, tag, env->res.status, op);
+
+        if (m.count) {
+            report_divergence(o, trace_path, (int) idx, tag, op, &m);
+            rc = 1;
+            break;
+        }
+    }
+
+    s3_mbt_env_fs_teardown(env, fsname);
+
+    free(o->expect_buf);
+    free(o->xml_buf);
+    free(o);
+    json_decref(trace);
+    alarm(0);
+
+    return rc;
+} /* run_trace */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    static struct option long_options[] = {
+        { "trace",          required_argument,          0,                          't'       },
+        { "trace-dir",      required_argument,          0,                          'D'       },
+        { "exclude-prefix", required_argument,          0,                          'X'       },
+        { "block-size",     required_argument,          0,                          'b'       },
+        { "verbose",        no_argument,                0,                          'v'       },
+        { "dry-run",        no_argument,                0,                          'n'       },
+        { 0,                0,                          0,                          0         }
+    };
+    struct s3_mbt_env    env;
+    char               **traces;
+    int                  ntraces;
+    int                  block_size = 8192;
+    int                  verbose = 0, dry_run = 0;
+    int                  failures = 0;
+    int                  i, c;
+
+    /* mbt_collect_traces scans raw argv for the trace options; getopt then
+     * only needs to recognize the rest. */
+    traces = mbt_collect_traces(argc, argv, &ntraces);
+
+    while ((c = getopt_long(argc, argv, "t:D:X:b:vn", long_options,
+                            NULL)) != -1) {
+        switch (c) {
+            case 't':
+            case 'D':
+            case 'X':
+                break;
+            case 'b':
+                block_size = atoi(optarg);
+                break;
+            case 'v':
+                verbose = 1;
+                break;
+            case 'n':
+                dry_run = 1;
+                break;
+            default:
+                fprintf(stderr,
+                        "usage: %s [--trace f.itf.json | --trace-dir dir]\n"
+                        "          [--exclude-prefix p] [--block-size n]\n"
+                        "          [--verbose] [--dry-run]\n", argv[0]);
+                return 2;
+        } /* switch */
+    }
+
+    if (ntraces == 0) {
+        fprintf(stderr, "no traces given (--trace / --trace-dir)\n");
+        return 2;
+    }
+
+    s3_mbt_env_open(&env);
+
+    for (i = 0; i < ntraces; i++) {
+        char fsname[32];
+
+        snprintf(fsname, sizeof(fsname), "fs_%d", i);
+        failures += run_trace(&env, traces[i], fsname, block_size, verbose,
+                              dry_run);
+    }
+
+    s3_mbt_env_stop(&env);
+    mbt_free_traces(traces, ntraces);
+
+    if (failures) {
+        fprintf(stderr, "%d trace(s) diverged\n", failures);
+        return 1;
+    }
+
+    printf("%d trace(s) replayed with no divergence\n", ntraces);
+    return 0;
+} /* main */

--- a/src/server/s3/tests/quint/s3_mbt_replay.c
+++ b/src/server/s3/tests/quint/s3_mbt_replay.c
@@ -212,36 +212,158 @@ blocks_of(
     return n;
 } /* blocks_of */
 
-/* Model post-state lookup: the size in blocks of (bucket, key) in the ITF
- * `bkts` map, or -1 if absent.  bkts = {#map:[[name, {#map:[[comps, blocks]]}]]} */
+/* Model post-state navigation.  bkts = {#map:[[name, Bkt]]} where Bkt =
+ * { objs: {#map:[[comps, Obj]]}, btags: {#set}, mpu: {#map:[[id, Mpu]]} },
+ * Obj = { data: [...], mtag, tags: {#set} }, Mpu = { key, parts: {#map} }. */
+
+static json_t *
+model_bucket(
+    json_t     *post_bkts,
+    const char *bucket)
+{
+    json_t *outer = json_object_get(post_bkts, "#map");
+    size_t  i;
+
+    for (i = 0; i < json_array_size(outer); i++) {
+        json_t *pair = json_array_get(outer, i);
+
+        if (strcmp(json_string_value(json_array_get(pair, 0)), bucket) == 0) {
+            return json_array_get(pair, 1);
+        }
+    }
+    return NULL;
+} /* model_bucket */
+
+/* The post-state Obj record of (bucket, key), or NULL. */
+static json_t *
+model_obj(
+    json_t     *post_bkts,
+    const char *bucket,
+    const char *key)
+{
+    json_t *bk = model_bucket(post_bkts, bucket);
+    json_t *inner;
+    size_t  j;
+
+    if (!bk) {
+        return NULL;
+    }
+    inner = json_object_get(json_object_get(bk, "objs"), "#map");
+    for (j = 0; j < json_array_size(inner); j++) {
+        json_t *kv = json_array_get(inner, j);
+        char    kstr[MBT_MAX_KEYLEN];
+
+        key_str(json_array_get(kv, 0), kstr, sizeof(kstr));
+        if (strcmp(kstr, key) == 0) {
+            return json_array_get(kv, 1);
+        }
+    }
+    return NULL;
+} /* model_obj */
+
 static int
 model_size_blocks(
     json_t     *post_bkts,
     const char *bucket,
     const char *key)
 {
-    json_t *outer = json_object_get(post_bkts, "#map");
-    size_t  i, j;
+    json_t *o = model_obj(post_bkts, bucket, key);
 
-    for (i = 0; i < json_array_size(outer); i++) {
-        json_t *pair = json_array_get(outer, i);
+    if (!o) {
+        return -1;
+    }
+    return (int) json_array_size(json_object_get(o, "data"));
+} /* model_size_blocks */
 
-        if (strcmp(json_string_value(json_array_get(pair, 0)), bucket) != 0) {
-            continue;
+/* The post-state Mpu record of (bucket, uplid), or NULL. */
+static json_t *
+model_mpu(
+    json_t     *post_bkts,
+    const char *bucket,
+    int64_t     uplid)
+{
+    json_t *bk = model_bucket(post_bkts, bucket);
+    json_t *inner;
+    size_t  j;
+
+    if (!bk) {
+        return NULL;
+    }
+    inner = json_object_get(json_object_get(bk, "mpu"), "#map");
+    for (j = 0; j < json_array_size(inner); j++) {
+        json_t *kv = json_array_get(inner, j);
+
+        if (itf_i64(json_array_get(kv, 0)) == uplid) {
+            return json_array_get(kv, 1);
         }
-        json_t *inner = json_object_get(json_array_get(pair, 1), "#map");
-        for (j = 0; j < json_array_size(inner); j++) {
-            json_t *kv = json_array_get(inner, j);
-            char    kstr[MBT_MAX_KEYLEN];
+    }
+    return NULL;
+} /* model_mpu */
 
-            key_str(json_array_get(kv, 0), kstr, sizeof(kstr));
-            if (strcmp(kstr, key) == 0) {
-                return (int) json_array_size(json_array_get(kv, 1));
-            }
+/* The size in blocks of one uploaded part in the post-state, or -1. */
+static int
+model_part_blocks(
+    json_t     *post_bkts,
+    const char *bucket,
+    int64_t     uplid,
+    int64_t     pn)
+{
+    json_t *m = model_mpu(post_bkts, bucket, uplid);
+    json_t *parts;
+    size_t  j;
+
+    if (!m) {
+        return -1;
+    }
+    parts = json_object_get(json_object_get(m, "parts"), "#map");
+    for (j = 0; j < json_array_size(parts); j++) {
+        json_t *kv = json_array_get(parts, j);
+
+        if (itf_i64(json_array_get(kv, 0)) == pn) {
+            return (int) json_array_size(json_array_get(kv, 1));
         }
     }
     return -1;
-} /* model_size_blocks */
+} /* model_part_blocks */
+
+/* The model mtag -> (Content-Type, x-amz-meta-m) mapping the harness sends
+ * on PUT and expects echoed on GET/HEAD; mtag 0 sends neither and the
+ * response Content-Type falls back to application/octet-stream. */
+static const char *
+mtag_content_type(int mtag)
+{
+    return mtag == 1 ? "text/plain"
+         : mtag == 2 ? "application/json" : NULL;
+} /* mtag_content_type */
+
+static const char *
+mtag_meta(int mtag)
+{
+    return mtag == 1 ? "v1" : mtag == 2 ? "v2" : NULL;
+} /* mtag_meta */
+
+/* A tag id set as its sorted id array; the harness maps id i to the
+ * ("tk<i>", "tv<i>") pair. */
+static int
+tagset_of(
+    json_t *tags,
+    int    *ids,
+    int     max)
+{
+    json_t *arr = json_object_get(tags, "#set");
+    int     n   = 0;
+    int     want;
+    size_t  i;
+
+    for (want = 1; want <= 9 && n < max; want++) {
+        for (i = 0; i < json_array_size(arr); i++) {
+            if (itf_i64(json_array_get(arr, i)) == want) {
+                ids[n++] = want;
+            }
+        }
+    }
+    return n;
+} /* tagset_of */
 
 /* ---- deviation registry -------------------------------------------------- */
 
@@ -284,18 +406,23 @@ dev_copy_is_self(json_t *op)
 static const struct deviation known_deviations[] = {
     /* AWS DeleteObject returns 204 No Content; chimera returns 200 for an
      * existing key... */
-    { "delete-object-200",          "ODeleteObject",            204,    200, NULL              },
+    { "delete-object-200",          "ODeleteObject",            204,               200,               NULL
+    },
     /* ...and 404 NoSuchKey for a missing one (AWS is idempotent). */
-    { "delete-object-missing-404",  "ODeleteObject",            204,    404, NULL              },
+    { "delete-object-missing-404",  "ODeleteObject",            204,               404,               NULL
+    },
     /* AWS answers DELETE on a non-empty bucket with 409 BucketNotEmpty;
      * chimera maps BUCKET_NOT_EMPTY through its default 500 InternalError. */
-    { "delete-bucket-nonempty-500", "ODeleteBucket",            409,    500, NULL              },
+    { "delete-bucket-nonempty-500", "ODeleteBucket",            409,               500,               NULL
+    },
     /* AWS rejects a copy of an object onto itself (no metadata directive)
      * with 400 InvalidRequest; chimera performs it and returns 200. */
-    { "copy-self-200",              "OCopyObject",              400,    200, dev_copy_is_self  },
+    { "copy-self-200",              "OCopyObject",              400,               200,               dev_copy_is_self
+    },
     /* AWS returns 206 for every satisfiable Range, including one resolving
     * to the whole object; chimera collapses whole-object ranges to 200. */
-    { "range-full-200",             "OGetObject",               206,    200, dev_range_is_full },
+    { "range-full-200",             "OGetObject",               206,               200,               dev_range_is_full
+    },
 };
 
 static const struct deviation *
@@ -335,16 +462,165 @@ struct hist_ent {
     char op_dump[512];
 };
 
-struct oracle {
-    struct s3_mbt_env *env;
-    int                block_size;
-    int                verbose;
-    struct etag_ent    etags[MBT_MAX_ETAGS];
-    struct hist_ent    history[MBT_HIST];
-    int                hist_len;
-    uint8_t           *expect_buf;   /* expected-body scratch */
-    char              *xml_buf;      /* NUL-terminated response body copy */
+/* One live multipart upload: the model's abstract id, the wire's 32-hex
+ * UploadId learned from the Initiate response, and enough context to abort
+ * it at trace teardown (an in-flight upload holds VFS handles that would
+ * otherwise pin the per-trace filesystem forever). */
+struct upl_ent {
+    int  used;
+    long uplid;
+    char bucket[80];
+    char key[MBT_MAX_KEYLEN];
+    char wire[40];
 };
+
+#define MBT_MAX_UPLOADS 64
+
+/* Per-part ETag learned from UploadPart/UploadPartCopy, keyed by the model
+ * upload id + part number; replayed into the Complete manifest and checked
+ * against ListParts. */
+struct part_etag_ent {
+    int  used;
+    long uplid;
+    long pn;
+    char etag[160];
+};
+
+#define MBT_MAX_PART_ETAGS  256
+
+/* A syntactically valid (32 hex chars) upload id no Initiate ever minted,
+ * for the model's UNKNOWN_UPLOAD requests. */
+#define MBT_UNKNOWN_WIRE_ID "ffffffffffffffffffffffffffffffff"
+
+struct oracle {
+    struct s3_mbt_env   *env;
+    int                  block_size;
+    int                  verbose;
+    struct etag_ent      etags[MBT_MAX_ETAGS];
+    struct upl_ent       upls[MBT_MAX_UPLOADS];
+    struct part_etag_ent petags[MBT_MAX_PART_ETAGS];
+    struct hist_ent      history[MBT_HIST];
+    int                  hist_len;
+    uint8_t             *expect_buf; /* expected-body scratch */
+    char                *xml_buf;    /* NUL-terminated response body copy */
+};
+
+static struct upl_ent *
+upl_find(
+    struct oracle *o,
+    long           uplid)
+{
+    int i;
+
+    for (i = 0; i < MBT_MAX_UPLOADS; i++) {
+        if (o->upls[i].used && o->upls[i].uplid == uplid) {
+            return &o->upls[i];
+        }
+    }
+    return NULL;
+} /* upl_find */
+
+/* The wire UploadId a model id maps to; the unknown sentinel otherwise. */
+static const char *
+upl_wire(
+    struct oracle *o,
+    long           uplid)
+{
+    struct upl_ent *e = upl_find(o, uplid);
+
+    return e ? e->wire : MBT_UNKNOWN_WIRE_ID;
+} /* upl_wire */
+
+static void
+upl_learn(
+    struct oracle *o,
+    long           uplid,
+    const char    *bucket,
+    const char    *key,
+    const char    *wire)
+{
+    int i;
+
+    for (i = 0; i < MBT_MAX_UPLOADS; i++) {
+        if (!o->upls[i].used) {
+            o->upls[i].used  = 1;
+            o->upls[i].uplid = uplid;
+            snprintf(o->upls[i].bucket, sizeof(o->upls[i].bucket), "%s", bucket);
+            snprintf(o->upls[i].key, sizeof(o->upls[i].key), "%s", key);
+            snprintf(o->upls[i].wire, sizeof(o->upls[i].wire), "%s", wire);
+            return;
+        }
+    }
+    fprintf(stderr, "harness limit: more than %d uploads; raise "
+            "MBT_MAX_UPLOADS\n", MBT_MAX_UPLOADS);
+    exit(3);
+} /* upl_learn */
+
+static void
+petag_set(
+    struct oracle *o,
+    long           uplid,
+    long           pn,
+    const char    *etag)
+{
+    int i, free_i = -1;
+
+    for (i = 0; i < MBT_MAX_PART_ETAGS; i++) {
+        if (o->petags[i].used && o->petags[i].uplid == uplid &&
+            o->petags[i].pn == pn) {
+            snprintf(o->petags[i].etag, sizeof(o->petags[i].etag), "%s", etag);
+            return;
+        }
+        if (!o->petags[i].used && free_i < 0) {
+            free_i = i;
+        }
+    }
+    if (free_i < 0) {
+        fprintf(stderr, "harness limit: more than %d part etags; raise "
+                "MBT_MAX_PART_ETAGS\n", MBT_MAX_PART_ETAGS);
+        exit(3);
+    }
+    o->petags[free_i].used  = 1;
+    o->petags[free_i].uplid = uplid;
+    o->petags[free_i].pn    = pn;
+    snprintf(o->petags[free_i].etag, sizeof(o->petags[free_i].etag), "%s", etag);
+} /* petag_set */
+
+static const char *
+petag_get(
+    struct oracle *o,
+    long           uplid,
+    long           pn)
+{
+    int i;
+
+    for (i = 0; i < MBT_MAX_PART_ETAGS; i++) {
+        if (o->petags[i].used && o->petags[i].uplid == uplid &&
+            o->petags[i].pn == pn) {
+            return o->petags[i].etag;
+        }
+    }
+    return NULL;
+} /* petag_get */
+
+/* Drop an upload's map entry and its part ETags (Complete/Abort consumed it). */
+static void
+upl_forget(
+    struct oracle *o,
+    long           uplid)
+{
+    struct upl_ent *e = upl_find(o, uplid);
+    int             i;
+
+    if (e) {
+        e->used = 0;
+    }
+    for (i = 0; i < MBT_MAX_PART_ETAGS; i++) {
+        if (o->petags[i].used && o->petags[i].uplid == uplid) {
+            o->petags[i].used = 0;
+        }
+    }
+} /* upl_forget */
 
 static struct etag_ent *
 etag_find(
@@ -777,9 +1053,11 @@ op_put_object(
     n = blocks_of(op_field(op, "data"), syms, 64);
     s3_mbt_expand_blocks(syms, n, o->block_size, o->expect_buf);
 
-    req.path     = path;
-    req.body     = o->expect_buf;
-    req.body_len = (size_t) n * o->block_size;
+    req.path         = path;
+    req.body         = o->expect_buf;
+    req.body_len     = (size_t) n * o->block_size;
+    req.content_type = mtag_content_type((int) op_i64(op, "mtag"));
+    req.meta         = mtag_meta((int) op_i64(op, "mtag"));
 
     res = s3_mbt_call(o->env, &req);
 
@@ -794,6 +1072,46 @@ op_put_object(
         check_error_code(o, res, op, m);
     }
 } /* op_put_object */
+
+/* GET/HEAD metadata echo: the stored Content-Type (or the
+ * application/octet-stream fallback) and the x-amz-meta-m value, both from
+ * the post-state object's mtag. */
+static void
+check_meta_echo(
+    struct oracle            *o,
+    const struct s3_mbt_resp *res,
+    json_t                   *post_bkts,
+    const char               *bucket,
+    const char               *key,
+    const char               *what,
+    struct mism              *m)
+{
+    json_t     *obj = model_obj(post_bkts, bucket, key);
+    int         mtag;
+    const char *want_ct;
+    const char *want_meta;
+
+    (void) o;
+    if (!obj) {
+        mism_add(m, "%s: %s/%s missing from model post-state", what, bucket,
+                 key);
+        return;
+    }
+    mtag      = (int) itf_i64(json_object_get(obj, "mtag"));
+    want_ct   = mtag_content_type(mtag);
+    want_meta = mtag_meta(mtag);
+
+    if (strcmp(res->content_type,
+               want_ct ? want_ct : "application/octet-stream") != 0) {
+        mism_add(m, "%s: Content-Type '%s', expected '%s'", what,
+                 res->content_type,
+                 want_ct ? want_ct : "application/octet-stream");
+    }
+    if (strcmp(res->meta, want_meta ? want_meta : "") != 0) {
+        mism_add(m, "%s: x-amz-meta-m '%s', expected '%s'", what, res->meta,
+                 want_meta ? want_meta : "");
+    }
+} /* check_meta_echo */
 
 static void
 op_get_object(
@@ -852,6 +1170,7 @@ op_get_object(
                      res->content_length, got_len);
         }
         etag_check(o, bucket, key, res->etag, "GetObject", m);
+        check_meta_echo(o, res, post_bkts, bucket, key, "GetObject", m);
         /* On a tolerated whole-object 200 (range-full-200) there is no
         * Content-Range; only an exact 206 must carry the right one. */
         if (st == ST_MATCH && expected == 206) {
@@ -915,6 +1234,30 @@ op_head_object(
                      res->has_content_length ? res->content_length : -1);
         }
         etag_check(o, bucket, key, res->etag, "HeadObject", m);
+        check_meta_echo(o, res, post_bkts, bucket, key, "HeadObject", m);
+
+        /* x-amz-tagging-count must report the object's tag count; with no
+         * tags AWS omits the header while the server under test sends "0",
+         * so the zero case accepts either. */
+        {
+            json_t *obj = model_obj(post_bkts, bucket, key);
+
+            if (obj) {
+                int ntags = (int) json_array_size(
+                    json_object_get(json_object_get(obj, "tags"), "#set"));
+
+                if (ntags > 0) {
+                    if (atoi(res->tag_count) != ntags) {
+                        mism_add(m, "HeadObject x-amz-tagging-count '%s', "
+                                 "expected %d", res->tag_count, ntags);
+                    }
+                } else if (res->tag_count[0] &&
+                           strcmp(res->tag_count, "0") != 0) {
+                    mism_add(m, "HeadObject x-amz-tagging-count '%s', "
+                             "expected 0/absent", res->tag_count);
+                }
+            }
+        }
     }
 } /* op_head_object */
 
@@ -1040,6 +1383,9 @@ op_list_objects(
     struct s3_mbt_resp *res;
     unsigned            expected  = (unsigned) op_i64(op, "status");
     int                 delim     = op_bool(op, "delim");
+    int                 mode      = (int) op_i64(op, "mode");
+    const char         *ctag      = mode == 3 ? "<Version>" : "<Contents>";
+    const char         *ctag_end  = mode == 3 ? "</Version>" : "</Contents>";
     json_t             *want_keys = op_field(op, "keys");
     json_t             *want_pfxs = op_field(op, "prefixes");
     size_t              off       = 0;
@@ -1054,24 +1400,39 @@ op_list_objects(
     key_str(op_field(op, "startAfter"), sa, sizeof(sa));
 
     /* params in byte order, values percent-encoded the way the SDKs send
-     * them, matching the harness's sign-what-you-send contract */
+     * them, matching the harness's sign-what-you-send contract.  The three
+     * modes dress the same walk differently: V1 uses marker, V2 list-type=2
+     * + start-after, Versions the bare versions subresource + key-marker. */
     if (delim) {
         off += snprintf(query + off, sizeof(query) - off, "delimiter=%%2F&");
     }
-    off += snprintf(query + off, sizeof(query) - off, "list-type=2&max-keys=%"
-                    PRId64, op_i64(op, "maxKeys"));
+    if (sa[0] && mode != 2) {
+        char enc[2 * MBT_MAX_KEYLEN];
+
+        qenc(sa, enc, sizeof(enc));
+        off += snprintf(query + off, sizeof(query) - off, "%s=%s&",
+                        mode == 1 ? "marker" : "key-marker", enc);
+    }
+    if (mode == 2) {
+        off += snprintf(query + off, sizeof(query) - off, "list-type=2&");
+    }
+    off += snprintf(query + off, sizeof(query) - off, "max-keys=%" PRId64,
+                    op_i64(op, "maxKeys"));
     if (pfx[0]) {
         char enc[2 * MBT_MAX_KEYLEN];
 
         qenc(pfx, enc, sizeof(enc));
         off += snprintf(query + off, sizeof(query) - off, "&prefix=%s", enc);
     }
-    if (sa[0]) {
+    if (sa[0] && mode == 2) {
         char enc[2 * MBT_MAX_KEYLEN];
 
         qenc(sa, enc, sizeof(enc));
         off += snprintf(query + off, sizeof(query) - off, "&start-after=%s",
                         enc);
+    }
+    if (mode == 3) {
+        off += snprintf(query + off, sizeof(query) - off, "&versions=");
     }
 
     req.path  = path;
@@ -1088,16 +1449,17 @@ op_list_objects(
         return;
     }
 
-    /* Walk the <Contents> blocks in order: keys, sizes, ETags. */
+    /* Walk the <Contents> (or <Version>) blocks in order: keys, sizes,
+     * ETags. */
     cur = resp_xml(o, res);
-    while ((cur = strstr(cur, "<Contents>")) != NULL) {
-        const char *blk_end = strstr(cur, "</Contents>");
+    while ((cur = strstr(cur, ctag)) != NULL) {
+        const char *blk_end = strstr(cur, ctag_end);
         const char *p;
         char        size_txt[32];
         char        etag_txt[160];
 
         p = xml_text_after(cur, "Key", text, sizeof(text));
-        if (!p || (blk_end && p > blk_end + strlen("</Contents>"))) {
+        if (!p || (blk_end && p > blk_end + strlen(ctag_end))) {
             mism_add(m, "ListObjects: malformed <Contents> block");
             break;
         }
@@ -1126,7 +1488,7 @@ op_list_objects(
             etag_check(o, bucket, text, etag_txt, "ListObjects", m);
         }
         nkeys++;
-        cur += strlen("<Contents>");
+        cur += strlen(ctag);
     }
 
     /* Then the <CommonPrefixes> blocks, in order. */
@@ -1167,18 +1529,822 @@ op_list_objects(
         mism_add(m, "ListObjects: IsTruncated '%s', expected '%s'", itrunc,
                  op_bool(op, "truncated") ? "true" : "false");
     }
-    kcount[0] = '\0';
-    if (xml_text_after(o->xml_buf, "KeyCount", kcount, sizeof(kcount))) {
-        int want = (int) (json_array_size(want_keys) +
-                          json_array_size(want_pfxs));
+    /* KeyCount is a V2-only element. */
+    if (mode == 2) {
+        kcount[0] = '\0';
+        if (xml_text_after(o->xml_buf, "KeyCount", kcount, sizeof(kcount))) {
+            int want = (int) (json_array_size(want_keys) +
+                              json_array_size(want_pfxs));
 
-        if (atoi(kcount) != want) {
-            mism_add(m, "ListObjects: KeyCount %s, expected %d", kcount, want);
+            if (atoi(kcount) != want) {
+                mism_add(m, "ListObjects: KeyCount %s, expected %d", kcount,
+                         want);
+            }
+        } else {
+            mism_add(m, "ListObjects: response lacks <KeyCount>");
         }
-    } else {
-        mism_add(m, "ListObjects: response lacks <KeyCount>");
     }
 } /* op_list_objects */
+
+/* ---- DeleteObjects batch ------------------------------------------------- */
+
+static void
+op_delete_objects(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[128];
+    char                bucket[80];
+    char                body[4096];
+    size_t              blen = 0;
+    struct s3_mbt_req   req  = { .method = EVPL_HTTP_REQUEST_TYPE_POST };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    int                 quiet    = op_bool(op, "quiet");
+    json_t             *keys     = op_field(op, "keys");
+    size_t              i;
+    const char         *cur;
+    char                text[MBT_MAX_KEYLEN];
+    int                 ndel = 0;
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    build_path(op, "bucket", NULL, path, sizeof(path));
+
+    blen += snprintf(body + blen, sizeof(body) - blen, "<Delete>");
+    if (quiet) {
+        blen += snprintf(body + blen, sizeof(body) - blen,
+                         "<Quiet>true</Quiet>");
+    }
+    for (i = 0; i < json_array_size(keys); i++) {
+        char kstr[MBT_MAX_KEYLEN];
+
+        key_str(json_array_get(keys, i), kstr, sizeof(kstr));
+        blen += snprintf(body + blen, sizeof(body) - blen,
+                         "<Object><Key>%s</Key></Object>", kstr);
+    }
+    blen += snprintf(body + blen, sizeof(body) - blen, "</Delete>");
+
+    req.path     = path;
+    req.query    = "delete=";
+    req.body     = (const uint8_t *) body;
+    req.body_len = blen;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "ODeleteObjects", op, expected,
+                     (unsigned) res->status, m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+
+    /* every named key is gone; drop the learned ETags */
+    for (i = 0; i < json_array_size(keys); i++) {
+        char kstr[MBT_MAX_KEYLEN];
+
+        key_str(json_array_get(keys, i), kstr, sizeof(kstr));
+        etag_forget(o, bucket, kstr);
+    }
+
+    /* non-quiet: one <Deleted><Key> per named key, in request order;
+     * quiet: none.  Never an <Error> (every key is deletable as root). */
+    cur = resp_xml(o, res);
+    while ((cur = strstr(cur, "<Deleted>")) != NULL) {
+        if (!xml_text_after(cur, "Key", text, sizeof(text))) {
+            mism_add(m, "DeleteObjects: malformed <Deleted> block");
+            break;
+        }
+        if (!quiet && ndel < (int) json_array_size(keys)) {
+            char want[MBT_MAX_KEYLEN];
+
+            key_str(json_array_get(keys, ndel), want, sizeof(want));
+            if (strcmp(want, text) != 0) {
+                mism_add(m, "DeleteObjects: Deleted[%d] = '%s', expected '%s'",
+                         ndel, text, want);
+            }
+        }
+        ndel++;
+        cur += strlen("<Deleted>");
+    }
+    if (quiet && ndel != 0) {
+        mism_add(m, "DeleteObjects: %d <Deleted> entries in Quiet mode", ndel);
+    }
+    if (!quiet && ndel != (int) json_array_size(keys)) {
+        mism_add(m, "DeleteObjects: %d <Deleted> entries, expected %zu", ndel,
+                 json_array_size(keys));
+    }
+    if (strstr(o->xml_buf, "<Error>")) {
+        mism_add(m, "DeleteObjects: unexpected <Error> entry");
+    }
+} /* op_delete_objects */
+
+/* ---- GetObjectAttributes ------------------------------------------------- */
+
+static void
+op_get_attrs(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                bucket[80], key[MBT_MAX_KEYLEN];
+    char                text[160];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_GET };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    key_str(op_field(op, "key"), key, sizeof(key));
+    build_path(op, "bucket", "key", path, sizeof(path));
+
+    /* The x-amz-object-attributes header is deliberately not sent: the
+     * server ignores it and always reports the filesystem-suppliable fixed
+     * set (ETag, StorageClass, ObjectSize) this handler checks.  (AWS would
+     * 400 without the header; that strictness is not modeled.) */
+    req.path  = path;
+    req.query = "attributes=";
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OGetAttrs", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+
+    if (xml_text_after(resp_xml(o, res), "ObjectSize", text, sizeof(text))) {
+        int64_t want = op_i64(op, "sizeBlocks") * o->block_size;
+
+        if (strtoll(text, NULL, 10) != want) {
+            mism_add(m, "GetAttrs: ObjectSize %s, expected %" PRId64, text,
+                     want);
+        }
+    } else {
+        mism_add(m, "GetAttrs: response lacks <ObjectSize>");
+    }
+    if (!xml_text_after(o->xml_buf, "StorageClass", text, sizeof(text)) ||
+        strcmp(text, "STANDARD") != 0) {
+        mism_add(m, "GetAttrs: StorageClass missing or not STANDARD");
+    }
+    /* the attributes ETag is the same value GET/HEAD report, unquoted */
+    if (xml_text_after(o->xml_buf, "ETag", text, sizeof(text))) {
+        char quoted[164];
+
+        snprintf(quoted, sizeof(quoted), "\"%s\"", text);
+        etag_check(o, bucket, key, quoted, "GetAttrs", m);
+    } else {
+        mism_add(m, "GetAttrs: response lacks <ETag>");
+    }
+} /* op_get_attrs */
+
+/* ---- tagging ------------------------------------------------------------- */
+
+/* <Tagging><TagSet><Tag><Key>tk<i></Key><Value>tv<i></Value></Tag>... */
+static size_t
+tagging_body(
+    const int *ids,
+    int        n,
+    char      *out,
+    size_t     outlen)
+{
+    size_t off = 0;
+    int    i;
+
+    off += snprintf(out + off, outlen - off, "<Tagging><TagSet>");
+    for (i = 0; i < n; i++) {
+        off += snprintf(out + off, outlen - off,
+                        "<Tag><Key>tk%d</Key><Value>tv%d</Value></Tag>",
+                        ids[i], ids[i]);
+    }
+    off += snprintf(out + off, outlen - off, "</TagSet></Tagging>");
+    return off;
+} /* tagging_body */
+
+/* Collect the tag ids of a <Tagging> response (tags named tk<i> carrying
+ * value tv<i>). */
+static int
+parse_tagset(
+    struct oracle            *o,
+    const struct s3_mbt_resp *res,
+    int                      *ids,
+    int                       max,
+    struct mism              *m)
+{
+    const char *cur = resp_xml(o, res);
+    char        ktext[64], vtext[64];
+    int         n = 0;
+
+    while ((cur = strstr(cur, "<Tag>")) != NULL) {
+        if (!xml_text_after(cur, "Key", ktext, sizeof(ktext)) ||
+            !xml_text_after(cur, "Value", vtext, sizeof(vtext))) {
+            mism_add(m, "tagging: malformed <Tag> block");
+            break;
+        }
+        if (strncmp(ktext, "tk", 2) != 0) {
+            mism_add(m, "tagging: unexpected tag key '%s'", ktext);
+        } else if (n < max) {
+            ids[n] = atoi(ktext + 2);
+            if (strncmp(vtext, "tv", 2) != 0 || atoi(vtext + 2) != ids[n]) {
+                mism_add(m, "tagging: tag %s has value '%s'", ktext, vtext);
+            }
+        }
+        n++;
+        cur += strlen("<Tag>");
+    }
+    return n;
+} /* parse_tagset */
+
+/* Compare a parsed tag-id list against the label's tag set. */
+static void
+check_tagset(
+    json_t      *want_tags,
+    const int   *ids,
+    int          n,
+    const char  *what,
+    struct mism *m)
+{
+    int want_ids[16];
+    int wn = tagset_of(want_tags, want_ids, 16);
+    int i, j, found;
+
+    if (n != wn) {
+        mism_add(m, "%s: %d tags, expected %d", what, n, wn);
+        return;
+    }
+    for (i = 0; i < wn; i++) {
+        found = 0;
+        for (j = 0; j < n; j++) {
+            if (ids[j] == want_ids[i]) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            mism_add(m, "%s: tag id %d missing", what, want_ids[i]);
+        }
+    }
+} /* check_tagset */
+
+/* One handler serves the object- and bucket-level variants of each tagging
+ * verb; the object one has a key. */
+static void
+tagging_common(
+    struct oracle              *o,
+    json_t                     *op,
+    struct mism                *m,
+    const char                 *tag,
+    enum evpl_http_request_type method,
+    int                         has_key,
+    int                         send_tags)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                body[2048];
+    struct s3_mbt_req   req = { .method = method };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    int                 ids[16];
+    int                 n;
+
+    build_path(op, "bucket", has_key ? "key" : NULL, path, sizeof(path));
+    req.path  = path;
+    req.query = "tagging=";
+
+    if (send_tags) {
+        n            = tagset_of(op_field(op, "tags"), ids, 16);
+        req.body     = (const uint8_t *) body;
+        req.body_len = tagging_body(ids, n, body, sizeof(body));
+    }
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, tag, op, expected, (unsigned) res->status, m)
+        != ST_MATCH) {
+        return;
+    }
+    if (expected != 200 && expected != 204) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+    if (method == EVPL_HTTP_REQUEST_TYPE_GET && expected == 200) {
+        n = parse_tagset(o, res, ids, 16, m);
+        check_tagset(op_field(op, "tags"), ids, n, tag, m);
+    }
+} /* tagging_common */
+
+static void
+op_put_obj_tagging(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    (void) post_bkts;
+    tagging_common(o, op, m, "OPutObjTagging", EVPL_HTTP_REQUEST_TYPE_PUT,
+                   1, 1);
+} /* op_put_obj_tagging */
+
+static void
+op_get_obj_tagging(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    (void) post_bkts;
+    tagging_common(o, op, m, "OGetObjTagging", EVPL_HTTP_REQUEST_TYPE_GET,
+                   1, 0);
+} /* op_get_obj_tagging */
+
+static void
+op_del_obj_tagging(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    (void) post_bkts;
+    tagging_common(o, op, m, "ODelObjTagging", EVPL_HTTP_REQUEST_TYPE_DELETE,
+                   1, 0);
+} /* op_del_obj_tagging */
+
+static void
+op_put_bkt_tagging(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    (void) post_bkts;
+    tagging_common(o, op, m, "OPutBktTagging", EVPL_HTTP_REQUEST_TYPE_PUT,
+                   0, 1);
+} /* op_put_bkt_tagging */
+
+static void
+op_get_bkt_tagging(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    (void) post_bkts;
+    tagging_common(o, op, m, "OGetBktTagging", EVPL_HTTP_REQUEST_TYPE_GET,
+                   0, 0);
+} /* op_get_bkt_tagging */
+
+static void
+op_del_bkt_tagging(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    (void) post_bkts;
+    tagging_common(o, op, m, "ODelBktTagging", EVPL_HTTP_REQUEST_TYPE_DELETE,
+                   0, 0);
+} /* op_del_bkt_tagging */
+
+/* ---- multipart ----------------------------------------------------------- */
+
+static void
+op_create_mpu(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                bucket[80], key[MBT_MAX_KEYLEN];
+    char                text[64];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_POST };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    key_str(op_field(op, "key"), key, sizeof(key));
+    build_path(op, "bucket", "key", path, sizeof(path));
+    req.path  = path;
+    req.query = "uploads=";
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OCreateMpu", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+    if (!xml_text_after(resp_xml(o, res), "UploadId", text, sizeof(text)) ||
+        strlen(text) != 32) {
+        mism_add(m, "CreateMpu: missing/malformed <UploadId> ('%s')", text);
+        return;
+    }
+    upl_learn(o, (long) op_i64(op, "uplid"), bucket, key, text);
+
+    if (!xml_text_after(o->xml_buf, "Key", text, sizeof(text)) ||
+        strcmp(text, key) != 0) {
+        mism_add(m, "CreateMpu: <Key> mismatch");
+    }
+} /* op_create_mpu */
+
+static void
+op_upload_part(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                query[96];
+    int                 syms[64];
+    int                 n;
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_PUT };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    long                uplid    = (long) op_i64(op, "uplid");
+    long                pn       = (long) op_i64(op, "partNum");
+
+    (void) post_bkts;
+    build_path(op, "bucket", "key", path, sizeof(path));
+    snprintf(query, sizeof(query), "partNumber=%ld&uploadId=%s", pn,
+             upl_wire(o, uplid));
+
+    n = blocks_of(op_field(op, "data"), syms, 64);
+    s3_mbt_expand_blocks(syms, n, o->block_size, o->expect_buf);
+
+    req.path     = path;
+    req.query    = query;
+    req.body     = o->expect_buf;
+    req.body_len = (size_t) n * o->block_size;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OUploadPart", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+    if (res->etag[0] != '"') {
+        mism_add(m, "UploadPart: ETag missing/unquoted ('%s')", res->etag);
+        return;
+    }
+    petag_set(o, uplid, pn, res->etag);
+} /* op_upload_part */
+
+static void
+op_upload_part_copy(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                query[96];
+    char                src[MBT_MAX_KEYLEN + 96];
+    char                range_hdr[80];
+    char                text[160];
+    char                sk[MBT_MAX_KEYLEN];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_PUT };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    long                uplid    = (long) op_i64(op, "uplid");
+    long                pn       = (long) op_i64(op, "partNum");
+    const char         *rtag     = op_tag(op, "range");
+    json_t             *rval     = json_object_get(op_field(op, "range"), "value");
+    int64_t             bs       = o->block_size;
+
+    (void) post_bkts;
+    build_path(op, "bucket", "key", path, sizeof(path));
+    key_str(op_field(op, "srcKey"), sk, sizeof(sk));
+    snprintf(src, sizeof(src), "/%s/%s", op_str(op, "srcBucket"), sk);
+    snprintf(query, sizeof(query), "partNumber=%ld&uploadId=%s", pn,
+             upl_wire(o, uplid));
+
+    req.path        = path;
+    req.query       = query;
+    req.copy_source = src;
+
+    if (strcmp(rtag, "RClosed") == 0) {
+        snprintf(range_hdr, sizeof(range_hdr),
+                 "bytes=%" PRId64 "-%" PRId64,
+                 itf_i64(json_object_get(rval, "first")) * bs,
+                 (itf_i64(json_object_get(rval, "last")) + 1) * bs - 1);
+        req.copy_range = range_hdr;
+    }
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OUploadPartCopy", op, expected,
+                     (unsigned) res->status, m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+    /* the part's ETag arrives in the <CopyPartResult> body, not a header */
+    if (!strstr(resp_xml(o, res), "<CopyPartResult")) {
+        mism_add(m, "UploadPartCopy: response lacks <CopyPartResult>");
+        return;
+    }
+    if (!xml_text_after(o->xml_buf, "ETag", text, sizeof(text))) {
+        mism_add(m, "UploadPartCopy: response lacks <ETag>");
+        return;
+    }
+    petag_set(o, uplid, pn, text);
+} /* op_upload_part_copy */
+
+static void
+op_complete_mpu(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                query[96];
+    char                bucket[80], key[MBT_MAX_KEYLEN];
+    char                body[4096];
+    char                text[160];
+    size_t              blen = 0;
+    struct s3_mbt_req   req  = { .method = EVPL_HTTP_REQUEST_TYPE_POST };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    long                uplid    = (long) op_i64(op, "uplid");
+    json_t             *manifest = op_field(op, "manifest");
+    size_t              i;
+
+    (void) post_bkts;
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    key_str(op_field(op, "key"), key, sizeof(key));
+    build_path(op, "bucket", "key", path, sizeof(path));
+    snprintf(query, sizeof(query), "uploadId=%s", upl_wire(o, uplid));
+
+    blen += snprintf(body + blen, sizeof(body) - blen,
+                     "<CompleteMultipartUpload>");
+    for (i = 0; i < json_array_size(manifest); i++) {
+        long        pn = (long) itf_i64(json_array_get(manifest, i));
+        const char *pe = petag_get(o, uplid, pn);
+
+        /* a never-uploaded part still needs a syntactically valid ETag --
+         * the parser requires one per <Part> */
+        blen += snprintf(body + blen, sizeof(body) - blen,
+                         "<Part><PartNumber>%ld</PartNumber><ETag>%s</ETag>"
+                         "</Part>", pn,
+                         pe ? pe : "\"00000000000000000000000000000000\"");
+    }
+    blen += snprintf(body + blen, sizeof(body) - blen,
+                     "</CompleteMultipartUpload>");
+
+    req.path     = path;
+    req.query    = query;
+    req.body     = (const uint8_t *) body;
+    req.body_len = blen;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OCompleteMpu", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+
+    /* the upload is consumed and the key now holds the assembled object;
+     * its ETag will be learned from the next read -- the Complete
+     * response's own "<hex>-<N>" ETag is a digest over the part ETags and
+     * is NOT the value later GET/HEAD report (deviation
+     * mpu-complete-etag-detached; AWS reports one consistent value) */
+    upl_forget(o, uplid);
+    etag_forget(o, bucket, key);
+
+    if (!strstr(resp_xml(o, res), "<CompleteMultipartUploadResult")) {
+        mism_add(m, "CompleteMpu: response lacks result element");
+        return;
+    }
+    if (xml_text_after(o->xml_buf, "ETag", text, sizeof(text))) {
+        char want_suffix[16];
+
+        snprintf(want_suffix, sizeof(want_suffix), "-%zu\"",
+                 json_array_size(manifest));
+        if (strlen(text) < strlen(want_suffix) ||
+            strcmp(text + strlen(text) - strlen(want_suffix),
+                   want_suffix) != 0) {
+            mism_add(m, "CompleteMpu: ETag '%s' lacks part-count suffix %s",
+                     text, want_suffix);
+        }
+    } else {
+        mism_add(m, "CompleteMpu: response lacks <ETag>");
+    }
+} /* op_complete_mpu */
+
+static void
+op_abort_mpu(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                query[96];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_DELETE };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    long                uplid    = (long) op_i64(op, "uplid");
+
+    (void) post_bkts;
+    build_path(op, "bucket", "key", path, sizeof(path));
+    snprintf(query, sizeof(query), "uploadId=%s", upl_wire(o, uplid));
+    req.path  = path;
+    req.query = query;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OAbortMpu", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected == 204) {
+        upl_forget(o, uplid);
+    } else {
+        check_error_code(o, res, op, m);
+    }
+} /* op_abort_mpu */
+
+static void
+op_list_parts(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[MBT_MAX_KEYLEN + 96];
+    char                query[96];
+    char                bucket[80];
+    char                text[160];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_GET };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    long                uplid    = (long) op_i64(op, "uplid");
+    json_t             *want     = op_field(op, "partNums");
+    const char         *cur;
+    int                 np = 0;
+
+    snprintf(bucket, sizeof(bucket), "%s", op_str(op, "bucket"));
+    build_path(op, "bucket", "key", path, sizeof(path));
+    snprintf(query, sizeof(query), "uploadId=%s", upl_wire(o, uplid));
+    req.path  = path;
+    req.query = query;
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OListParts", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+
+    cur = resp_xml(o, res);
+    while ((cur = strstr(cur, "<Part>")) != NULL) {
+        long pn;
+
+        if (!xml_text_after(cur, "PartNumber", text, sizeof(text))) {
+            mism_add(m, "ListParts: malformed <Part> block");
+            break;
+        }
+        pn = atol(text);
+        if (np < (int) json_array_size(want) &&
+            pn != itf_i64(json_array_get(want, np))) {
+            mism_add(m, "ListParts: part[%d] = %ld, expected %" PRId64, np,
+                     pn, itf_i64(json_array_get(want, np)));
+        }
+        if (xml_text_after(cur, "Size", text, sizeof(text))) {
+            int mb = model_part_blocks(post_bkts, bucket, uplid, pn);
+
+            if (mb >= 0 &&
+                strtoll(text, NULL, 10) != (int64_t) mb * o->block_size) {
+                mism_add(m, "ListParts: part %ld Size %s, model %d blocks",
+                         pn, text, mb);
+            }
+        }
+        if (xml_text_after(cur, "ETag", text, sizeof(text))) {
+            const char *pe = petag_get(o, uplid, pn);
+
+            if (pe && strcmp(pe, text) != 0) {
+                mism_add(m, "ListParts: part %ld ETag '%s', learned '%s'",
+                         pn, text, pe);
+            }
+        }
+        np++;
+        cur += strlen("<Part>");
+    }
+    if (np != (int) json_array_size(want)) {
+        mism_add(m, "ListParts: %d parts, expected %zu", np,
+                 json_array_size(want));
+    }
+} /* op_list_parts */
+
+static void
+op_list_mpu(
+    struct oracle *o,
+    json_t        *op,
+    json_t        *post_bkts,
+    struct mism   *m)
+{
+    char                path[128];
+    char                ktext[MBT_MAX_KEYLEN], utext[64];
+    struct s3_mbt_req   req = { .method = EVPL_HTTP_REQUEST_TYPE_GET };
+    struct s3_mbt_resp *res;
+    unsigned            expected = (unsigned) op_i64(op, "status");
+    json_t             *want     = json_object_get(op_field(op, "uploads"), "#set");
+    const char         *cur;
+    int                 nup = 0;
+
+    (void) post_bkts;
+    build_path(op, "bucket", NULL, path, sizeof(path));
+    req.path  = path;
+    req.query = "uploads=";
+
+    res = s3_mbt_call(o->env, &req);
+
+    if (check_status(o, "OListMpu", op, expected, (unsigned) res->status,
+                     m) != ST_MATCH) {
+        return;
+    }
+    if (expected != 200) {
+        check_error_code(o, res, op, m);
+        return;
+    }
+
+    /* Compared as a set: each response row's UploadId must map (via the
+     * learned wire ids) to a model upload whose {key, uplid} the label
+     * carries; the counts must agree. */
+    cur = resp_xml(o, res);
+    while ((cur = strstr(cur, "<Upload>")) != NULL) {
+        struct upl_ent *e;
+        int             found = 0;
+        size_t          i;
+
+        if (!xml_text_after(cur, "Key", ktext, sizeof(ktext)) ||
+            !xml_text_after(cur, "UploadId", utext, sizeof(utext))) {
+            mism_add(m, "ListMpu: malformed <Upload> block");
+            break;
+        }
+        e = NULL;
+        for (i = 0; i < MBT_MAX_UPLOADS; i++) {
+            if (o->upls[i].used && strcmp(o->upls[i].wire, utext) == 0) {
+                e = &o->upls[i];
+                break;
+            }
+        }
+        if (!e) {
+            mism_add(m, "ListMpu: unknown UploadId '%s' (key '%s')", utext,
+                     ktext);
+        } else {
+            for (i = 0; i < json_array_size(want); i++) {
+                json_t *row = json_array_get(want, i);
+                char    wk[MBT_MAX_KEYLEN];
+
+                key_str(json_object_get(row, "key"), wk, sizeof(wk));
+                if (itf_i64(json_object_get(row, "uplid")) == e->uplid &&
+                    strcmp(wk, ktext) == 0) {
+                    found = 1;
+                    break;
+                }
+            }
+            if (!found) {
+                mism_add(m, "ListMpu: upload %ld ('%s') not in the model set",
+                         e->uplid, ktext);
+            }
+        }
+        nup++;
+        cur += strlen("<Upload>");
+    }
+    if (nup != (int) json_array_size(want)) {
+        mism_add(m, "ListMpu: %d uploads, expected %zu", nup,
+                 json_array_size(want));
+    }
+} /* op_list_mpu */
 
 /* ---- dispatch ------------------------------------------------------------ */
 
@@ -1186,16 +2352,33 @@ static const struct {
     const char  *tag;
     op_handler_t fn;
 } handlers[] = {
-    { "OCreateBucket", op_create_bucket       },
-    { "OHeadBucket",   op_head_bucket         },
-    { "ODeleteBucket", op_delete_bucket       },
-    { "OListBuckets",  op_list_buckets        },
-    { "OPutObject",    op_put_object          },
-    { "OGetObject",    op_get_object          },
-    { "OHeadObject",   op_head_object         },
-    { "ODeleteObject", op_delete_object       },
-    { "OCopyObject",   op_copy_object         },
-    { "OListObjects",  op_list_objects        },
+/* *INDENT-OFF* */
+    { "OCreateBucket",   op_create_bucket    },
+    { "OHeadBucket",     op_head_bucket      },
+    { "ODeleteBucket",   op_delete_bucket    },
+    { "OListBuckets",    op_list_buckets     },
+    { "OPutObject",      op_put_object       },
+    { "OGetObject",      op_get_object       },
+    { "OHeadObject",     op_head_object      },
+    { "ODeleteObject",   op_delete_object    },
+    { "ODeleteObjects",  op_delete_objects   },
+    { "OCopyObject",     op_copy_object      },
+    { "OGetAttrs",       op_get_attrs        },
+    { "OListObjects",    op_list_objects     },
+    { "OPutObjTagging",  op_put_obj_tagging  },
+    { "OGetObjTagging",  op_get_obj_tagging  },
+    { "ODelObjTagging",  op_del_obj_tagging  },
+    { "OPutBktTagging",  op_put_bkt_tagging  },
+    { "OGetBktTagging",  op_get_bkt_tagging  },
+    { "ODelBktTagging",  op_del_bkt_tagging  },
+    { "OCreateMpu",      op_create_mpu       },
+    { "OUploadPart",     op_upload_part      },
+    { "OUploadPartCopy", op_upload_part_copy },
+    { "OCompleteMpu",    op_complete_mpu     },
+    { "OAbortMpu",       op_abort_mpu        },
+    { "OListParts",      op_list_parts       },
+    { "OListMpu",        op_list_mpu         },
+/* *INDENT-ON* */
 };
 
 static op_handler_t
@@ -1360,6 +2543,31 @@ run_trace(
         }
     }
 
+    /* Abort any upload the trace left in flight: an in-flight upload holds
+     * open VFS handles (pinning the per-trace filesystem so rmfs never
+     * drains), and its record lives in a process-global table keyed only by
+     * id and bucket NAME -- unaborted, it would resurface in the next
+     * trace's same-named bucket's ListMultipartUploads. */
+    {
+        int u;
+
+        for (u = 0; u < MBT_MAX_UPLOADS; u++) {
+            struct s3_mbt_req areq = { .method = EVPL_HTTP_REQUEST_TYPE_DELETE };
+            char              apath[MBT_MAX_KEYLEN + 96];
+            char              aquery[96];
+
+            if (!o->upls[u].used) {
+                continue;
+            }
+            snprintf(apath, sizeof(apath), "/%s/%s", o->upls[u].bucket,
+                     o->upls[u].key);
+            snprintf(aquery, sizeof(aquery), "uploadId=%s", o->upls[u].wire);
+            areq.path  = apath;
+            areq.query = aquery;
+            s3_mbt_call(env, &areq);
+        }
+    }
+
     s3_mbt_env_fs_teardown(env, fsname);
 
     free(o->expect_buf);
@@ -1377,19 +2585,34 @@ main(
     char **argv)
 {
     static struct option long_options[] = {
-        { "trace",          required_argument,          0,                          't'       },
-        { "trace-dir",      required_argument,          0,                          'D'       },
-        { "exclude-prefix", required_argument,          0,                          'X'       },
-        { "block-size",     required_argument,          0,                          'b'       },
-        { "verbose",        no_argument,                0,                          'v'       },
-        { "dry-run",        no_argument,                0,                          'n'       },
-        { 0,                0,                          0,                          0         }
+        { "trace",          required_argument,          0,
+          't'                                                                                                                                                                                      }
+        ,
+        { "trace-dir",      required_argument,          0,
+          'D'                                                                                                                                                                                      }
+        ,
+        { "exclude-prefix", required_argument,          0,
+          'X'                                                                                                                                                                                      }
+        ,
+        { "block-size",     required_argument,          0,
+          'b'                                                                                                                                                                                      }
+        ,
+        { "verbose",        no_argument,                0,
+          'v'                                                                                                                                                                                      }
+        ,
+        { "dry-run",        no_argument,                0,
+          'n'                                                                                                                                                                                      }
+        ,
+        { "sigv2",          no_argument,                0,
+          '2'                                                                                                                                                                                      }
+        ,
+        { 0,                0,                          0,                         0 }
     };
     struct s3_mbt_env    env;
     char               **traces;
     int                  ntraces;
     int                  block_size = 8192;
-    int                  verbose = 0, dry_run = 0;
+    int                  verbose = 0, dry_run = 0, sigv2 = 0;
     int                  failures = 0;
     int                  i, c;
 
@@ -1397,7 +2620,7 @@ main(
      * only needs to recognize the rest. */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:b:vn", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:b:vn2", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -1413,11 +2636,14 @@ main(
             case 'n':
                 dry_run = 1;
                 break;
+            case '2':
+                sigv2 = 1;
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace f.itf.json | --trace-dir dir]\n"
                         "          [--exclude-prefix p] [--block-size n]\n"
-                        "          [--verbose] [--dry-run]\n", argv[0]);
+                        "          [--sigv2] [--verbose] [--dry-run]\n", argv[0]);
                 return 2;
         } /* switch */
     }
@@ -1428,6 +2654,7 @@ main(
     }
 
     s3_mbt_env_open(&env);
+    env.sigv2 = sigv2;
 
     for (i = 0; i < ntraces; i++) {
         char fsname[32];

--- a/src/server/s3/tests/quint/s3_mbt_replay.c
+++ b/src/server/s3/tests/quint/s3_mbt_replay.c
@@ -1514,8 +1514,11 @@ op_list_objects(
     }
 
     if (nkeys != (int) json_array_size(want_keys)) {
-        mism_add(m, "ListObjects: %d keys, expected %zu", nkeys,
-                 json_array_size(want_keys));
+        /* name the tail keys the model did not predict -- the first
+         * unexpected one is usually the story (a phantom entry, a stale
+         * cache hit, an internal temp name) */
+        mism_add(m, "ListObjects: %d keys, expected %zu (last parsed: '%s')",
+                 nkeys, json_array_size(want_keys), text);
     }
     if (npfx != (int) json_array_size(want_pfxs)) {
         mism_add(m, "ListObjects: %d common prefixes, expected %zu", npfx,
@@ -2590,34 +2593,24 @@ main(
     char **argv)
 {
     static struct option long_options[] = {
-        { "trace",          required_argument,          0,
-          't'                                                                                                                                                                                      }
-        ,
-        { "trace-dir",      required_argument,          0,
-          'D'                                                                                                                                                                                      }
-        ,
-        { "exclude-prefix", required_argument,          0,
-          'X'                                                                                                                                                                                      }
-        ,
-        { "block-size",     required_argument,          0,
-          'b'                                                                                                                                                                                      }
-        ,
-        { "verbose",        no_argument,                0,
-          'v'                                                                                                                                                                                      }
-        ,
-        { "dry-run",        no_argument,                0,
-          'n'                                                                                                                                                                                      }
-        ,
-        { "sigv2",          no_argument,                0,
-          '2'                                                                                                                                                                                      }
-        ,
-        { 0,                0,                          0,                         0 }
+/* *INDENT-OFF* */
+        { "trace",          required_argument, 0, 't' },
+        { "trace-dir",      required_argument, 0, 'D' },
+        { "exclude-prefix", required_argument, 0, 'X' },
+        { "block-size",     required_argument, 0, 'b' },
+        { "verbose",        no_argument,       0, 'v' },
+        { "dry-run",        no_argument,       0, 'n' },
+        { "sigv2",          no_argument,       0, '2' },
+        { "backend",        required_argument, 0, 'B' },
+        { 0, 0, 0, 0 }
+/* *INDENT-ON* */
     };
     struct s3_mbt_env    env;
     char               **traces;
     int                  ntraces;
     int                  block_size = 8192;
     int                  verbose = 0, dry_run = 0, sigv2 = 0;
+    const char          *backend  = "memfs";
     int                  failures = 0;
     int                  i, c;
 
@@ -2625,7 +2618,7 @@ main(
      * only needs to recognize the rest. */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:b:vn2", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:b:vn2B:", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -2644,11 +2637,14 @@ main(
             case '2':
                 sigv2 = 1;
                 break;
+            case 'B':
+                backend = optarg;
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace f.itf.json | --trace-dir dir]\n"
                         "          [--exclude-prefix p] [--block-size n]\n"
-                        "          [--sigv2] [--verbose] [--dry-run]\n", argv[0]);
+                        "          [--sigv2] [--backend m] [--verbose] [--dry-run]\n", argv[0]);
                 mbt_free_traces(traces, ntraces);
                 return 2;
         } /* switch */
@@ -2660,7 +2656,7 @@ main(
         return 2;
     }
 
-    s3_mbt_env_open(&env);
+    s3_mbt_env_open_module(&env, backend);
     env.sigv2 = sigv2;
 
     for (i = 0; i < ntraces; i++) {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -3169,6 +3169,22 @@ chimera_server_add_s3_cred(
     return chimera_s3_add_cred(server->s3_shared, access_key, secret_key, pinned);
 } /* chimera_server_add_s3_cred */
 
+SYMBOL_EXPORT int
+chimera_server_remove_s3_cred(
+    struct chimera_server *server,
+    const char            *access_key)
+{
+    return chimera_s3_remove_cred(server->s3_shared, access_key);
+} /* chimera_server_remove_s3_cred */
+
+SYMBOL_EXPORT void
+chimera_server_advance_s3_cred_clock(
+    struct chimera_server *server,
+    int64_t                seconds)
+{
+    chimera_s3_advance_cred_clock(server->s3_shared, seconds);
+} /* chimera_server_advance_s3_cred_clock */
+
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_winbind_enabled(
     struct chimera_server_config *config,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -969,6 +969,19 @@ chimera_server_add_s3_cred(
     const char            *secret_key,
     int                    pinned);
 
+int
+chimera_server_remove_s3_cred(
+    struct chimera_server *server,
+    const char            *access_key);
+
+/* Advance the S3 credential cache's synthetic clock and sweep expired
+ * credentials synchronously (test instrumentation; see
+ * chimera_s3_advance_cred_clock). */
+void
+chimera_server_advance_s3_cred_clock(
+    struct chimera_server *server,
+    int64_t                seconds);
+
 void
 chimera_server_config_set_smb_winbind_enabled(
     struct chimera_server_config *config,


### PR DESCRIPTION
Add a model-based test suite for the S3 server — the S3 sibling of the NFS3/SMB2 MBT suites — and fix the ten server defects it surfaced.

## The suite

The Quint model lives in the specs repo (chimera-nas/specs#7): the AWS S3 REST API (API Reference 2006-03-01, us-east-1 semantics) scoped to the operations chimera serves — bucket lifecycle, the object core (Put with metadata, ranged Get, Head, Delete, Copy), DeleteObjects batches, GetObjectAttributes, object/bucket tagging, ListObjects V1/V2/Versions, and the full multipart upload surface. Object keys are modeled as component lists whose byte order matches component order (listing order, prefix matching and delimiter rollup are structural), with directory components disjoint from leaf components so every generated key set is realizable on a POSIX filesystem — the deliberate scope is S3-on-POSIX, not the flat-namespace cases no filesystem gateway can represent.

`src/server/s3/tests/quint/` owns the C replay harness: the chimera server and the libevpl HTTP/1.1 client in one process over the inproc transport — no port, netns, lock or daemon, every trace fully parallel. Requests are genuinely signed (SigV4 with UNSIGNED-PAYLOAD and a fixed x-amz-date keeps them byte-deterministic; a `--sigv2` mode drives the whole corpus through the V2 verifier). The replayer checks status lines, S3 error codes, headers, body bytes, and listing/multipart result sets; ETags and UploadIds are never predicted — the oracle learns them and requires consistency.

The corpus replays against **every builtin backend** (`--backend memfs|diskfs|cairn|linux|io_uring`, provisioned the way the nfs3 harness does it; passthrough backends root their trees at `$CHIMERA_MBT_SCRATCH` and skip 77 without a name_to_handle_at-capable filesystem). Registered ctests, all green: the memfs probe + three batches (normal, multipart at the 5 MiB AWS part minimum, SigV2), `batch_diskfs`, `batch_cairn`, and `batch_multipart_cairn`.

Credential TTL expiry is exercised by ticking a synthetic clock: the cred cache carries an offset applied to every expiry decision, and `chimera_server_advance_s3_cred_clock()` advances it and sweeps synchronously — in the spirit of libevpl's virtual clock (which cannot govern this off-loop pthread component), tests tick time instead of waiting on it.

## Server fixes the model surfaced

On memfs:

- **`file_real_length` was stale on recycled requests**: PUT/DELETE nondeterministically answered 206 with a fabricated Content-Range after a GET reused the request slot.
- **The bucket/key split scanned past `?`**: a legal unencoded `/` in a query value (`?delimiter=/`, `?prefix=d/`) corrupted the bucket name into a 404 (the AWS SDKs' percent-encoding had masked it).
- **ListObjects start-key and phantom-prefix semantics**: a CommonPrefix sorting at or before the start key was dropped even with member keys past it, and empty directories (DeleteObject husks, or dirs made over NFS/SMB) surfaced as phantom CommonPrefixes. All `/`-delimiter CommonPrefixes now derive from file keys with start-key filtering at collection; this forfeits the old one-level walk pruning, which could not tell a populated group from an empty husk.
- **Zero-length GETs leaked their open handle** when the VFS chain completed inline before RECEIVE_COMPLETE (no WANT_DATA ever fires for a 0-byte body) — pinning the filesystem and hanging shutdown.
- **Failed-routing POST bodies resurrected the request**: DeleteObjects/CompleteMultipartUpload against a missing bucket ran the body machinery on never-initialized state and overwrote the 404 with a fabricated success.
- **CompleteMultipartUpload leaked its manifest body on every error path** — up to 16 MiB per rejected Complete.

Replaying against the other backends surfaced four more, invisible on memfs because its VFS callbacks complete inline and it creates unlinked temp files:

- **Requests completed on asynchronous VFS error paths were never answered**: a family of completion callbacks set the failed request COMPLETE and relied on the RECEIVE_COMPLETE tail to respond — which has already passed on an async backend. A DELETE of a key with missing parent directories wedged a cairn connection forever. The respond-if-received idiom is now applied at every such site.
- **Tagging composed xattr names on the stack**: `chimera_vfs_set_xattr` keeps the caller's pointers until completion, and cairn's delegation thread read a returned frame (stack-use-after-return under ASan). The names now live in the heap tagging context.
- **In-flight temp files listed as objects**: on backends without CREATE_UNLINKED, multipart parts and PutObject temps are real `._chimera_*` files, and ListObjects reported them (AWS never lists an upload's parts as objects). The listing collection now skips the internal temp-name prefix; DeleteBucket deliberately still sees them, since an in-flight upload blocking deletion matches AWS semantics.
- **DeleteObjects laundered lookup failures into successful deletes**: any parent lookup/open error was recorded as `<Deleted>`, so a transient passthrough ESTALE left the object on disk while the response claimed it removed — later listings and HEADs saw it "resurrect". Only ENOENT/ENOTDIR parents count as gone now; other failures report an honest `<Error>InternalError`.

Genuine chimera-vs-AWS behavior differences are tolerated via a deviation registry and pinned by the probe (which goes red when one is fixed — the retirement signal): DeleteObject 200/404-vs-204, DeleteBucket-nonempty 500-vs-409, self-copy 200-vs-400, whole-object-Range 200-vs-206, and the Complete-response ETag being detached from the object's later GET/HEAD ETag.

## Known issues the suite documents but does not fix

Two withheld batches, with rationale and repro recipes in the quint CMakeLists:

- **diskfs multipart** intermittently SEGVs (~1-in-2 on `stepMultipart_64_0x11_1`): PutObject's create_unlinked+link_at publish gets its link_at completion delivered on the diskfs IQ/txn thread, and the follow-on getattr in `chimera_s3_put_finish_common` races the owning thread.
- **linux/io_uring** exhibit intermittent ESTALE path lookups for directories that demonstrably exist (deterministic on `stepList_128_0x1_3`). With the harness's cache-disable knob the failure moves earlier — a PUT's final getattr loses its attributes — so the fault is in the passthrough module, not the cache layer. Run manually with `--backend linux|io_uring`.

## Coverage

Measured with clang source-based coverage over `src/server/s3/` (harness excluded): the full backend matrix reaches **80.0%** of the server's 8,049 instrumented lines (memfs-only: 74.0%). Per-file: metadata 91.1%, dispatch 88.0%, copy 87.4%, bucket 86.0%, get 83.0%, list 82.1%, multipart 81.8%, put 78.5%, DeleteObjects 75.9%, cred cache 73.0%, auth 72.2%.

## Specs pin

chimera-nas/specs#7 is merged; `ext/specs` is pinned to the specs-main merge commit `1b63c8b`, whose trace bundle is published, so the macOS merge-queue jobs can fetch it.
