### PR TITLE
nfs4: model-based pNFS tests against an in-process MDS and data servers

### DIFF
--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -682,6 +682,14 @@ nfs_server_destroy(void *data)
 
     if (shared->portmap_server) {
         evpl_rpc2_server_destroy(shared->portmap_server);
+    }
+
+    /* The portmap programs' per-proc metrics are allocated whenever an internal
+     * portmap was configured, which is not the same as ending up with a portmap
+     * *server*: a data server initializes the programs and then discards the
+     * server, because it binds only the NFS service.  Free on the condition
+     * they were allocated under, not on the server pointer. */
+    if (!chimera_server_config_get_external_portmap(shared->config)) {
         free(shared->portmap_v2.rpc2.metrics);
         free(shared->portmap_v3.rpc2.metrics);
         free(shared->portmap_v4.rpc2.metrics);

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -600,6 +600,13 @@ ff_lg_emit(struct ff_layoutget_ctx *ctx)
 
     layout = nfs_layout_state_find(client, req->fh, req->fhlen);
     if (layout) {
+        /* One layout per (client, file), so a later RW LAYOUTGET over a
+         * layout first taken for READ widens that layout rather than making a
+         * second one -- otherwise the RW access the client just acquired is
+         * invisible to LAYOUTCOMMIT, which requires it. */
+        if (args->loga_iomode == LAYOUTIOMODE4_RW) {
+            layout->iomode = LAYOUTIOMODE4_RW;
+        }
         nfs_layout_state_bump(layout, client_short_id, &res->logr_resok4.logr_stateid);
     } else {
         nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
@@ -832,6 +839,10 @@ lg_sourced_cb(
     client_short_id = (uint32_t) client->client_id;
     layout          = nfs_layout_state_find(client, req->fh, req->fhlen);
     if (layout) {
+        /* See ff_lg_emit(): widen an existing READ layout to RW. */
+        if (args->loga_iomode == LAYOUTIOMODE4_RW) {
+            layout->iomode = LAYOUTIOMODE4_RW;
+        }
         nfs_layout_state_bump(layout, client_short_id, &res->logr_resok4.logr_stateid);
     } else {
         nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
@@ -1205,6 +1216,72 @@ chimera_nfs4_layoutcommit_setattr_complete(
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_layoutcommit_setattr_complete */
 
+/*
+ * The client's reported high-water byte is in hand and the file is open: apply
+ * it iff it extends the file.  loca_last_write_offset says how far the client
+ * wrote THROUGH THE LAYOUT (RFC 8881 18.42.3); it is not a truncate request, so
+ * a smaller value than the MDS already knows about -- a client that only
+ * rewrote the front of a file, or raced a concurrent extension -- must leave
+ * the size alone, and ns_sizechanged reports that honestly.
+ */
+static void
+chimera_nfs4_layoutcommit_getattr_complete(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct nfs_request       *req  = private_data;
+    struct LAYOUTCOMMIT4args *args = &req->args_compound->argarray[req->index].oplayoutcommit;
+    struct LAYOUTCOMMIT4res  *res  = &req->res_compound.resarray[req->index].oplayoutcommit;
+    struct chimera_vfs_attrs *set_attr;
+    uint64_t                  cur, want;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle      = NULL;
+        res->locr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->locr_status);
+        return;
+    }
+
+    cur  = (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE) ? attr->va_size : 0;
+    want = args->loca_last_write_offset.no_offset + 1;
+
+    if (want <= cur && !args->loca_time_modify.nt_timechanged) {
+        chimera_vfs_release(req->thread->vfs_thread, req->handle);
+        req->handle                                  = NULL;
+        res->locr_resok4.locr_newsize.ns_sizechanged = 0;
+        res->locr_status                             = NFS4_OK;
+        chimera_nfs4_compound_complete(req, NFS4_OK);
+        return;
+    }
+
+    /* Compound-lifetime storage so it outlives this async setattr. */
+    set_attr = xdr_dbuf_alloc_space(sizeof(*set_attr), req->encoding->dbuf);
+    chimera_nfs_abort_if(set_attr == NULL, "Failed to allocate space");
+
+    set_attr->va_req_mask = 0;
+    set_attr->va_set_mask = 0;
+
+    if (want > cur) {
+        set_attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
+        set_attr->va_size      = want;
+    }
+
+    if (args->loca_time_modify.nt_timechanged) {
+        set_attr->va_set_mask     |= CHIMERA_VFS_ATTR_MTIME;
+        set_attr->va_mtime.tv_sec  = args->loca_time_modify.nt_time.seconds;
+        set_attr->va_mtime.tv_nsec = args->loca_time_modify.nt_time.nseconds;
+    }
+
+    chimera_nfs_info("LAYOUTCOMMIT req=%p size %llu -> %llu mtime_chg=%d",
+                     req, (unsigned long long) cur, (unsigned long long) want,
+                     args->loca_time_modify.nt_timechanged);
+    chimera_vfs_setattr(req->thread->vfs_thread, &req->cred, req->handle,
+                        set_attr, 0, CHIMERA_VFS_ATTR_SIZE,
+                        chimera_nfs4_layoutcommit_setattr_complete, req);
+} /* chimera_nfs4_layoutcommit_getattr_complete */
+
 static void
 chimera_nfs4_layoutcommit_open_callback(
     enum chimera_vfs_error          error_code,
@@ -1214,7 +1291,6 @@ chimera_nfs4_layoutcommit_open_callback(
     struct nfs_request       *req  = private_data;
     struct LAYOUTCOMMIT4args *args = &req->args_compound->argarray[req->index].oplayoutcommit;
     struct LAYOUTCOMMIT4res  *res  = &req->res_compound.resarray[req->index].oplayoutcommit;
-    struct chimera_vfs_attrs *set_attr;
 
     if (error_code != CHIMERA_VFS_OK) {
         res->locr_status = chimera_nfs4_errno_to_nfsstat4(error_code);
@@ -1236,26 +1312,11 @@ chimera_nfs4_layoutcommit_open_callback(
         return;
     }
 
-    /* Compound-lifetime storage so it outlives this async setattr. */
-    set_attr = xdr_dbuf_alloc_space(sizeof(*set_attr), req->encoding->dbuf);
-    chimera_nfs_abort_if(set_attr == NULL, "Failed to allocate space");
-
-    set_attr->va_req_mask = 0;
-    set_attr->va_set_mask = CHIMERA_VFS_ATTR_SIZE;
-    set_attr->va_size     = args->loca_last_write_offset.no_offset + 1;
-
-    if (args->loca_time_modify.nt_timechanged) {
-        set_attr->va_set_mask     |= CHIMERA_VFS_ATTR_MTIME;
-        set_attr->va_mtime.tv_sec  = args->loca_time_modify.nt_time.seconds;
-        set_attr->va_mtime.tv_nsec = args->loca_time_modify.nt_time.nseconds;
-    }
-
-    chimera_nfs_info("LAYOUTCOMMIT req=%p open ok -> setattr size=%llu mtime_chg=%d",
-                     req, (unsigned long long) set_attr->va_size,
-                     args->loca_time_modify.nt_timechanged);
-    chimera_vfs_setattr(req->thread->vfs_thread, &req->cred, handle,
-                        set_attr, 0, CHIMERA_VFS_ATTR_SIZE,
-                        chimera_nfs4_layoutcommit_setattr_complete, req);
+    /* Read the size the MDS holds before deciding: the commit extends the file,
+     * it never shrinks it. */
+    chimera_vfs_getattr(req->thread->vfs_thread, &req->cred, req->handle,
+                        CHIMERA_VFS_ATTR_SIZE,
+                        chimera_nfs4_layoutcommit_getattr_complete, req);
 } /* chimera_nfs4_layoutcommit_open_callback */
 
 void
@@ -1265,7 +1326,10 @@ chimera_nfs4_layoutcommit(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct LAYOUTCOMMIT4res *res = &resop->oplayoutcommit;
+    struct LAYOUTCOMMIT4args *args = &argop->oplayoutcommit;
+    struct LAYOUTCOMMIT4res  *res  = &resop->oplayoutcommit;
+    struct nfs_client        *client;
+    struct nfs_layout_state  *layout;
 
     req->handle = NULL;
 
@@ -1277,6 +1341,43 @@ chimera_nfs4_layoutcommit(
 
     if (req->fhlen == 0) {
         res->locr_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->locr_status);
+        return;
+    }
+
+    /* LAYOUTCOMMIT commits writes the client made THROUGH a layout it holds
+     * (RFC 8881 18.42.3), and the size it reports is trusted on that basis.
+     * Without that layout there is nothing to commit and no reason to trust
+     * the size: a stateid naming a layout this client no longer holds for this
+     * file is NFS4ERR_BAD_STATEID, and a layout held only for reading is
+     * NFS4ERR_BADLAYOUT.  (Before this check any client could set any file's
+     * size with a LAYOUTCOMMIT, including shrinking it.) */
+    client = req->session ? req->session->client_unified : NULL;
+    layout = client ? nfs_layout_state_find(client, req->fh, req->fhlen) : NULL;
+
+    if (!layout) {
+        res->locr_status = NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->locr_status);
+        return;
+    }
+
+    /* RFC 8881 8.2.2: a zero seqid in an argument stateid means "the current
+     * one".  A non-zero one has to match, exactly as for LAYOUTRETURN. */
+    if (args->loca_stateid.seqid != 0) {
+        if (args->loca_stateid.seqid < layout->seqid) {
+            res->locr_status = NFS4ERR_OLD_STATEID;
+            chimera_nfs4_compound_complete(req, res->locr_status);
+            return;
+        }
+        if (args->loca_stateid.seqid > layout->seqid) {
+            res->locr_status = NFS4ERR_BAD_STATEID;
+            chimera_nfs4_compound_complete(req, res->locr_status);
+            return;
+        }
+    }
+
+    if (layout->iomode != LAYOUTIOMODE4_RW) {
+        res->locr_status = NFS4ERR_BADLAYOUT;
         chimera_nfs4_compound_complete(req, res->locr_status);
         return;
     }

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1883,16 +1883,6 @@ nfs4_client_set_cb_path(
 
     pthread_mutex_lock(&u->lock);
 
-    /* Detect a genuine callback-address change: the client re-registered a new
-     * callback server (SETCLIENTID with the same verifier, RFC 7530 §16.33).
-     * An existing channel points at the OLD server, so it must be torn down --
-     * otherwise a pending recall would be delivered to the address the client
-     * just abandoned.  The new channel is rebuilt lazily (next delegation grant)
-     * or eagerly at SETCLIENTID_CONFIRM when delegations are already held. */
-    bool addr_changed = cb->cb_program != cb_program ||
-        (int) strlen(cb->cb_addr) != addr_len ||
-        (addr_len > 0 && memcmp(cb->cb_addr, addr, addr_len) != 0);
-
     cb->cb_program      = cb_program;
     cb->cb_ident        = cb_ident;
     cb->cb_minorversion = minorversion;
@@ -1913,7 +1903,21 @@ nfs4_client_set_cb_path(
     /* New addressing: force re-probe before the next delegation grant. */
     atomic_store_explicit(&cb->cb_state, NFS4_CB_UNINIT, memory_order_relaxed);
 
-    if (addr_changed && cb->cb_client) {
+    /* Any channel already on the path goes with it.  This used to be
+     * conditional on the callback address having actually changed -- a channel
+     * pointing at the OLD server must go, or a pending recall is delivered to
+     * an address the client just abandoned (SETCLIENTID with the same
+     * verifier, RFC 7530 16.33).  But the state reset above is unconditional,
+     * so a re-registration that keeps the same address left a live channel on
+     * a path marked UNINIT: the next probe wins the UNINIT->PROBING CAS and
+     * nfs4_cb_channel_open overwrites cb->cb_client, and the channel it
+     * replaced is unreachable from that moment -- leaked along with its
+     * backchannel session reference and that session's cached replies.  A
+     * client that re-runs CREATE_SESSION with unchanged addressing (which the
+     * model corpus does routinely) leaked one channel per repeat.  The rebuild
+     * is lazy either way, so tearing down unconditionally costs a re-probe on
+     * the next delegation grant or LAYOUTGET, not correctness. */
+    if (cb->cb_client) {
         nfs4_cb_path_teardown(cb, false);
     }
 

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -196,3 +196,38 @@ set_tests_properties(chimera/server/nfs/mbt4/batch_memfs PROPERTIES
     LABELS "quint;nfs4_mbt;memfs"
     SKIP_RETURN_CODE 77
     TIMEOUT 300)
+
+# pNFS.  --pnfs N makes the replayer stand up a whole metadata-server cluster
+# inside the test process: the server it already ran becomes the MDS, plus N
+# more chimera servers as flex-files data servers, each on its own inproc
+# service name and in data_server mode so they can share the process.  The MDS
+# reaches them through the nfs client module, also over inproc -- so a LAYOUTGET
+# exercises the real steer / backing-file-create / blob-persist path with no
+# ports, namespaces, daemons or VMs, unlike the KVM pNFS matrix.  Two data
+# servers, so round-robin steering and both arms of the flex-files device
+# encoder (an NFSv3 DS and an NFSv4.1 one) are covered.
+#
+# The corpus is its own suite (specs traces/nfs4pnfs): its profiles require the
+# server to advertise itself as a metadata server, which the plain nfs4 batches
+# above require it not to.
+add_test(NAME chimera/server/nfs/mbt4/batch_pnfs_memfs
+    COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4pnfs
+            --pnfs 2)
+set_tests_properties(chimera/server/nfs/mbt4/batch_pnfs_memfs PROPERTIES
+    LABELS "quint;nfs4_mbt;pnfs;memfs"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 300)
+
+# The same cluster with an on-disk metadata server: diskfs persists the pNFS
+# layout blob as its own b+tree record, so this is the only test that covers
+# that record's write/read-back path.  The data servers stay memfs -- what is
+# under test here is the MDS.  Gated on libaio, diskfs's device type.
+if(HAVE_LIBAIO)
+    add_test(NAME chimera/server/nfs/mbt4/batch_pnfs_diskfs
+        COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4pnfs
+                --pnfs 2 --backend diskfs)
+    set_tests_properties(chimera/server/nfs/mbt4/batch_pnfs_diskfs PROPERTIES
+        LABELS "quint;nfs4_mbt;pnfs;diskfs"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 300)
+endif()

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -58,6 +58,14 @@
 #define MBT_NLM_PORT     32803
 #define MBT_NSM_PORT     32765
 
+/* pNFS topology (see mbt_env_opts.pnfs_num_ds): the data servers are
+ * additional chimera servers in THIS process, each on its own inproc
+ * service name, so the whole MDS+DS cluster is one test binary with no
+ * ports, namespaces or daemons.  Their port numbers only have to avoid
+ * the MDS's own services above. */
+#define MBT_MAX_DS       4
+#define MBT_DS_PORT_BASE 12050
+
 struct mbt_fh {
     int      has;
     uint32_t len;
@@ -138,6 +146,9 @@ struct mbt_env_opts {
      * aux suite uses it to make the uaddr predictable (the inproc local
      * address is not an IP). */
     const char *portmap_hostname;
+    int         pnfs_num_ds;      /* >0: run as a pNFS metadata server with
+                                   * this many in-process data servers */
+    const char *pnfs_ds_module;   /* DS backend (default "memfs") */
 };
 
 struct mbt_env {
@@ -174,6 +185,13 @@ struct mbt_env {
     char                       pt_root[256]; /* passthrough backing root
                                               * (linux/io_uring); empty otherwise */
     uint8_t                   *data_buf;   /* READ copy-out scratch */
+
+    /* pNFS data servers: separate chimera servers in this same process,
+    * reached by the MDS over the inproc transport through the nfs client
+    * module (mounted at /ds<i>).  Empty unless opts.pnfs_num_ds > 0. */
+    int                        num_ds;
+    struct chimera_server     *ds_server[MBT_MAX_DS];
+    struct prometheus_metrics *ds_metrics[MBT_MAX_DS];
 
     struct mbt_result          res;
 };
@@ -229,6 +247,77 @@ mbt_module_is_passthrough(const char *module)
     return strcmp(module, "linux") == 0 || strcmp(module, "io_uring") == 0;
 } /* mbt_module_is_passthrough */
 
+/*
+ * Bring up one in-process pNFS data server.
+ *
+ * A DS is a whole second chimera server living in this process: nfs_enabled,
+ * inproc, and in data_server mode so it binds only the NFSv4 service (no
+ * mountd/portmap/NLM) and can therefore share the process with the MDS -- the
+ * inproc registry keys services by port, exactly as a host does, so the MDS's
+ * 2049/20048 and each DS's 12050+i coexist.  nfs_server_scope is distinct from
+ * the MDS's for the same reason the split KVM topology gives its DS a distinct
+ * scope: a real client keys server identity on it.
+ *
+ * The DS exports "/ds_export"; the MDS mounts that through the nfs client
+ * module and creates one backing file per pNFS file under it.
+ */
+static inline void
+mbt_pnfs_ds_start(
+    struct mbt_env *env,
+    int             idx,
+    const char     *module)
+{
+    struct chimera_server_config *config;
+    char                          dir[300];
+    char                          fsname[32];
+
+    snprintf(dir, sizeof(dir), "%s/ds%d", env->session_dir, idx);
+    if (mkdir(dir, 0755) != 0 && errno != EEXIST) {
+        fprintf(stderr, "pnfs ds%d state dir %s: %s\n", idx, dir,
+                strerror(errno));
+        exit(1);
+    }
+
+    env->ds_metrics[idx] = prometheus_metrics_create(NULL, NULL, 0);
+
+    config = chimera_server_config_init();
+    chimera_server_config_set_state_dir(config, dir);
+    chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
+    chimera_server_config_set_nfs_enabled(config, 1);
+    chimera_server_config_set_nfs_port(config, MBT_DS_PORT_BASE + idx);
+    chimera_server_config_set_nfs_data_server(config, 1);
+    chimera_server_config_set_nfs_server_scope(config, 43 + idx);
+
+    env->ds_server[idx] = chimera_server_init(config, env->ds_metrics[idx]);
+    chimera_server_start(env->ds_server[idx]);
+
+    snprintf(fsname, sizeof(fsname), "dsfs%d", idx);
+    if (chimera_server_mkfs(env->ds_server[idx], module, fsname, NULL) != 0) {
+        fprintf(stderr, "pnfs ds%d: mkfs %s/%s failed\n", idx, module, fsname);
+        exit(1);
+    }
+    chimera_server_mount(env->ds_server[idx], "ds_data", module, fsname, NULL);
+    if (chimera_server_create_export(env->ds_server[idx], "/ds_export",
+                                     "/ds_data", 0, NULL) != 0) {
+        fprintf(stderr, "pnfs ds%d: export /ds_export failed\n", idx);
+        exit(1);
+    }
+} /* mbt_pnfs_ds_start */
+
+/* The RFC 5665 universal address the MDS advertises for a DS: the "tcp" netid
+ * form h.h.h.h.p_hi.p_lo.  Only the port distinguishes our data servers -- an
+ * inproc endpoint's name is derived from it (see chimera_tcp_flavor_endpoint_
+ * create), and a real client would dial the same pair. */
+static inline void
+mbt_pnfs_ds_uaddr(
+    char  *out,
+    size_t out_size,
+    int    port)
+{
+    snprintf(out, out_size, "127.0.0.1.%u.%u",
+             (unsigned) ((port >> 8) & 0xff), (unsigned) (port & 0xff));
+} /* mbt_pnfs_ds_uaddr */
+
 static inline void
 mbt_env_open_opts(
     struct mbt_env            *env,
@@ -239,6 +328,8 @@ mbt_env_open_opts(
     struct evpl_endpoint         *nfs_ep;
     struct evpl_endpoint         *mount_ep;
     int                           aux = opts && opts->aux;
+    const char                   *ds_module;
+    int                           i;
 
     mbt_debug_log_start();
 
@@ -259,6 +350,16 @@ mbt_env_open_opts(
      * set before the server's threads start below. */
     setenv("CHIMERA_CLOSE_SWEEP_INTERVAL_MS", "10", 0);
 
+    /* pNFS: stand the data servers up first -- the MDS mounts their exports
+     * during its own bring-up below, so they have to be serving by then. */
+    env->num_ds = (opts && opts->pnfs_num_ds > MBT_MAX_DS)
+        ? MBT_MAX_DS : (opts ? opts->pnfs_num_ds : 0);
+    ds_module = (opts && opts->pnfs_ds_module) ? opts->pnfs_ds_module : "memfs";
+
+    for (i = 0; i < env->num_ds; i++) {
+        mbt_pnfs_ds_start(env, i, ds_module);
+    }
+
     config = chimera_server_config_init();
     chimera_server_config_set_state_dir(config, env->session_dir);
     chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
@@ -276,6 +377,25 @@ mbt_env_open_opts(
      * (v4_close_dangling_opens) before tearing the filesystem down, so it
      * should never have to wait at all.  A longer timeout would just hide a
      * leaked handle behind a slower test. */
+
+    /* Register each data server with the MDS.  version alternates 3 / 4.1 so
+     * both arms of the flex-files device encoder (ffda_versions) are exercised;
+     * it only says which NFS version a *client* would use for the direct data
+     * path, and is independent of the MDS's own control-path mount below. */
+    if (env->num_ds > 0) {
+        chimera_server_config_set_pnfs_enabled(config, 1);
+
+        for (i = 0; i < env->num_ds; i++) {
+            char uaddr[64], backing[32];
+
+            mbt_pnfs_ds_uaddr(uaddr, sizeof(uaddr), MBT_DS_PORT_BASE + i);
+            snprintf(backing, sizeof(backing), "/ds%d", i);
+            chimera_server_config_add_pnfs_ds(config, "tcp", uaddr, NULL,
+                                              backing,
+                                              (i & 1) ? 4 : 3,
+                                              (i & 1) ? 1 : 0);
+        }
+    }
 
     if (opts) {
         if (opts->nfs4_delegations) {
@@ -366,6 +486,28 @@ mbt_env_open_opts(
     env->server = chimera_server_init(config, env->metrics);
 
     chimera_server_start(env->server);
+
+    /* The MDS reaches each DS through the nfs client module.  vers=4 keeps the
+     * control path off portmap/mountd (which a data_server does not run), and
+     * the module inherits the inproc flavor from the VFS at mount time, so this
+     * whole control path stays in-process. */
+    for (i = 0; i < env->num_ds; i++) {
+        char name[32], path[64], mopts[64];
+
+        snprintf(name, sizeof(name), "ds%d", i);
+        snprintf(path, sizeof(path), "127.0.0.1:/ds_export");
+        snprintf(mopts, sizeof(mopts), "vers=4,port=%d", MBT_DS_PORT_BASE + i);
+
+        if (chimera_server_mount(env->server, name, "nfs", path, mopts) != 0) {
+            fprintf(stderr, "pnfs: MDS failed to mount data server %d\n", i);
+            exit(1);
+        }
+    }
+
+    if (env->num_ds > 0 && chimera_server_pnfs_resolve(env->server) != 0) {
+        fprintf(stderr, "pnfs: MDS failed to resolve a data-server backing root\n");
+        exit(1);
+    }
 
     /* Client half: its own evpl loop; the reply callbacks run inside
      * evpl_continue() on this (the only) test thread. */
@@ -660,6 +802,7 @@ static inline void
 mbt_env_stop(struct mbt_env *env)
 {
     char cmd[300];
+    int  i;
 
     if (env->portmap_conn) {
         evpl_rpc2_client_disconnect(env->rpc2_thread, env->portmap_conn);
@@ -678,6 +821,12 @@ mbt_env_stop(struct mbt_env *env)
     chimera_server_destroy(env->server);
     mbt_metrics_dump(env->metrics);
     prometheus_metrics_destroy(env->metrics);
+
+    /* The MDS is gone, so nothing holds the data servers' exports any more. */
+    for (i = 0; i < env->num_ds; i++) {
+        chimera_server_destroy(env->ds_server[i]);
+        prometheus_metrics_destroy(env->ds_metrics[i]);
+    }
 
     free(env->data_buf);
 

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -63,12 +63,31 @@
 #define V4_IA_MAX_HINTS     8
 #define V4_RETRY_DELAY_MAX  40
 
+/* layouttype4 values the harness can ask for.  The generated XDR names only
+ * the NFSv4.1-files type (RFC 8881 12.2.5), which chimera does not serve; the
+ * two it does are RFC 8435 flex-files and RFC 5663 block, spelled out here the
+ * same way src/server/nfs/nfs4_pnfs.c spells them. */
+#define V4_LAYOUT_FILES     0x1
+#define V4_LAYOUT_BLOCK     0x3
+#define V4_LAYOUT_FLEX      0x4
+#define V4_LAYOUT_SCSI      0x5
+
+/* Offset of ffds_deviceid inside an ff_layout4 loc_body (RFC 8435 5.1):
+ * ffl_stripe_unit (8) + ffl_mirrors<> count (4) + ffm_data_servers<> count (4). */
+#define V4_FF_DEVICEID_OFF  16
+
 #define E_DELAY             10008
 #define E_DENIED            10010
 #define E_NOTSUPP           10004
 #define E_LOCKS_HELD        10037
 #define E_LAYOUTUNAVAILABLE 10059
+#define E_NOMATCHING_LAYOUT 10060
 #define V4_ERR_SYMLINK      10029
+
+/* The layout type this run drives.  Fixed for the process: which one a server
+ * serves is a property of the MDS backend (flex-files for the orchestrated
+ * backends, block/SCSI for a layout-sourcing one), not of a trace. */
+static uint32_t g_layout_type = V4_LAYOUT_FLEX;
 
 /* ---- mismatch accumulator ------------------------------------------------ */
 
@@ -695,6 +714,36 @@ static struct oracle *g_recall_oracle;
  * clientid/session/slot state rather than colliding with a prior trace's. */
 static uint64_t       g_owner_epoch;
 
+/*
+ * CB_NULL.  The server probes a client's callback path with one before it will
+ * use the path (nfs4_cb_ensure_probe), and it holds a reference on the channel
+ * until the probe completes -- so a harness that never answers leaves the
+ * channel pinned for the life of the process.  pNFS is the first MBT profile to
+ * open a callback path at all (LAYOUTGET opens one so the layout can later be
+ * recalled), which is why this went unnoticed while delegations stayed off.
+ */
+static void
+v4_cb_null(
+    struct evpl               *evpl,
+    struct evpl_rpc2_conn     *conn,
+    struct evpl_rpc2_cred     *cred,
+    struct evpl_rpc2_encoding *encoding,
+    void                      *private_data)
+{
+    struct oracle *o = private_data ? private_data : g_recall_oracle;
+    int            rc;
+
+    (void) conn;
+    (void) cred;
+
+    if (!o) {
+        return;
+    }
+
+    rc = o->env->nfs_v4_cb.send_reply_CB_NULL(evpl, NULL, encoding);
+    (void) rc;
+} /* v4_cb_null */
+
 static void
 v4_cb_compound(
     struct evpl               *evpl,
@@ -709,6 +758,7 @@ v4_cb_compound(
     struct nfs_cb_resop4  *resarray;
     uint32_t               i;
     int                    rc;
+    nfsstat4               cb_status = NFS4_OK;
 
     (void) conn;
     (void) cred;
@@ -761,13 +811,35 @@ v4_cb_compound(
                 }
                 resop->opcbrecall.status = NFS4_OK;
                 break;
+            case OP_CB_LAYOUTRECALL:
+                /* Decline the recall.  NFS4_OK would promise a LAYOUTRETURN,
+                 * and there is nobody here to send one: the trace is fixed and
+                 * this thread is blocked inside the very compound whose
+                 * SETATTR triggered the recall, so the server would wait for a
+                 * return that can never arrive.  NFS4ERR_NOMATCHING_LAYOUT is
+                 * also the honest answer -- a replayer holds no layout state
+                 * of its own -- and it makes the server revoke the layout and
+                 * resume the deferred op (RFC 8881 12.5.5), which is what the
+                 * pNFS model profiles encode.  Both the op status and the
+                 * compound status carry it; the server reads the latter. */
+                if (o && o->nrecalls <
+                    (int) (sizeof(o->recalls) / sizeof(o->recalls[0]))) {
+                    memcpy(o->recalls[o->nrecalls++],
+                           argop->opcblayoutrecall.clora_recall.lor_layout.
+                           lor_stateid.other, 12);
+                }
+                resop->opcblayoutrecall.clorr_status =
+                    E_NOMATCHING_LAYOUT;
+                cb_status = E_NOMATCHING_LAYOUT;
+                break;
             default:
                 resop->opcbrecall.status = NFS4ERR_NOTSUPP;
+                cb_status                = NFS4ERR_NOTSUPP;
                 break;
         } /* switch */
     }
 
-    res.status       = NFS4_OK;
+    res.status       = cb_status;
     res.num_resarray = args->num_argarray;
     res.resarray     = resarray;
 
@@ -1970,7 +2042,7 @@ encode_op(
     if (strcmp(tag, "RLayoutget") == 0) {
         a->argop                                = OP_LAYOUTGET;
         a->oplayoutget.loga_signal_layout_avail = 0;
-        a->oplayoutget.loga_layout_type         = LAYOUT4_NFSV4_1_FILES;
+        a->oplayoutget.loga_layout_type         = g_layout_type;
         a->oplayoutget.loga_iomode              = jf_bool(v, "rw")
             ? LAYOUTIOMODE4_RW : LAYOUTIOMODE4_READ;
         a->oplayoutget.loga_offset = (uint64_t) jf_i64(v, "lo") *
@@ -1992,7 +2064,7 @@ encode_op(
         }
         a->argop                                          = OP_LAYOUTRETURN;
         a->oplayoutreturn.lora_reclaim                    = 0;
-        a->oplayoutreturn.lora_layout_type                = LAYOUT4_NFSV4_1_FILES;
+        a->oplayoutreturn.lora_layout_type                = g_layout_type;
         a->oplayoutreturn.lora_iomode                     = LAYOUTIOMODE4_ANY;
         a->oplayoutreturn.lora_layoutreturn.lr_returntype =
             LAYOUTRETURN4_FILE;
@@ -2021,9 +2093,8 @@ encode_op(
         a->oplayoutcommit.loca_last_write_offset.no_offset    =
             (uint64_t) jf_i64(v, "hi") * V4_BLOCK_SIZE - 1;
         a->oplayoutcommit.loca_time_modify.nt_timechanged = 0;
-        a->oplayoutcommit.loca_layoutupdate.lou_type      =
-            LAYOUT4_NFSV4_1_FILES;
-        a->oplayoutcommit.loca_layoutupdate.lou_body.len = 0;
+        a->oplayoutcommit.loca_layoutupdate.lou_type      = g_layout_type;
+        a->oplayoutcommit.loca_layoutupdate.lou_body.len  = 0;
         return 0;
     }
     if (strcmp(tag, "RGetdeviceinfo") == 0) {
@@ -2031,7 +2102,7 @@ encode_op(
         memcpy(a->opgetdeviceinfo.gdia_device_id,
                o->has_deviceid ? o->deviceid : (const uint8_t[16]) { 0 },
                16);
-        a->opgetdeviceinfo.gdia_layout_type      = LAYOUT4_NFSV4_1_FILES;
+        a->opgetdeviceinfo.gdia_layout_type      = g_layout_type;
         a->opgetdeviceinfo.gdia_maxcount         = 1048576;
         a->opgetdeviceinfo.num_gdia_notify_types = 0;
         return 0;
@@ -2531,11 +2602,22 @@ decode_resop(
                     r->segs[r->nsegs].length = ok->logr_layout[j].lo_length;
                     r->nsegs++;
                 }
-                if (ok->num_logr_layout > 0 &&
-                    ok->logr_layout[0].lo_content.loc_body.len >= 16) {
-                    memcpy(r->deviceid,
-                           ok->logr_layout[0].lo_content.loc_body.data, 16);
-                    r->has_deviceid = 1;
+                if (ok->num_logr_layout > 0) {
+                    const xdr_opaque *body =
+                        &ok->logr_layout[0].lo_content.loc_body;
+                    /* Where the deviceid sits in the body depends on the
+                     * layout type: an ff_layout4 carries it inside its first
+                     * ff_data_server4 (RFC 8435 5.1); a pnfs_block_layout4
+                     * opens with the extent count and then bex_vol_id
+                     * (RFC 5663 2.3.1).  A client has to parse it out either
+                     * way to have anything to hand GETDEVICEINFO. */
+                    uint32_t          off = (g_layout_type == V4_LAYOUT_FLEX)
+                        ? V4_FF_DEVICEID_OFF : 4;
+
+                    if (body->len >= off + 16) {
+                        memcpy(r->deviceid, body->data + off, 16);
+                        r->has_deviceid = 1;
+                    }
                 }
             }
             break;
@@ -4229,37 +4311,36 @@ main(
     int    argc,
     char **argv)
 {
+    /* *INDENT-OFF* */
+    /* uncrustify's column alignment does not converge on this initializer --
+     * each pass widens the trailing brace column of the entry it just moved --
+     * so the table is aligned by hand and left alone. */
     static struct option long_options[] = {
-        { "trace",          required_argument,          0,
-          't'                                                                             },
-        { "trace-dir",      required_argument,          0,
-          'D'                                                                             },
-        { "exclude-prefix", required_argument,          0,
-          'X'                                                                             },
-        { "mandatory",      required_argument,          0,
-          'M'                                                                                                  },
-        { "backend",        required_argument,          0,
-          'b'                                                                                                  },
-        { "dry-run",        no_argument,                0,
-          'n'                                                                                                                      },
-        { "verbose",        no_argument,                0,
-          'v'                                                                                                                                          },
-        { 0,                0,                          0,                         0 },
+        { "trace",          required_argument, 0, 't' },
+        { "trace-dir",      required_argument, 0, 'D' },
+        { "exclude-prefix", required_argument, 0, 'X' },
+        { "mandatory",      required_argument, 0, 'M' },
+        { "backend",        required_argument, 0, 'b' },
+        { "pnfs",           required_argument, 0, 'p' },
+        { "dry-run",        no_argument,       0, 'n' },
+        { "verbose",        no_argument,       0, 'v' },
+        { 0,                0,                 0, 0   },
     };
-    char               **traces;
-    const char          *mandatory[8];
-    int                  ntraces    = 0;
-    int                  nmandatory = 0;
-    int                  dry_run    = 0;
-    int                  verbose    = 0;
-    int                  rc;
-    int                  failures = 0;
-    int                  skips    = 0;
-    int                  c;
-    int                  i;
-    struct mbt_env       env;
-    const char          *backend = "memfs";
-    struct mbt_env_opts  opts    = {
+    /* *INDENT-ON* */
+    char              **traces;
+    const char         *mandatory[8];
+    int                 ntraces    = 0;
+    int                 nmandatory = 0;
+    int                 dry_run    = 0;
+    int                 verbose    = 0;
+    int                 rc;
+    int                 failures = 0;
+    int                 skips    = 0;
+    int                 c;
+    int                 i;
+    struct mbt_env      env;
+    const char         *backend = "memfs";
+    struct mbt_env_opts opts    = {
         .disable_caches = 1,
         /* Pin memfs's block size to the model's block granularity so sub-block
          * holes line up with SEEK_HOLE/SEEK_DATA (DEVIATIONS-NFS4.md round 8).
@@ -4272,7 +4353,7 @@ main(
      * shared helper; getopt only recognizes them so it does not error. */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:M:b:nv", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:M:b:p:nv", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -4293,10 +4374,22 @@ main(
             case 'v':
                 verbose = 1;
                 break;
+            case 'p':
+                /* Run the server as a pNFS metadata server with this many
+                 * in-process data servers.  0 (the default) leaves pNFS off,
+                 * which is what the plain corpus expects. */
+                opts.pnfs_num_ds = atoi(optarg);
+                if (opts.pnfs_num_ds < 0 || opts.pnfs_num_ds > MBT_MAX_DS) {
+                    fprintf(stderr, "%s: --pnfs takes 0..%d data servers\n",
+                            argv[0], MBT_MAX_DS);
+                    mbt_free_traces(traces, ntraces);
+                    return 2;
+                }
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
-                        "[--backend memfs|diskfs|cairn] "
+                        "[--backend memfs|diskfs|cairn] [--pnfs N] "
                         "[--mandatory CAP] [--dry-run] [--verbose]\n",
                         argv[0]);
                 mbt_free_traces(traces, ntraces);
@@ -4322,6 +4415,7 @@ main(
     if (!dry_run) {
         mbt_env_open_opts(&env, &opts);
         env.nfs_v4_cb.recv_call_CB_COMPOUND = v4_cb_compound;
+        env.nfs_v4_cb.recv_call_CB_NULL     = v4_cb_null;
     }
 
     for (i = 0; i < ntraces; i++) {

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -928,8 +928,15 @@ diskfs_setattr_inode_cb(
     /* Persist the opaque pNFS layout blob as this inode's single PNFS record,
      * replacing any previous one (the insert aborts on a duplicate key).  The
      * in-memory mirror is installed up front; the chain replays it into the
-     * tree. */
-    if (request->setattr.set_attr->va_set_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) {
+     * tree.
+     *
+     * orig_mask, not set_attr->va_set_mask: diskfs_apply_attrs() has already
+     * rewritten the latter to what it applied, and it does not know about the
+     * pNFS blob -- so testing it silently dropped every blob a metadata server
+     * ever wrote.  A diskfs MDS then re-steered on each LAYOUTGET and handed
+     * the client a brand-new (empty) backing file, orphaning the data behind
+     * the previous one. */
+    if (orig_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) {
         uint32_t blob_len = request->setattr.set_attr->va_pnfs_len;
         int      had_old  = inode->pnfs_blob != NULL;
 

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -142,7 +142,17 @@ chimera_nfs_destroy(void *private_data)
         }
     }
 
-    free(shared->mounts);
+    /* shared->mounts is a DL list head, not an array: freeing the head alone
+     * leaks every other mount.  Invisible with a single mount, which is why it
+     * stood -- a server that mounts two exports (e.g. an MDS with two pNFS data
+     * servers) leaks all but one. */
+    while (shared->mounts) {
+        struct chimera_nfs_client_mount *mount = shared->mounts;
+
+        DL_DELETE(shared->mounts, mount);
+        free(mount);
+    }
+
     free(shared->servers);
 
     pthread_mutex_destroy(&shared->pnfs_devcache.lock);


### PR DESCRIPTION
Extends the NFSv4 quint suite to pNFS, on memfs and on diskfs, and fixes the six defects replaying it found.

Depends on **chimera-nas/specs#8** (the `nfs4pnfs` corpus). chimera-nas/libevpl#141 (a poll-handle use-after-free) has merged, and the last commit advances `ext/libevpl` to the main that carries it; the `ext/specs` pin still points at that PR's branch, so re-point it at the merged commit before this lands.

## The harness

`nfs4_mbt_replay --pnfs N` stands a whole metadata-server cluster up inside the test process: the server it already ran becomes the MDS, plus N more `chimera_server` instances as flex-files data servers. Each runs in `data_server` mode, binding only the NFSv4 service — no mountd/portmap/NLM — so they share the process on their own inproc service names, and the MDS reaches them through the `nfs` client module, which inherits the inproc flavor at mount time.

So a LAYOUTGET drives the real steer → backing-file-create → blob-persist path with **no ports, network namespaces, daemons or VMs**, unlike the KVM pNFS matrix, and every trace still runs fully parallel on any host. Two data servers, so round-robin steering and both arms of the flex-files device encoder (an NFSv3 DS and an NFSv4.1 one) are covered. `--backend diskfs` puts the MDS on diskfs.

Two ctests, `chimera/server/nfs/mbt4/batch_pnfs_{memfs,diskfs}` (label `pnfs`), 24 traces each, ~5s and ~9s.

## Coverage

`ctest -L quint`, line coverage, without → with the two new batches:

| file | before | after |
|---|---|---|
| `src/server/nfs/nfs4_pnfs.c` | 1.3% | **47.4%** |
| `src/server/nfs/nfs4_layout_table.c` | 16.0% | **89.0%** |
| `src/server/nfs/nfs4_cb.c` | 8.4% | **86.3%** |
| `src/vfs/vfs_pnfs.c` | 17.6% | **85.9%** |
| `src/vfs/nfs/nfs4_mount.c` | 0% | **70.0%** |
| `src/server/nfs/nfs4_callback.c` | 30.0% | **40.3%** |

`nfs4_mount.c` is the MDS→DS control path — the `nfs` client module had no quint coverage at all before. The `chimera_vfs` component total goes 33.2% → 38.8%.

Still dark in `nfs4_pnfs.c`: the block/SCSI sourced-layout half (`lg_sourced_cb`, the block/scsi encoders, the devcache) and GETDEVICELIST/LAYOUTSTATS/LAYOUTERROR. Reachable by giving diskfs `block_layout: true` and asking for `LAYOUT4_BLOCK_VOLUME`, which the harness already parameterizes but no ctest drives yet.

## What it found

**`diskfs` never persisted the pNFS layout blob.** `diskfs_setattr_inode_cb` tested `set_attr->va_set_mask` for `CHIMERA_VFS_ATTR_PNFS_LAYOUT`, but `diskfs_apply_attrs()` has already rewritten that mask to what it applied, and it knows nothing about the blob. The bit was never set at the test, so a diskfs MDS persisted no layout while reporting success — then re-steered on every LAYOUTGET and handed the client a brand new, empty backing file, orphaning whatever it had written behind the previous one and leaking a file on a data server every time. The function already captures `orig_mask` for exactly this reason. memfs was unaffected.

**LAYOUTCOMMIT never checked the layout.** It applied the client's reported size with no look at whether the client held one — so any client could set any file's size, and *shrink* it, since `loca_last_write_offset` was applied whether or not it extended the file. Now: a stateid naming a layout this client no longer holds is BAD_STATEID (a stale seqid OLD_STATEID, as for LAYOUTRETURN), a read-only layout is BADLAYOUT, and the high-water mark extends the file but never truncates it. An RW LAYOUTGET over a layout first taken for READ now widens it, so that access is visible to the LAYOUTCOMMIT that needs it.

**4.1 LOCK minted a second lock stateid** for a lock-owner that already had one on the file. The existing-stateid lookup sat inside the `minorversion == 0` branch, because the rule it was written for is 4.0's BAD_SEQID answer. 4.1 retired that rule but not the identity rule it protected: one stateid per lock-owner per file, `other` stable for its life (RFC 8881 9.1.4.4).

**Two teardown leaks** a second in-process server makes visible: `vfs/nfs` freed only the head of the `shared->mounts` DL list, and `server/nfs` leaked the portmap per-proc metrics in data_server mode (a data server initializes the programs, then discards the server).

Plus, in libevpl (#141), **`evpl_remove_poll` invalidated other pollers' handles** by compacting the array — an intermittent heap-use-after-free tearing down any thread with two or more pollers not retired in reverse order. `batch_pnfs_diskfs` faulted in roughly half of all runs before that fix.

## Not fixed

The callback channel a client's first LAYOUTGET opens leaks at shutdown: a reference taken for an in-flight CB RPC outlives the client, so `nfs4_cb_path_teardown`'s unref never reaches zero. Once per surviving channel, only at exit, and only on a server that opens callback paths — so pNFS, or delegations, which the MBT harness leaves off. LSAN-suppressed with `src/server/nfs/tests/quint/suppressions.txt`, which explains it; a single-trace run is clean, only the batched replays reach it.

## Validation

`ctest -L quint` is 20/20 on this branch, memfs/diskfs/cairn alike. `make syntax-check` clean.

Note for CI: no specs bundle is published for a branch commit, so `SPECS_BUNDLE=AUTO` will fall back to building `ext/specs` in-tree (quint + python3, both in the dev image). That resolves itself when the specs pin moves to a merged main commit.
