### PR TITLE
vfs: storing a pNFS layout is not a metadata change

### DIFF
--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -5267,6 +5267,9 @@ diskfs_apply_attrs(
 {
     struct timespec now;
     uint64_t        set_mask = attr->va_set_mask;
+    /* See memfs_apply_attrs() for why a layout-blob-only setattr is exempt
+     * from the ctime and change-attribute bumps below. */
+    int             layout_only = (set_mask == CHIMERA_VFS_ATTR_PNFS_LAYOUT);
 
     clock_gettime(CLOCK_REALTIME, &now);
     attr->va_set_mask = CHIMERA_VFS_ATTR_ATOMIC;
@@ -5360,12 +5363,14 @@ diskfs_apply_attrs(
             inode->ctime_sec  = t.tv_sec;
             inode->ctime_nsec = t.tv_nsec;
         }
-    } else {
+    } else if (!layout_only) {
         inode->ctime_sec  = now.tv_sec;
         inode->ctime_nsec = now.tv_nsec;
     }
 
     /* Any setattr is a metadata change; advance the native change counter. */
-    inode->change++;
+    if (!layout_only) {
+        inode->change++;
+    }
 
 } /* diskfs_apply_attrs */

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1812,7 +1812,8 @@ memfs_apply_attrs(
     struct chimera_vfs_attrs *attr)
 {
     struct timespec now;
-    uint64_t        set_mask = attr->va_set_mask;
+    uint64_t        set_mask    = attr->va_set_mask;
+    int             layout_only = (set_mask == CHIMERA_VFS_ATTR_PNFS_LAYOUT);
 
     chimera_vfs_realtime(&now);
 
@@ -1931,12 +1932,23 @@ memfs_apply_attrs(
     if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
         chimera_vfs_resolve_set_time(&attr->va_ctime, &now, &inode->ctime);
-    } else {
+    } else if (!layout_only) {
         inode->ctime = now;
     }
 
-    /* Any setattr is a metadata change; advance the native change counter. */
-    inode->change++;
+    /* Any setattr is a metadata change; advance the native change counter.
+     *
+     * The exception is a setattr carrying the pNFS layout blob and nothing
+     * else.  That blob is the metadata server's own bookkeeping, not a
+     * client-visible attribute, and the LAYOUTGET that stores it does not
+     * modify the file (RFC 8881 18.43) -- bumping change (and ctime, above)
+     * made the first LAYOUTGET on a file invalidate every client's cached
+     * attributes for a write nobody asked for.  The test is for the layout
+     * bit ALONE: memfs_setattr() masks SIZE off before calling here, so an
+     * empty mask still means a real metadata change. */
+    if (!layout_only) {
+        inode->change++;
+    }
 
 } /* memfs_apply_attrs */
 


### PR DESCRIPTION
`nfs4_layoutget()` persists its opaque per-file layout blob
(`CHIMERA_VFS_ATTR_PNFS_LAYOUT`) through `chimera_vfs_setattr()`, and both
`memfs_apply_attrs()` and `diskfs_apply_attrs()` end with "any setattr is a
metadata change" — stamp ctime, advance the change counter. So the first
LAYOUTGET on a file moves its ctime and bumps its change attribute,
invalidating every client's cached attributes for a write no client asked for.
RFC 8881 §18.43 does not have LAYOUTGET modify the file.

The blob is the metadata server's own bookkeeping and is not readable as a
client attribute, so a setattr carrying it and nothing else now leaves both
alone. The test is for that bit *alone* rather than for its absence:
`memfs_setattr()` masks SIZE off before calling `apply_attrs`, so an empty mask
still has to count as a real metadata change — treating "no other bits" as
"nothing happened" stops a plain SETATTR(size) from advancing `change` at all,
which the model corpus catches immediately.

## Scope

This PR was originally a stepData corpus change plus this fix. Everything else
in it has been overtaken by main — the grace problem it worked around was
solved generally by the `reclaimFirst` wrapper, and COPY reaches the wire via
`fbcbd9f` — so it is now just the one commit. What remains of the model side is
chimera-nas/specs#13, which is independent of this and needs no pin bump here.

## Caveat worth reading before merging

**No test in the tree currently fails without this.** It was found by a corpus
variant whose `stepData` generated LAYOUTGET against files whose change
attribute a later GETATTR read back; main's corpus does not produce that shape,
which is why #1569 merged green with the bug present. The justification is the
RFC and the leak of server-private state into a client-visible attribute, not a
red test. Happy to add a probe that pins it if you would rather not merge on
argument alone.

## Validation

`ctest -L quint` 32/32 on the rebased branch, `make syntax-check` clean.
