### PR TITLE
vfs: a file handle that no longer names anything is ESTALE, not ENOENT

### DIFF
--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -68,10 +68,31 @@ target_link_libraries(nfs4_mbt_replay
 # do not hang.  Goes red when chimera is fixed -- the signal to retire a
 # deviation -- or if a deadlock regresses.  Needs no trace corpus.
 add_test(NAME chimera/server/nfs/mbt/deviation_probe_memfs
-    COMMAND $<TARGET_FILE:nfs3_mbt_probe>)
+    COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b memfs)
 set_tests_properties(chimera/server/nfs/mbt/deviation_probe_memfs PROPERTIES
     LABELS "quint;nfs3_mbt;memfs"
     TIMEOUT 60)
+
+# The same probe against the on-disk backends.  Most of what it guards is in
+# the NFS3 layer and backend-independent, but the stale-filehandle case (F6) is
+# each backend's own: they each resolve a handle themselves, and each had to
+# learn to tell a handle that no longer names anything from a name that was
+# never there.
+if(HAVE_LIBAIO)
+    add_test(NAME chimera/server/nfs/mbt/deviation_probe_diskfs
+        COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b diskfs)
+    set_tests_properties(chimera/server/nfs/mbt/deviation_probe_diskfs PROPERTIES
+        LABELS "quint;nfs3_mbt;diskfs"
+        TIMEOUT 60)
+endif()
+
+if(CAIRN_ENABLED)
+    add_test(NAME chimera/server/nfs/mbt/deviation_probe_cairn
+        COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b cairn)
+    set_tests_properties(chimera/server/nfs/mbt/deviation_probe_cairn PROPERTIES
+        LABELS "quint;nfs3_mbt;cairn"
+        TIMEOUT 60)
+endif()
 
 # Auxiliary-protocol ground truth: pins which portmap/rpcbind, MOUNT, NLM and
 # NSM procedures chimera registers, and the constants their replies carry --

--- a/src/server/nfs/tests/quint/nfs3_mbt_probe.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_probe.c
@@ -20,11 +20,55 @@
  *   - F5 (RMDIR/REMOVE type enforcement, was D4) -- asserts the fixed
  *     behavior: RMDIR of a non-directory is NOTDIR, REMOVE of a directory
  *     is ISDIR, and the target survives the rejected call.
+ *   - F6 (a filehandle whose object is gone) -- asserts NFS3ERR_STALE,
+ *     which is what RFC 1813 section 3.3 describes and what every error
+ *     list that mentions a dead handle names.  It used to be
+ *     NFS3ERR_NOENT, which is not in SETATTR's or LINK's error list at
+ *     all and which a client takes as final where it would retry a
+ *     path resolution on STALE.
  */
 
 #include "nfs3_mbt_common.h"
 
 static int failures = 0;
+
+/*
+ * Wait for a filehandle to go stale.
+ *
+ * The contract is that a handle stops resolving once its object is gone, not
+ * that it stops on the very next call.  memfs and cairn free the inode inline;
+ * diskfs reclaims it in the background, and a client cannot tell the difference
+ * because it has already been told the remove succeeded.
+ *
+ * The gap between checks is the part that matters, and it is not arbitrary.
+ * Resolving a handle puts it back in the VFS handle cache, which pins the
+ * object until the close sweep releases it -- so a tight poll keeps alive
+ * exactly the thing it is waiting to see die, and never terminates.  Checking
+ * at an interval well clear of the sweep leaves the handle idle long enough to
+ * be reclaimed between attempts.
+ *
+ * An unlinked object that something holds open is a different case and stays
+ * reachable, which is why nothing here holds one open.
+ */
+#define PROBE_STALE_GAP_US 250000
+#define PROBE_STALE_TRIES  20
+
+static uint32_t
+await_stale(
+    struct mbt_env      *env,
+    const struct mbt_fh *fh)
+{
+    uint32_t st = NFS3_OK;
+    int      i;
+
+    for (i = 0; i < PROBE_STALE_TRIES && st == NFS3_OK; i++) {
+        st = mbt_getattr(env, fh)->status;
+        if (st == NFS3_OK) {
+            usleep(PROBE_STALE_GAP_US);
+        }
+    }
+    return st;
+} /* await_stale */
 
 static void
 expect(
@@ -41,23 +85,41 @@ expect(
 } /* expect */
 
 int
-main(void)
+main(
+    int    argc,
+    char **argv)
 {
-    struct mbt_env    *env = malloc(sizeof(*env));
-    struct mbt_result *res;
-    struct mbt_fh      root;
-    struct mbt_fh      sl;
-    struct mbt_fh      d1;
-    struct mbt_fh      pd;
-    uint8_t            verf_a[NFS3_CREATEVERFSIZE] =
+    struct mbt_env     *env = malloc(sizeof(*env));
+    struct mbt_env_opts opts;
+    const char         *backend = "memfs";
+    int                 i;
+    struct mbt_result  *res;
+    struct mbt_fh       root;
+    struct mbt_fh       sl;
+    struct mbt_fh       d1;
+    struct mbt_fh       pd;
+    uint8_t             verf_a[NFS3_CREATEVERFSIZE] =
     { 0, 0, 0, 0, 0xab, 0xcd, 0x12, 0x34 };
-    uint8_t            verf_b[NFS3_CREATEVERFSIZE] =
+    uint8_t             verf_b[NFS3_CREATEVERFSIZE] =
     { 0, 0, 0, 0, 0, 0, 0xbe, 0xef };
+
+    /* The fixes this guards are in the NFS3 layer, except F6, which is in
+     * each storage backend -- so the backend is selectable and every one that
+     * this build has is registered as its own test. */
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-b") == 0 && i + 1 < argc) {
+            backend = argv[++i];
+        }
+    }
 
     /* A deadlock regression would hang a call forever; die loudly. */
     alarm(60);
 
