### PR TITLE
tests/quint: debug-mode replay with log+metrics artifacts; exactly-once S3 publish; per-backend coverage rows

### DIFF
--- a/scripts/ci_coverage_report.py
+++ b/scripts/ci_coverage_report.py
@@ -26,9 +26,11 @@ What counts is first-party, hand-written, non-test source.  Test sources are out
 because a suite cannot meaningfully cover the other suites; generated marshallers
 and the bundled ext/ projects are out because neither is code this repository is
 asking the models to reach -- one is emitted from a .x file and the other has its
-own repository and its own tests.  etc/coverage-report.sh applies the latter two
-(COVERAGE_INCLUDE_GENERATED / COVERAGE_INCLUDE_EXT fold them back in); this only
-has to drop the tests.
+own repository and its own tests.  The benchmark plugins (src/fio, src/elbencho)
+are out for the same reason: they are driven by fio/elbencho, not by anything a
+protocol model can emit.  etc/coverage-report.sh applies the generated and
+ext/ exclusions (COVERAGE_INCLUDE_GENERATED / COVERAGE_INCLUDE_EXT fold them
+back in); this drops the tests and the benchmark plugins.
 
 <build_root> is optional, and only useful alongside COVERAGE_INCLUDE_GENERATED:
 generated sources are compiled from under the build tree, which mirrors the
@@ -54,16 +56,29 @@ BAR_WIDTH = 10
 def component(rel):
     """Bucket a repo-relative path into the unit we report on.
 
-    src/server/ is split one level deeper than everything else: "the NFS server"
-    and "the SMB server" are the units someone actually reasons about, whereas
-    "src/server" as a whole is not.
+    src/server/ and src/vfs/ are split one level deeper than everything else:
+    "the NFS server" and "the memfs backend" are the units someone actually
+    reasons about, whereas "src/server" or "src/vfs" as a whole is not.
+    Files directly under src/vfs (the dispatch/procedure core every backend
+    sits behind) stay together as their own src/vfs row.
     """
     parts = rel.split("/")
-    if len(parts) >= 4 and parts[0] == "src" and parts[1] == "server":
+    if len(parts) >= 4 and parts[0] == "src" and parts[1] in ("server", "vfs"):
         return "/".join(parts[:3])
     if len(parts) >= 3:
         return "/".join(parts[:2])
     return parts[0]
+
+
+# Benchmark plugins (chimera's fio and elbencho engines): first-party, but not
+# core chimera -- nothing a protocol model emits can reach them, so carrying
+# them as permanent 0% rows would only obscure the components the suite is
+# accountable for.
+BENCH_PLUGINS = ("src/fio", "src/elbencho")
+
+
+def is_bench_plugin(rel):
+    return any(rel == p or rel.startswith(p + "/") for p in BENCH_PLUGINS)
 
 
 def is_test_source(rel):
@@ -112,7 +127,7 @@ def main():
         rel = relative(os.path.realpath(entry["filename"]), (root, build_root))
         # None: compiled from outside the checkout entirely -- the container's
         # own /fio clone, say.  Not code this repository can be measured on.
-        if rel is None or is_test_source(rel):
+        if rel is None or is_test_source(rel) or is_bench_plugin(rel):
             continue
         summary = entry.get("summary", {})
         if summary.get("lines", {}).get("count", 0) == 0:

--- a/src/common/mbt_artifacts.h
+++ b/src/common/mbt_artifacts.h
@@ -1,0 +1,106 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Debug-log and metrics artifacts for the quint MBT harnesses.
+ *
+ * Every quint harness runs the chimera stack at CHIMERA_LOG_DEBUG with the
+ * log routed to a file: the per-request dump paths -- nfs3_dump_* and
+ * nfs4_dump_*, smb_dump_*, the vfs_dump macros -- are compiled in but dead
+ * at the default INFO level, so replaying the corpus in debug mode is what
+ * makes the model traffic execute them at all.  Routing to a file rather than
+ * stdout keeps the harness's own reporting -- and the line-protocol
+ * drivers' stdout protocol -- clean.
+ *
+ * At teardown each harness scrapes its Prometheus registry once through
+ * chimera_metrics_dump_file(), the same rendering the live /metrics
+ * endpoint serves, again purely so every corpus run exercises the metrics
+ * export path end to end.
+ *
+ * Both artifacts land in the process's working directory (for a ctest, the
+ * registering directory's build tree) as <name>.debug.log and
+ * <name>.metrics.prom.  <name> is $CHIMERA_MBT_ARTIFACTS when set -- each
+ * quint ctest sets it to its own test name so tests sharing a harness
+ * binary do not clobber each other -- and falls back to the program's
+ * short name for manual runs.
+ */
+
+#ifndef CHIMERA_MBT_ARTIFACTS_H
+#define CHIMERA_MBT_ARTIFACTS_H
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/logging.h"
+#include "metrics/metrics.h"
+
+static inline const char *
+mbt_artifacts_name(void)
+{
+    const char *name = getenv("CHIMERA_MBT_ARTIFACTS");
+
+    if (name && *name) {
+        return name;
+    }
+#ifdef __APPLE__
+    return getprogname();
+#else  /* ifdef __APPLE__ */
+    {
+        /* Declared in <errno.h> only under _GNU_SOURCE, which the including
+         * harness may or may not define; the symbol itself is always there. */
+        extern char *program_invocation_short_name;
+
+        return program_invocation_short_name;
+    }
+#endif /* ifdef __APPLE__ */
+} /* mbt_artifacts_name */
+
+/* Call before the first chimera_*_init: routes the log to <name>.debug.log
+ * and raises the level to CHIMERA_LOG_DEBUG.  Idempotent, so environments
+ * that cycle within one process (the probes) set up logging exactly once. */
+static inline void
+mbt_debug_log_start(void)
+{
+    static int started = 0;
+    char       path[512];
+    FILE      *fp;
+
+    if (started) {
+        return;
+    }
+    started = 1;
+
+    snprintf(path, sizeof(path), "%s.debug.log", mbt_artifacts_name());
+
+    fp = fopen(path, "w");
+    if (!fp) {
+        fprintf(stderr, "mbt_artifacts: cannot open %s: %s\n",
+                path, strerror(errno));
+        exit(1);
+    }
+
+    chimera_log_set_file(fp);
+    chimera_log_init();
+    ChimeraLogLevel = CHIMERA_LOG_DEBUG;
+} /* mbt_debug_log_start */
+
+/* Call at teardown, while the registry is still alive.  Environments that
+ * cycle within one process rewrite the file each time; the final cycle's
+ * scrape is the artifact.  A failed dump fails the test -- the scrape is
+ * part of what the harness exists to exercise. */
+static inline void
+mbt_metrics_dump(struct prometheus_metrics *metrics)
+{
+    char path[512];
+
+    snprintf(path, sizeof(path), "%s.metrics.prom", mbt_artifacts_name());
+
+    if (chimera_metrics_dump_file(metrics, path) != 0) {
+        fprintf(stderr, "mbt_artifacts: metrics dump to %s failed\n", path);
+        exit(1);
+    }
+} /* mbt_metrics_dump */
+
+#endif /* CHIMERA_MBT_ARTIFACTS_H */

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -19,14 +19,14 @@
 
 add_executable(posix_quint_driver posix_driver.c)
 target_link_libraries(posix_quint_driver
-    chimera_posix chimera_client chimera_server jansson)
+    chimera_posix chimera_client chimera_server chimera_metrics jansson)
 
 # Pure-C replayer: reuses posix_driver.c's op engine in-process (no Python, no
 # line-protocol subprocess) to load ITF traces and run the model oracle.
 add_executable(posix_mbt_replay posix_mbt_replay.c)
 target_include_directories(posix_mbt_replay PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(posix_mbt_replay
-    chimera_posix chimera_client chimera_server jansson)
+    chimera_posix chimera_client chimera_server chimera_metrics jansson)
 
 if(NOT SPECS_BUNDLE_AVAILABLE)
     message(STATUS "posix MBT replay ctest skipped (no specs trace corpus)")
@@ -53,6 +53,7 @@ add_test(NAME chimera/posix/mbt/batch_memfs
             --exclude-prefix nfs3_ --exclude-prefix nfs4_ --exclude-prefix disk_
             --exclude-prefix fuse_)
 set_tests_properties(chimera/posix/mbt/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_memfs"
     LABELS "quint;posix_mbt;memfs"
     SKIP_RETURN_CODE 77
     TIMEOUT 300)

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -48,6 +48,7 @@
 #include "common/platform.h"
 #include "common/tcp_flavor.h"
 #include "prometheus-c.h"
