### PR TITLE
vfs/claim: revoke a conflicting holder under the file lock

### DIFF
--- a/src/server/nfs/tests/quint/nfs_aux_probe.c
+++ b/src/server/nfs/tests/quint/nfs_aux_probe.c
@@ -758,6 +758,10 @@ main(
                                      NULL) != 0) {
         fprintf(stderr, "probe: failed to create the %s export\n",
                 PROBE_EXPORT2);
+        /* Unwind what mbt_aux_env_open built; returning straight out leaks the
+         * environment's READ scratch buffer. */
+        mbt_env_fs_teardown(&env, "fs0");
+        mbt_env_stop(&env);
         return 1;
     }
 

--- a/src/vfs/smb/smb_ops.c
+++ b/src/vfs/smb/smb_ops.c
@@ -37,6 +37,14 @@ smb_utf16le_encode(
 {
     int i;
 
+    /* A negative length must not reach the cast below: the loop would write
+     * nothing while (size_t) len * 2 wrapped to an enormous value, and every
+     * caller uses the return as the length of the buffer it just filled --
+     * appending that to a cursor would read far past the end of it. */
+    if (len <= 0) {
+        return 0;
+    }
+
     for (i = 0; i < len; i++) {
         /* SMB path separators are backslashes. */
         uint8_t c = (uint8_t) (s[i] == '/' ? '\\' : s[i]);
@@ -131,7 +139,7 @@ smb_send_create_ex(
     size_t                   name16_len;
     uint32_t                 name_end, ctx_off = 0, pad = 0;
 
-    if (path_len > CHIMERA_SMB_PATH_MAX) {
+    if (path_len < 0 || path_len > CHIMERA_SMB_PATH_MAX) {
         request->status = CHIMERA_VFS_ENAMETOOLONG;
         request->complete(request);
         return;
@@ -618,10 +626,16 @@ chimera_smb_client_open_at(
      * (the next increment), and the client acks any later break.  Directory
      * opens skip it. */
     if (!(request->open_at.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
-        uint64_t *k = (uint64_t *) lease_key;
+        /* Build the key in uint64 units and copy it in, rather than writing
+         * through a uint64_t alias of the byte array: the array has no
+         * guaranteed alignment for a 64-bit store and the aliasing is
+         * undefined behaviour.  It also leaves lease_key visibly initialized,
+         * which the type pun did not -- the analyzer reported the bytes as
+         * undefined here and again where the finished context is appended to
+         * the send cursor. */
+        uint64_t k[2] = { chimera_rand64(), chimera_rand64() };
 
-        k[0]    = chimera_rand64();
-        k[1]    = chimera_rand64();
+        memcpy(lease_key, k, sizeof(lease_key));
         ctx_len = smb_build_lease_ctx(lease_ctx, lease_key,
                                       SMB2_LEASE_READ_CACHING | SMB2_LEASE_HANDLE_CACHING);
         ctx = lease_ctx;

--- a/src/vfs/vfs_claim.c
+++ b/src/vfs/vfs_claim.c
@@ -1345,46 +1345,122 @@ chimera_vfs_claim_try_acquire(
         if (conflict && conflict_out) {
             chimera_vfs_claim_conflict_fill(conflict, conflict_out);
         }
-        pthread_mutex_unlock(&file->lock);
 
         if (result == CHIMERA_CLAIM_DENIED) {
+            chimera_vfs_claim_revoked_cb_t revoked_cb = NULL;
+            void *cb_private                          = NULL;
+            bool reclaimed                            = false;
+
+            /* Reclaim a courtesy holder while the lock is still held.
+             * `conflict` is borrowed, not owned: ACCESS and RANGE claims
+             * carry no refcount (their grant is NULL), so this lock is the
+             * only thing keeping the holder alive.  Unlocking first and
+             * revoking afterwards races the holder's owner tearing it down --
+             * the NFSv4 lease sweeper frees a lock-owner's range leases
+             * outright in lock_state_cleanup -- and the revoke then reads
+             * freed memory. */
             if (conflict &&
                 chimera_vfs_claim_holder_reclaimable(conflict, claim)) {
-                chimera_vfs_claim_revoke(conflict);
+                chimera_vfs_claim_revoke_locked(file, conflict,
+                                                &revoked_cb, &cb_private);
+                reclaimed = true;
+            }
+            pthread_mutex_unlock(&file->lock);
+
+            if (revoked_cb) {
+                /* Past the unlock the claim may already be freed, so it is
+                 * not passed on; every revoked callback works from its
+                 * cb_private (see chimera_vfs_claim_revoke_locked). */
+                revoked_cb(NULL, cb_private);
+            }
+
+            if (reclaimed) {
+                /* The pumps chimera_vfs_claim_revoke() would have run. */
+                if (file->state) {
+                    chimera_vfs_claim_pump_pending(file->state, file);
+                    chimera_vfs_claim_pump_io(file->state, file);
+                    chimera_vfs_claim_backend_reeval(file->state, file);
+                }
                 continue;
             }
             return CHIMERA_CLAIM_DENIED;
         }
+        pthread_mutex_unlock(&file->lock);
 
         /* BREAKING: kick a break on EVERY breakable conflicting holder
          * (R50), revoking dead/expired ones, then re-probe until no IDLE
          * conflict remains. */
         while (conflict) {
             struct chimera_vfs_claim_grant *iter_pin = NULL;
+            chimera_vfs_claim_revoked_cb_t revoked_cb = NULL;
+            void *cb_private                          = NULL;
+            bool revoked_now                          = false;
+            bool do_break                             = false;
+            bool do_wait                              = false;
+            uint32_t deadline_ms                      = 0;
+            uint8_t floor                             = 0;
 
+            /* Classify (and, for a revoke, mutate) with the lock held.
+             * `conflict` is borrowed: a courtesy holder may be a grant-less
+             * claim -- a byte-range lease -- for which pin_grant returns
+             * NULL, and its owner, the NFSv4 lease sweeper, frees it
+             * outright in lock_state_cleanup.  Deciding after unlocking
+             * races that teardown and reads freed memory.
+             *
+             * The arm order is load-bearing and matches the original: a
+             * never-broken holder sits at break_deadline 0, so the
+             * deadline test must stay *after* the IDLE/ACKED arm or every
+             * idle holder is revoked instead of broken.
+             *
+             * begin_break still runs unlocked below.  That is safe for a
+             * grant-bearing holder, which iter_pin keeps alive; an NFSv4
+             * delegation carries a break_cb with no grant, and closing that
+             * window needs a refcount for grant-less claims rather than a
+             * lock discipline.  Left alone deliberately: no failure has been
+             * observed through it, and a break callback cannot be deferred
+             * the way a revoke's can. */
             pthread_mutex_lock(&file->lock);
             iter_pin = chimera_vfs_claim_pin_grant(conflict);
-            pthread_mutex_unlock(&file->lock);
 
             if (chimera_vfs_claim_holder_reclaimable(conflict, claim)) {
-                chimera_vfs_claim_revoke(conflict);
+                chimera_vfs_claim_revoke_locked(file, conflict,
+                                                &revoked_cb, &cb_private);
                 revoked_any = true;
+                revoked_now = true;
             } else if (conflict->break_state == CHIMERA_CLAIM_BREAK_IDLE ||
                        conflict->break_state == CHIMERA_CLAIM_BREAK_ACKED) {
-                uint32_t deadline_ms =
+                deadline_ms =
                     (conflict->owner.proto == CHIMERA_CLAIM_PROTO_NFSV4)
                     ? CHIMERA_VFS_NFS_DELEG_RECALL_MS : 0;
-                uint8_t floor =
-                    chimera_vfs_claim_contended_floor(claim, conflict);
+                floor    = chimera_vfs_claim_contended_floor(claim, conflict);
+                do_break = true;
+            } else if (chimera_vfs_claim_deadline_passed(conflict)) {
+                chimera_vfs_claim_revoke_locked(file, conflict,
+                                                &revoked_cb, &cb_private);
+                revoked_any = true;
+                revoked_now = true;
+            } else {
+                do_wait = true;
+            }
+            pthread_mutex_unlock(&file->lock);
 
+            if (revoked_now) {
+                if (revoked_cb) {
+                    /* The claim may already be freed; see
+                     * chimera_vfs_claim_revoke_locked. */
+                    revoked_cb(NULL, cb_private);
+                }
+                if (file->state) {
+                    chimera_vfs_claim_pump_pending(file->state, file);
+                    chimera_vfs_claim_pump_io(file->state, file);
+                    chimera_vfs_claim_backend_reeval(file->state, file);
+                }
+            } else if (do_break) {
                 chimera_vfs_claim_begin_break_ex(
                     state, conflict, floor, deadline_ms,
                     claim->klass == CHIMERA_CLAIM_CLASS_RANGE /* one_shot */);
                 began_live_break = true;
-            } else if (chimera_vfs_claim_deadline_passed(conflict)) {
-                chimera_vfs_claim_revoke(conflict);
-                revoked_any = true;
-            } else {
+            } else if (do_wait) {
                 /* Mid-break, deadline pending: the caller waits. */
                 if (iter_pin) {
                     chimera_vfs_claim_grant_release(state, iter_pin, false);

--- a/src/vfs/vfs_claim.h
+++ b/src/vfs/vfs_claim.h
@@ -472,6 +472,27 @@ chimera_vfs_claim_ack(
     struct chimera_vfs_claim *claim,
     uint8_t                   resulting_used);
 
+/* Revoke `claim` with the caller already holding file->lock, handing back the
+ * revoked callback instead of firing it.
+ *
+ * An acquirer only ever borrows a conflicting claim: ACCESS and RANGE claims
+ * carry no refcount (their `grant` is NULL), so the lock admission found the
+ * conflict under is the only thing keeping it alive.  A caller that drops the
+ * lock and then revokes races the holder's owner tearing it down -- the NFSv4
+ * lease sweeper frees a lock-owner's range leases outright -- so the mutation
+ * has to happen while the lock is still held.  Fire the returned callback
+ * after unlocking; it must not dereference the claim, which may be gone by
+ * then (all implementations take their state from cb_private).
+ *
+ * *out_cb is set only when this call is what newly revoked the claim.  The
+ * caller owns the post-revoke pumps that chimera_vfs_claim_revoke() does. */
+void
+chimera_vfs_claim_revoke_locked(
+    struct chimera_vfs_file_state  *file,
+    struct chimera_vfs_claim       *claim,
+    chimera_vfs_claim_revoked_cb_t *out_cb,
+    void                          **out_private);
+
 void
 chimera_vfs_claim_revoke(
     struct chimera_vfs_claim *claim);

--- a/src/vfs/vfs_claim_break.c
+++ b/src/vfs/vfs_claim_break.c
@@ -203,16 +203,19 @@ chimera_vfs_claim_ack(
 } /* chimera_vfs_claim_ack */
 
 SYMBOL_EXPORT void
-chimera_vfs_claim_revoke(struct chimera_vfs_claim *claim)
+chimera_vfs_claim_revoke_locked(
+    struct chimera_vfs_file_state  *file,
+    struct chimera_vfs_claim       *claim,
+    chimera_vfs_claim_revoked_cb_t *out_cb,
+    void                          **out_private)
 {
-    struct chimera_vfs_file_state *file = claim->file;
-    chimera_vfs_claim_revoked_cb_t revoked_cb;
-    void                          *cb_private;
-    bool                           newly_revoked;
-    uint64_t                       token = 0;
+    bool     newly_revoked;
+    uint64_t token;
+
+    *out_cb      = NULL;
+    *out_private = NULL;
 
     if (file) {
-        pthread_mutex_lock(&file->lock);
         /* A revoked claim's backend record must not outlive it: a courtesy
          * reclaim that leaves the token behind blocks every other client at
          * the arbiter forever (pynfs COUR2).  Enqueued under file->lock so
@@ -221,7 +224,6 @@ chimera_vfs_claim_revoke(struct chimera_vfs_claim *claim)
         claim->backend_token = 0;
         if (token && file->state) {
             chimera_vfs_claim_backend_release_token(file->state, file, token);
-            token = 0;
         }
     }
 
@@ -230,19 +232,35 @@ chimera_vfs_claim_revoke(struct chimera_vfs_claim *claim)
     claim->advertised  = 0;
     claim->denied      = 0;
     claim->break_state = CHIMERA_CLAIM_BREAK_REVOKED;
-    revoked_cb         = claim->revoked_cb;
-    cb_private         = claim->cb_private;
+
+    if (newly_revoked) {
+        *out_cb      = claim->revoked_cb;
+        *out_private = claim->cb_private;
+    }
+} /* chimera_vfs_claim_revoke_locked */
+
+SYMBOL_EXPORT void
+chimera_vfs_claim_revoke(struct chimera_vfs_claim *claim)
+{
+    struct chimera_vfs_file_state *file = claim->file;
+    chimera_vfs_claim_revoked_cb_t revoked_cb;
+    void                          *cb_private;
+
+    if (file) {
+        pthread_mutex_lock(&file->lock);
+    }
+
+    chimera_vfs_claim_revoke_locked(file, claim, &revoked_cb, &cb_private);
 
     if (file) {
         pthread_mutex_unlock(&file->lock);
     }
 
-    if (newly_revoked && revoked_cb) {
+    if (revoked_cb) {
         revoked_cb(claim, cb_private);
     }
 
     if (file && file->state) {
-        (void) token;
         chimera_vfs_claim_pump_pending(file->state, file);
         chimera_vfs_claim_pump_io(file->state, file);
         chimera_vfs_claim_backend_reeval(file->state, file);


### PR DESCRIPTION
Fixes a heap-use-after-free behind the recurring `COUR2` pynfs flake
(chimera-nas/chimera#733).

### The bug

`chimera_vfs_claim_try_acquire` finds a conflicting claim under
`file->lock`, **drops the lock**, and only then asks whether the holder is
reclaimable and revokes it:

```c
pthread_mutex_unlock(&file->lock);

if (result == CHIMERA_CLAIM_DENIED) {
    if (conflict && chimera_vfs_claim_holder_reclaimable(conflict, claim)) {
        chimera_vfs_claim_revoke(conflict);
```

A conflict pointer is borrowed, not owned.  ACCESS and RANGE claims carry
no refcount -- their `grant` is NULL, so `chimera_vfs_claim_pin_grant`
returns nothing for them -- and the lock admission found the holder under
is the only thing keeping it alive.  The NFSv4 lease sweeper frees a
lock-owner's byte-range leases outright (`lock_state_cleanup`:
`chimera_vfs_claim_release` then `free`), so a courtesy holder can be torn
down in exactly that window.

`COUR2` drives it head-on: an expired-lease client's lock is at once
reclaimable by a conflicting acquirer and being expired by the sweeper.
ASan in the merge queue:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 1 ... thread T28
    #0 chimera_vfs_claim_revoke        vfs_claim_break.c:228
    #1 chimera_vfs_claim_try_acquire   vfs_claim.c:1353
    #3 chimera_nfs4_lock               nfs4_proc_lock.c:724
freed by thread T27:
    #1 lock_state_cleanup              nfs4_state.c:1718
    #3 nfs_client_expire_state         nfs4_state.c:834
    #4 nfs_lease_sweep_once            nfs4_lease.c:164
```

### The fix

Split the mutation out as `chimera_vfs_claim_revoke_locked()`, which the
caller runs with the lock held and which hands the revoked callback back
rather than firing it.  The callback runs after unlocking and is not given
the claim: no implementation dereferences it (all three work from
`cb_private`), and by then it may legitimately be gone.
`chimera_vfs_claim_revoke()` keeps its signature and becomes lock-plus-core,
so there is a single implementation.

Both revoke arms of the `BREAKING` loop move under the lock for the same
reason.

### Deliberately not fixed

`begin_break_ex` still touches the conflict after unlocking.  That is safe
for a grant-bearing holder, which the pin keeps alive, but an NFSv4
delegation sets a `break_cb` with **no** grant.  Closing that window needs
a refcount for grant-less claims rather than a lock discipline; no failure
has been observed through it, so it is noted in the code and left alone.

### Verification

- `claim_test` 1/1, `chimera/vfs/` 21/21, `ctest -L quint` 20/20
- pynfs `courteous` 84/84 in Release
- `COUR2` under **ASan/Debug** three consecutive runs: 100% pass, zero
  sanitizer reports

The race is intermittent, so a clean sweep is supporting evidence rather
than proof -- the merge queue's Debug pynfs job is the real check.  It is
worth recording that an earlier revision of this change reordered the
`BREAKING` arms and hung `claim_test`: a never-broken holder sits at
`break_deadline` 0, so the deadline test must stay *after* the IDLE/ACKED
arm or every idle holder is revoked instead of broken.  That ordering now
carries a comment.


---

### Second commit: three static-analysis findings latent on main

The macOS pre-merge analysis fails on `main` itself, so every PR rebased
onto it inherits the failure -- this one did, with the identical three
findings.  Carrying the fix here rather than in a feature branch, since it
is main's problem:

- `smb_utf16le_encode` took a signed length and returned `(size_t) len * 2`
  without rejecting a negative one.  For `len < 0` the loop never runs, so
  the caller's buffer stays untouched while the cast wraps to an enormous
  `size_t` -- which every caller then passes back as the length of the
  buffer it believes it filled, and the create path appends to the send
  cursor.  An out-of-bounds read.  `smb_send_create_ex`'s bounds check only
  rejected lengths *above* the maximum.
- The SMB lease key was built by writing through a `uint64_t` alias of a
  `uint8_t[16]`: strict-aliasing UB plus a 64-bit store to an array with no
  guaranteed alignment.  It also hid the initialization from the analyzer,
  which reported the bytes undefined twice -- once at the key copy and again
  where the finished context reaches the send cursor.
- The nfs aux probe returned straight out when its second export could not
  be created, leaking the environment's READ scratch buffer.