-    mbt_env_start(env);
+    memset(&opts, 0, sizeof(opts));
+    opts.module = backend;
+    mbt_env_start_opts(env, &opts);
+
+    printf("backend: %s\n", backend);
 
     res = mbt_mnt(env, "/share");
     if (res->rpc_err || res->status != MNT3_OK) {
@@ -142,6 +204,65 @@ main(void)
     expect("RENAME child onto a name resolving to its parent",
            mbt_rename(env, &pd, "f", 1, &root, "pd", 2)->status,
            NFS3ERR_ISDIR);
+
+    printf("F6 a filehandle whose object is gone -> STALE:\n");
+    {
+        struct mbt_fh gone;
+        struct mbt_fh gone_dir;
+
+        /*
+         * The handle is used once while its object is live, so the server has
+         * had every chance to cache it, and then the object is removed.  What
+         * is left is a well-formed handle that names nothing -- which is the
+         * definition of stale, and is distinct from a name that was never
+         * there.
+         */
+        res = mbt_create(env, &root, "f6", 2, GUARDED, 0777, NULL);
+        if (res->status != NFS3_OK || !res->obj_fh.has) {
+            fprintf(stderr, "CREATE f6 failed: %u\n", res->status);
+            return 1;
+        }
+        gone = res->obj_fh;
+        expect("GETATTR while live", mbt_getattr(env, &gone)->status, NFS3_OK);
+        expect("REMOVE f6", mbt_remove(env, &root, "f6", 2)->status, NFS3_OK);
+
+        expect("GETATTR on a dead file handle",
+               await_stale(env, &gone), NFS3ERR_STALE);
+        expect("SETATTR on a dead file handle",
+               mbt_setattr(env, &gone, -1, 0, NULL)->status, NFS3ERR_STALE);
+        expect("LINK from a dead file handle",
+               mbt_link(env, &gone, &root, "f6b", 3)->status, NFS3ERR_STALE);
+
+        /* A dead DIRECTORY handle is stale for the operations that take one,
+         * including those that also carry a name: the name never gets looked
+         * at, because there is nothing to look in. */
+        res = mbt_mkdir(env, &root, "d6", 2, 0777);
+        if (res->status != NFS3_OK || !res->obj_fh.has) {
+            fprintf(stderr, "MKDIR d6 failed: %u\n", res->status);
+            return 1;
+        }
+        gone_dir = res->obj_fh;
+        expect("RMDIR d6", mbt_rmdir(env, &root, "d6", 2)->status, NFS3_OK);
+
+        expect("directory handle goes stale",
+               await_stale(env, &gone_dir), NFS3ERR_STALE);
+        expect("LOOKUP in a dead directory handle",
+               mbt_lookup(env, &gone_dir, "x", 1)->status, NFS3ERR_STALE);
+        expect("READDIR of a dead directory handle",
+               mbt_readdir(env, &gone_dir)->status, NFS3ERR_STALE);
+        expect("CREATE in a dead directory handle",
+               mbt_create(env, &gone_dir, "x", 1, GUARDED, 0777, NULL)->status,
+               NFS3ERR_STALE);
+        expect("REMOVE in a dead directory handle",
+               mbt_remove(env, &gone_dir, "x", 1)->status, NFS3ERR_STALE);
+
+        /* And a name that was never there is still NFS3ERR_NOENT: the point of
+        * the change is to tell the two apart, not to answer STALE for both. */
+        expect("LOOKUP of a name that does not exist",
+               mbt_lookup(env, &root, "nope", 4)->status, NFS3ERR_NOENT);
+        expect("REMOVE of a name that does not exist",
+               mbt_remove(env, &root, "nope", 4)->status, NFS3ERR_NOENT);
+    }
 
     mbt_env_stop(env);
     free(env);

--- a/src/server/smb/smb_ea.h
+++ b/src/server/smb/smb_ea.h
@@ -59,6 +59,7 @@ chimera_smb_ea_status(enum chimera_vfs_error err)
         case CHIMERA_VFS_EEXIST:
             return SMB2_STATUS_OBJECT_NAME_COLLISION;
         case CHIMERA_VFS_ENOENT:
+        case CHIMERA_VFS_ESTALE:
             return SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
         default:
             return SMB2_STATUS_INTERNAL_ERROR;

--- a/src/server/smb/smb_proc_close.c
+++ b/src/server/smb/smb_proc_close.c
@@ -76,7 +76,11 @@ chimera_smb_close_doc_status(enum chimera_vfs_error error_code)
         case CHIMERA_VFS_ENOTEMPTY: return SMB2_STATUS_DIRECTORY_NOT_EMPTY;
         case CHIMERA_VFS_EACCES:
         case CHIMERA_VFS_EPERM:     return SMB2_STATUS_ACCESS_DENIED;
-        case CHIMERA_VFS_ENOENT:    return SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
+        case CHIMERA_VFS_ENOENT:
+        /* A handle whose object is gone reports ESTALE now that the backends
+         * distinguish it from a name that was never there; SMB has one status
+         * for both. */
+        case CHIMERA_VFS_ESTALE:    return SMB2_STATUS_OBJECT_NAME_NOT_FOUND;
         default:                    return SMB2_STATUS_INTERNAL_ERROR;
     } /* switch */
 } /* chimera_smb_close_doc_status */

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -104,7 +104,8 @@ chimera_smb_set_info_rename_callback(
         case CHIMERA_VFS_EACCES:
         case CHIMERA_VFS_EPERM:     status = SMB2_STATUS_ACCESS_DENIED; break;
         case CHIMERA_VFS_EEXIST:    status = SMB2_STATUS_OBJECT_NAME_COLLISION; break;
-        case CHIMERA_VFS_ENOENT:    status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND; break;
+        case CHIMERA_VFS_ENOENT:
+        case CHIMERA_VFS_ESTALE:    status = SMB2_STATUS_OBJECT_NAME_NOT_FOUND; break;
         case CHIMERA_VFS_ENOTEMPTY: status = SMB2_STATUS_DIRECTORY_NOT_EMPTY; break;
         case CHIMERA_VFS_EISDIR:    status = SMB2_STATUS_FILE_IS_A_DIRECTORY; break;
         case CHIMERA_VFS_ENOTDIR:   status = SMB2_STATUS_NOT_A_DIRECTORY; break;

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1984,7 +1984,7 @@ cairn_getattr(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2016,7 +2016,7 @@ cairn_setattr(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2709,7 +2709,7 @@ cairn_lookup_at(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2816,7 +2816,7 @@ cairn_mkdir_at(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &parent_ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2934,7 +2934,7 @@ cairn_mknod_at(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &parent_ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3048,7 +3048,7 @@ cairn_remove_at(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &parent_ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3211,7 +3211,7 @@ cairn_readdir(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (rc) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3386,7 +3386,7 @@ cairn_open_fh(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (rc) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3464,7 +3464,7 @@ cairn_open_at(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &parent_ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3778,7 +3778,7 @@ cairn_read(
 
     if (rc) {
         cairn_read_end(thread);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4072,7 +4072,7 @@ cairn_write(
          * server thread and must be released there. The server's write completion
          * callback handles the release after this request completes via doorbell.
          */
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4170,7 +4170,7 @@ cairn_allocate(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (rc) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4224,7 +4224,7 @@ cairn_seek(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (rc) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4412,7 +4412,7 @@ cairn_symlink_at(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &parent_ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4512,7 +4512,7 @@ cairn_readlink(
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
 
     if (rc) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4613,7 +4613,7 @@ cairn_rename_at(
         rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &old_parent_ih);
 
         if (unlikely(rc)) {
-            request->status = CHIMERA_VFS_ENOENT;
+            request->status = CHIMERA_VFS_ESTALE;
             request->complete(request);
             return;
         }
@@ -4634,7 +4634,7 @@ cairn_rename_at(
         if (cmp < 0) {
             rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &old_parent_ih);
             if (rc) {
-                request->status = CHIMERA_VFS_ENOENT;
+                request->status = CHIMERA_VFS_ESTALE;
                 request->complete(request);
                 return;
             }
@@ -4643,7 +4643,7 @@ cairn_rename_at(
                                     new_parent_ih);
             if (rc) {
                 cairn_inode_handle_release(&old_parent_ih);
-                request->status = CHIMERA_VFS_ENOENT;
+                request->status = CHIMERA_VFS_ESTALE;
                 request->complete(request);
                 return;
             }
@@ -4651,7 +4651,7 @@ cairn_rename_at(
             rc = cairn_inode_get_fh(thread, request->rename_at.new_fh, request->rename_at.new_fhlen, &
                                     new_parent_ih);
             if (rc) {
-                request->status = CHIMERA_VFS_ENOENT;
+                request->status = CHIMERA_VFS_ESTALE;
                 request->complete(request);
                 return;
             }
@@ -4659,7 +4659,7 @@ cairn_rename_at(
             rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &old_parent_ih);
             if (rc) {
                 cairn_inode_handle_release(&new_parent_ih);
-                request->status = CHIMERA_VFS_ENOENT;
+                request->status = CHIMERA_VFS_ESTALE;
                 request->complete(request);
                 return;
             }
@@ -4932,7 +4932,7 @@ cairn_link_at(
     rc = cairn_inode_get_fh(thread, request->link_at.dir_fh, request->link_at.dir_fhlen, &parent_ih);
 
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4950,7 +4950,7 @@ cairn_link_at(
 
     if (rc) {
         cairn_inode_handle_release(&parent_ih);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -5047,7 +5047,7 @@ cairn_commit_op(
      * to reject a stale handle). */
     rc = cairn_inode_get_fh(thread, request->fh, request->fh_len, &ih);
     if (unlikely(rc)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }

--- a/src/vfs/diskfs/diskfs_inode.c
+++ b/src/vfs/diskfs/diskfs_inode.c
@@ -173,14 +173,15 @@ diskfs_inode_release_one(
         w = inode->wait_head;
 
         if (w->gen != inode->gen) {
-            /* The inode this waiter referenced was freed/replaced.  Fail
-             * it with ENOENT rather than handing back a stale inode. */
+            /* The inode this waiter referenced was freed/replaced, so the
+             * handle it came from no longer names anything: ESTALE rather
+             * than handing back a stale inode. */
             inode->wait_head = w->next;
             if (!inode->wait_head) {
                 inode->wait_tail = NULL;
             }
             inode->wait_count--;
-            w->status = CHIMERA_VFS_ENOENT;
+            w->status = CHIMERA_VFS_ESTALE;
             w->next   = granted;
             granted   = w;
             continue;
@@ -314,7 +315,7 @@ diskfs_inode_acquire(
         inode = txn->inodes[i].inode;
         if (inode->inum == inum) {
             if (unlikely(inode->gen != gen)) {
-                cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+                cb(NULL, CHIMERA_VFS_ESTALE, private_data);
             } else {
                 cb(inode, CHIMERA_VFS_OK, private_data);
             }
@@ -331,7 +332,7 @@ diskfs_inode_acquire(
         /* Cached under a different generation: the handle is stale. */
         diskfs_metric_inode_cache(thread, DISKFS_METRIC_INODE_CACHE_STALE);
         pthread_mutex_unlock(&shard->lock);
-        cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+        cb(NULL, CHIMERA_VFS_ESTALE, private_data);
         return;
     }
 
@@ -347,7 +348,7 @@ diskfs_inode_acquire(
         if (sm_inum_valid(thread->shared->space_map, inum)) {
             diskfs_inode_load(thread, txn, fs, inum, gen, mode, cb, private_data);
         } else {
-            cb(NULL, CHIMERA_VFS_ENOENT, private_data);
+            cb(NULL, CHIMERA_VFS_ESTALE, private_data);
         }
         return;
     }

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -867,7 +867,7 @@ diskfs_inode_load_resume(
         /* No such inode (stale generation, tombstone, or the block has been
          * reallocated to something else entirely). */
         diskfs_block_unpin(self, blk, DISKFS_BLOCK_CLEAN);
-        lc->cb(NULL, CHIMERA_VFS_ENOENT, lc->private_data);
+        lc->cb(NULL, CHIMERA_VFS_ESTALE, lc->private_data);
         free(lc);
         return;
     }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -555,7 +555,8 @@ memfs_inode_get_fh(
  * points at a struct memfs_stream_open (carrying base inode + named stream);
  * an untagged non-zero value is a plain base-inode pointer; zero falls back to
  * decoding the file handle (which may itself carry a stream id).  Returns the
- * locked inode or NULL (caller maps to ENOENT).  *out_stream is the target
+ * locked inode or NULL, which means the handle no longer names anything and
+ * the caller reports ESTALE.  *out_stream is the target
  * named fork, or NULL for the default/unnamed fork. */
 static inline struct memfs_inode *
 memfs_resolve_io(
@@ -1048,7 +1049,12 @@ memfs_inode_free(
         inode->remote = NULL;
     }
 
-    /* Increment generation so stale file handles return ESTALE */
+    /* Bump the generation so a handle taken before this inode was freed no
+     * longer resolves.  memfs_inode_get_fh then returns NULL for it and every
+     * caller reports ESTALE, which is what RFC 1813 section 3.3 asks for --
+     * "the file referred to by that file handle no longer exists".  An inode
+     * with open handles is not freed here at all, so an unlinked-but-open file
+     * keeps resolving, as it must. */
     inode->gen++;
 
     pthread_mutex_lock(&inode_list->lock);
@@ -2010,7 +2016,7 @@ memfs_getattr(
                              request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2039,7 +2045,7 @@ memfs_commit(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2070,7 +2076,7 @@ memfs_setattr(
                              request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2577,7 +2583,7 @@ memfs_getparent(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2664,7 +2670,7 @@ memfs_lookup_at(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -2801,7 +2807,7 @@ memfs_mkdir_at(
     parent_inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         memfs_inode_free(thread, inode);
         memfs_dirent_free(thread, dirent);
@@ -2961,7 +2967,7 @@ memfs_mknod_at(
     parent_inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         memfs_inode_free(thread, inode);
         memfs_dirent_free(thread, dirent);
@@ -3057,7 +3063,7 @@ memfs_remove_at(
     parent_inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3226,7 +3232,7 @@ memfs_readdir(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (!inode) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3376,7 +3382,7 @@ memfs_open_fh(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (!inode) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3410,7 +3416,7 @@ memfs_open_at(
     parent_inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!parent_inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3804,7 +3810,7 @@ memfs_read(
                              request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -3961,7 +3967,7 @@ memfs_write(
                              request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -4157,7 +4163,7 @@ memfs_allocate(
                              request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -5139,7 +5145,7 @@ memfs_seek(
                              request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -5258,7 +5264,7 @@ memfs_read_plus(
                              request->fh, request->fh_len, &stream);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -5377,7 +5383,7 @@ memfs_write_same(
         inode = memfs_resolve_io(fs, request->write_same.handle,
                                  request->fh, request->fh_len, &stream);
         if (unlikely(!inode)) {
-            request->status = CHIMERA_VFS_ENOENT;
+            request->status = CHIMERA_VFS_ESTALE;
             request->complete(request);
             return;
         }
@@ -5414,7 +5420,7 @@ memfs_write_same(
 
     if (unlikely(!inode)) {
         free(tmpl);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -5595,7 +5601,7 @@ memfs_symlink_at(
     parent_inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (!parent_inode) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         memfs_inode_free(thread, inode);
         memfs_dirent_free(thread, dirent);
@@ -5672,7 +5678,7 @@ memfs_readlink(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (!inode) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -5749,7 +5755,7 @@ memfs_rename_at(
                                               request->fh_len);
 
         if (!old_parent_inode) {
-            request->status = CHIMERA_VFS_ENOENT;
+            request->status = CHIMERA_VFS_ESTALE;
             request->complete(request);
             return;
         }
@@ -5805,7 +5811,7 @@ memfs_rename_at(
 
         if (!new_parent_inode) {
             pthread_mutex_unlock(&old_parent_inode->lock);
-            request->status = CHIMERA_VFS_ENOENT;
+            request->status = CHIMERA_VFS_ESTALE;
             request->complete(request);
             return;
         }
@@ -6097,7 +6103,7 @@ memfs_link_at(
                                       request->link_at.dir_fhlen);
 
     if (!parent_inode) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6143,7 +6149,7 @@ memfs_link_at(
 
     if (!inode) {
         pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6285,7 +6291,7 @@ memfs_get_xattr(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6323,7 +6329,7 @@ memfs_set_xattr(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6393,7 +6399,7 @@ memfs_list_xattrs(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6436,7 +6442,7 @@ memfs_remove_xattr(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6495,7 +6501,7 @@ memfs_open_stream(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6599,7 +6605,7 @@ memfs_list_streams(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
@@ -6669,7 +6675,7 @@ memfs_remove_stream(
     inode = memfs_inode_get_fh(fs, request->fh, request->fh_len);
 
     if (unlikely(!inode)) {
-        request->status = CHIMERA_VFS_ENOENT;
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }


### PR DESCRIPTION
RFC 1813 section 3.3 defines `NFS3ERR_STALE` as "the file referred to by that file handle no longer exists", and `NFS3ERR_NOENT` does not appear in the error list of `SETATTR`, `LINK`, `READLINK` or any other operation that takes a handle and no name. Chimera answered `NOENT` for both, because every backend reported a handle that failed to resolve the same way it reported a name that was never there, and the NFSv3 status map faithfully passed that through.

It matters to a client. Linux treats `ESTALE` as a signal that its cached handle is worthless and the path should be resolved again; `ENOENT` it takes as the final answer. A client that removes a file and later presents a handle it had cached is told the file was never there rather than that its handle is out of date.

## What changed

The distinction is the backend's to make — it is the only layer that knows whether the failure was the handle or the name — so each one now makes it at the point where it resolves a handle, and nowhere else:

| backend | where |
|---|---|
| memfs | `memfs_inode_get_fh` / `memfs_resolve_io` returning NULL (31 sites) |
| cairn | `cairn_inode_get_fh` failing (23 sites) |
| diskfs | the four places an inode is gone or under another generation, plus the on-disk `nlink == 0` check |
| linux, io_uring | already correct — `open_by_handle_at` returns ESTALE and `linux_common.h` maps it |

A name lookup that finds nothing is untouched and still `NOENT`, which is the whole point. The deliberate `ENOENT` for an operation *through* an unlinked directory (matching what Linux returns for `*at()` calls) is untouched too.

For reference, this is what knfsd does, in two places: each filesystem's `->fh_to_dentry` compares the generation the handle carries against the inode's and returns `-ESTALE` on mismatch (`ext4_nfs_get_inode`), and `nfsd_set_fh_dentry` then normalises *everything* a decode can fail with — other than `ENOMEM` and `ETIMEDOUT` — to `ESTALE`. A filehandle path has no name to fail on, so `ENOENT` is structurally impossible there.

## Not affected

- **NFSv4** already folded `ENOENT` into `NFS4ERR_STALE` at `PUTFH`, and now receives what it was inferring. The nfs4 model has always specified `E_STALE` here.
- **SMB** keeps the one status it has for both, so its behaviour is unchanged.
- **POSIX / FUSE** surface the errno directly; `ESTALE` is the correct one and the FUSE kernel client acts on it.

## Testing

`nfs3_mbt_probe` gains an F6 section and learns `-b`, so the case is asserted against all three storage backends rather than only memfs. That is what caught two things worth knowing:

- diskfs reclaims asynchronously, so the handle goes stale shortly after the remove rather than on the next call;
- probing a handle re-pins it in the VFS handle cache, so a tight poll keeps alive exactly the thing it is waiting to see freed. The probe checks at an interval well clear of the close sweep for that reason.

Verified locally in the devcontainer: 20/20 `-L quint`, 41/42 `chimera/vfs/|chimera/server/nfs/` (the one failure is the known container-only `zerorange_diskfs_io_uring` io_uring SEGV, reproduced identically on unmodified code), 9/9 FUSE in a privileged container with `CHIMERA_REQUIRE_FUSE=1`, 30/30 smb, and 87 posix tests run directly against memfs — the 4 failures there reproduce identically on unmodified code.