+#include "common/mbt_artifacts.h"
 
 #define DRIVER_BLOCK_SIZE 4096
 #define MAX_PIDS          4
@@ -1008,8 +1009,7 @@ posix_env_setup(
      * worker/sweep threads start in chimera_posix_init. */
     setenv("CHIMERA_CLOSE_SWEEP_INTERVAL_MS", "10", 0);
 
-    chimera_log_init();
-    ChimeraLogLevel = CHIMERA_LOG_ERROR;
+    mbt_debug_log_start();
 
     metrics = prometheus_metrics_create(NULL, NULL, 0);
 
@@ -1187,6 +1187,7 @@ posix_env_teardown(void)
     if (g_server) {
         chimera_server_destroy(g_server);
     }
+    mbt_metrics_dump(g_metrics);
     prometheus_metrics_destroy(g_metrics);
 } /* posix_env_teardown */
 

--- a/src/server/fuse/tests/quint/CMakeLists.txt
+++ b/src/server/fuse/tests/quint/CMakeLists.txt
@@ -6,11 +6,12 @@
 # in for /dev/fuse, so it needs no device, no mount, and no privileges and
 # runs unconditionally rather than behind the fuse_probe capability gate.
 add_executable(fuse_sim_probe fuse_sim_probe.c)
-target_link_libraries(fuse_sim_probe chimera_server chimera_vfs chimera_common)
+target_link_libraries(fuse_sim_probe chimera_server chimera_vfs chimera_common chimera_metrics)
 
 add_test(NAME chimera/fuse/sim/probe COMMAND fuse_sim_probe)
 
 set_tests_properties(chimera/fuse/sim/probe PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=fuse_sim_probe"
     TIMEOUT 60
     LABELS "fuse")
 
@@ -20,7 +21,7 @@ set_tests_properties(chimera/fuse/sim/probe PROPERTIES
 # FUSE server -- coverage no existing corpus reaches.
 add_executable(fuse_quint_driver fuse_quint_driver.c)
 target_link_libraries(fuse_quint_driver
-    chimera_server chimera_vfs chimera_common jansson)
+    chimera_server chimera_vfs chimera_common chimera_metrics jansson)
 
 if(NOT SPECS_BUNDLE_AVAILABLE)
     message(STATUS "fuse MBT replay ctest skipped (no specs trace corpus)")
@@ -47,6 +48,7 @@ add_test(NAME chimera/fuse/mbt/batch_memfs
             --trace-dir ${SPECS_BUNDLE_DIR}/posix
             --include-prefix fuse_)
 set_tests_properties(chimera/fuse/mbt/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=fuse_batch_memfs"
     LABELS "quint;fuse;posix_mbt;memfs"
     SKIP_RETURN_CODE 77
     TIMEOUT 600)

--- a/src/server/fuse/tests/quint/fuse_sim.h
+++ b/src/server/fuse/tests/quint/fuse_sim.h
@@ -54,6 +54,7 @@
 #include "server/server.h"
 #include "server/fuse/fuse.h"
 #include "prometheus-c.h"
+#include "common/mbt_artifacts.h"
 
 /* Room for a max_write payload plus headers, matching what the server asks
  * the kernel for. */
