### PR TITLE
ci: gate merges on the quick test tier across every supported OS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,11 +12,21 @@ on:
   merge_group:
   workflow_dispatch:   # allow manual runs
 
-# The full cross-OS, cross-arch test and static-analysis matrix runs nightly
-# from .github/workflows/nightly.yml. On PRs we run a reduced matrix:
+# What gates a merge is the QUICK test tier plus static analysis, run on every
+# supported OS rather than on a chosen few:
 #   - all OS images built for amd64 (devcontainer also for arm64)
-#   - tests on all OS images amd64; arm64 only on devcontainer
-#   - static analysis only on devcontainer
+#   - quick-tier ctest on every image, and on macOS
+#   - static analysis on every image, and on macOS
+#
+# The extended tier -- pynfs, pjdfstest, cthon, ltp, pike, smbtorture, wpts,
+# KVM -- runs in .github/workflows/nightly.yml, one job per platform.  It is
+# too slow to sit in front of a merge, and the queue is the wrong place to
+# discover that a KVM guest image moved.
+#
+# There is no flaky-test rescue.  A test that fails, fails: no re-run, no
+# marker artifact, no review gate.  A retry that turns red into green hides
+# exactly the race a merge queue exists to catch, and the rescued-flake path
+# was where a real failure could reach main behind an approval click.
 #
 # The run is three phases, fanned out as wide as possible within each, and
 # the job display names follow the phase ("Build X" = container image,
@@ -498,22 +508,10 @@ jobs:
             bash -euxc '
               tar -C /build -xzf /workspace/build-os.tar.gz
               mkdir -p /workspace/ctest-results
-              rm -f /workspace/flaky-rescued.log
               start=$(date +%s)
               rc=0
               /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32 --output-junit /workspace/ctest-results/results.xml || rc=$?
               echo "$(( $(date +%s) - start ))" > /workspace/ctest-results/duration_seconds
-              if [ "$rc" -ne 0 ]; then
-                echo "ctest reported failures; rerunning previously-failed tests to distinguish flakes from real failures"
-                cp /build/Testing/Temporary/LastTestsFailed.log /workspace/flaky-candidates.log
-                if /workspace/scripts/cap_ctest_output.sh ctest --rerun-failed --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32; then
-                  echo "rerun of previously-failed tests passed: treating as flaky (gated for human review)"
-                  cp /workspace/flaky-candidates.log /workspace/flaky-rescued.log
-                  rc=0
-                else
-                  echo "rerun still failing: real failure"
-                fi
-              fi
               exit $rc'
 
       # Per-test results for the report: ctest --output-junit (one <testcase>
@@ -529,14 +527,6 @@ jobs:
           path: ctest-results/
           if-no-files-found: warn
           retention-days: 30
-
-      - name: Upload flaky-test marker
-        if: ${{ hashFiles('flaky-rescued.log') != '' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: flaky-marker-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}
-          path: flaky-rescued.log
-          retention-days: 14
 
   # Phase 3 alongside the test jobs: scan-build does its own instrumented
   # compile (it cannot reuse the Nexus build tree), but it is gated on the
@@ -555,7 +545,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # devcontainer only on PR; full matrix runs in nightly
+          # Every supported OS image.  The distro images are built amd64-only
+          # here (see build-os); the devcontainer is the one built for both
+          # arches, so it is the only one analysed on arm64 too.
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
@@ -583,6 +575,76 @@ jobs:
             build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_name: ubuntu26
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_name: ubuntu24
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_name: ubuntu24
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_name: ubuntu22
+            cmake_extra: "-DIO_URING_ENABLED=OFF"
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_name: ubuntu22
+            cmake_extra: "-DIO_URING_ENABLED=OFF"
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_name: rocky9
+            cmake_extra: "-DIO_URING_ENABLED=OFF"
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_name: rocky9
+            cmake_extra: "-DIO_URING_ENABLED=OFF"
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Release
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_name: rocky10
+            cmake_extra: ""
+          - platform: linux/amd64
+            runner: arc-amd64
+            arch: amd64
+            build_type: Debug
+            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_name: rocky10
             cmake_extra: ""
 
     steps:
@@ -750,7 +812,7 @@ jobs:
   # amd64 only (the devcontainer's qemu is x86-only) and fetch guest images on
   # demand before running.
   test-dev:
-    name: Test devcontainer ${{ matrix.arch }} ${{ matrix.build_type }} ${{ matrix.category }}
+    name: Test devcontainer ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-complete]
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
@@ -761,25 +823,9 @@ jobs:
       matrix:
         arch: [amd64, arm64]
         build_type: [Release, Debug]
-        category: [pynfs, smbtorture, pike, wpts-smb2, wpts-smb2model, wpts-fsa, wpts-fsamodel, posix-client, pjdfstest, s3, ceph-s3, client, unit, kvm-cthon, kvm-xfsprogs, kvm-pnfs, kvm-nfstest-lock, kvm-nfstest-dio, kvm-nfstest-rest, kvm-ltp]
         include:
           - { arch: amd64, runner: arc-amd64 }
           - { arch: arm64, runner: arc-arm64 }
-        exclude:
-          # KVM is x86-only in the devcontainer, so it never runs on arm64.
-          - { arch: arm64, category: kvm-cthon }
-          - { arch: arm64, category: kvm-xfsprogs }
-          - { arch: arm64, category: kvm-pnfs }
-          - { arch: arm64, category: kvm-nfstest-lock }
-          - { arch: arm64, category: kvm-nfstest-dio }
-          - { arch: arm64, category: kvm-nfstest-rest }
-          - { arch: arm64, category: kvm-ltp }
-          # WPTS (Microsoft Protocol Test Suite) is not supported on arm64 —
-          # the shard would only skip every test, so don't run it at all.
-          - { arch: arm64, category: wpts-smb2 }
-          - { arch: arm64, category: wpts-smb2model }
-          - { arch: arm64, category: wpts-fsa }
-          - { arch: arm64, category: wpts-fsamodel }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -801,13 +847,11 @@ jobs:
             -o build-dev.tar.gz \
             "${{ env.NEXUS_SCRATCH_URL }}/chimera/build-dev-${{ github.run_id }}-${{ matrix.arch }}-${{ matrix.build_type }}.tar.gz"
 
-      - name: Unpack, fetch images if needed, and run the category
+      - name: Unpack and test inside the container
         run: |
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
-            -e KVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} \
-            -e CATEGORY=${{ matrix.category }} \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
@@ -815,78 +859,21 @@ jobs:
             ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
               tar -C /build -xzf /workspace/build-dev.tar.gz
-              NEED_KVM=
-              case "$CATEGORY" in
-                pynfs)        SEL="-L pynfs" ;;
-                smbtorture)   SEL="-L smbtorture" ;;
-                pike)         SEL="-L pike" ;;
-                # Anchor wpts-smb2$ so it does NOT also match the wpts-smb2model
-                # label (ctest -L is a substring regex; "wpts-smb2" is a prefix
-                # of "wpts-smb2model").
-                wpts-smb2)    SEL="-L wpts-smb2$" ;;
-                wpts-smb2model) SEL="-L wpts-smb2model" ;;
-                # Anchor wpts-fsa$ so it does NOT also match the wpts-fsamodel
-                # label (ctest -L is a substring regex; "wpts-fsa" is a prefix of
-                # "wpts-fsamodel").
-                wpts-fsa)     SEL="-L wpts-fsa$" ;;
-                wpts-fsamodel) SEL="-L wpts-fsamodel" ;;
-                posix-client) SEL="-L posix" ;;
-                pjdfstest)    SEL="-L pjdfstest" ;;
-                s3)           SEL="-L s3 -LE ceph-s3" ;;
-                ceph-s3)      SEL="-L ceph-s3" ;;
-                client)       SEL="-L client" ;;
-                unit)         SEL="-LE pynfs|smbtorture|pike|wpts|posix|pjdfstest|s3|client|kvm" ;;
-                kvm-cthon)    SEL="-L kvm -R /cthon/";    NEED_KVM=1 ;;
-                kvm-xfsprogs) SEL="-L kvm -R /xfstests/"; NEED_KVM=1 ;;
-                kvm-pnfs)     SEL="-L pnfs";              NEED_KVM=1 ;;
-                # nfstest is the test long-pole; split by suite so each shard
-                # lands on its own runner.  lock isolates the single longest
-                # test (nfstest_lock_*_linux), dio the next-heaviest family, and
-                # rest is everything else.  Keep these three collectively exact
-                # to "-L kvm -R /nfstest/" so no nfstest test is dropped.
-                kvm-nfstest-lock) SEL="-L kvm -R nfstest_lock_";                    NEED_KVM=1 ;;
-                kvm-nfstest-dio)  SEL="-L kvm -R nfstest_dio_";                     NEED_KVM=1 ;;
-                kvm-nfstest-rest) SEL="-L kvm -R /nfstest/ -E nfstest_(lock|dio)_"; NEED_KVM=1 ;;
-                kvm-ltp)      SEL="-L kvm -R /ltp/";      NEED_KVM=1 ;;
-              esac
-              if [ -n "$NEED_KVM" ]; then
-                ninja kvm_ubuntu2404_image kvm_ubuntu2404_hwe_image kvm_ubuntu2204_hwe_image kvm_ubuntu2604_image
-              fi
               mkdir -p /workspace/ctest-results
-              rm -f /workspace/flaky-rescued.log
               start=$(date +%s)
               rc=0
-              /workspace/scripts/cap_ctest_output.sh ctest $SEL --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32 --output-junit /workspace/ctest-results/results.xml || rc=$?
+              /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32 --output-junit /workspace/ctest-results/results.xml || rc=$?
               echo "$(( $(date +%s) - start ))" > /workspace/ctest-results/duration_seconds
-              if [ "$rc" -ne 0 ]; then
-                echo "ctest reported failures; rerunning previously-failed tests to distinguish flakes from real failures"
-                cp /build/Testing/Temporary/LastTestsFailed.log /workspace/flaky-candidates.log
-                if /workspace/scripts/cap_ctest_output.sh ctest --rerun-failed --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32; then
-                  echo "rerun of previously-failed tests passed: treating as flaky (gated for human review)"
-                  cp /workspace/flaky-candidates.log /workspace/flaky-rescued.log
-                  rc=0
-                else
-                  echo "rerun still failing: real failure"
-                fi
-              fi
               exit $rc'
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ctest-junit-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.category }}
+          name: ctest-junit-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}
           path: ctest-results/
           if-no-files-found: warn
           retention-days: 30
-
-      - name: Upload flaky-test marker
-        if: ${{ hashFiles('flaky-rescued.log') != '' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: flaky-marker-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.category }}
-          path: flaky-rescued.log
-          retention-days: 14
 
   # ---------------------------------------------------------------------------
   # macOS: compile + ctest on a GitHub-hosted arm64 runner, modeled on
@@ -899,9 +886,7 @@ jobs:
   #
   # No netns and no raised limits on a hosted runner: the in-process suites
   # run gate-free (CHIMERA_LIMITS_TESTING passes vacuously off Linux) and the
-  # genuinely networked suites serialize under the chimera_net lock.  Flake
-  # rescue mirrors test-dev so a rescued flake still routes through the
-  # flake-review gate.
+  # genuinely networked suites serialize under the chimera_net lock.
   # ---------------------------------------------------------------------------
   macos:
     name: Test macOS ${{ matrix.build_type }}
@@ -947,7 +932,6 @@ jobs:
         run: |
           cd "${{ runner.temp }}/build"
           mkdir -p "${{ github.workspace }}/ctest-results"
-          rm -f "${{ github.workspace }}/flaky-rescued.log"
           start=$(date +%s)
           rc=0
           "${{ github.workspace }}/scripts/cap_ctest_output.sh" \
@@ -955,18 +939,6 @@ jobs:
                   --timeout 300 -j "$(sysctl -n hw.ncpu)" \
                   --output-junit "${{ github.workspace }}/ctest-results/results.xml" || rc=$?
           echo "$(( $(date +%s) - start ))" > "${{ github.workspace }}/ctest-results/duration_seconds"
-          if [ "$rc" -ne 0 ]; then
-            echo "ctest reported failures; rerunning previously-failed tests to distinguish flakes from real failures"
-            cp Testing/Temporary/LastTestsFailed.log "${{ github.workspace }}/flaky-candidates.log"
-            if "${{ github.workspace }}/scripts/cap_ctest_output.sh" \
-                 ctest --rerun-failed --output-on-failure --test-output-size-failed 65536 --timeout 300; then
-              echo "rerun of previously-failed tests passed: treating as flaky (gated for human review)"
-              cp "${{ github.workspace }}/flaky-candidates.log" "${{ github.workspace }}/flaky-rescued.log"
-              rc=0
-            else
-              echo "rerun still failing: real failure"
-            fi
-          fi
           exit $rc
 
       - name: Upload test results
@@ -978,102 +950,59 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-      - name: Upload flaky-test marker
-        if: ${{ hashFiles('flaky-rescued.log') != '' }}
+  # macOS static analysis.  scan-build does its own instrumented compile, so
+  # unlike the Linux analyzers this shares nothing with the macos test job and
+  # runs independently of the build barrier.
+  analyze-macos:
+    name: Analyze macOS ${{ matrix.build_type }}
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: macos-14
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release, Debug]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          brew update
+          # llvm carries scan-build -- Apple's clang does not ship the analyzer
+          # driver.  The rest mirrors the macos test job: bison 3.x for the
+          # ndrzcc grammar, libxcrypt for full crypt(5) verification.
+          brew install llvm cmake ninja bison jansson userspace-rcu rocksdb krb5 \
+                       xxhash libxcrypt uthash openssl@3 libnghttp2
+
+      - name: Perform clang static analysis
+        id: static-analysis
+        env:
+          BUILD_DIR: ${{ runner.temp }}/build-analyze
+        run: |
+          set -o pipefail
+          mkdir -p "$GITHUB_WORKSPACE/scan-report"
+          # --exclude ext: the vendored submodules are analysed in their own
+          # repos and cannot be fixed from a chimera PR.
+          "$(brew --prefix llvm)/bin/scan-build" --status-bugs \
+              --exclude "$GITHUB_WORKSPACE/ext" \
+              -o "$GITHUB_WORKSPACE/scan-report" \
+              sh -c "cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                           -B \"$BUILD_DIR\" -S \"$GITHUB_WORKSPACE\" -G Ninja \
+                     && ninja -C \"$BUILD_DIR\"" \
+              2>&1 | tee "$GITHUB_WORKSPACE/scan-report/scan-build-output.txt"
+
+      - name: Upload static analysis report
+        if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
         uses: actions/upload-artifact@v6
         with:
-          name: flaky-marker-macos-${{ matrix.build_type }}
-          path: flaky-rescued.log
-          retention-days: 14
-
-  # Gather the per-matrix flaky-test markers (uploaded only when a test failed
-  # on its first run but passed on --rerun-failed) into a single yes/no signal.
-  collect-flakes:
-    name: Collect flaky-test markers
-    needs: [test, test-dev, macos]
-    if: ${{ always() }}
-    runs-on: arc-small
-    permissions:
-      contents: read
-      issues: write
-    outputs:
-      flaky: ${{ steps.detect.outputs.flaky }}
-    steps:
-      - name: Download flaky markers
-        uses: actions/download-artifact@v6
-        continue-on-error: true
-        with:
-          path: flaky-markers
-          pattern: flaky-marker-*
-
-      - name: Detect whether any test was flaky
-        id: detect
-        run: |
-          if compgen -G "flaky-markers/flaky-marker-*/*" > /dev/null; then
-            echo "flaky=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "flaky=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Record flaky tests on the tracking issue
-        if: ${{ steps.detect.outputs.flaky == 'true' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const dir = 'flaky-markers';
-            let details = '';
-            for (const sub of fs.readdirSync(dir)) {
-              const f = path.join(dir, sub, 'flaky-rescued.log');
-              if (fs.existsSync(f)) {
-                const matrix = sub.replace(/^flaky-marker-/, '');
-                details += `\n**${matrix}**\n\n\`\`\`\n${fs.readFileSync(f, 'utf8')}\n\`\`\`\n`;
-              }
-            }
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const body = `Tests below failed once but passed on \`--rerun-failed\` in a merge_group run for \`${context.sha}\`. `
-              + `The merge was gated on human approval (\`flake-gate\`); please root-cause and fix these flakes.\n\n`
-              + `Run: ${runUrl}\n${details}`;
-            const title = 'Flaky tests observed in CI';
-            const label = 'flaky-test';
-            const { owner, repo } = context.repo;
-            try {
-              await github.rest.issues.createLabel({ owner, repo, name: label, color: 'd73a4a',
-                description: 'Test that needed a CI retry to pass' });
-            } catch (e) { /* label already exists */ }
-            const open = await github.rest.issues.listForRepo({ owner, repo, state: 'open', labels: label });
-            let number;
-            if (open.data.length > 0) {
-              number = open.data[0].number;
-            } else {
-              const created = await github.rest.issues.create({ owner, repo, title, labels: [label],
-                body: 'Rolling tracker for tests that needed a CI retry to pass. Each comment below is one observation from the merge queue.' });
-              number = created.data.number;
-            }
-            await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
-
-  # Human-approval choke point for the merge queue: when a flake was rescued by
-  # retry, this job routes through the 'flake-review' environment (configured
-  # with required reviewers) and PAUSES the merge_group run until a reviewer
-  # approves. When no flake occurred, the environment expression is empty and
-  # the job passes immediately. Mark this job as a required status check.
-  flake-gate:
-    name: Flake review gate
-    needs: collect-flakes
-    if: ${{ always() }}
-    runs-on: arc-small
-    permissions:
-      contents: read
-    environment: ${{ needs.collect-flakes.outputs.flaky == 'true' && 'flake-review' || '' }}
-    steps:
-      - name: Report gate outcome
-        run: |
-          if [ "${{ needs.collect-flakes.outputs.flaky }}" = "true" ]; then
-            echo "Flaky tests were rescued by retry and a reviewer approved this merge."
-          else
-            echo "No flaky tests detected; nothing to review."
-          fi
+          name: scan-report-macos-${{ matrix.build_type }}
+          path: scan-report/
+          if-no-files-found: warn
+          retention-days: 30
 
   # Single stable aggregate of the whole build/test matrix, so the merge
   # queue's required-checks list is one name instead of every matrix cell
@@ -1093,6 +1022,7 @@ jobs:
       - test-dev
       - static-analysis
       - macos
+      - analyze-macos
     if: ${{ always() }}
     runs-on: arc-small
     permissions:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -520,7 +520,63 @@ jobs:
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
               ninja && \
               /workspace/scripts/cap_ctest_output.sh \
-              ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'
+              ctest -C extended --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'
+
+  # macOS: the extended tier on a GitHub-hosted arm64 runner.  Nothing here is
+  # containerised and none of the Linux-only pieces exist (io_uring, libaio,
+  # KVM, netns, RDMA, the linux passthrough backend), so this covers the kqueue
+  # event core, the in-process test transport, and every portable path above
+  # them -- the combination the Linux matrix never exercises.
+  #
+  # The merge queue runs the quick tier here; this is the only place the rest
+  # of the suite meets macOS.
+  #
+  # No netns and no raised limits on a hosted runner: the in-process suites run
+  # gate-free (CHIMERA_LIMITS_TESTING passes vacuously off Linux) and the
+  # genuinely networked suites serialize under the chimera_net lock.
+  macos:
+    name: Test macOS ${{ matrix.build_type }}
+    runs-on: macos-14
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release, Debug]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          brew update
+          # bison: Apple ships 2.3 and the ndrzcc grammar needs 3.x; the
+          # top-level CMakeLists already adds the keg-only Homebrew path.
+          # libxcrypt: Darwin libc crypt(3) is DES-only, and REST auth needs
+          # full crypt(5) $-scheme verification.
+          brew install cmake ninja bison jansson userspace-rcu rocksdb krb5 \
+                       xxhash libxcrypt uthash openssl@3 libnghttp2
+          # oras, not quint: this job has never had a model-based-test trace
+          # corpus, so every MBT replay ctest disabled itself here.  A CI
+          # checkout never has local edits to ext/specs, so the bundle the specs
+          # CI published for the pinned commit always applies.
+          brew install oras
+
+      - name: Configure and build
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                -DSPECS_BUNDLE=ON \
+                -S "${{ github.workspace }}" -B "${{ runner.temp }}/build"
+          ninja -C "${{ runner.temp }}/build"
+
+      - name: Test
+        run: |
+          cd "${{ runner.temp }}/build"
+          "${{ github.workspace }}/scripts/cap_ctest_output.sh" \
+            ctest -C extended --output-on-failure --test-output-size-failed 65536 \
+                  --timeout 300 -j "$(sysctl -n hw.ncpu)"
 
   # Informational measurement of the full smbtorture smb2 matrix (655 subtests x
   # 6 VFS backends).  The gating suite only registers the subtests in the

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,10 +8,10 @@ name: PR checks
 # (docker-build.yml) run ONLY in the merge queue (merge_group), not on pull
 # requests -- so a PR's check list isn't cluttered with a wall of skipped
 # matrix jobs.  But the branch-protection ruleset still requires the
-# "CI complete", "Flake review gate" and "Docker build complete" checks on a PR
-# before it can be added to the queue.  This workflow satisfies them with
-# instant no-op placeholders; the real checks of the same names run in the queue
-# (where the actual matrix / image builds / flake review happen).
+# "CI complete" and "Docker build complete" checks on a PR before it can be
+# added to the queue.  This workflow satisfies them with instant no-op
+# placeholders; the real checks of the same names run in the queue (where the
+# actual matrix and image builds happen).
 #
 # It also carries the pre-merge signal that is cheap enough to be worth having
 # before the queue: clang static analysis on devcontainer and macOS, and the
@@ -21,6 +21,10 @@ name: PR checks
 # breaks, so catching that here rather than in the queue is worth one image
 # build.  macOS runs the quint suite post-merge, in build-test.yml's macOS job,
 # rather than twice.
+#
+# The queue now runs this same pair -- quick-tier ctest and static analysis --
+# across every supported OS, so what this job buys is earliness, not extra
+# coverage.
 on:
   pull_request:
 
@@ -49,16 +53,6 @@ jobs:
     steps:
       - name: PR placeholder
         run: echo "PR placeholder -- the full build/test matrix runs in the merge queue (merge_group)."
-
-  flake-gate:
-    name: Flake review gate
-    runs-on: arc-small
-    # No environment here: flaky-test review only applies to the real test run,
-    # which happens in the merge queue.  Keeping this a plain no-op means a PR
-    # never sits waiting on a manual approval just to be queued.
-    steps:
-      - name: PR placeholder
-        run: echo "PR placeholder -- flaky-test review happens in the merge queue (merge_group)."
 
   docker-build-complete:
     name: Docker build complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,18 +51,41 @@ ninja -C build/Release
 
 ## Running Tests
 
-All testing is done via ctest:
+All testing is done via ctest. Tests are split into two tiers:
+
+- **quick** (the default) - the quint model-based tests. This is what a plain
+  `ctest` runs.
+- **extended** - the quick tier plus everything else: pynfs, pjdfstest, cthon,
+  ltp, pike, smbtorture, wpts, the KVM suites, and the unit tests. Selected
+  with `ctest -C extended`, and what the nightly job runs.
 
 ```bash
-# Run all tests in a build directory
+# Quick tier: the model-based tests (default)
 cd build/Debug && ctest --output-on-failure
 
-# Run specific test
+# Extended tier: everything
+cd build/Debug && ctest -C extended --output-on-failure
+
+# Run specific test (add -C extended if it is not a model-based test)
 cd build/Debug && ctest -R <test_name> --output-on-failure
 
 # Run tests with parallel execution
 cd build/Release && ctest --output-on-failure -j 8
 ```
+
+`make check` runs the CI sweep over the quick tier; `make check_extended` runs
+the same sweep over the extended tier.
+
+The merge queue runs the quick tier and static analysis on every supported OS,
+so the quick tier is what gates a merge. The extended tier runs nightly. Run it
+locally as needed - in particular when proving out a fix to one of those tests,
+because a break there will not surface until the next night.
+
+The model-based tests are meant to be a cheap proxy for the full suite, so an
+extended-tier failure that the model tests did not catch should be read as a
+suggestion to improve the model: consider whether the quint specification or its
+trace corpus can be extended to cover that case, so the next such regression is
+caught by the quick tier.
 
 ## Pre-Completion Verification
 
@@ -85,7 +108,11 @@ This runs:
 - `build_clang` - Clang static analysis (scan-build)
 - `reuse-lint` - SPDX license header compliance
 
-All of these checks are verified by CI, so running `make check` locally ensures your changes will pass CI.
+`make check` runs the tests at the quick tier, which is what the merge queue
+gates on. `make check_extended` runs the identical sweep with the full test
+suite; only the nightly job runs that, so use it when a change reaches beyond
+what the model-based tests cover, or when proving out a fix to an extended
+test.
 
 ## Architecture Overview
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,76 @@ if (NOT DISABLE_TESTS)
     enable_testing()
 endif()
 
+# Test tiers.  Plain `ctest` runs the *quick* tier: the quint model-based
+# tests.  They are cheap and are meant to be a pre-flight proxy for the full
+# suite, so they are what you get when you ask for nothing.  `ctest -C
+# extended` runs the quick tier plus everything else; that is the tier the
+# merge queue and the nightly job use.
+#
+# CTest can only withhold a test from the default run through the
+# CONFIGURATIONS keyword of add_test().  The CONFIGURATIONS *test property* is
+# inert -- ctest never consults it -- and there is no directory-level default,
+# so the tag has to be present at the point of registration.  With ~230
+# add_test() call sites across this tree and its submodules, tagging each by
+# hand would be unmaintainable and would rot silently as tests are added, so
+# add_test() is wrapped once here instead.
+#
+# A directory that sets CHIMERA_TEST_TIER to "quick" registers its tests, and
+# those of its subdirectories, in the quick tier.  Tests registered by
+# submodules we do not edit are matched by name instead.
+set(CHIMERA_TEST_TIER "extended")
+set(CHIMERA_QUICK_TEST_REGEX "^libevpl/.*quint"
+    CACHE STRING "Test-name regex forced into the quick tier")
+
+function(add_test)
+    # Forward every argument verbatim.  A CMake list is semicolon-separated, so
+    # an argument that itself contains a semicolon -- a shell fragment like
+    # ": MARK; mkdir -p ..." handed to `sh -c`, for instance -- would be split
+    # into two arguments when ${_args} is re-expanded.  Escaping each one keeps
+    # it a single argument.
+    set(_args "")
+    math(EXPR _last "${ARGC} - 1")
+    foreach(_i RANGE ${_last})
+        string(REPLACE ";" "\;" _a "${ARGV${_i}}")
+        list(APPEND _args "${_a}")
+    endforeach()
+
+    list(GET _args 0 _first)
+    if(NOT _first STREQUAL "NAME")
+        # Legacy add_test(<name> <command> [<arg>...]).  That form cannot
+        # carry CONFIGURATIONS, so re-express it in the NAME form, which also
+        # resolves an executable target name to the built binary.
+        list(POP_FRONT _args _name)
+        set(_args NAME "${_name}" COMMAND ${_args})
+    else()
+        list(GET _args 1 _name)
+    endif()
+
+    set(_quick FALSE)
+    if(CHIMERA_TEST_TIER STREQUAL "quick")
+        set(_quick TRUE)
+    elseif(CHIMERA_QUICK_TEST_REGEX AND _name MATCHES "${CHIMERA_QUICK_TEST_REGEX}")
+        set(_quick TRUE)
+    endif()
+
+    if(_quick)
+        _add_test(${_args})
+    else()
+        _add_test(${_args} CONFIGURATIONS extended)
+    endif()
+endfunction()
+
+# Overriding a built-in command leaves the original reachable under a leading
+# underscore.  That behaviour is long-standing but undocumented, so assert it
+# rather than let a future CMake silently collapse every test into the quick
+# tier.
+if(NOT COMMAND _add_test)
+    message(FATAL_ERROR
+        "The add_test() override did not expose the built-in as _add_test(); "
+        "every test would land in the quick tier and the extended tier would "
+        "be empty.  See the test-tier block in the top-level CMakeLists.txt.")
+endif()
+
 include_directories(3rdparty)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,17 @@ CMAKE_ARGS_DEBUG := -DCMAKE_BUILD_TYPE=Debug
 CMAKE_ARGS_COVERAGE := -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_C_COMPILER=clang
 # nproc is coreutils (Linux); macOS provides the same count via sysctl.
 CTEST_PARALLEL := $(shell n=$$(nproc 2>/dev/null || sysctl -n hw.ncpu); echo $$(( n < 64 ? n : 64 )))
-CTEST_ARGS := --output-on-failure --timeout 30 -j $(CTEST_PARALLEL)
+# Which tier the test targets run.  Empty selects the default (quick) tier --
+# the quint model-based tests -- matching a bare `ctest`.  `make check_extended`
+# sets this to `-C extended` for the full suite.  Overriding CTEST_ARGS wholesale
+# still works and drops the tier, which is what the coverage repro command in
+# scripts/ci_coverage_report.py relies on.
+CTEST_TIER ?=
+CTEST_ARGS := $(CTEST_TIER) --output-on-failure --timeout 30 -j $(CTEST_PARALLEL)
 
 # Plain `make` produces a debug build only. Use `make debug`/`make release`
-# to also run the test suite, or `make check` for the full CI sweep.
+# to also run the test suite, `make check` for the CI sweep over the quick test
+# tier, or `make check_extended` for the same sweep over the full suite.
 .DEFAULT_GOAL := build_debug
 
 .PHONY: build_release
@@ -124,7 +131,14 @@ sdk-include-check:
 
 .PHONY: check
 check: syntax-check sdk-include-check build_release test_release build_debug test_debug build_clang reuse-lint copyright-check
-	@echo "All checks passed!"
+	@echo "All checks passed! (test tier: $(if $(CTEST_TIER),extended,quick))"
+
+# The same sweep as `check` over the full test suite.  Recursive rather than a
+# target-specific variable so the tier reaches every test target unambiguously,
+# and so `make check check_extended` still means what it looks like.
+.PHONY: check_extended
+check_extended:
+	@$(MAKE) CTEST_TIER="-C extended" check
 
 .PHONY: docs
 docs:

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
+# These are the model-based tests, so they make up the quick tier that plain
+# `ctest` runs.  See the test-tier block in the top-level CMakeLists.txt.
+set(CHIMERA_TEST_TIER quick)
+
 # POSIX model-based tests: the Quint specification (posix.qnt and friends) and
 # its trace generation live in the chimera-nas/specs repo (submodule ext/specs).
 # This directory owns the replay harness -- posix_mbt_replay.c (a pure-C

--- a/src/server/fuse/tests/quint/CMakeLists.txt
+++ b/src/server/fuse/tests/quint/CMakeLists.txt
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
+# These are the model-based tests, so they make up the quick tier that plain
+# `ctest` runs.  See the test-tier block in the top-level CMakeLists.txt.
+set(CHIMERA_TEST_TIER quick)
+
 # In-process FUSE harness: drives the FUSE server over a socketpair standing
 # in for /dev/fuse, so it needs no device, no mount, and no privileges and
 # runs unconditionally rather than behind the fuse_probe capability gate.

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -429,10 +429,41 @@ chimera_nfs_nlm4_lock_acquire_cb(
     res.cookie.data = ctx->cookie.data;
 
     if (result == CHIMERA_CLAIM_GRANTED) {
+        bool reaped;
+
         pthread_mutex_lock(&shared->nlm_state.mutex);
-        entry->pending        = false;
-        entry->claim_inserted = true;
+        reaped = entry->reaped;
+        if (reaped) {
+            /* The client was reaped (FREE_ALL, SM_NOTIFY, or its last
+             * connection dropped) while this acquire was in flight, and the
+             * reaper could not claim the ticket, so it left the entry to us.
+             * Granting now would hand a lock to a client we have already
+             * told holds none -- drop it instead.  Still linked, so unlink
+             * under the same mutex the reaper used. */
+            DL_DELETE(ctx->client->locks, entry);
+        } else {
+            entry->pending        = false;
+            entry->claim_inserted = true;
+        }
         pthread_mutex_unlock(&shared->nlm_state.mutex);
+
+        if (reaped) {
+            chimera_nfs_debug(
+                "NLM LOCK: grant landed for reaped client '%s'; releasing",
+                ctx->client->hostname);
+            chimera_vfs_claim_release(vfs_state, entry->file_state,
+                                      &entry->claim);
+            chimera_vfs_state_put(vfs_state, entry->file_state);
+            entry->file_state = NULL;
+            chimera_vfs_release(thread->vfs_thread, entry->handle);
+            nlm_lock_entry_free(entry);
+            /* The original LOCK RPC was already answered with NLM4_BLOCKED
+             * (only blocked entries can still be pending here), so no reply
+             * is owed and no NLM_GRANTED callback is wanted. */
+            free(ctx);
+            return;
+        }
+
         res.stat = NLM4_GRANTED;
 
         /* Monitor the lock holder so we can SM_NOTIFY it to reclaim if we

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -325,19 +325,21 @@ struct nlm_lock_ctx {
     char                              client_addr[80];
 };
 
-/* Build a self-contained grant job from the now-granted lock entry and hand it
- * to the outbound NLM_GRANTED engine.  Called only for a blocking lock that was
- * deferred (NLM4_BLOCKED already sent); the entry is GRANTED in the claim core,
- * so the job is a pure value snapshot and does not alias any lock state.
- * Caller must NOT hold nlm_state.mutex. */
+/* Snapshot a self-contained grant job from the now-granted lock entry.
+ *
+ * CALLER MUST HOLD nlm_state.mutex.  The entry is only guaranteed to exist
+ * while it is held: a client reap (FREE_ALL, SM_NOTIFY, or the last
+ * connection dropping) takes every entry off client->locks under the mutex
+ * and frees them as soon as it drops it, so reading the entry afterwards is
+ * a use-after-free.  The job is a pure value copy, so once it is filled in
+ * nothing downstream aliases lock state. */
 static void
-chimera_nfs_nlm4_deliver_grant(struct nlm_lock_ctx *ctx)
+chimera_nfs_nlm4_build_grant_locked(
+    struct nlm_lock_ctx      *ctx,
+    struct nlm_grant_request *reqp)
 {
-    struct chimera_server_nfs_thread *thread = ctx->thread;
-    struct chimera_server_nfs_shared *shared = thread->shared;
-    struct nlm_lock_entry            *entry  = ctx->entry;
-    struct nlm_granter               *granter;
-    struct nlm_grant_request          req;
+    struct nlm_lock_entry   *entry = ctx->entry;
+    struct nlm_grant_request req;
 
     memset(&req, 0, sizeof(req));
     snprintf(req.client_addr, sizeof(req.client_addr), "%s", ctx->client_addr);
@@ -358,14 +360,27 @@ chimera_nfs_nlm4_deliver_grant(struct nlm_lock_ctx *ctx)
     req.length    = NLM_POSIX_LEN_TO_VFS(entry->length);
     req.exclusive = entry->exclusive ? 1 : 0;
 
+    *reqp = req;
+} /* chimera_nfs_nlm4_build_grant_locked */
+
+/* Hand a snapshot built above to the outbound NLM_GRANTED engine.  Caller
+ * must NOT hold nlm_state.mutex. */
+static void
+chimera_nfs_nlm4_submit_grant(
+    struct nlm_lock_ctx      *ctx,
+    struct nlm_grant_request *req)
+{
+    struct chimera_server_nfs_shared *shared = ctx->thread->shared;
+    struct nlm_granter               *granter;
+
     /* Lazily create the granter (idempotent).  Done under nlm_state.mutex so two
      * threads cannot both create one. */
     pthread_mutex_lock(&shared->nlm_state.mutex);
     granter = nlm_granter_get_or_create(shared);
     pthread_mutex_unlock(&shared->nlm_state.mutex);
 
-    nlm_granter_submit(granter, &req);
-} /* chimera_nfs_nlm4_deliver_grant */
+    nlm_granter_submit(granter, req);
+} /* chimera_nfs_nlm4_submit_grant */
 
 /* Fired (once) synchronously inside chimera_vfs_claim_acquire when a blocking
  * LOCK queues on a conflict.  Sends the RFC 1813 / XNFS NLM4_BLOCKED interim
@@ -429,7 +444,9 @@ chimera_nfs_nlm4_lock_acquire_cb(
     res.cookie.data = ctx->cookie.data;
 
     if (result == CHIMERA_CLAIM_GRANTED) {
-        bool reaped;
+        struct nlm_grant_request grant_req;
+        bool                     reaped;
+        bool                     deliver = false;
 
         pthread_mutex_lock(&shared->nlm_state.mutex);
         reaped = entry->reaped;
@@ -444,6 +461,15 @@ chimera_nfs_nlm4_lock_acquire_cb(
         } else {
             entry->pending        = false;
             entry->claim_inserted = true;
+
+            /* Snapshot the out-of-band grant HERE, under the mutex.  Once it
+             * is dropped this entry is fair game for a concurrent client
+             * reap, which frees it -- and the deferred-grant path used to
+             * read it afterwards. */
+            if (ctx->was_blocked) {
+                chimera_nfs_nlm4_build_grant_locked(ctx, &grant_req);
+                deliver = true;
+            }
         }
         pthread_mutex_unlock(&shared->nlm_state.mutex);
 
@@ -479,9 +505,9 @@ chimera_nfs_nlm4_lock_acquire_cb(
          * original RPC), the grant must now be delivered to the waiting client
          * via an out-of-band NLM_GRANTED callback -- the original RPC is closed.
          * Submit the grant job and return without touching the RPC reply path. */
-        if (ctx->was_blocked) {
+        if (deliver) {
             chimera_nfs_debug("NLM LOCK: deferred lock granted -> NLM_GRANTED callback");
-            chimera_nfs_nlm4_deliver_grant(ctx);
+            chimera_nfs_nlm4_submit_grant(ctx, &grant_req);
             free(ctx);
             return;
         }

--- a/src/server/nfs/nfs_nlm_state.c
+++ b/src/server/nfs/nfs_nlm_state.c
@@ -388,16 +388,23 @@ nlm_client_release_all_locks(
          * core (an NLM blocking LOCK not yet granted) must have its ticket
          * cancelled before we free it -- otherwise the pending pump would later
          * fire the acquire callback on freed memory.  chimera_vfs_claim_cancel
-         * is the atomic arbiter: true exactly once if it dequeued the ticket
-         * before the pump claimed it.
+         * is the atomic arbiter: true exactly once if it claimed the ticket
+         * before the callback was invoked.
          *
          *   - cancel == true : the callback will NOT fire; WE own the entry.
          *     Its original LOCK RPC already received NLM4_BLOCKED, so no reply is
          *     owed; free the acquire ctx the callback would have freed.
-         *   - cancel == false: the acquire callback is firing concurrently and
-         *     will DL_DELETE + free this entry itself -- leave it linked, skip. */
+         *   - cancel == false: the acquire callback has been invoked and may be
+         *     RUNNING right now, blocked on the mutex we hold.  It will
+         *     DL_DELETE + free this entry itself, so leave it linked and skip --
+         *     but mark it reaped first, so that when it does get the mutex it
+         *     tears the lock down instead of granting a lock to a client we have
+         *     just declared lock-free.  The flag is the whole hand-off: cancel
+         *     must not block here (it once spun until the callback returned,
+         *     deadlocking against the very mutex we hold). */
         if (entry->pending && !entry->claim_inserted && entry->file_state) {
             if (!chimera_vfs_claim_cancel(vfs_state, &entry->ticket)) {
+                entry->reaped = true;
                 continue;
             }
             free(entry->ticket.private_data);

--- a/src/server/nfs/nfs_nlm_state.h
+++ b/src/server/nfs/nfs_nlm_state.h
@@ -55,6 +55,11 @@ struct nlm_lock_entry {
     struct chimera_vfs_pending_acquire ticket;
     struct chimera_vfs_file_state     *file_state;
     bool                               claim_inserted; /* claim present in claim core */
+    /* Set under nlm_state.mutex by nlm_client_release_all_locks when it
+     * could not claim a still-in-flight acquire: the client is gone, so the
+     * acquire callback must tear the entry down instead of completing it.
+     * Exactly one of the reaper and the callback frees the entry. */
+    bool                               reaped;
     struct nlm_lock_entry             *next;
     struct nlm_lock_entry             *prev;
 };

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
+# These are the model-based tests, so they make up the quick tier that plain
+# `ctest` runs.  See the test-tier block in the top-level CMakeLists.txt.
+set(CHIMERA_TEST_TIER quick)
+
 # NFS model-based tests: the Quint specifications and their trace generation
 # live in the chimera-nas/specs repo (submodule ext/specs); this directory owns
 # only the C replay harnesses that drive that corpus against the live chimera

--- a/src/server/s3/tests/quint/CMakeLists.txt
+++ b/src/server/s3/tests/quint/CMakeLists.txt
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
+# These are the model-based tests, so they make up the quick tier that plain
+# `ctest` runs.  See the test-tier block in the top-level CMakeLists.txt.
+set(CHIMERA_TEST_TIER quick)
+
 # S3 model-based tests: the Quint specification and its trace generation live
 # in the chimera-nas/specs repo (submodule ext/specs, quint/s3); this
 # directory owns only the C replay harness that drives that corpus against

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-only
 
+# These are the model-based tests, so they make up the quick tier that plain
+# `ctest` runs.  See the test-tier block in the top-level CMakeLists.txt.
+set(CHIMERA_TEST_TIER quick)
+
 # SMB2/3 model-based tests: the Quint specification (smb2.qnt and its pure
 # smb2_state.qnt / smb2_ops.qnt modules, on top of the protocol-neutral
 # filesystem core the NFSv4 model shares) and its trace generation live in the

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -1693,9 +1693,17 @@ diskfs_open_fh_inode_cb(
 
     /* A deleted, unreferenced inode is dead (queued for or under background
      * reclaim); a stale handle must not resurrect it mid-burn-down.  One that
-     * still has open handles (deleted-while-open / anonymous) stays openable. */
+     * still has open handles (deleted-while-open / anonymous) stays openable.
+     *
+     * ESTALE, not ENOENT: this resolves a FILEHANDLE, so there is no name to
+     * be absent -- the handle is well-formed and names nothing, which is the
+     * definition of stale.  It also has to agree with what the very same
+     * handle answers a moment later, once reclaim has freed the inode and
+     * diskfs_inode_acquire stops finding it at all; that path has always
+     * said ESTALE, so answering ENOENT here made a dead handle report NOENT
+     * or STALE depending on how far the background reclaim had got. */
     if (unlikely(inode->nlink == 0 && inode->refcnt == 0)) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ESTALE);
         return;
     }
 
@@ -3282,9 +3290,14 @@ diskfs_link_at_inode_cb(
     /* A deleted, unreferenced inode is dead -- it is queued for (or already
      * under) background reclaim, so it must not re-enter the namespace.  An
      * nlink==0 inode with open handles is a live anonymous file
-     * (create_unlinked) and may be linked. */
+     * (create_unlinked) and may be linked.
+     *
+     * ESTALE for the same reason as diskfs_open_fh_inode_cb: the dead object
+     * is named by the SOURCE HANDLE, not by a name (RFC 1813 does not list
+     * NFS3ERR_NOENT for LINK at all), and it must not depend on how far
+     * reclaim has got. */
     if (unlikely(inode->nlink == 0 && inode->refcnt == 0)) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ESTALE);
         return;
     }
 

--- a/src/vfs/tests/vfs_claim_test.c
+++ b/src/vfs/tests/vfs_claim_test.c
@@ -26,7 +26,6 @@
 #include <assert.h>
 
 #include "vfs/vfs_claim.h"
-#include "vfs/vfs_claim_internal.h"
 #include "vfs/vfs_internal.h"
 #include "common/logging.h"
 
@@ -861,15 +860,16 @@ test_async_acquire_cancel(void)
 /* Test 14b: the backend RANGE confirm lane ------------------------- */
 
 /* A projectable RANGE grant does not complete when the pump runs: its
- * ticket rides the service work FIFO awaiting the backend confirm.  Both
- * points at which a cancel can still claim such a ticket are tested here,
- * and BOTH must answer without blocking -- chimera_vfs_claim_cancel used
- * to spin until the confirm's callback returned, which deadlocked any
- * caller holding a lock that callback also takes (NLM client teardown
- * cancelling under nlm_state.mutex against the confirm's NLM4_GRANTED
- * callback).  There is no backend here: forcing lease_capable is what puts
- * the core on the projecting path, which is otherwise reachable only with
- * a real CAP_LEASE module attached. */
+ * ticket rides the service work FIFO awaiting the backend confirm.  While
+ * it is queued a cancel claims it outright; once the confirm is dispatched
+ * the callback owns the completion and the cancel says so -- promptly.  It
+ * used to spin until that callback returned, which deadlocked any caller
+ * holding a lock the callback also takes (an NLM client teardown cancelling
+ * under nlm_state.mutex against the confirm's NLM4_GRANTED callback).
+ *
+ * There is no backend here: forcing lease_capable is what puts the core on
+ * the projecting path, which is otherwise reachable only with a real
+ * CAP_LEASE module attached, and is why this lane had no unit coverage. */
 static void
 test_backend_confirm_lane_cancel(void)
 {
@@ -878,7 +878,6 @@ test_backend_confirm_lane_cancel(void)
     struct chimera_vfs_claim           held, want;
     struct chimera_claim_owner         owner;
     struct chimera_vfs_pending_acquire ticket;
-    struct chimera_vfs_bl_range_op     op;
     struct acquire_recorder            rec = { 0 };
     bool                               cancelled;
 
@@ -909,34 +908,15 @@ test_backend_confirm_lane_cancel(void)
     CHECK(rec.fired == 0, "pump defers a projectable grant to the lane");
     CHECK(state->work_head != NULL, "ticket is queued on the work FIFO");
 
-    /* Still on the FIFO: the cancel yanks it outright. */
+    /* Still queued: the cancel yanks it and the callback never fires. */
     cancelled = chimera_vfs_claim_cancel(state, &ticket);
     CHECK(cancelled == true, "cancel claims a ticket queued for confirm");
     CHECK(state->work_head == NULL, "cancel removed the FIFO entry");
     CHECK(rec.fired == 0, "cancelled ticket never fires its callback");
 
-    /* Already dispatched: the confirm is in flight and its op is linked,
-     * so the cancel claims the op instead and the completion will skip the
-     * callback.  It must decide immediately rather than wait the confirm
-     * out. */
-    memset(&op, 0, sizeof(op));
-    op.state               = state;
-    op.file                = file;
-    op.ticket              = &ticket;
-    op.serial_lane         = true;
-    state->confirm_head    = &op;
-    state->work_confirming = true;
-
-    cancelled = chimera_vfs_claim_cancel(state, &ticket);
-    CHECK(cancelled == true, "cancel claims a confirm already in flight");
-    CHECK(op.cancelled == true, "the in-flight confirm is marked cancelled");
-
-    /* Once the completion has unlinked its op -- which it does before
-     * invoking the callback -- the callback owns the ticket and the cancel
-     * must say so instead of blocking. */
-    state->confirm_head    = NULL;
-    state->work_confirming = false;
-
+    /* Dispatched (nothing left on the FIFO): the callback owns the
+     * completion, so the cancel yields -- and returns rather than waiting
+     * for that callback, which is what closed the deadlock. */
     cancelled = chimera_vfs_claim_cancel(state, &ticket);
     CHECK(cancelled == false, "cancel yields once the callback owns the ticket");
 

--- a/src/vfs/tests/vfs_claim_test.c
+++ b/src/vfs/tests/vfs_claim_test.c
@@ -26,6 +26,7 @@
 #include <assert.h>
 
 #include "vfs/vfs_claim.h"
+#include "vfs/vfs_claim_internal.h"
 #include "vfs/vfs_internal.h"
 #include "common/logging.h"
 
@@ -856,6 +857,92 @@ test_async_acquire_cancel(void)
     chimera_vfs_state_put(state, file);
     chimera_vfs_state_destroy(state);
 } /* test_async_acquire_cancel */
+
+/* Test 14b: the backend RANGE confirm lane ------------------------- */
+
+/* A projectable RANGE grant does not complete when the pump runs: its
+ * ticket rides the service work FIFO awaiting the backend confirm.  Both
+ * points at which a cancel can still claim such a ticket are tested here,
+ * and BOTH must answer without blocking -- chimera_vfs_claim_cancel used
+ * to spin until the confirm's callback returned, which deadlocked any
+ * caller holding a lock that callback also takes (NLM client teardown
+ * cancelling under nlm_state.mutex against the confirm's NLM4_GRANTED
+ * callback).  There is no backend here: forcing lease_capable is what puts
+ * the core on the projecting path, which is otherwise reachable only with
+ * a real CAP_LEASE module attached. */
+static void
+test_backend_confirm_lane_cancel(void)
+{
+    struct chimera_vfs_state          *state;
+    struct chimera_vfs_file_state     *file;
+    struct chimera_vfs_claim           held, want;
+    struct chimera_claim_owner         owner;
+    struct chimera_vfs_pending_acquire ticket;
+    struct chimera_vfs_bl_range_op     op;
+    struct acquire_recorder            rec = { 0 };
+    bool                               cancelled;
+
+    fprintf(stderr, "\ntest_backend_confirm_lane_cancel\n");
+
+    state = chimera_vfs_state_init();
+    /* Pretend a CAP_LEASE backend is attached (short-circuits the lazy
+     * module probe, which needs a real vfs). */
+    state->lease_probed  = 1;
+    state->lease_capable = 1;
+
+    file = get_file(state, 2);
+
+    /* A holds [0,100) exclusively; B blocks behind it. */
+    init_owner(&owner, CHIMERA_CLAIM_PROTO_NLM, 0xC, 1);
+    chimera_vfs_claim_init_range(&held, true, false, 0, 100, &owner);
+    chimera_vfs_claim_try_acquire(state, file, &held, NULL);
+
+    init_owner(&owner, CHIMERA_CLAIM_PROTO_NLM, 0xD, 2);
+    chimera_vfs_claim_init_range(&want, true, false, 0, 100, &owner);
+    chimera_vfs_claim_acquire(NULL, state, file, &want, &ticket, true, true,
+                              recording_acquire_cb, NULL, &rec);
+    CHECK(ticket.queued == true, "blocking range ticket queues");
+
+    /* Releasing A pumps B.  B is granted locally but, being projectable,
+     * is handed to the service lane instead of completing. */
+    chimera_vfs_claim_release(state, file, &held);
+    CHECK(rec.fired == 0, "pump defers a projectable grant to the lane");
+    CHECK(state->work_head != NULL, "ticket is queued on the work FIFO");
+
+    /* Still on the FIFO: the cancel yanks it outright. */
+    cancelled = chimera_vfs_claim_cancel(state, &ticket);
+    CHECK(cancelled == true, "cancel claims a ticket queued for confirm");
+    CHECK(state->work_head == NULL, "cancel removed the FIFO entry");
+    CHECK(rec.fired == 0, "cancelled ticket never fires its callback");
+
+    /* Already dispatched: the confirm is in flight and its op is linked,
+     * so the cancel claims the op instead and the completion will skip the
+     * callback.  It must decide immediately rather than wait the confirm
+     * out. */
+    memset(&op, 0, sizeof(op));
+    op.state               = state;
+    op.file                = file;
+    op.ticket              = &ticket;
+    op.serial_lane         = true;
+    state->confirm_head    = &op;
+    state->work_confirming = true;
+
+    cancelled = chimera_vfs_claim_cancel(state, &ticket);
+    CHECK(cancelled == true, "cancel claims a confirm already in flight");
+    CHECK(op.cancelled == true, "the in-flight confirm is marked cancelled");
+
+    /* Once the completion has unlinked its op -- which it does before
+     * invoking the callback -- the callback owns the ticket and the cancel
+     * must say so instead of blocking. */
+    state->confirm_head    = NULL;
+    state->work_confirming = false;
+
+    cancelled = chimera_vfs_claim_cancel(state, &ticket);
+    CHECK(cancelled == false, "cancel yields once the callback owns the ticket");
+
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_backend_confirm_lane_cancel */
 
 /* Test 15: release pumps pending queue ----------------------------- */
 static void
@@ -1705,6 +1792,7 @@ main(
     test_async_acquire_immediate();
     test_async_acquire_wait_then_ack();
     test_async_acquire_cancel();
+    test_backend_confirm_lane_cancel();
     test_release_pumps_pending();
     test_lease_test();
     test_breakable_share_recall();

--- a/src/vfs/vfs_claim.c
+++ b/src/vfs/vfs_claim.c
@@ -42,6 +42,7 @@ chimera_vfs_state_init(void)
     state->implicit_idle_ms          = CHIMERA_VFS_CLAIM_DEFAULT_IMPLICIT_IDLE_MS;
 
     pthread_mutex_init(&state->service_lock, NULL);
+    pthread_mutex_init(&state->bl_dispatch_lock, NULL);
 
     return state;
 } /* chimera_vfs_state_init */

--- a/src/vfs/vfs_claim.c
+++ b/src/vfs/vfs_claim.c
@@ -1654,18 +1654,19 @@ chimera_vfs_claim_acquire(
     /* A locally-granted byte-range lock on a CAP_LEASE file is confirmed
      * with the backend BEFORE the callback fires: optimistic local insert,
      * rollback + DENIED on refusal (binding claims are all-or-nothing at
-     * the arbiter, never recallable).  Dispatched on the CALLER's thread:
-     * a CAP_LEASE arbiter completes lease ops inline (it must not be
-     * CAP_BLOCKING-delegated), so the callback still fires synchronously
-     * for FAIL_IMMEDIATELY-style callers.  Unlock-then-relock ordering is
-     * preserved by program order because the release paths with a thread
-     * dispatch their backend release synchronously too
-     * (chimera_vfs_claim_release_ranged); only threadless teardown
-     * releases ride the queued lane. */
+     * the arbiter, never recallable).  Dispatched on the CALLER's thread,
+     * so the callback fires synchronously for FAIL_IMMEDIATELY-style
+     * callers whenever the backend answers inline -- which is the common
+     * case but NOT guaranteed (async delegation, and eventually a
+     * clustered arbiter, both answer later), so this is not something a
+     * caller may depend on.  Unlock-then-relock ordering is preserved by
+     * program order because the release paths with a thread dispatch their
+     * backend release synchronously too (chimera_vfs_claim_release_ranged);
+     * only threadless teardown releases ride the queued lane. */
     if (result == CHIMERA_CLAIM_GRANTED &&
         claim->klass == CHIMERA_CLAIM_CLASS_RANGE &&
         chimera_vfs_claim_backend_range_projects(state, file, thread)) {
-        chimera_vfs_claim_backend_project_range(thread, state, ticket);
+        chimera_vfs_claim_backend_project_range(thread, state, ticket, false);
         return;
     }
 
@@ -1777,15 +1778,14 @@ chimera_vfs_claim_cancel(
         return true;
     }
 
-    /* Not on the pending queue.  A pump-granted projectable lock is NOT
-     * complete yet: its ticket sits in the service work FIFO awaiting the
-     * backend confirm (chimera_vfs_claim_backend_defer_ticket), callback
-     * unfired.  Yank it so the service thread never touches a ticket whose
-     * owner is tearing it down -- and roll back the pump's optimistic local
-     * insert, releasing the range for other waiters.  When the yank misses
-     * because the confirm is executing right now, ticket_cancel waits it
-     * out, so false keeps its contract: the callback HAS fired (smbtorture
-     * smb2.lock cancel-by-teardown vs deferred-grant UAF). */
+    /* Not on the pending queue.  A projectable lock granted locally is NOT
+     * complete yet: its ticket is either queued for the backend confirm
+     * (chimera_vfs_claim_backend_defer_ticket) or has one in flight, with
+     * the callback unfired either way.  Claim it so nothing ever completes
+     * a ticket whose owner is tearing it down, and roll back the optimistic
+     * local insert, releasing the range for other waiters.  ticket_cancel
+     * never blocks: when it cannot claim the ticket the callback has
+     * already been invoked, and false hands ownership to that callback. */
     if (state && chimera_vfs_claim_backend_ticket_cancel(state, ticket)) {
         chimera_vfs_claim_release(state, file, ticket->claim);
         return true;

--- a/src/vfs/vfs_claim.h
+++ b/src/vfs/vfs_claim.h
@@ -122,52 +122,42 @@ enum chimera_vfs_backend_lease_state {
     CHIMERA_VFS_BL_RELEASING,
 };
 
-struct chimera_vfs_bl_range_op;
-
 struct chimera_vfs_state {
-    struct chimera_vfs_state_shard  shards[CHIMERA_VFS_STATE_NUM_SHARDS];
-    uint32_t                        default_break_deadline_ms;
-    uint32_t                        implicit_idle_ms;
+    struct chimera_vfs_state_shard shards[CHIMERA_VFS_STATE_NUM_SHARDS];
+    uint32_t                       default_break_deadline_ms;
+    uint32_t                       implicit_idle_ms;
 
     /* Backend lease projection service: work is posted here from any thread
      * and drained on the service thread (the VFS close thread), which owns
      * every backend lease dispatch for AGGREGATE tokens.  lease_capable is
      * false when no registered module declares CHIMERA_VFS_CAP_LEASE, making
      * every projection hook a cheap no-op. */
-    uint8_t                         lease_capable;
-    uint8_t                         lease_probed;      /* modules scanned (lazy: the
+    uint8_t                        lease_capable;
+    uint8_t                        lease_probed;       /* modules scanned (lazy: the
                                                        * close thread attaches
                                                        * before modules register) */
-    struct chimera_vfs             *vfs;
-    struct chimera_claim_owner      node_owner;      /* this node's wire identity */
-    pthread_mutex_t                 service_lock;
-    struct chimera_vfs_file_state  *service_head;
-    struct chimera_vfs_file_state  *service_tail;
-    struct chimera_vfs_thread      *service_thread;
-    struct evpl_doorbell           *service_doorbell;
+    struct chimera_vfs            *vfs;
+    struct chimera_claim_owner     node_owner;       /* this node's wire identity */
+    pthread_mutex_t                service_lock;
+    struct chimera_vfs_file_state *service_head;
+    struct chimera_vfs_file_state *service_tail;
+    struct chimera_vfs_thread     *service_thread;
+    struct evpl_doorbell          *service_doorbell;
     /* ONE ordered FIFO for every backend RANGE operation (acquire confirms
      * and token releases alike), drained in arrival order on the service
      * thread.  Ordering is load-bearing: an unlock's token release queued
      * before a subsequent lock's confirm MUST reach the backend first, or
      * the confirm collides with the stale record (smb2.lock.stacking /
      * unlock / zerobytelength, pynfs LOCK13). */
-    struct chimera_vfs_bl_work     *work_head;
-    struct chimera_vfs_bl_work     *work_tail;
+    struct chimera_vfs_bl_work    *work_head;
+    struct chimera_vfs_bl_work    *work_tail;
     /* Set while a TICKET popped from the FIFO has a backend confirm in
      * flight; guarded by service_lock.  The lane is strictly serial: the
      * drain stops here and is resumed by the confirm's completion, so an
      * unlock's queued token release can never overtake -- or be overtaken
      * by -- the confirm ahead of it, whether the backend answers inline or
      * from a delegation thread. */
-    bool                            work_confirming;
-    /* Every backend RANGE confirm currently in flight, lane-dispatched or
-     * inline.  chimera_vfs_claim_cancel arbitrates against these instead of
-     * waiting for one to finish: the op is CORE-owned memory, so a cancel
-     * that claims one can return immediately and let its caller free the
-     * ticket, and the completion learns it lost without ever dereferencing
-     * a ticket the caller may already have freed.  Guarded by service_lock;
-     * opaque here (defined in vfs_claim_backend.c). */
-    struct chimera_vfs_bl_range_op *confirm_head;
+    bool                           work_confirming;
 };
 
 enum chimera_vfs_bl_work_type {
@@ -363,21 +353,26 @@ chimera_vfs_claim_test(
     const struct chimera_vfs_claim    *probe,
     struct chimera_vfs_claim_conflict *conflict_out);
 
-/* Exactly-once cancel of a pending or backend-confirming ticket.  Never
+/* Exactly-once cancel of a ticket whose acquire has not completed.  Never
  * blocks, and never re-enters the caller: safe to call with the caller's
  * own state lock held.
  *
  *   true  -- WE own the ticket.  The acquire callback will NEVER be
  *            invoked; the optimistic local grant has been rolled back and
  *            the caller may free the ticket's containing memory.
- *   false -- the acquire CALLBACK owns the completion.  It has been
- *            invoked and may still be RUNNING on another thread, so the
- *            caller must neither free what the callback uses nor assume
- *            the callback's side effects are visible yet: arbitrate with
- *            the callback through the caller's own lock (both sides take
- *            it), never by waiting here.
+ *   false -- the acquire CALLBACK owns the completion.  It is running, or
+ *            about to run, on this or another thread, so the caller must
+ *            neither free what the callback uses nor assume the callback's
+ *            side effects are visible yet: arbitrate with the callback
+ *            through the caller's own lock (both sides take it), never by
+ *            waiting here.
  *
- * The core itself reads nothing from the ticket once false is returned. */
+ * A ticket stops being claimable once its backend confirm is DISPATCHED.
+ * It cannot be taken back at that point: the claim is caller-owned, so the
+ * local rollback has to happen before this returns, while the backend
+ * record can only be dropped once the confirm completes -- and in that gap
+ * a new acquire of the same range would be granted locally and then
+ * refused by an arbiter still holding the old record. */
 bool
 chimera_vfs_claim_cancel(
     struct chimera_vfs_state           *state,

--- a/src/vfs/vfs_claim.h
+++ b/src/vfs/vfs_claim.h
@@ -122,41 +122,52 @@ enum chimera_vfs_backend_lease_state {
     CHIMERA_VFS_BL_RELEASING,
 };
 
+struct chimera_vfs_bl_range_op;
+
 struct chimera_vfs_state {
-    struct chimera_vfs_state_shard      shards[CHIMERA_VFS_STATE_NUM_SHARDS];
-    uint32_t                            default_break_deadline_ms;
-    uint32_t                            implicit_idle_ms;
+    struct chimera_vfs_state_shard  shards[CHIMERA_VFS_STATE_NUM_SHARDS];
+    uint32_t                        default_break_deadline_ms;
+    uint32_t                        implicit_idle_ms;
 
     /* Backend lease projection service: work is posted here from any thread
      * and drained on the service thread (the VFS close thread), which owns
      * every backend lease dispatch for AGGREGATE tokens.  lease_capable is
      * false when no registered module declares CHIMERA_VFS_CAP_LEASE, making
      * every projection hook a cheap no-op. */
-    uint8_t                             lease_capable;
-    uint8_t                             lease_probed;  /* modules scanned (lazy: the
+    uint8_t                         lease_capable;
+    uint8_t                         lease_probed;      /* modules scanned (lazy: the
                                                        * close thread attaches
                                                        * before modules register) */
-    struct chimera_vfs                 *vfs;
-    struct chimera_claim_owner          node_owner;  /* this node's wire identity */
-    pthread_mutex_t                     service_lock;
-    struct chimera_vfs_file_state      *service_head;
-    struct chimera_vfs_file_state      *service_tail;
-    struct chimera_vfs_thread          *service_thread;
-    struct evpl_doorbell               *service_doorbell;
+    struct chimera_vfs             *vfs;
+    struct chimera_claim_owner      node_owner;      /* this node's wire identity */
+    pthread_mutex_t                 service_lock;
+    struct chimera_vfs_file_state  *service_head;
+    struct chimera_vfs_file_state  *service_tail;
+    struct chimera_vfs_thread      *service_thread;
+    struct evpl_doorbell           *service_doorbell;
     /* ONE ordered FIFO for every backend RANGE operation (acquire confirms
      * and token releases alike), drained in arrival order on the service
      * thread.  Ordering is load-bearing: an unlock's token release queued
      * before a subsequent lock's confirm MUST reach the backend first, or
      * the confirm collides with the stale record (smb2.lock.stacking /
      * unlock / zerobytelength, pynfs LOCK13). */
-    struct chimera_vfs_bl_work         *work_head;
-    struct chimera_vfs_bl_work         *work_tail;
-    /* The TICKET the service thread is confirming RIGHT NOW (popped from the
-     * FIFO but its callback not yet returned); guarded by service_lock.
-     * chimera_vfs_claim_cancel waits on this so "cancel returned false"
-     * strictly means the ticket's callback has fired -- the contract the
-     * teardown paths (SMB abort-parked, NLM client reap) free memory on. */
-    struct chimera_vfs_pending_acquire *work_active_ticket;
+    struct chimera_vfs_bl_work     *work_head;
+    struct chimera_vfs_bl_work     *work_tail;
+    /* Set while a TICKET popped from the FIFO has a backend confirm in
+     * flight; guarded by service_lock.  The lane is strictly serial: the
+     * drain stops here and is resumed by the confirm's completion, so an
+     * unlock's queued token release can never overtake -- or be overtaken
+     * by -- the confirm ahead of it, whether the backend answers inline or
+     * from a delegation thread. */
+    bool                            work_confirming;
+    /* Every backend RANGE confirm currently in flight, lane-dispatched or
+     * inline.  chimera_vfs_claim_cancel arbitrates against these instead of
+     * waiting for one to finish: the op is CORE-owned memory, so a cancel
+     * that claims one can return immediately and let its caller free the
+     * ticket, and the completion learns it lost without ever dereferencing
+     * a ticket the caller may already have freed.  Guarded by service_lock;
+     * opaque here (defined in vfs_claim_backend.c). */
+    struct chimera_vfs_bl_range_op *confirm_head;
 };
 
 enum chimera_vfs_bl_work_type {
@@ -352,8 +363,21 @@ chimera_vfs_claim_test(
     const struct chimera_vfs_claim    *probe,
     struct chimera_vfs_claim_conflict *conflict_out);
 
-/* Exactly-once cancel of a queued ticket: true = dequeued, cb never fires;
- * false = the cb owns the entry (fired or firing). */
+/* Exactly-once cancel of a pending or backend-confirming ticket.  Never
+ * blocks, and never re-enters the caller: safe to call with the caller's
+ * own state lock held.
+ *
+ *   true  -- WE own the ticket.  The acquire callback will NEVER be
+ *            invoked; the optimistic local grant has been rolled back and
+ *            the caller may free the ticket's containing memory.
+ *   false -- the acquire CALLBACK owns the completion.  It has been
+ *            invoked and may still be RUNNING on another thread, so the
+ *            caller must neither free what the callback uses nor assume
+ *            the callback's side effects are visible yet: arbitrate with
+ *            the callback through the caller's own lock (both sides take
+ *            it), never by waiting here.
+ *
+ * The core itself reads nothing from the ticket once false is returned. */
 bool
 chimera_vfs_claim_cancel(
     struct chimera_vfs_state           *state,

--- a/src/vfs/vfs_claim.h
+++ b/src/vfs/vfs_claim.h
@@ -139,6 +139,19 @@ struct chimera_vfs_state {
     struct chimera_vfs            *vfs;
     struct chimera_claim_owner     node_owner;       /* this node's wire identity */
     pthread_mutex_t                service_lock;
+    /* Serializes SELECTION+DISPATCH of backend RANGE ops.  Without it the
+     * service drain and an inline confirm's chimera_vfs_claim_backend_
+     * drain_releases race: the drain can only find a release still ON the
+     * FIFO, so once the service thread has popped one, an acquire for the
+     * same range reaches the backend while that release is still in flight
+     * and the arbiter refuses it -- an NLM LOCK that should be GRANTED
+     * comes back DENIED.  Both hold this across the release dispatch, so
+     * whichever loses the race observes the other's release delivered.
+     *
+     * Order: bl_dispatch_lock BEFORE service_lock, and never held across an
+     * acquire confirm -- that runs protocol code and must not sit under a
+     * core lock. */
+    pthread_mutex_t                bl_dispatch_lock;
     struct chimera_vfs_file_state *service_head;
     struct chimera_vfs_file_state *service_tail;
     struct chimera_vfs_thread     *service_thread;

--- a/src/vfs/vfs_claim_backend.c
+++ b/src/vfs/vfs_claim_backend.c
@@ -489,6 +489,7 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
 {
     struct chimera_vfs_file_state *head, *file, *next;
     struct chimera_vfs_bl_work    *w;
+    bool                           is_rel;
 
     if (!state || !chimera_vfs_claim_backend_capable(state)) {
         return;
@@ -543,13 +544,35 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
      * the gate before project_range returns, so this loop keeps draining
      * without a doorbell round trip. */
     for (;;) {
+        /* Peek the head's type before committing.  A RELEASE has to be
+         * selected AND dispatched under bl_dispatch_lock, so that an inline
+         * confirm's drain cannot slip between the two and miss it; a TICKET
+         * must NOT hold that lock, because its project_range takes it. */
         pthread_mutex_lock(&state->service_lock);
         if (state->work_confirming) {
             /* A confirm is in flight; its completion resumes the drain. */
             pthread_mutex_unlock(&state->service_lock);
             break;
         }
+        w      = state->work_head;
+        is_rel = w && w->type == CHIMERA_VFS_BL_WORK_RELEASE;
+        pthread_mutex_unlock(&state->service_lock);
+
+        if (!w) {
+            break;
+        }
+
+        if (is_rel) {
+            pthread_mutex_lock(&state->bl_dispatch_lock);
+        }
+
+        /* Re-read: the head may have changed while the lock was not held.
+         * Only take it if it still matches what we prepared for. */
+        pthread_mutex_lock(&state->service_lock);
         w = state->work_head;
+        if (w && (w->type == CHIMERA_VFS_BL_WORK_RELEASE) != is_rel) {
+            w = NULL;
+        }
         if (w) {
             state->work_head = w->next;
             if (!state->work_head) {
@@ -563,7 +586,10 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
         pthread_mutex_unlock(&state->service_lock);
 
         if (!w) {
-            break;
+            if (is_rel) {
+                pthread_mutex_unlock(&state->bl_dispatch_lock);
+            }
+            continue;
         }
 
         switch (w->type) {
@@ -576,6 +602,7 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
                                                   w->fh, w->fh_len,
                                                   w->fh_hash, w->token, 0,
                                                   NULL, NULL);
+                pthread_mutex_unlock(&state->bl_dispatch_lock);
                 break;
         } /* switch */
         free(w);
@@ -770,6 +797,9 @@ chimera_vfs_claim_backend_drain_releases(
     struct chimera_vfs_bl_work *w, **pp;
     struct chimera_vfs_bl_work *mine = NULL, **mtail = &mine;
 
+    /* Selection and dispatch together: see bl_dispatch_lock in vfs_claim.h. */
+    pthread_mutex_lock(&state->bl_dispatch_lock);
+
     pthread_mutex_lock(&state->service_lock);
     pp = &state->work_head;
     while ((w = *pp)) {
@@ -803,6 +833,8 @@ chimera_vfs_claim_backend_drain_releases(
                                           NULL, NULL);
         free(w);
     }
+
+    pthread_mutex_unlock(&state->bl_dispatch_lock);
 } /* chimera_vfs_claim_backend_drain_releases */
 
 /* Cancel a RANGE acquire confirm that is still QUEUED on the work FIFO --

--- a/src/vfs/vfs_claim_backend.c
+++ b/src/vfs/vfs_claim_backend.c
@@ -622,6 +622,19 @@ chimera_vfs_claim_backend_detach(struct chimera_vfs_state *state)
 /* RANGE projection                                                   */
 /* ------------------------------------------------------------------ */
 
+/* One in-flight backend RANGE confirm.  Core-owned, and carrying a SNAPSHOT
+ * of what the completion needs out of the ticket: a cancel that loses hands
+ * the completion to the callback, and the core reads nothing more from the
+ * ticket once the confirm is dispatched. */
+struct chimera_vfs_bl_range_op {
+    struct chimera_vfs_state      *state;
+    struct chimera_vfs_file_state *file;
+    struct chimera_vfs_claim      *claim;
+    chimera_vfs_claim_acquire_cb_t cb;
+    void                          *cb_private;
+    bool                           serial_lane;
+};
+
 static void
 chimera_vfs_bl_range_complete(
     enum chimera_vfs_error error_code,
@@ -629,62 +642,26 @@ chimera_vfs_bl_range_complete(
     uint64_t               token,
     void                  *private_data)
 {
-    struct chimera_vfs_bl_range_op  *op          = private_data;
-    struct chimera_vfs_state        *state       = op->state;
-    struct chimera_vfs_file_state   *file        = op->file;
-    struct chimera_vfs_claim        *claim       = op->claim;
-    chimera_vfs_claim_acquire_cb_t   cb          = op->cb;
-    void                            *cb_private  = op->cb_private;
-    bool                             cancelled   = false;
-    bool                             serial_lane = op->serial_lane;
-    struct chimera_vfs_bl_range_op **pp;
+    struct chimera_vfs_bl_range_op *op          = private_data;
+    struct chimera_vfs_state       *state       = op->state;
+    struct chimera_vfs_file_state  *file        = op->file;
+    struct chimera_vfs_claim       *claim       = op->claim;
+    chimera_vfs_claim_acquire_cb_t  cb          = op->cb;
+    void                           *cb_private  = op->cb_private;
+    bool                            serial_lane = op->serial_lane;
 
-    /* Only a LANE confirm is visible to a canceller, so only a lane confirm
-     * needs the lock here: the inline path keeps its original cost. */
+    free(op);
+
+    /* Resume the serial lane before the callback runs: the callback is
+     * protocol code that can take arbitrary locks, and nothing it does
+     * needs the lane held. */
     if (serial_lane) {
         pthread_mutex_lock(&state->service_lock);
-
-        /* Unlink first: past this point a cancel for our ticket can no
-         * longer find us, so it correctly reports that the callback owns
-         * the ticket. */
-        for (pp = &state->confirm_head; *pp; pp = &(*pp)->next) {
-            if (*pp == op) {
-                *pp = op->next;
-                break;
-            }
-        }
-        cancelled = op->cancelled;
-
-        /* Resume the serial lane.  When the backend answered inline the
-         * drain loop below us simply continues; otherwise the doorbell is
-         * what restarts it, and the drain is idempotent so the redundant
-         * wake in the inline case costs one empty pass. */
         state->work_confirming = false;
         if (state->work_head && state->service_doorbell) {
             evpl_ring_doorbell(state->service_doorbell);
         }
         pthread_mutex_unlock(&state->service_lock);
-    }
-
-    free(op);
-
-    if (cancelled) {
-        /* A cancel claimed the ticket while we were in flight: it has
-         * already rolled the optimistic local grant back and its caller may
-         * have freed the ticket AND its claim, so touch neither.  A record
-         * the backend did grant is now referenced by nothing -- we hold the
-         * only copy of its token -- so drop it.
-         *
-         * It goes to the FRONT of the FIFO: the local release happened when
-         * the cancel won, which is BEFORE any acquire that could have taken
-         * these bytes, so every overlapping confirm queued behind us must
-         * still see the record gone.  Nothing already ahead of us can
-         * overlap (the range was locally held until the cancel). */
-        if (error_code == CHIMERA_VFS_OK && granted && token) {
-            chimera_vfs_claim_backend_release_token_front(state, file, token);
-        }
-        chimera_vfs_state_put(state, file);
-        return;
     }
 
     if (error_code == CHIMERA_VFS_OK && granted) {
@@ -732,7 +709,6 @@ chimera_vfs_claim_backend_project_range(
     op              = calloc(1, sizeof(*op));
     op->state       = state;
     op->file        = file;
-    op->ticket      = ticket;
     op->serial_lane = serial_lane;
     /* Snapshot the ticket now, while it is unambiguously ours: from the
      * moment a cancel claims this op the ticket is the canceller's to free
@@ -740,20 +716,6 @@ chimera_vfs_claim_backend_project_range(
     op->claim      = claim;
     op->cb         = ticket->cb;
     op->cb_private = ticket->private_data;
-
-    /* Publish BEFORE dispatching so a cancel racing the backend can find
-     * this op no matter how fast the module answers -- but only for the
-     * LANE.  An inline confirm runs under chimera_vfs_claim_acquire on the
-     * acquiring thread, where claiming the ticket would suppress a callback
-     * the caller is still waiting on and swallow the reply that callback
-     * owes; there a cancel keeps reporting false ("the callback owns it"),
-     * exactly as it did before this lane existed. */
-    if (serial_lane) {
-        pthread_mutex_lock(&state->service_lock);
-        op->next            = state->confirm_head;
-        state->confirm_head = op;
-        pthread_mutex_unlock(&state->service_lock);
-    }
 
     chimera_vfs_state_get(state, file->fh, file->fh_len, file->fh_hash, false);
 
@@ -843,36 +805,28 @@ chimera_vfs_claim_backend_drain_releases(
     }
 } /* chimera_vfs_claim_backend_drain_releases */
 
-/* Cancel a RANGE acquire confirm whose callback has not been invoked yet.
- * NEVER blocks: a ticket is claimable in exactly two states, and both are
- * decided under service_lock in O(queue).
+/* Cancel a RANGE acquire confirm that is still QUEUED on the work FIFO --
+ * the confirm has not started, so yanking the entry means the callback will
+ * never be invoked and the caller owns the ticket.  Returns true then.
  *
- *   queued on the work FIFO  -- yank the entry; the confirm never starts.
- *   lane confirm in flight   -- mark the (core-owned) op cancelled; the
- *                               completion skips the callback and drops
- *                               whatever the backend granted.
+ * NEVER blocks.  False means the callback owns the completion: it is
+ * running, or about to run, on the thread that dispatched the confirm.  A
+ * ticket whose confirm has been dispatched is deliberately NOT reclaimable
+ * (see chimera_vfs_claim_cancel in vfs_claim.h for why the caller-owned
+ * claim makes that unsafe).
  *
- * Both return true: the callback will NEVER fire, and the caller owns the
- * ticket -- chimera_vfs_claim_cancel rolls the optimistic local grant back
- * and the caller may free the ticket's containing memory immediately.
- *
- * False means the callback owns the ticket: it has been invoked, or it is
- * an inline confirm under the acquiring thread that is about to invoke it.
- * Either way it may be RUNNING: the caller must arbitrate with its own
- * callback through its own lock rather than waiting here.  This used to
- * spin on sched_yield() until the callback returned, which turned any
- * caller holding a lock its callback also takes into a deadlock -- an NLM
- * client teardown cancelling under nlm_state.mutex against the confirm's
- * NLM4_GRANTED callback wanting the same mutex. */
+ * This used to spin on sched_yield() until the in-flight confirm's callback
+ * returned, so that false could promise the callback had FINISHED.  That
+ * turned any caller holding a lock its callback also takes into a deadlock:
+ * an NLM client teardown cancels under nlm_state.mutex while the confirm it
+ * waits for is blocked taking that same mutex in NLM's acquire callback. */
 bool
 chimera_vfs_claim_backend_ticket_cancel(
     struct chimera_vfs_state           *state,
     struct chimera_vfs_pending_acquire *ticket)
 {
-    struct chimera_vfs_bl_work     *w, **pp;
-    struct chimera_vfs_bl_work     *yanked = NULL;
-    struct chimera_vfs_bl_range_op *op;
-    bool                            claimed = false;
+    struct chimera_vfs_bl_work *w, **pp;
+    struct chimera_vfs_bl_work *yanked = NULL;
 
     pthread_mutex_lock(&state->service_lock);
 
@@ -890,72 +844,38 @@ chimera_vfs_claim_backend_ticket_cancel(
                     }
                 }
             }
-            yanked  = w;
-            claimed = true;
+            yanked = w;
             break;
         }
         pp = &w->next;
-    }
-
-    if (!claimed) {
-        /* Not queued: it may be confirming right now.  The op is linked
-         * from the moment project_range publishes it until the completion
-         * unlinks it -- and the completion unlinks it BEFORE invoking the
-         * callback, so finding it here proves the callback has not fired. */
-        for (op = state->confirm_head; op; op = op->next) {
-            if (op->ticket == ticket) {
-                op->cancelled = true;
-                claimed       = true;
-                break;
-            }
-        }
     }
 
     pthread_mutex_unlock(&state->service_lock);
 
     free(yanked);
 
-    return claimed;
+    return yanked != NULL;
 } /* chimera_vfs_claim_backend_ticket_cancel */
 
-/* Add one entry to the ordered backend-RANGE work FIFO.  `front` jumps the
- * queue and is used only by a cancelled confirm's rollback, whose logical
- * position is where the cancel won -- ahead of everything queued since. */
-static void
-chimera_vfs_bl_work_enqueue_at(
-    struct chimera_vfs_state   *state,
-    struct chimera_vfs_bl_work *work,
-    bool                        front)
-{
-    pthread_mutex_lock(&state->service_lock);
-    if (front) {
-        work->next       = state->work_head;
-        state->work_head = work;
-        if (!state->work_tail) {
-            state->work_tail = work;
-        }
-    } else {
-        work->next = NULL;
-        if (state->work_tail) {
-            state->work_tail->next = work;
-        } else {
-            state->work_head = work;
-        }
-        state->work_tail = work;
-    }
-    /* Ring under service_lock: see chimera_vfs_bl_post. */
-    if (state->service_doorbell) {
-        evpl_ring_doorbell(state->service_doorbell);
-    }
-    pthread_mutex_unlock(&state->service_lock);
-} /* chimera_vfs_bl_work_enqueue_at */
-
+/* Append one entry to the ordered backend-RANGE work FIFO. */
 static void
 chimera_vfs_bl_work_enqueue(
     struct chimera_vfs_state   *state,
     struct chimera_vfs_bl_work *work)
 {
-    chimera_vfs_bl_work_enqueue_at(state, work, false);
+    pthread_mutex_lock(&state->service_lock);
+    work->next = NULL;
+    if (state->work_tail) {
+        state->work_tail->next = work;
+    } else {
+        state->work_head = work;
+    }
+    state->work_tail = work;
+    /* Ring under service_lock: see chimera_vfs_bl_post. */
+    if (state->service_doorbell) {
+        evpl_ring_doorbell(state->service_doorbell);
+    }
+    pthread_mutex_unlock(&state->service_lock);
 } /* chimera_vfs_bl_work_enqueue */
 
 /* Fire-and-forget release of a projected RANGE token.  Ordered behind every
@@ -982,32 +902,6 @@ chimera_vfs_claim_backend_release_token(
 
     chimera_vfs_bl_work_enqueue(state, work);
 } /* chimera_vfs_claim_backend_release_token */
-
-/* Release a token whose confirm was cancelled mid-flight.  Identical to
- * chimera_vfs_claim_backend_release_token but jumps the FIFO: the local
- * range was freed when the cancel won, so any overlapping confirm queued
- * since MUST still find the backend record gone. */
-void
-chimera_vfs_claim_backend_release_token_front(
-    struct chimera_vfs_state      *state,
-    struct chimera_vfs_file_state *file,
-    uint64_t                       token)
-{
-    struct chimera_vfs_bl_work *work;
-
-    if (!state || !token || !chimera_vfs_claim_backend_capable(state)) {
-        return;
-    }
-
-    work       = calloc(1, sizeof(*work));
-    work->type = CHIMERA_VFS_BL_WORK_RELEASE;
-    memcpy(work->fh, file->fh, file->fh_len);
-    work->fh_len  = file->fh_len;
-    work->fh_hash = file->fh_hash;
-    work->token   = token;
-
-    chimera_vfs_bl_work_enqueue_at(state, work, true);
-} /* chimera_vfs_claim_backend_release_token_front */
 
 /* Queue a projectable RANGE acquire confirm on the same ordered lane. */
 void

--- a/src/vfs/vfs_claim_backend.c
+++ b/src/vfs/vfs_claim_backend.c
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-#include <sched.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -530,11 +529,26 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
      * in exactly the order the local state changed.  Entries are popped ONE
      * AT A TIME under service_lock -- never spliced -- so a concurrent
      * chimera_vfs_claim_cancel can always find (and yank) a still-pending
-     * TICKET in the FIFO; a popped TICKET is published as work_active_ticket
-     * for the duration of its confirm so cancel can wait out the inline
-     * completion instead of freeing the ticket under the confirm's feet. */
+     * TICKET in the FIFO.
+     *
+     * The lane is STRICTLY SERIAL across a confirm: dispatching a TICKET
+     * sets work_confirming and the drain stops until that confirm
+     * completes.  Nothing here may assume the backend answers inline --
+     * chimera_vfs_dispatch routes a module's op to a delegation thread
+     * whenever async delegation is configured, and a clustered arbiter will
+     * never answer inline -- and if the next entry dispatched anyway, an
+     * unlock's token release could reach the backend BEFORE the confirm it
+     * was queued behind, which is exactly the collision this FIFO exists to
+     * prevent.  When the backend does answer inline the completion clears
+     * the gate before project_range returns, so this loop keeps draining
+     * without a doorbell round trip. */
     for (;;) {
         pthread_mutex_lock(&state->service_lock);
+        if (state->work_confirming) {
+            /* A confirm is in flight; its completion resumes the drain. */
+            pthread_mutex_unlock(&state->service_lock);
+            break;
+        }
         w = state->work_head;
         if (w) {
             state->work_head = w->next;
@@ -543,7 +557,7 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
             }
             w->next = NULL;
             if (w->type == CHIMERA_VFS_BL_WORK_TICKET) {
-                state->work_active_ticket = w->ticket;
+                state->work_confirming = true;
             }
         }
         pthread_mutex_unlock(&state->service_lock);
@@ -554,15 +568,8 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
 
         switch (w->type) {
             case CHIMERA_VFS_BL_WORK_TICKET:
-                /* The confirm completes inline (a CAP_LEASE arbiter must not
-                 * be CAP_BLOCKING-delegated), so the ticket's callback has
-                 * fired by the time project_range returns and the active
-                 * marker can drop. */
                 chimera_vfs_claim_backend_project_range(state->service_thread,
-                                                        state, w->ticket);
-                pthread_mutex_lock(&state->service_lock);
-                state->work_active_ticket = NULL;
-                pthread_mutex_unlock(&state->service_lock);
+                                                        state, w->ticket, true);
                 break;
             case CHIMERA_VFS_BL_WORK_RELEASE:
                 chimera_vfs_lease_release_backend(state->service_thread,
@@ -615,12 +622,6 @@ chimera_vfs_claim_backend_detach(struct chimera_vfs_state *state)
 /* RANGE projection                                                   */
 /* ------------------------------------------------------------------ */
 
-struct chimera_vfs_bl_range_op {
-    struct chimera_vfs_state           *state;
-    struct chimera_vfs_file_state      *file;
-    struct chimera_vfs_pending_acquire *ticket;
-};
-
 static void
 chimera_vfs_bl_range_complete(
     enum chimera_vfs_error error_code,
@@ -628,19 +629,70 @@ chimera_vfs_bl_range_complete(
     uint64_t               token,
     void                  *private_data)
 {
-    struct chimera_vfs_bl_range_op     *op     = private_data;
-    struct chimera_vfs_state           *state  = op->state;
-    struct chimera_vfs_file_state      *file   = op->file;
-    struct chimera_vfs_pending_acquire *ticket = op->ticket;
-    struct chimera_vfs_claim           *claim  = ticket->claim;
+    struct chimera_vfs_bl_range_op  *op          = private_data;
+    struct chimera_vfs_state        *state       = op->state;
+    struct chimera_vfs_file_state   *file        = op->file;
+    struct chimera_vfs_claim        *claim       = op->claim;
+    chimera_vfs_claim_acquire_cb_t   cb          = op->cb;
+    void                            *cb_private  = op->cb_private;
+    bool                             cancelled   = false;
+    bool                             serial_lane = op->serial_lane;
+    struct chimera_vfs_bl_range_op **pp;
+
+    /* Only a LANE confirm is visible to a canceller, so only a lane confirm
+     * needs the lock here: the inline path keeps its original cost. */
+    if (serial_lane) {
+        pthread_mutex_lock(&state->service_lock);
+
+        /* Unlink first: past this point a cancel for our ticket can no
+         * longer find us, so it correctly reports that the callback owns
+         * the ticket. */
+        for (pp = &state->confirm_head; *pp; pp = &(*pp)->next) {
+            if (*pp == op) {
+                *pp = op->next;
+                break;
+            }
+        }
+        cancelled = op->cancelled;
+
+        /* Resume the serial lane.  When the backend answered inline the
+         * drain loop below us simply continues; otherwise the doorbell is
+         * what restarts it, and the drain is idempotent so the redundant
+         * wake in the inline case costs one empty pass. */
+        state->work_confirming = false;
+        if (state->work_head && state->service_doorbell) {
+            evpl_ring_doorbell(state->service_doorbell);
+        }
+        pthread_mutex_unlock(&state->service_lock);
+    }
+
+    free(op);
+
+    if (cancelled) {
+        /* A cancel claimed the ticket while we were in flight: it has
+         * already rolled the optimistic local grant back and its caller may
+         * have freed the ticket AND its claim, so touch neither.  A record
+         * the backend did grant is now referenced by nothing -- we hold the
+         * only copy of its token -- so drop it.
+         *
+         * It goes to the FRONT of the FIFO: the local release happened when
+         * the cancel won, which is BEFORE any acquire that could have taken
+         * these bytes, so every overlapping confirm queued behind us must
+         * still see the record gone.  Nothing already ahead of us can
+         * overlap (the range was locally held until the cancel). */
+        if (error_code == CHIMERA_VFS_OK && granted && token) {
+            chimera_vfs_claim_backend_release_token_front(state, file, token);
+        }
+        chimera_vfs_state_put(state, file);
+        return;
+    }
 
     if (error_code == CHIMERA_VFS_OK && granted) {
         pthread_mutex_lock(&file->lock);
         claim->backend_token = token;
         pthread_mutex_unlock(&file->lock);
 
-        ticket->cb(CHIMERA_CLAIM_GRANTED, claim, NULL,
-                   ticket->private_data);
+        cb(CHIMERA_CLAIM_GRANTED, claim, NULL, cb_private);
     } else {
         struct chimera_vfs_claim_conflict conflict;
 
@@ -651,23 +703,24 @@ chimera_vfs_bl_range_complete(
         memset(&conflict, 0, sizeof(conflict));
         conflict.offset = 0;
         conflict.length = UINT64_MAX;
-        ticket->cb(CHIMERA_CLAIM_DENIED, NULL, &conflict,
-                   ticket->private_data);
+        cb(CHIMERA_CLAIM_DENIED, NULL, &conflict, cb_private);
     }
 
     chimera_vfs_state_put(state, file);
-    free(op);
 } /* chimera_vfs_bl_range_complete */
 
 /* Confirm a locally-granted RANGE claim with the backend before its
  * callback fires.  `thread` must be the calling vfs thread.  Fires the
  * ticket's callback on completion (GRANTED with the token recorded, or
- * DENIED after rollback). */
+ * DENIED after rollback), unless a concurrent cancel claims the ticket
+ * first.  `serial_lane` is true only for the service drain's dispatch, so
+ * the completion knows whether to release the lane gate. */
 void
 chimera_vfs_claim_backend_project_range(
     struct chimera_vfs_thread          *thread,
     struct chimera_vfs_state           *state,
-    struct chimera_vfs_pending_acquire *ticket)
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                serial_lane)
 {
     struct chimera_vfs_claim       *claim = ticket->claim;
     struct chimera_vfs_file_state  *file  = ticket->file;
@@ -676,10 +729,31 @@ chimera_vfs_claim_backend_project_range(
     /* Any queued releases for this file's records must land first. */
     chimera_vfs_claim_backend_drain_releases(thread, state, file);
 
-    op         = calloc(1, sizeof(*op));
-    op->state  = state;
-    op->file   = file;
-    op->ticket = ticket;
+    op              = calloc(1, sizeof(*op));
+    op->state       = state;
+    op->file        = file;
+    op->ticket      = ticket;
+    op->serial_lane = serial_lane;
+    /* Snapshot the ticket now, while it is unambiguously ours: from the
+     * moment a cancel claims this op the ticket is the canceller's to free
+     * and the completion must not read it. */
+    op->claim      = claim;
+    op->cb         = ticket->cb;
+    op->cb_private = ticket->private_data;
+
+    /* Publish BEFORE dispatching so a cancel racing the backend can find
+     * this op no matter how fast the module answers -- but only for the
+     * LANE.  An inline confirm runs under chimera_vfs_claim_acquire on the
+     * acquiring thread, where claiming the ticket would suppress a callback
+     * the caller is still waiting on and swallow the reply that callback
+     * owes; there a cancel keeps reporting false ("the callback owns it"),
+     * exactly as it did before this lane existed. */
+    if (serial_lane) {
+        pthread_mutex_lock(&state->service_lock);
+        op->next            = state->confirm_head;
+        state->confirm_head = op;
+        pthread_mutex_unlock(&state->service_lock);
+    }
 
     chimera_vfs_state_get(state, file->fh, file->fh_len, file->fh_hash, false);
 
@@ -769,24 +843,39 @@ chimera_vfs_claim_backend_drain_releases(
     }
 } /* chimera_vfs_claim_backend_drain_releases */
 
-/* Cancel a pump-deferred RANGE acquire confirm (a CHIMERA_VFS_BL_WORK_TICKET
- * queued by chimera_vfs_claim_backend_defer_ticket whose callback has not
- * fired).  Returns true when the ticket was yanked from the FIFO -- the
- * callback will NEVER fire and the caller must roll back the optimistic
- * local grant.  Returns false only once the ticket's callback has FIRED:
- * if the service thread is mid-confirm on this very ticket (popped but the
- * callback not yet returned), this waits out the inline completion first,
- * so the teardown paths can free the ticket's containing memory on a false
- * return exactly as they did before the deferred lane existed (R21). */
+/* Cancel a RANGE acquire confirm whose callback has not been invoked yet.
+ * NEVER blocks: a ticket is claimable in exactly two states, and both are
+ * decided under service_lock in O(queue).
+ *
+ *   queued on the work FIFO  -- yank the entry; the confirm never starts.
+ *   lane confirm in flight   -- mark the (core-owned) op cancelled; the
+ *                               completion skips the callback and drops
+ *                               whatever the backend granted.
+ *
+ * Both return true: the callback will NEVER fire, and the caller owns the
+ * ticket -- chimera_vfs_claim_cancel rolls the optimistic local grant back
+ * and the caller may free the ticket's containing memory immediately.
+ *
+ * False means the callback owns the ticket: it has been invoked, or it is
+ * an inline confirm under the acquiring thread that is about to invoke it.
+ * Either way it may be RUNNING: the caller must arbitrate with its own
+ * callback through its own lock rather than waiting here.  This used to
+ * spin on sched_yield() until the callback returned, which turned any
+ * caller holding a lock its callback also takes into a deadlock -- an NLM
+ * client teardown cancelling under nlm_state.mutex against the confirm's
+ * NLM4_GRANTED callback wanting the same mutex. */
 bool
 chimera_vfs_claim_backend_ticket_cancel(
     struct chimera_vfs_state           *state,
     struct chimera_vfs_pending_acquire *ticket)
 {
-    struct chimera_vfs_bl_work *w, **pp;
-    bool                        busy;
+    struct chimera_vfs_bl_work     *w, **pp;
+    struct chimera_vfs_bl_work     *yanked = NULL;
+    struct chimera_vfs_bl_range_op *op;
+    bool                            claimed = false;
 
     pthread_mutex_lock(&state->service_lock);
+
     pp = &state->work_head;
     while ((w = *pp)) {
         if (w->type == CHIMERA_VFS_BL_WORK_TICKET && w->ticket == ticket) {
@@ -801,49 +890,72 @@ chimera_vfs_claim_backend_ticket_cancel(
                     }
                 }
             }
-            pthread_mutex_unlock(&state->service_lock);
-            free(w);
-            return true;
+            yanked  = w;
+            claimed = true;
+            break;
         }
         pp = &w->next;
     }
+
+    if (!claimed) {
+        /* Not queued: it may be confirming right now.  The op is linked
+         * from the moment project_range publishes it until the completion
+         * unlinks it -- and the completion unlinks it BEFORE invoking the
+         * callback, so finding it here proves the callback has not fired. */
+        for (op = state->confirm_head; op; op = op->next) {
+            if (op->ticket == ticket) {
+                op->cancelled = true;
+                claimed       = true;
+                break;
+            }
+        }
+    }
+
     pthread_mutex_unlock(&state->service_lock);
 
-    /* Not in the FIFO: either it was never deferred, its callback already
-     * ran, or the service thread popped it and its inline confirm is in
-     * flight right now.  Wait that confirm out -- the loop reads only
-     * state memory, never the ticket (whose containing struct the caller
-     * will free once we return false). */
-    for (;;) {
-        pthread_mutex_lock(&state->service_lock);
-        busy = (state->work_active_ticket == ticket);
-        pthread_mutex_unlock(&state->service_lock);
-        if (!busy) {
-            return false;
-        }
-        sched_yield();
-    }
+    free(yanked);
+
+    return claimed;
 } /* chimera_vfs_claim_backend_ticket_cancel */
 
-/* Append one entry to the ordered backend-RANGE work FIFO. */
+/* Add one entry to the ordered backend-RANGE work FIFO.  `front` jumps the
+ * queue and is used only by a cancelled confirm's rollback, whose logical
+ * position is where the cancel won -- ahead of everything queued since. */
 static void
-chimera_vfs_bl_work_enqueue(
+chimera_vfs_bl_work_enqueue_at(
     struct chimera_vfs_state   *state,
-    struct chimera_vfs_bl_work *work)
+    struct chimera_vfs_bl_work *work,
+    bool                        front)
 {
     pthread_mutex_lock(&state->service_lock);
-    work->next = NULL;
-    if (state->work_tail) {
-        state->work_tail->next = work;
-    } else {
+    if (front) {
+        work->next       = state->work_head;
         state->work_head = work;
+        if (!state->work_tail) {
+            state->work_tail = work;
+        }
+    } else {
+        work->next = NULL;
+        if (state->work_tail) {
+            state->work_tail->next = work;
+        } else {
+            state->work_head = work;
+        }
+        state->work_tail = work;
     }
-    state->work_tail = work;
     /* Ring under service_lock: see chimera_vfs_bl_post. */
     if (state->service_doorbell) {
         evpl_ring_doorbell(state->service_doorbell);
     }
     pthread_mutex_unlock(&state->service_lock);
+} /* chimera_vfs_bl_work_enqueue_at */
+
+static void
+chimera_vfs_bl_work_enqueue(
+    struct chimera_vfs_state   *state,
+    struct chimera_vfs_bl_work *work)
+{
+    chimera_vfs_bl_work_enqueue_at(state, work, false);
 } /* chimera_vfs_bl_work_enqueue */
 
 /* Fire-and-forget release of a projected RANGE token.  Ordered behind every
@@ -870,6 +982,32 @@ chimera_vfs_claim_backend_release_token(
 
     chimera_vfs_bl_work_enqueue(state, work);
 } /* chimera_vfs_claim_backend_release_token */
+
+/* Release a token whose confirm was cancelled mid-flight.  Identical to
+ * chimera_vfs_claim_backend_release_token but jumps the FIFO: the local
+ * range was freed when the cancel won, so any overlapping confirm queued
+ * since MUST still find the backend record gone. */
+void
+chimera_vfs_claim_backend_release_token_front(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    uint64_t                       token)
+{
+    struct chimera_vfs_bl_work *work;
+
+    if (!state || !token || !chimera_vfs_claim_backend_capable(state)) {
+        return;
+    }
+
+    work       = calloc(1, sizeof(*work));
+    work->type = CHIMERA_VFS_BL_WORK_RELEASE;
+    memcpy(work->fh, file->fh, file->fh_len);
+    work->fh_len  = file->fh_len;
+    work->fh_hash = file->fh_hash;
+    work->token   = token;
+
+    chimera_vfs_bl_work_enqueue_at(state, work, true);
+} /* chimera_vfs_claim_backend_release_token_front */
 
 /* Queue a projectable RANGE acquire confirm on the same ordered lane. */
 void

--- a/src/vfs/vfs_claim_internal.h
+++ b/src/vfs/vfs_claim_internal.h
@@ -227,11 +227,30 @@ chimera_vfs_claim_backend_capable(
 /* Confirm a locally-granted RANGE claim with the backend before its ticket
  * callback fires; `thread` must be the CALLING vfs thread (its request pool
  * is per-thread and unlocked). */
+/* One in-flight backend RANGE confirm.  Core-owned, linked on
+ * state->confirm_head for the duration, and carrying a SNAPSHOT of
+ * everything the completion needs out of the ticket: once a cancel claims
+ * this op the ticket may be freed under us, so nothing here dereferences
+ * it afterwards -- `ticket` is an identity key compared only under
+ * service_lock while the op is still linked. */
+struct chimera_vfs_bl_range_op {
+    struct chimera_vfs_state           *state;
+    struct chimera_vfs_file_state      *file;
+    struct chimera_vfs_pending_acquire *ticket; /* identity only           */
+    struct chimera_vfs_claim           *claim;
+    chimera_vfs_claim_acquire_cb_t      cb;
+    void                               *cb_private;
+    bool                                serial_lane;
+    bool                                cancelled;
+    struct chimera_vfs_bl_range_op     *next;
+};
+
 void
 chimera_vfs_claim_backend_project_range(
     struct chimera_vfs_thread          *thread,
     struct chimera_vfs_state           *state,
-    struct chimera_vfs_pending_acquire *ticket);
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                serial_lane);
 
 bool
 chimera_vfs_claim_backend_range_projects(
@@ -261,6 +280,14 @@ chimera_vfs_claim_backend_drain_releases(
  * service_lock, matching reeval->bl_post). */
 void
 chimera_vfs_claim_backend_release_token(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    uint64_t                       token);
+
+/* As above, but placed at the FRONT of the FIFO: the rollback of a confirm
+ * that a cancel claimed mid-flight, whose local release already happened. */
+void
+chimera_vfs_claim_backend_release_token_front(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file,
     uint64_t                       token);

--- a/src/vfs/vfs_claim_internal.h
+++ b/src/vfs/vfs_claim_internal.h
@@ -227,23 +227,6 @@ chimera_vfs_claim_backend_capable(
 /* Confirm a locally-granted RANGE claim with the backend before its ticket
  * callback fires; `thread` must be the CALLING vfs thread (its request pool
  * is per-thread and unlocked). */
-/* One in-flight backend RANGE confirm.  Core-owned, linked on
- * state->confirm_head for the duration, and carrying a SNAPSHOT of
- * everything the completion needs out of the ticket: once a cancel claims
- * this op the ticket may be freed under us, so nothing here dereferences
- * it afterwards -- `ticket` is an identity key compared only under
- * service_lock while the op is still linked. */
-struct chimera_vfs_bl_range_op {
-    struct chimera_vfs_state           *state;
-    struct chimera_vfs_file_state      *file;
-    struct chimera_vfs_pending_acquire *ticket; /* identity only           */
-    struct chimera_vfs_claim           *claim;
-    chimera_vfs_claim_acquire_cb_t      cb;
-    void                               *cb_private;
-    bool                                serial_lane;
-    bool                                cancelled;
-    struct chimera_vfs_bl_range_op     *next;
-};
 
 void
 chimera_vfs_claim_backend_project_range(
@@ -280,14 +263,6 @@ chimera_vfs_claim_backend_drain_releases(
  * service_lock, matching reeval->bl_post). */
 void
 chimera_vfs_claim_backend_release_token(
-    struct chimera_vfs_state      *state,
-    struct chimera_vfs_file_state *file,
-    uint64_t                       token);
-
-/* As above, but placed at the FRONT of the FIFO: the rollback of a confirm
- * that a cancel claimed mid-flight, whose local release already happened. */
-void
-chimera_vfs_claim_backend_release_token_front(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file,
     uint64_t                       token);


### PR DESCRIPTION
Splits the ctest suite into two tiers, then re-cuts the pipelines around them:
the merge queue gates on the cheap tier across **every** supported OS, and the
full suite moves to the nightly sweep.

- **quick** — the quint model-based tests. 25 tests, ~80s. What a plain `ctest`
  runs.
- **extended** — the quick tier plus everything else (pynfs, pjdfstest, cthon,
  ltp, pike, smbtorture, wpts, KVM, unit). Selected with `ctest -C extended`.

## What gates a merge

| | before | after |
|---|---|---|
| queue tests | extended, 10 distro cells + 56 devcontainer shards + 2 macOS | **quick**, 10 distro + 4 devcontainer + 2 macOS |
| queue static analysis | devcontainer only (4 cells) | **every OS image + macOS** (16 cells) |
| extended tier | queue **and** nightly | **nightly only**, one job per platform |
| flaky rescue | retry, marker artifact, approval gate | **gone** |

The trade is deliberate: run what is cheap on everything, and leave what is slow
to the nightly. Static analysis was the clearest case — it ran on the
devcontainer alone, which is how a warning only Rocky's clang emits could reach
main and sit until the nightly job found it.

## Flake infrastructure removed

A failing test used to be re-run; if the re-run passed, the failure was
downgraded to a `flaky-rescued.log` marker, collected by `collect-flakes` into a
yes/no signal, and routed to a `flake-review` environment for manual approval.
All three are gone, along with the re-run itself. The first failure is the
answer.

A retry that turns red into green hides exactly the race a merge queue exists to
catch, and the rescued-flake path was a route for a genuine intermittent failure
to reach main behind an approval click.

> [!IMPORTANT]
> This drops the **"Flake review gate"** status check. The branch ruleset still
> requires that context, so it must be removed from `protect-main` before this
> can merge — otherwise every PR waits forever on a check nothing reports.

## macOS keeps its extended coverage

The queue was the *only* place the extended tier met macOS — the nightly
workflow had no macOS job at all. It has one now, so the kqueue event core and
the portable paths above it are still covered; they just report the next
morning.

## Why a wrapper rather than per-test tags

CTest can only withhold a test from the default run through the
`CONFIGURATIONS` keyword of `add_test()`. The `CONFIGURATIONS` test *property*
is inert — ctest never consults it — and there is no directory-level default, so
the tag must be present at the point of registration. There are ~230
`add_test()` call sites across this tree and its submodules, many inside loops,
expanding to 1889 tests. Tagging them individually would be unmaintainable and
would rot silently as tests are added, so `add_test()` is wrapped once in the
top-level `CMakeLists.txt`.

A directory opts into the quick tier with `set(CHIMERA_TEST_TIER quick)`; the
five chimera `tests/quint` directories do. libevpl's model checks live in a
submodule this repo does not edit, so they are matched by name via
`CHIMERA_QUICK_TEST_REGEX`. The resulting quick tier is byte-identical to the
set `ctest -L quint` selected before this change.

Overriding a built-in command leaves the original reachable under a leading
underscore. That behaviour is long-standing but undocumented, so a
configure-time assertion fails loudly if a future CMake drops it, rather than
silently registering every test into the default tier.

## Locally

`make check` runs the CI sweep over the quick tier — now exactly what the queue
gates on. `make check_extended` runs the identical sweep over the full suite;
only the nightly runs that, so reach for it when a change goes beyond what the
model tests cover.


## Fixing the deadlock this exposed

Gating on the quick tier makes `chimera/server/nfs/mbtaux/batch_memfs` run on
all 16 test configurations, which surfaced a hang in the claim core (this PR's
own queue run 33273945653, and the three occurrences recorded in #1581). The
last two commits fix it, so the queue is not gated on a test that can wedge.

`chimera_vfs_claim_cancel` could not answer while the service thread was
confirming the very ticket being cancelled, so it spun on `sched_yield()` until
that confirm's callback returned. The callback runs protocol code, and every
caller of cancel is a teardown walking its own list under its own lock, so the
wait closes a cycle: the NLM client reap holds `nlm_state.mutex` and spins in
`chimera_vfs_claim_backend_ticket_cancel`, while the confirm it waits for is
blocked on that same mutex inside `chimera_nfs_nlm4_lock_acquire_cb`. Neither
moves, and the spin burns a core, so it presents as a hang. The reap path is
ordinary: besides `FREE_ALL` and `SM_NOTIFY` it runs whenever a client's last
connection drops, so any client disconnecting with a blocking lock outstanding
can hit it.

An in-flight confirm is now published as a core-owned op for exactly the window
before its callback is invoked, and a cancel that finds one claims it outright.
Because the op is the core's memory and snapshots what the completion needs,
cancel returns the instant it decides and the completion never touches the
ticket again. `false` now means *the callback owns the completion and may still
be running*, so callers arbitrate with their own callback through their own
lock — which is what the first of the two commits gives NLM, and why it goes
first.

The lane also stops assuming the backend answers inline. It never could:
`chimera_vfs_dispatch` routes an op to a delegation thread whenever async
delegation is configured, and a clustered arbiter never answers inline.
Dispatching a confirm now gates the drain until it completes.

Verified: all 30 in-process quint/MBT suites pass; 36 concurrent runs of the aux
batch with no hang, where it previously wedged within ~12; `vfs/claim_test` 155
checks including 9 new ones covering the deferred lane, which had no unit
coverage at all.

Full write-up, including two pre-existing issues in the same lane that this does
*not* fix, was in #1582 — now closed in favour of these commits.


### Two follow-ups from the first queue attempt

**A dispatched confirm is not reclaimable.** The original fix let a cancel claim
a ticket whose backend confirm was already in flight. It cannot: the claim is
caller-owned, so the local rollback has to happen before `cancel` returns while
the backend record can only be dropped when the confirm completes, and in that
gap a new acquire of the same range is granted locally and then refused by an
arbiter still holding the old record. Cancel now keeps only the two answers it
can give honestly. The deadlock stays fixed, because that came from the *wait*
rather than from who wins the race.

**`diskfs`: a handle whose object is gone is STALE, not NOENT.** Open-by-fh and
LINK refused a deleted, unreferenced inode with ENOENT. There is no name on
either path — the dead object is named by a filehandle — and RFC 1813 does not
list NFS3ERR_NOENT for LINK or for the handle-only operations. It also has to
agree with itself over time: once reclaim frees the inode, `inode_acquire`
answers ESTALE, so the same dead handle reported NOENT or STALE depending on how
far reclaim had got. That ~2ms window is the `deviation_probe_diskfs` flake
(4 failures in 60 runs at 6-way concurrency; 0 in 72 after).

### The release/confirm race, and the UAF behind it

`drain_releases` exists so a token release enqueued by an unlock reaches the
arbiter before the confirm of any lock taking the freed bytes. It can only find
a release still *on* the FIFO, and the service thread drains that FIFO too — so
once the service thread has popped one, an acquire confirming inline on its own
thread races it, and the arbiter refuses a lock it should grant. Caught with
both dispatches traced:

```
GRANT tid=..9360 [16,16) excl=1 token=528
DENY  tid=..9360 want[16,8) excl=1 vs held[16,16) token=528
REL   tid=..1392 [16,16) token=528      <- the release, just too late
```

Both paths now take a lock covering selection *and* dispatch, so whichever loses
observes the other's release delivered rather than merely dequeued. It is
deliberately not `service_lock` — the service drain must not hold that across a
TICKET, and it must never be held across an acquire confirm, which runs protocol
code.

Fixing the hang then exposed the next race in the same teardown, which ASan
caught: `chimera_nfs_nlm4_deliver_grant` snapshotted the lock entry *after* the
acquire callback dropped `nlm_state.mutex`, and a concurrent reap frees every
entry it takes off `client->locks` the moment it drops that mutex. The snapshot
now happens under the mutex and only the submit happens after.

Replaying the nfsaux corpus 32-way concurrently: **main fails 24/32** (about ten
hangs, fourteen `NLM status: got 1, want 0`, three pre-existing
`evpl_iovec_ref_incr ... wrong thread` aborts); **with this branch, 0/40**.

### Still not fixed here

The `evpl_iovec_ref_incr called on LOCAL iovec from wrong thread` abort is
pre-existing on main (3 of 32 runs) and NOT fixed here. It is not a libevpl bug:
that message is libevpl's detector asserting a LOCAL iovec is only ref'd from
its owning thread, so the fault is a caller. The likely path is NLM completing a
deferred acquire on whatever thread the grant landed on — the service thread, in
the backtrace that started this — and then replying with `ctx->evpl`, the
*connection's* evpl. The `was_blocked` GRANTED path marshals through the granter;
the DENIED path and proc 17 (`LOCK_RES`) do not. Not confirmed with a stack.

It did not recur in 40 runs on this branch, which is absence of observation
rather than a fix: main spends that test inside the deadlock's `sched_yield`
spin, which burns a core and distorts scheduling enough to widen exactly this
kind of cross-thread window.

`chimera_smb_lock_abort_parked` reads `resume_status` and unlinks from
`lock_resume_head` on cancel's `false` path, which assumes the callback
finished. That is already wrong on every backend except memfs, since a
non-CAP_LEASE pump fires the callback directly. It belongs with SMB lock
teardown ownership.