@@ -374,6 +375,8 @@ fuse_sim_open(
     sim->fd        = sv[0];
     sim->server_fd = sv[1];
 
+    mbt_debug_log_start();
+
     sim->metrics = prometheus_metrics_create(NULL, NULL, 0);
 
     config = chimera_server_config_init();
@@ -427,6 +430,7 @@ fuse_sim_close(struct fuse_sim *sim)
 {
     chimera_server_destroy(sim->server);
     close(sim->fd);
+    mbt_metrics_dump(sim->metrics);
     prometheus_metrics_destroy(sim->metrics);
 } /* fuse_sim_close */
 

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -31,37 +31,37 @@ add_executable(nfs3_mbt_replay nfs3_mbt_replay.c)
 target_include_directories(nfs3_mbt_replay PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
 target_link_libraries(nfs3_mbt_replay
-    chimera_server chimera_nfs_common jansson)
+    chimera_server chimera_nfs_common chimera_metrics jansson)
 
 add_executable(nfs3_mbt_probe nfs3_mbt_probe.c)
 target_include_directories(nfs3_mbt_probe PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
 target_link_libraries(nfs3_mbt_probe
-    chimera_server chimera_nfs_common jansson)
+    chimera_server chimera_nfs_common chimera_metrics jansson)
 
 add_executable(nfs4_deleg_probe nfs4_deleg_probe.c)
 target_include_directories(nfs4_deleg_probe PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
 target_link_libraries(nfs4_deleg_probe
-    chimera_server chimera_nfs_common jansson)
+    chimera_server chimera_nfs_common chimera_metrics jansson)
 
 add_executable(nfs_aux_probe nfs_aux_probe.c)
 target_include_directories(nfs_aux_probe PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
 target_link_libraries(nfs_aux_probe
-    chimera_server chimera_nfs_common jansson)
+    chimera_server chimera_nfs_common chimera_metrics jansson)
 
 add_executable(nfs_aux_mbt_replay nfs_aux_mbt_replay.c)
 target_include_directories(nfs_aux_mbt_replay PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
 target_link_libraries(nfs_aux_mbt_replay
-    chimera_server chimera_nfs_common jansson)
+    chimera_server chimera_nfs_common chimera_metrics jansson)
 
 add_executable(nfs4_mbt_replay nfs4_mbt_replay.c)
 target_include_directories(nfs4_mbt_replay PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
 target_link_libraries(nfs4_mbt_replay
-    chimera_server chimera_nfs_common jansson)
+    chimera_server chimera_nfs_common chimera_metrics jansson)
 
 # Deviation probe: asserts each documented chimera deviation (DEVIATIONS.md)
 # still reproduces, and that the two fixed deadlocks (LINK/RENAME self-alias)
@@ -70,6 +70,7 @@ target_link_libraries(nfs4_mbt_replay
 add_test(NAME chimera/server/nfs/mbt/deviation_probe_memfs
     COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b memfs)
 set_tests_properties(chimera/server/nfs/mbt/deviation_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_deviation_probe_memfs"
     LABELS "quint;nfs3_mbt;memfs"
     TIMEOUT 60)
 
@@ -100,6 +101,7 @@ endif()
 add_test(NAME chimera/server/nfs/mbtaux/probe_memfs
     COMMAND $<TARGET_FILE:nfs_aux_probe>)
 set_tests_properties(chimera/server/nfs/mbtaux/probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_probe_memfs"
     LABELS "quint;nfsaux_mbt;memfs"
     TIMEOUT 120)
 
@@ -108,6 +110,7 @@ set_tests_properties(chimera/server/nfs/mbtaux/probe_memfs PROPERTIES
 add_test(NAME chimera/server/nfs/mbt4/deleg_probe_memfs
     COMMAND $<TARGET_FILE:nfs4_deleg_probe>)
 set_tests_properties(chimera/server/nfs/mbt4/deleg_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_deleg_probe_memfs"
     LABELS "quint;nfs4_mbt;multiproto;memfs"
     TIMEOUT 90)
 
@@ -127,6 +130,7 @@ endif()
 add_test(NAME chimera/server/nfs/mbt/batch_memfs
     COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3)
 set_tests_properties(chimera/server/nfs/mbt/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_memfs"
     LABELS "quint;nfs3_mbt;memfs"
     TIMEOUT 300)
 
@@ -142,6 +146,7 @@ if(HAVE_LIBAIO)
         COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
                 --backend diskfs)
     set_tests_properties(chimera/server/nfs/mbt/batch_diskfs PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_diskfs"
         LABELS "quint;nfs3_mbt;diskfs"
         TIMEOUT 300)
 endif()
@@ -151,6 +156,7 @@ if(CAIRN_ENABLED)
         COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
                 --backend cairn)
     set_tests_properties(chimera/server/nfs/mbt/batch_cairn PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_cairn"
         LABELS "quint;nfs3_mbt;cairn"
         TIMEOUT 300)
 endif()
@@ -172,6 +178,7 @@ add_test(NAME chimera/server/nfs/mbtaux/batch_memfs
     COMMAND $<TARGET_FILE:nfs_aux_mbt_replay> --paranoid
             --trace-dir ${SPECS_BUNDLE_DIR}/nfsaux)
 set_tests_properties(chimera/server/nfs/mbtaux/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_batch_memfs"
     LABELS "quint;nfsaux_mbt;memfs"
     TIMEOUT 600)
 
@@ -181,6 +188,7 @@ set_tests_properties(chimera/server/nfs/mbtaux/batch_memfs PROPERTIES
 add_test(NAME chimera/server/nfs/mbt4/batch_memfs
     COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4)
 set_tests_properties(chimera/server/nfs/mbt4/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_memfs"
     LABELS "quint;nfs4_mbt;memfs"
     SKIP_RETURN_CODE 77
     TIMEOUT 300)

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -32,6 +32,7 @@
 #include "server/server.h"
 #include "common/tcp_flavor.h"
 #include "prometheus-c.h"
+#include "common/mbt_artifacts.h"
 
 #include "nfs3_xdr.h"
 #include "nfs4_xdr.h"
@@ -238,6 +239,8 @@ mbt_env_open_opts(
     struct evpl_endpoint         *nfs_ep;
     struct evpl_endpoint         *mount_ep;
     int                           aux = opts && opts->aux;
+
+    mbt_debug_log_start();
 
     memset(env, 0, sizeof(*env));
 
@@ -673,6 +676,7 @@ mbt_env_stop(struct mbt_env *env)
     evpl_destroy(env->evpl);
 
     chimera_server_destroy(env->server);
+    mbt_metrics_dump(env->metrics);
     prometheus_metrics_destroy(env->metrics);
 
     free(env->data_buf);

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -157,6 +157,15 @@ struct chimera_s3_request {
     union {
         struct {
             int                      tmp_name_len;
+            /* The publish (rename/link of the staged file into place) must
+             * fire exactly once, when the body is fully written AND the
+             * metadata xattr chain is done.  Body drain and the xattr chain
+             * run concurrently on async backends, so both the last write
+             * completion and the metadata-done callback can observe the
+             * finished state: meta_pending gates the publish until the
+             * xattrs land and published latches the first fire. */
+            int                      meta_pending;
+            int                      published;
             struct chimera_vfs_attrs set_attr;
             char                     tmp_name[64];
         } put;

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -135,6 +135,15 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
 {
     struct chimera_server_s3_thread *thread = request->thread;
 
+    /* Both the last write completion and the metadata-done resume can reach
+     * here believing the request is finished (see the field comments in
+     * s3_internal.h); publish only once, and never before the metadata
+     * xattrs are in place -- metadata_done re-drives this via put_recv. */
+    if (request->put.meta_pending || request->put.published) {
+        return;
+    }
+    request->put.published = 1;
+
     if (request->put.tmp_name_len) {
         chimera_s3_request_get(request);
 
@@ -347,6 +356,8 @@ chimera_s3_put_metadata_done(
         return;
     }
 
+    request->put.meta_pending = 0;
+
     chimera_s3_put_recv(evpl, request);
 } /* chimera_s3_put_metadata_done */
 
@@ -372,8 +383,9 @@ chimera_s3_put_create_unlinked_callback(
         return;
     }
 
-    request->file_handle = oh;
-    request->vfs_state   = CHIMERA_S3_VFS_STATE_RECV;
+    request->file_handle      = oh;
+    request->put.meta_pending = 1;
+    request->vfs_state        = CHIMERA_S3_VFS_STATE_RECV;
 
     /* The response ETag is attached after the body is written, from the
      * object's final attributes (see chimera_s3_put_getattr_callback). */
@@ -407,8 +419,9 @@ chimera_s3_put_create_callback(
         return;
     }
 
-    request->file_handle = oh;
-    request->vfs_state   = CHIMERA_S3_VFS_STATE_RECV;
+    request->file_handle      = oh;
+    request->put.meta_pending = 1;
+    request->vfs_state        = CHIMERA_S3_VFS_STATE_RECV;
 
     /* The response ETag is attached after the body is written, from the
      * object's final attributes (see chimera_s3_put_getattr_callback). */
@@ -523,6 +536,9 @@ chimera_s3_put(
     const char *dirpath = request->path;
     int         dirpathlen;
     const char *tagging_hdr;
+
+    request->put.meta_pending = 0;
+    request->put.published    = 0;
 
     /* x-amz-tagging: parse + validate the tag set now so a violation is
      * reported as 400 InvalidTag before any object bytes are written. The tags

--- a/src/server/s3/tests/quint/CMakeLists.txt
+++ b/src/server/s3/tests/quint/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(s3_mbt_replay chimera_server chimera_metrics OpenSSL::Cryp
 add_test(NAME chimera/server/s3/mbt/probe_memfs
     COMMAND $<TARGET_FILE:s3_mbt_probe>)
 set_tests_properties(chimera/server/s3/mbt/probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_probe_memfs"
     LABELS "quint;s3_mbt;memfs"
     TIMEOUT 60)
 
@@ -65,6 +66,7 @@ add_test(NAME chimera/server/s3/mbt/batch_memfs
     COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
             --exclude-prefix stepMultipart_)
 set_tests_properties(chimera/server/s3/mbt/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_memfs"
     LABELS "quint;s3_mbt;memfs"
     TIMEOUT 300)
 
@@ -75,6 +77,7 @@ add_test(NAME chimera/server/s3/mbt/batch_multipart_memfs
             --exclude-prefix stepList_ --exclude-prefix stepBucket_
             --exclude-prefix stepTag_)
 set_tests_properties(chimera/server/s3/mbt/batch_multipart_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_multipart_memfs"
     LABELS "quint;s3_mbt;memfs"
     TIMEOUT 300)
 
@@ -85,12 +88,6 @@ set_tests_properties(chimera/server/s3/mbt/batch_multipart_memfs PROPERTIES
 # mkdtemp session dir.  Gated on the storage each backend needs.
 #
 # Withheld batches, and why:
-#  - diskfs multipart: PutObject's create_unlinked+link_at publish at
-#    multipart scale intermittently SEGVs -- the link_at completion is
-#    delivered on the diskfs IQ/txn thread and the follow-on getattr races
-#    the owning thread (chimera_s3_put_finish_common -> chimera_vfs_getattr,
-#    ~1-in-2 on stepMultipart_64_0x11_1).  Re-enable when the diskfs
-#    completion threading is settled.
 #  - linux/io_uring (passthrough): need a name_to_handle_at-capable scratch
 #    filesystem ($CHIMERA_MBT_SCRATCH; overlayfs/tmpfs skip 77) and an
 #    io_uring-capable environment, and both exhibit intermittent ESTALE
@@ -109,6 +106,26 @@ if(HAVE_LIBAIO)
         COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
                 --backend diskfs --exclude-prefix stepMultipart_)
     set_tests_properties(chimera/server/s3/mbt/batch_diskfs PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_diskfs"
+        LABELS "quint;s3_mbt;diskfs"
+        TIMEOUT 300)
+
+    # Previously withheld: PutObject's publish could double-fire when the
+    # body drain outran the async metadata xattr chain (or vice versa), and
+    # at multipart scale on diskfs the second link_at's failure path crashed
+    # into the first's completion (~1-in-2 on stepMultipart_64_0x11_1).
+    # Fixed by the exactly-once publish handshake in s3_put.c (meta_pending
+    # gate + published latch); debug-level replay made the window wide
+    # enough to pin the real cause, which was never diskfs's completion
+    # threading.
+    add_test(NAME chimera/server/s3/mbt/batch_multipart_diskfs
+        COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+                --backend diskfs --block-size 5242880
+                --exclude-prefix step_ --exclude-prefix stepData_
+                --exclude-prefix stepList_ --exclude-prefix stepBucket_
+                --exclude-prefix stepTag_)
+    set_tests_properties(chimera/server/s3/mbt/batch_multipart_diskfs PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_multipart_diskfs"
         LABELS "quint;s3_mbt;diskfs"
         TIMEOUT 300)
 endif()
@@ -118,6 +135,7 @@ if(CAIRN_ENABLED)
         COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
                 --backend cairn --exclude-prefix stepMultipart_)
     set_tests_properties(chimera/server/s3/mbt/batch_cairn PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_cairn"
         LABELS "quint;s3_mbt;cairn"
         TIMEOUT 300)
 
@@ -128,6 +146,7 @@ if(CAIRN_ENABLED)
                 --exclude-prefix stepList_ --exclude-prefix stepBucket_
                 --exclude-prefix stepTag_)
     set_tests_properties(chimera/server/s3/mbt/batch_multipart_cairn PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_multipart_cairn"
         LABELS "quint;s3_mbt;cairn"
         TIMEOUT 300)
 endif()
@@ -140,5 +159,6 @@ add_test(NAME chimera/server/s3/mbt/batch_sigv2_memfs
     COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
             --sigv2 --exclude-prefix stepMultipart_)
 set_tests_properties(chimera/server/s3/mbt/batch_sigv2_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_sigv2_memfs"
     LABELS "quint;s3_mbt;memfs"
     TIMEOUT 300)

--- a/src/server/s3/tests/quint/s3_mbt_common.h
+++ b/src/server/s3/tests/quint/s3_mbt_common.h
@@ -44,6 +44,7 @@
 #include "server/s3/s3.h"
 #include "common/tcp_flavor.h"
 #include "prometheus-c.h"
+#include "common/mbt_artifacts.h"
 
 #define S3_MBT_PORT        5000
 /* Multipart traces replay with 5 MiB blocks; whole-object GETs of an
@@ -574,6 +575,8 @@ s3_mbt_env_open_module(
     struct chimera_server_config *config;
     struct evpl_thread_config    *tcfg;
 
+    mbt_debug_log_start();
+
     memset(env, 0, sizeof(*env));
 
     snprintf(env->session_dir, sizeof(env->session_dir), "/tmp/s3_mbt_XXXXXX");
@@ -819,6 +822,7 @@ s3_mbt_env_stop(struct s3_mbt_env *env)
     evpl_destroy(env->evpl);
 
     chimera_server_destroy(env->server);
+    mbt_metrics_dump(env->metrics);
     prometheus_metrics_destroy(env->metrics);
 
     free(env->body_buf);

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(smb2_smoke_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/smoke_probe_memfs
     COMMAND $<TARGET_FILE:smb2_smoke_probe>)
 set_tests_properties(chimera/server/smb/mbt/smoke_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_smoke_probe_memfs"
     LABELS "quint;smb_mbt;memfs"
     TIMEOUT 60)
 
@@ -42,6 +43,7 @@ target_link_libraries(smb2_oplock_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/oplock_probe_memfs
     COMMAND $<TARGET_FILE:smb2_oplock_probe>)
 set_tests_properties(chimera/server/smb/mbt/oplock_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_oplock_probe_memfs"
     LABELS "quint;smb_mbt;memfs"
     TIMEOUT 90)
 
@@ -56,6 +58,7 @@ target_link_libraries(smb2_durable_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/durable_probe_memfs
     COMMAND $<TARGET_FILE:smb2_durable_probe>)
 set_tests_properties(chimera/server/smb/mbt/durable_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_durable_probe_memfs"
     LABELS "quint;smb_mbt;memfs"
     TIMEOUT 120)
 
@@ -71,6 +74,7 @@ target_link_libraries(smb2_replay_probe chimera_server chimera_metrics)
 add_test(NAME chimera/server/smb/mbt/replay_probe_memfs
     COMMAND $<TARGET_FILE:smb2_replay_probe>)
 set_tests_properties(chimera/server/smb/mbt/replay_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_replay_probe_memfs"
     LABELS "quint;smb_mbt;memfs"
     TIMEOUT 120)
 
@@ -100,5 +104,6 @@ add_test(NAME chimera/server/smb/mbt/batch_memfs
 # was close enough to the ceiling to flake.  This is a batch of 40 tests in one
 # ctest, not a single case.
 set_tests_properties(chimera/server/smb/mbt/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_batch_memfs"
     LABELS "quint;smb_mbt;memfs"
     TIMEOUT 600)

--- a/src/server/smb/tests/quint/smb2_mbt_common.h
+++ b/src/server/smb/tests/quint/smb2_mbt_common.h
@@ -57,6 +57,7 @@
 #include "server/server.h"
 #include "common/tcp_flavor.h"
 #include "prometheus-c.h"
+#include "common/mbt_artifacts.h"
 
 #include "evpl/evpl.h"
 
@@ -657,6 +658,8 @@ smb2_env_open_opts(
 {
     struct chimera_server_config *config;
 
+    mbt_debug_log_start();
+
     memset(env, 0, sizeof(*env));
 
     /* Sweep the VFS open cache aggressively.  When a trace's connections are
@@ -889,6 +892,7 @@ smb2_env_stop(struct smb2_env *env)
         free(env->conns[i]);
     }
     chimera_server_destroy(env->server);
+    mbt_metrics_dump(env->metrics);
     prometheus_metrics_destroy(env->metrics);
 
     snprintf(cmd, sizeof(cmd), "rm -rf %s", env->session_dir);


### PR DESCRIPTION
Follows #1568 (the S3 MBT suite), now merged; rebased onto main so only the three commits here remain.

## Debug-mode replay with log + metrics artifacts

Every quint MBT harness (posix, nfs3/nfs4, nfsaux, smb2, s3, fuse) now runs the chimera stack at `CHIMERA_LOG_DEBUG` with the log routed to `<test>.debug.log`, and scrapes its Prometheus registry once at teardown into `<test>.metrics.prom` through `chimera_metrics_dump_file()` — the same exposition the live `/metrics` endpoint serves. The point is coverage of the reporting machinery itself: the per-request dump paths (`nfs3_dump_*`/`nfs4_dump_*`, `smb_dump_*`, the `vfs_dump` macros) are dead code at the default INFO level, and nothing exercised the metrics export. Routing to a file keeps the harnesses' stdout — including the posix/fuse drivers' line protocol — clean.

The shared wiring is `src/common/mbt_artifacts.h`; each ctest names its artifacts via a per-test `CHIMERA_MBT_ARTIFACTS` environment value so tests sharing a binary do not clobber each other, with the program name as the fallback for manual runs. Artifacts land in the ctest working directory (the registering directory's build tree).

Cost: debug-level replay inflates the long batches (smb2 batch ~11s → ~70-90s; its log is ~145 MB) — all inside the existing ctest TIMEOUTs.

## s3: PutObject publish now fires exactly once

Debug-level timing immediately earned its keep. PutObject drains the body concurrently with the async metadata-xattr chain, and both the last write completion and the metadata-done resume could conclude the request was finished — each firing the publish (`rename_at`/`link_at`). The loser's error path responded 500 and dropped the file handle; the winner's completion then ran `chimera_s3_put_finish_common` → `chimera_vfs_getattr` on a NULL handle. memfs never sees this (inline xattr completions), which is why it was only ever a backend "flake".

This is the same defect #1568 documented as the parked "diskfs multipart SEGV / link_at completion threading" — it was never diskfs's completion threading. The debug-log artifact pinned the sequence: two Rename submissions 30µs apart on one thread, the second failing ENOENT, the 500, then the crash in the first rename's completion.

Fixed with a `meta_pending` gate + `published` latch in the put path. With the fix, the previously withheld **s3 diskfs multipart batch passes reliably and is registered as a ctest** (8/8 hammered at debug level, where it previously SEGV'd ~1-in-2 at default level).

## Coverage report: per-backend vfs rows, benchmark plugins dropped

`scripts/ci_coverage_report.py` now splits `src/vfs` one level deeper, the way `src/server` already splits — memfs, diskfs, cairn, linux, io_uring (and sdk/memkv/…) each get their own row, with the dispatch/procedure core keeping the `src/vfs` row. `src/fio` and `src/elbencho` are excluded from the report: they are benchmark engine plugins driven by fio/elbencho, not by anything a protocol model can emit, so they could only ever be permanent 0% rows.

## Known timing sensitivity (documented, not fixed here)

The smb2 batch can diverge on a lock status under heavy host load (~1-in-7 on a saturated box; e.g. `smb2Base_stepInfo_500_0x9_5`, LOCK `[3,4)` excl granted/denied swapped between two opens): a closed handle's byte-range locks are released by the async VFS handle sweep rather than CLOSE processing, so a starved sweep leaves a stale conflict for the next LOCK. Pre-existing — load, not the log level, is the trigger; noted in the tests/quint commit message with the repro trace.

## Validation

- macOS native: full `-L quint` suite green (the only failure in a `-j 4` run was `libevpl/http/quint_model` hitting its timeout under load; it passes standalone).
- Linux container: full suite green with the fix; targeted hammering all green (cairn multipart 8/8, diskfs multipart 8/8, diskfs normal 6/6, smb2 batch 6/6 under load).
- Artifact spot checks: every registered quint ctest produces both files; the metrics dumps are valid Prometheus exposition (chimera + evpl series).
