### PR TITLE
smb: own the SMB2 model divergences here, and fix four of them

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -653,6 +653,7 @@ struct chimera_smb_request {
             struct chimera_vfs_file_state     *gen_parked_fs;
             struct chimera_vfs_pending_acquire gen_ticket;
             uint8_t                            gen_held_granted;
+            uint8_t                            gen_held_denied;
             uint8_t                            gen_parked;
             /* Set by chimera_smb_create_gen_open_file_normal when the share
              * conflict it could not resolve is against a durable holder that will

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -481,7 +481,8 @@ static inline void
 chimera_smb_create_finish_share_grant(
     struct chimera_smb_open_file  *open_file,
     struct chimera_vfs_file_state *file_state,
-    uint8_t                        held_granted);
+    uint8_t                        held_granted,
+    uint8_t                        held_denied);
 
 /* Resume a parked share acquire once the conflicting batch oplock has been
  * relinquished (GRANTED -> finish the open) or kept (DENIED -> SHARING_VIOLATION). */
@@ -1044,7 +1045,7 @@ chimera_smb_create_gen_open_file(
         uint32_t                          da = open_file->desired_access;
         uint32_t                          sa = open_file->share_access;
         uint8_t                           granted = 0, denied = 0;
-        uint8_t                           held_granted = 0;
+        uint8_t                           held_granted = 0, held_denied = 0;
         struct chimera_claim_owner        share_owner;
         struct chimera_vfs_claim_conflict conflict;
         enum chimera_vfs_claim_result     result;
@@ -1090,9 +1091,14 @@ chimera_smb_create_gen_open_file(
          * transiently for the conflict check, then shrink the held grant
          * once the claim is inserted (chimera_vfs_claim_shrink). */
         held_granted = granted;
-        if (request->create.create_disposition == SMB2_FILE_SUPERSEDE ||
+        held_denied  = denied;
+
+        bool truncating =
+            request->create.create_disposition == SMB2_FILE_SUPERSEDE ||
             request->create.create_disposition == SMB2_FILE_OVERWRITE ||
-            request->create.create_disposition == SMB2_FILE_OVERWRITE_IF) {
+            request->create.create_disposition == SMB2_FILE_OVERWRITE_IF;
+
+        if (truncating) {
             granted |= CHIMERA_CLAIM_W;
         }
 
@@ -1104,9 +1110,24 @@ chimera_smb_create_gen_open_file(
          * changing any conflict outcome (chimera_vfs_share_conflict and the
          * CACHING sole-access loop both treat a (0,0) entry as absent). */
         if (!(da & SMB2_SHAREMODE_ACCESS_MASK)) {
-            granted      = 0;
-            denied       = 0;
+            /* Whatever it asserted while opening, an attribute-only handle
+             * RETAINS nothing: the truncate's write was transient, so the
+             * handle blocks nobody afterwards. */
             held_granted = 0;
+            held_denied  = 0;
+
+            /* But only a true STAT open -- attribute-only AND non-truncating
+             * -- is exempt from arbitration in the first place.  A truncating
+             * open is going to modify the file, so it asserts the write it
+             * just took AND its ShareAccess, in both directions, exactly like
+             * an ordinary writer.  Zeroing them here discarded the very write
+             * bit added just above, which is the one case where the truncate
+             * is the ONLY source of it (MS-FSA 2.1.5.1.2; found by replaying
+             * the spec corpus against Samba, which refuses these). */
+            if (!truncating) {
+                granted = 0;
+                denied  = 0;
+            }
         }
 
         file_state = chimera_vfs_state_get(vfs_state,
@@ -1207,6 +1228,7 @@ chimera_smb_create_gen_open_file(
             request->create.gen_parked_open  = open_file;
             request->create.gen_parked_fs    = file_state;
             request->create.gen_held_granted = held_granted;
+            request->create.gen_held_denied  = held_denied;
             request->create.gen_parked       = 1;
             /* Publish this create's create_guid before the park: while it waits,
              * it is not in tree->open_files[], so only tree->pending_creates lets
@@ -1268,7 +1290,8 @@ chimera_smb_create_gen_open_file(
         }
 
         chimera_smb_create_finish_share_grant(open_file, file_state,
-                                              held_granted);
+                                              held_granted,
+                                              held_denied);
     }
 
     return chimera_smb_create_after_share(request, open_file);
@@ -1886,15 +1909,19 @@ static inline void
 chimera_smb_create_finish_share_grant(
     struct chimera_smb_open_file  *open_file,
     struct chimera_vfs_file_state *file_state,
-    uint8_t                        held_granted)
+    uint8_t                        held_granted,
+    uint8_t                        held_denied)
 {
-    /* Drop the transient truncate-write grant: the handle holds only the
-     * access it requested, so it must not block a later reader.  Shrink is
-     * the core's in-place downgrade verb (never conflicts; pumps waiters). */
-    if (held_granted != open_file->share_lease.used) {
+    /* Drop the transient truncate-write grant, and with it the ShareAccess an
+     * attribute-only truncating open asserted only to be arbitrated: the
+     * handle holds only the access it requested and denies only what such a
+     * handle may deny, so it must not block a later reader.  Shrink is the
+     * core's in-place downgrade verb (never conflicts; pumps waiters). */
+    if (held_granted != open_file->share_lease.used ||
+        held_denied != open_file->share_lease.denied) {
         chimera_vfs_claim_shrink(file_state, &open_file->share_lease,
                                  held_granted,
-                                 open_file->share_lease.denied);
+                                 held_denied);
     }
 
     open_file->share_file_state     = file_state;
@@ -1959,7 +1986,8 @@ chimera_smb_create_share_park_finish(
     if (result == CHIMERA_CLAIM_GRANTED) {
         /* The holder closed; the share reservation is now held. */
         chimera_smb_create_finish_share_grant(open_file, file_state,
-                                              request->create.gen_held_granted);
+                                              request->create.gen_held_granted,
+                                              request->create.gen_held_denied);
         chimera_smb_create_after_share(request, open_file);
         /* after_share hashed the open, so drop the in-flight registration only
          * now: a replay is covered by open_files[] from here on, with no window
@@ -2046,7 +2074,15 @@ chimera_smb_create_mkdir_open_callback(
      * client opening a directory under a lease key already held on another file
      * would slip past the check (smb2.lease.request opens fname2 as a directory
      * under LEASE1 and expects STATUS_INVALID_PARAMETER). */
-    if ((request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
+    /* Gated on leasing actually being advertised: MS-SMB2 3.3.5.9.8 conditions
+     * RqLs processing -- and with it the lease-key binding -- on the server
+     * supporting leases.  With smb_leases off the context is answered with a
+     * bare, cacheless RqLs reply and binds nothing, so enforcing the binding
+     * would refuse an open no lease was ever granted for.  (Found by replaying
+     * the spec corpus: the model made the same mistake, and Samba with
+     * `leases = no` ignores the context outright.) */
+    if (request->compound->thread->shared->config.leases &&
+        (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
         chimera_smb_session_lease_key_conflict(request->session_handle->session,
                                                request->create.rqls.key,
                                                oh->fh, oh->fh_len)) {
@@ -2711,7 +2747,15 @@ chimera_smb_create_open_at_callback(
      * reject the open with STATUS_INVALID_PARAMETER (smb2.lease.request /
      * duplicate_create / duplicate_open).  A re-open of the same file under the
      * key coalesces and is not a conflict. */
-    if ((request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
+    /* Gated on leasing actually being advertised: MS-SMB2 3.3.5.9.8 conditions
+     * RqLs processing -- and with it the lease-key binding -- on the server
+     * supporting leases.  With smb_leases off the context is answered with a
+     * bare, cacheless RqLs reply and binds nothing, so enforcing the binding
+     * would refuse an open no lease was ever granted for.  (Found by replaying
+     * the spec corpus: the model made the same mistake, and Samba with
+     * `leases = no` ignores the context outright.) */
+    if (request->compound->thread->shared->config.leases &&
+        (request->create.ctx_present_mask & CHIMERA_SMB_CREATE_CTX_RQLS) &&
         chimera_smb_session_lease_key_conflict(request->session_handle->session,
                                                request->create.rqls.key,
                                                oh->fh, oh->fh_len)) {

--- a/src/server/smb/smb_proc_flush.c
+++ b/src/server/smb/smb_proc_flush.c
@@ -54,6 +54,18 @@ chimera_smb_flush(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.13: FLUSH is a write-side operation.  A handle that holds
+     * neither FILE_WRITE_DATA nor FILE_APPEND_DATA may not flush, exactly as it
+     * may not write -- Windows fails FlushFileBuffers on a read-only handle
+     * with ERROR_ACCESS_DENIED, and so does Samba.  Checked before the pipe
+     * shortcut below so a read-only pipe handle is refused too. */
+    if (!(request->flush.open_file->granted_access &
+          (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA))) {
+        chimera_smb_open_file_release(request, request->flush.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
     if (!request->flush.open_file->handle) {
         /* Named-pipe FIDs carry no VFS handle; FLUSH on a pipe completes
          * immediately with success (MS-SMB2 3.3.5.15) -- do not deref NULL. */

--- a/src/server/smb/smb_proc_lock.c
+++ b/src/server/smb/smb_proc_lock.c
@@ -751,6 +751,19 @@ chimera_smb_lock(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.14: a byte-range lock is a data operation, so the handle
+     * must carry FILE_READ_DATA or FILE_WRITE_DATA.  A DELETE-only or
+     * attribute-only handle has no business locking a range and is refused
+     * ACCESS_DENIED.  Samba refuses these too (it answers INVALID_HANDLE, which
+     * the spec does not sanction); chimera had no access check here at all and
+     * granted the lock. */
+    if (unlikely(!(open_file->granted_access &
+                   (SMB2_FILE_READ_DATA | SMB2_FILE_WRITE_DATA)))) {
+        chimera_smb_open_file_release(request, open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_ACCESS_DENIED);
+        return;
+    }
+
     /* LockCount==0 is illegal, and more than CHIMERA_SMB_LOCK_MAX_ELEMENTS is
      * rejected rather than parsed; both reply INVALID_PARAMETER without dropping
      * the connection. */

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -99,11 +99,18 @@ endif()
 
 add_test(NAME chimera/server/smb/mbt/batch_memfs
     COMMAND $<TARGET_FILE:smb2_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/smb2)
-# 40 traces at depth 500 against an ASAN build, each standing up and tearing
-# down its own filesystem: measured at 55-105 s on a loaded container, so 120 s
-# was close enough to the ceiling to flake.  This is a batch of 40 tests in one
-# ctest, not a single case.
+# The whole generated corpus in one ctest, not a single case.  ext/specs
+# generates every instance and flavor unconditionally -- nothing is withheld on
+# account of what chimera does with it -- so this runs ~70 traces at depth
+# 300-500, each standing up and tearing down its own filesystem, against an
+# ASAN build on a loaded container.
+#
+# The batches chimera cannot drive yet are declined BY NAME in
+# smb2_mbt_deviations.h (smb2_mbt_trace_limits), each with the chimera bug that
+# would retire the entry, and reported as SKIP lines.  SKIP_RETURN_CODE turns a
+# run where nothing was drivable into a ctest SKIP rather than a false pass.
 set_tests_properties(chimera/server/smb/mbt/batch_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_batch_memfs"
     LABELS "quint;smb_mbt;memfs"
-    TIMEOUT 600)
+    TIMEOUT 1800
+    SKIP_RETURN_CODE 77)

--- a/src/server/smb/tests/quint/smb2_mbt_deviations.h
+++ b/src/server/smb/tests/quint/smb2_mbt_deviations.h
@@ -1,0 +1,239 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Registry of known chimera divergences from the SMB2 model.
+ *
+ * The models in ext/specs encode MS-SMB2 / MS-FSA, not chimera.  They are a
+ * published corpus with other consumers, and the corpus is generated
+ * UNCONDITIONALLY -- every instance and flavor, with nothing withheld on
+ * account of what any one server does with it.  So where chimera and the
+ * standard disagree, the disagreement is recorded HERE, in chimera, next to
+ * the code that has to change.  It is not encoded in the specs project, and it
+ * is never hidden by declining to generate the traces that would find it.
+ *
+ * Three outcomes, and the point of this file is to keep them apart:
+ *
+ *   1. a MODEL bug -- the spec says what chimera does.  Fix the model in
+ *      ext/specs; nothing belongs here.
+ *   2. a chimera DEVIATION -- chimera does something the standard does not
+ *      describe.  Record it here, with a citation, so the suite keeps running
+ *      and the divergence stays enumerable and attributable.
+ *   3. an unanalyzed difference -- neither of the above yet.  It must fail.
+ *
+ * This file is what separates (2) from (3).  A divergence matching an entry is
+ * reported as a DEVIATION and does not fail the run; anything else is a
+ * MISMATCH and does.  Same contract as the POSIX suite's
+ * src/posix/tests/quint/posix_deviations.py and as the Samba conformance
+ * harness in ext/specs/harness/samba -- never used to hide an unanalyzed
+ * failure, always carrying a citation, a root cause, and something that would
+ * retire it.
+ *
+ * Reconcilability.  Only divergences that leave chimera's state matching the
+ * model's are reconcilable, so replay can continue.  One that leaves the two
+ * holding different state would make every later command in the trace report a
+ * consequence rather than a finding; those are marked reconcilable = false and
+ * abandon the trace at the point they occur.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+struct smb2_mbt_deviation {
+    const char *id;
+    const char *spec;          /* MS-SMB2 / MS-FSA citation */
+    const char *summary;
+    const char *root_cause;    /* chimera source location */
+    const char *candidate_fix;
+    /* Model result tag this applies to ("RCreate", "RLock", ...); NULL = any. */
+    const char *op;
+    /* Status pair.  SMB2_MBT_ANY on either side means "any value". */
+    uint32_t    expected;
+    uint32_t    actual;
+    bool        reconcilable;
+};
+
+#define SMB2_MBT_ANY 0xFFFFFFFFu
+
+/* ------------------------------------------------------------------------
+ * Reply-level deviations.
+ * ------------------------------------------------------------------------ */
+
+static const struct smb2_mbt_deviation smb2_mbt_deviations[] = {
+    /* Empty by construction, not by luck: every reply-level divergence the
+     * generated corpus found against chimera has been FIXED in chimera rather
+     * than recorded here --
+     *
+     *   FLUSH without write access        smb_proc_flush.c
+     *   LOCK without read or write access smb_proc_lock.c
+     *   the attribute-only share bypass   smb_proc_create.c (held_granted /
+     *                                     held_denied)
+     *   the lease-key binding with        smb_proc_create.c (config.leases
+     *   leasing disabled                  gate)
+     *
+     * A new entry here should be rare and should feel like a decision. */
+    {
+        .id   = "CD-3",
+        .spec = "MS-FSA 2.1.5.1.2 (Open of Existing File): the sharing check "
+            "precedes any modification of the file",
+        .summary = "a truncating CREATE that is REFUSED with a sharing "
+            "violation still truncates the file",
+        .root_cause = "smb_proc_create.c builds the VFS open flags with "
+            "CHIMERA_VFS_OPEN_TRUNCATE and hands them to "
+            "chimera_vfs_open_at BEFORE the share-mode claim is "
+            "arbitrated, so the backend has already emptied the file "
+            "by the time the claim refuses the open.  A failed "
+            "operation with a side effect, and a destructive one: "
+            "the data is gone and the client is told the open did "
+            "not happen.  Both the model and the wire answer "
+            "STATUS_SHARING_VIOLATION, so nothing catches it at the "
+            "CREATE -- it surfaces later as a read that should have "
+            "returned data.  check_refused_create_side_effect in "
+            "smb2_mbt_replay.c compares the model's post-state size "
+            "against the wire's at the step that causes it.",
+        .candidate_fix = "open without CHIMERA_VFS_OPEN_TRUNCATE, acquire the "
+            "share claim, and only then truncate -- moving the "
+            "ARCHIVE / AllocationSize stamping, which currently "
+            "rides on the create-or-truncate open, to that same "
+            "deferred step.  The named-stream path "
+            "(chimera_smb_create_open_stream_chain) needs the "
+            "same treatment.",
+        .op       = "RCreateSideEffect",
+        .expected = SMB2_MBT_ANY,
+        .actual   = SMB2_MBT_ANY,
+        /* chimera's file is now empty and the model's is not.  Every later
+         * read, size query and hole check on that file would diverge. */
+        .reconcilable = false,
+    },
+    { 0 }
+};
+
+/* Find the deviation covering this divergence, or NULL. */
+static inline const struct smb2_mbt_deviation *
+smb2_mbt_deviation_find(
+    const char *op,
+    uint32_t    expected,
+    uint32_t    actual)
+{
+    const struct smb2_mbt_deviation *d;
+
+    for (d = smb2_mbt_deviations; d->id; d++) {
+        if (d->op && (!op || strcmp(d->op, op) != 0)) {
+            continue;
+        }
+        if (d->expected != SMB2_MBT_ANY && d->expected != expected) {
+            continue;
+        }
+        if (d->actual != SMB2_MBT_ANY && d->actual != actual) {
+            continue;
+        }
+        return d;
+    }
+    return NULL;
+} /* smb2_mbt_deviation_find */
+
+/* ------------------------------------------------------------------------
+ * Trace-level limits.
+ *
+ * Some divergences are not about one reply.  They are about whether this
+ * replayer can drive a whole batch at all -- because chimera misbehaves in a
+ * way that ends the trace, or because the trace is not deterministic against
+ * it.  The corpus still generates those batches; this table is what turns the
+ * batch into a reported SKIP instead of an unexplained pile of failures, and
+ * it names the chimera bug that would retire the entry.
+ *
+ * Matched against the trace file's basename, which the generator names
+ * <instance>_<flavor>_<steps>_<seed>_<seq>.itf.json.
+ * ------------------------------------------------------------------------ */
+
+struct smb2_mbt_trace_limit {
+    const char *prefix;        /* matched against the trace basename */
+    const char *id;
+    const char *summary;
+    const char *root_cause;
+    const char *candidate_fix;
+};
+
+static const struct smb2_mbt_trace_limit smb2_mbt_trace_limits[] = {
+    {
+        .prefix  = "smb2Durable_",
+        .id      = "CD-1",
+        .summary = "a parked durable handle outlives the per-trace share and "
+            "filesystem teardown, and tearing them down under it "
+            "corrupts the heap",
+        .root_cause = "a durable handle PARKS across a transport drop by "
+            "design, so it survives the connection.  The batch "
+            "replayer removes the share and the filesystem after "
+            "every trace, and chimera_smb_remove_share() frees the "
+            "share and destroys its sharemode table with no regard "
+            "for opens still referencing it -- a heap-use-after-free "
+            "in chimera_smb_sharemode_release().  Keeping the share "
+            "instead moves the problem to rmfs, which then spins on "
+            "EBUSY until the parked handle's 60 s durable timeout.  "
+            "The durable model and its ground-truth probe "
+            "(smb2_durable_probe) both pass; it is the teardown that "
+            "cannot survive a parked handle.",
+        .candidate_fix = "settle share/handle lifetime: make remove_share "
+            "release or adopt the opens still referencing the "
+            "share, so a parked durable handle cannot outlive its "
+            "sharemode table",
+    },
+    {
+        .prefix  = "smb2Leases_",
+        .id      = "CD-4",
+        .summary = "replay wedges on an ack-required oplock/lease break: a "
+            "CREATE parks on a deferral that never resumes",
+        .root_cause = "the harness's own wedge detector fires after 20 s on a "
+            "CREATE with an interim sent and a break queued "
+            "(reply_ready=0), and aborts the run.  The capped "
+            "sibling instance smb2ForceL2 -- the same model on a "
+            "share carrying SMB2_SHAREFLAG_FORCE_LEVELII_OPLOCK, "
+            "where every grant caps to a read cache and so no break "
+            "is ever ack-required -- replays all eight of its traces "
+            "to the end.  That localizes the wedge to the "
+            "ack-required break lifecycle.  Which side owns it is "
+            "NOT yet established: it is either a server deferral "
+            "that never resumes, or an acknowledgment this replayer "
+            "fails to send.  Recorded as a limit rather than a "
+            "chimera bug for exactly that reason.",
+        .candidate_fix = "drive one wedged trace under SMB2_MBT_DEBUG and "
+            "settle which side is waiting; the deterministic half "
+            "of this surface is already pinned green by "
+            "smb2_oplock_probe, so the difference between that "
+            "and this trace is the place to look",
+    },
+    {
+        .prefix  = "smb2Replay_",
+        .id      = "CD-2",
+        .summary = "replay-flagged traces are not deterministic against "
+            "chimera, so a divergence here cannot be trusted either way",
+        .root_cause = "the exactly-once layer's create reply cache (Q-13) "
+            "makes the observable outcome of an affected request "
+            "depend on timing rather than on the request, so the "
+            "same trace can replay green once and red the next "
+            "time.  Replaying it would trade the suite's "
+            "trustworthiness for coverage.  The deterministic half "
+            "of this surface is pinned by smb2_replay_probe, which "
+            "does pass.",
+        .candidate_fix = "make the create reply cache's lookup and its "
+            "eligibility window deterministic, then delete this "
+            "entry and let the batch replay",
+    },
+    { 0 }
+};
+
+static inline const struct smb2_mbt_trace_limit *
+smb2_mbt_trace_limit_find(const char *basename)
+{
+    const struct smb2_mbt_trace_limit *l;
+
+    for (l = smb2_mbt_trace_limits; l->id; l++) {
+        if (strncmp(basename, l->prefix, strlen(l->prefix)) == 0) {
+            return l;
+        }
+    }
+    return NULL;
+} /* smb2_mbt_trace_limit_find */

--- a/src/server/smb/tests/quint/smb2_mbt_replay.c
+++ b/src/server/smb/tests/quint/smb2_mbt_replay.c
@@ -41,6 +41,7 @@
  */
 
 #include "smb2_mbt_common.h"
+#include "smb2_mbt_deviations.h"
 #include "common/mbt_trace_dir.h"
 
 #include <stdarg.h>
@@ -60,40 +61,50 @@
 #define MAX_TREE 512
 #define MAX_FID  4096
 
-static struct smb2_env   g_env;
+static struct smb2_env                  g_env;
 /* The connection a live model session is bound to, NULL once a modeled
  * transport drop has taken it away. */
-static struct smb2_conn *g_conn_for_sess[MAX_SESS];
+static struct smb2_conn                *g_conn_for_sess[MAX_SESS];
 /* Every connection a session was EVER bound to, kept after the drop: a
  * reconnect must present the dropped session's ClientGuid (MS-SMB2 3.3.5.9.7 --
  * chimera refuses a leased or persistent reclaim from a different client), and
  * the model names the client by the session it is reconnecting FOR. */
-static struct smb2_conn *g_conn_hist[MAX_SESS];
-static uint32_t          g_wire_tree[MAX_TREE];
-static uint8_t           g_wire_fid[MAX_FID][16];
+static struct smb2_conn                *g_conn_hist[MAX_SESS];
+static uint32_t                         g_wire_tree[MAX_TREE];
+static uint8_t                          g_wire_fid[MAX_FID][16];
 /* Has this model FileId ever been learned from the wire?  A model fid is never
  * reused, so a SECOND reply carrying one the replayer already knows is the
  * model asserting "this is the same open" -- a replayed CREATE answered from
  * the reply cache, or a reclaim of a parked handle.  The wire FileId must then
  * be byte-identical, which is the exactly-once oracle MS-SMB2 3.3.5.9.10 asks
  * for stated as an assertion rather than a status comparison. */
-static int               g_fid_known[MAX_FID];
+static int                              g_fid_known[MAX_FID];
 /* Which connection owns each model FileId: a break notification for a handle
  * is pushed to the HOLDER's connection, and the acknowledgment must go back on
  * that same connection, so the fid -> conn binding is as load-bearing as the
  * fid -> wire FileId one. */
-static struct smb2_conn *g_conn_for_fid[MAX_FID];
+static struct smb2_conn                *g_conn_for_fid[MAX_FID];
 /* The model lease key (a small int) each handle's grant carries, or -1.  A
  * LEASE_BREAK acknowledgment is keyed by the 16-byte lease key, not by FileId. */
-static int               g_lease_key_for_fid[MAX_FID];
+static int                              g_lease_key_for_fid[MAX_FID];
 /* Which parked handles the replayer has already waited for (see park_barrier). */
-static int               g_park_barriered[MAX_FID];
+static int                              g_park_barriered[MAX_FID];
 /* The model state AFTER the message being replayed -- the `parked` map of which
  * is what tells the disconnect handler which handles the server still owes a
  * park. */
-static json_t           *g_post_sdb;
-static const char       *g_trace;
-static int               g_nmismatch;
+static json_t                          *g_post_sdb;
+static const char                      *g_trace;
+static int                              g_nmismatch;
+/* Divergences that matched the registry: reported, counted, not fatal. */
+static int                              g_ndeviation;
+/* Set when a non-reconcilable deviation fired: the model and chimera now hold
+ * different state, so the rest of the trace would report consequences. */
+static const struct smb2_mbt_deviation *g_abort_dev;
+/* Traces this replayer declined to drive, and why (smb2_mbt_trace_limits). */
+static int                              g_nskipped;
+/* Set when the model and chimera have parted ways and the rest of this trace
+ * would report consequences rather than findings. */
+static int                              g_abort_trace;
 
 /* Settle every server thread so the break notifications a command owes have
  * been delivered -- and so that "no break was sent" is a fact rather than a
@@ -182,6 +193,159 @@ mism(
     printf("\n");
     g_nmismatch++;
 } /* mism */
+
+/* Compare one status against the model's.  Returns 1 when the divergence is a
+ * RECORDED deviation -- reported and counted, but not a failure -- and 0 when
+ * the caller should report it as a mismatch.  Every status comparison in this
+ * file goes through here, so a divergence can only be excused by an entry in
+ * smb2_mbt_deviations.h, never by silence. */
+static int
+dev_status(
+    const char *op,
+    uint32_t    expected,
+    uint32_t    actual,
+    const char *what)
+{
+    const struct smb2_mbt_deviation *d =
+        smb2_mbt_deviation_find(op, expected, actual);
+
+    if (!d) {
+        return 0;
+    }
+
+    printf("DEVIATION %s [%s] %s status: model 0x%08x wire 0x%08x -- %s\n",
+           d->id, g_trace, what, expected, actual, d->summary);
+    g_ndeviation++;
+
+    if (!d->reconcilable) {
+        g_abort_dev = d;
+    }
+    return 1;
+} /* dev_status */
+
+/* Look one key up in an ITF map ({"#map": [[k, v], ...]}). */
+static json_t *
+itf_map_get(
+    json_t     *map,
+    const char *skey,
+    int64_t     ikey)
+{
+    json_t *entries = map ? json_object_get(map, "#map") : NULL;
+    size_t  n       = json_array_size(entries);
+
+    for (size_t i = 0; i < n; i++) {
+        json_t *pair = json_array_get(entries, i);
+        json_t *k    = json_array_get(pair, 0);
+
+        if (skey) {
+            const char *ks = json_string_value(k);
+            if (ks && strcmp(ks, skey) == 0) {
+                return json_array_get(pair, 1);
+            }
+        } else if (jint(k) == ikey) {
+            return json_array_get(pair, 1);
+        }
+    }
+    return NULL;
+} /* itf_map_get */
+
+/* The model's own belief about a file's size, read out of the trace's
+ * post-state.  Returns -1 when the name does not exist in the model. */
+static long long
+model_size_blocks(const char *name)
+{
+    json_t *fs, *inodes, *root, *ents, *ino, *node;
+
+    if (!g_post_sdb) {
+        return -1;
+    }
+    fs = json_object_get(g_post_sdb, "fs");
+    if (!fs) {
+        return -1;
+    }
+    inodes = json_object_get(fs, "inodes");
+    root   = itf_map_get(inodes, NULL, 0);
+    ents   = root ? json_object_get(root, "ents") : NULL;
+    ino    = ents ? itf_map_get(ents, name, 0) : NULL;
+    if (!ino) {
+        return -1;
+    }
+    node = itf_map_get(inodes, NULL, jint(ino));
+    if (!node) {
+        return -1;
+    }
+    return (long long) jint(json_object_get(node, "sizeBlocks"));
+} /* model_size_blocks */
+
+/* A divergence both sides report identically.
+ *
+ * A CREATE that is REFUSED must leave the file exactly as it found it.  When
+ * the model and the wire agree on the refusal, the status comparison sees
+ * nothing -- and if one of them truncated anyway, the damage surfaces dozens
+ * of steps later as a read that should have returned data.  So compare the
+ * model's post-state size against the server's, at the step that causes it,
+ * and only when it is observable (a file already empty cannot be emptied
+ * again).  Returns 1 if the trace should be abandoned.
+ *
+ * The probe open is attribute-only and non-truncating, so it takes no part in
+ * share arbitration in either direction and cannot change what the next
+ * modeled command sees. */
+static int
+check_refused_create_side_effect(
+    struct smb2_conn *c,
+    const char       *name,
+    uint32_t          disp,
+    uint32_t          status)
+{
+    const struct smb2_mbt_deviation *d;
+    struct smb2_create_out           out;
+    long long                        want, got;
+
+    if (status != ST_SHARING_VIOLATION) {
+        return 0;
+    }
+    if (disp != FILE_SUPERSEDE && disp != FILE_OVERWRITE &&
+        disp != FILE_OVERWRITE_IF) {
+        return 0;
+    }
+
+    want = model_size_blocks(name);
+    if (want < 0) {
+        return 0;
+    }
+
+    smb2_create(c, name, FILE_OPEN, FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                NULL, &out);
+    if (out.status != ST_SUCCESS) {
+        return 0;
+    }
+    /* The CREATE reply carries EndOfFile, so the size costs no extra round
+     * trip beyond the probe open itself. */
+    smb2_close(c, out.file_id);
+
+    if (out.end_of_file % BS) {
+        return 0;
+    }
+    got = (long long) (out.end_of_file / BS);
+    if (want == got) {
+        return 0;
+    }
+
+    d = smb2_mbt_deviation_find("RCreateSideEffect", SMB2_MBT_ANY,
+                                SMB2_MBT_ANY);
+    if (!d) {
+        mism("CREATE '%s' was refused by both, but the file is %lld block(s) "
+             "in the model and %lld on the wire -- a refused CREATE modified "
+             "something", name, want, got);
+        return 1;
+    }
+    printf("DEVIATION %s [%s] CREATE '%s': refused open left %lld block(s) in "
+           "the model and %lld on the wire -- %s\n",
+           d->id, g_trace, name, want, got, d->summary);
+    g_ndeviation++;
+    return !d->reconcilable;
+} /* check_refused_create_side_effect */
 
 /* A model id that has run off the end of one of the tables above is a HARNESS
  * limit, not a divergence: the trace is fine and the replayer cannot represent
@@ -753,8 +917,10 @@ do_create(
     uint32_t exp_st = (uint32_t) jfield(rv, "st");
 
     if (out.status != exp_st) {
-        mism("CREATE '%s' status: model 0x%08x wire 0x%08x", name, exp_st,
-             out.status);
+        if (!dev_status("RCreate", exp_st, out.status, name)) {
+            mism("CREATE '%s' status: model 0x%08x wire 0x%08x", name, exp_st,
+                 out.status);
+        }
         return;
     }
 
@@ -770,6 +936,11 @@ do_create(
     }
 
     if (out.status != ST_SUCCESS) {
+        /* Both sides refused.  That agreement can still hide a divergence:
+         * a refused CREATE must not have modified the file. */
+        if (check_refused_create_side_effect(c, name, disp, out.status)) {
+            g_abort_trace = 1;
+        }
         return;
     }
 
@@ -898,7 +1069,9 @@ do_close(
     }
     st = smb2_close(c, fid);
     if (st != exp_st) {
-        mism("CLOSE status: model 0x%08x wire 0x%08x", exp_st, st);
+        if (!dev_status("RClose", exp_st, st, "CLOSE")) {
+            mism("CLOSE status: model 0x%08x wire 0x%08x", exp_st, st);
+        }
     }
 } /* do_close */
 
@@ -927,7 +1100,9 @@ do_write(
     st = smb2_write(c, fid, (uint64_t) off * BS, buf, (uint32_t) (len * BS),
                     &count);
     if (st != exp_st) {
-        mism("WRITE status: model 0x%08x wire 0x%08x", exp_st, st);
+        if (!dev_status("RWrite", exp_st, st, "WRITE")) {
+            mism("WRITE status: model 0x%08x wire 0x%08x", exp_st, st);
+        }
         return;
     }
     if (st == ST_SUCCESS) {
@@ -963,7 +1138,9 @@ do_read(
     st = smb2_read(c, fid, (uint64_t) off * BS, (uint32_t) (len * BS), buf,
                    &rlen);
     if (st != exp_st) {
-        mism("READ status: model 0x%08x wire 0x%08x", exp_st, st);
+        if (!dev_status("RRead", exp_st, st, "READ")) {
+            mism("READ status: model 0x%08x wire 0x%08x", exp_st, st);
+        }
         return;
     }
     if (st != ST_SUCCESS) {
@@ -1116,7 +1293,9 @@ do_set_eof(
     }
     st = smb2_set_eof(c, fid, (uint64_t) sz * BS);
     if (st != exp_st) {
-        mism("SET_EOF status: model 0x%08x wire 0x%08x", exp_st, st);
+        if (!dev_status("RSetEof", exp_st, st, "SET_EOF")) {
+            mism("SET_EOF status: model 0x%08x wire 0x%08x", exp_st, st);
+        }
     }
 } /* do_set_eof */
 
@@ -1205,7 +1384,9 @@ do_flush(
     }
     st = smb2_flush(c, fid);
     if (st != exp_st) {
-        mism("FLUSH status: model 0x%08x wire 0x%08x", exp_st, st);
+        if (!dev_status("RFlush", exp_st, st, "FLUSH")) {
+            mism("FLUSH status: model 0x%08x wire 0x%08x", exp_st, st);
+        }
     }
 } /* do_flush */
 
@@ -1413,7 +1594,9 @@ do_logoff(
     uint32_t st     = smb2_logoff(c);
 
     if (st != exp_st) {
-        mism("LOGOFF status: model 0x%08x wire 0x%08x", exp_st, st);
+        if (!dev_status("RLogoff", exp_st, st, "LOGOFF")) {
+            mism("LOGOFF status: model 0x%08x wire 0x%08x", exp_st, st);
+        }
     }
     if (st == ST_SUCCESS) {
         /* The session id is dead.  Unbind it so a later command that names it
@@ -1439,7 +1622,10 @@ do_tree_disconnect(
     uint32_t st     = smb2_tree_disconnect(c);
 
     if (st != exp_st) {
-        mism("TREE_DISCONNECT status: model 0x%08x wire 0x%08x", exp_st, st);
+        if (!dev_status("RTreeDisconnect", exp_st, st, "TREE_DISCONNECT")) {
+            mism("TREE_DISCONNECT status: model 0x%08x wire 0x%08x", exp_st,
+                 st);
+        }
     }
 } /* do_tree_disconnect */
 
@@ -1724,6 +1910,22 @@ run_trace(
     const char *fsname,
     const char *path)
 {
+    /* The corpus is generated unconditionally, so it contains batches this
+     * replayer cannot drive against chimera.  Declining them HERE -- by name,
+     * with the chimera bug that would retire the entry -- keeps the gap
+     * visible and attributable, where declining to generate them made it
+     * invisible. */
+    const char                        *base = strrchr(path, '/');
+    const struct smb2_mbt_trace_limit *lim  =
+        smb2_mbt_trace_limit_find(base ? base + 1 : path);
+
+    if (lim) {
+        printf("SKIP %s [%s] %s\n", lim->id, base ? base + 1 : path,
+               lim->summary);
+        g_nskipped++;
+        return 0;
+    }
+
     json_error_t err;
     json_t      *root = json_load_file(path, 0, &err);
 
@@ -1765,8 +1967,9 @@ run_trace(
     memset(g_conn_for_fid, 0, sizeof(g_conn_for_fid));
     memset(g_park_barriered, 0, sizeof(g_park_barriered));
     memset(g_park_pending, 0, sizeof(g_park_pending));
-    g_trace     = path;
-    g_nmismatch = 0;
+    g_trace       = path;
+    g_nmismatch   = 0;
+    g_abort_trace = 0;
 
     /* Per-trace too: a fid's lease key must not survive into the next trace.
      * -1 means 'no lease key bound to this fid'. */
@@ -1792,6 +1995,15 @@ run_trace(
         }
         g_post_sdb = json_object_get(st_i, sdbkey);
         do_message(jval(lo));
+        if (g_abort_trace) {
+            /* A non-reconcilable deviation fired: the model and chimera now
+             * hold different state, so every later command would report the
+             * consequence rather than a finding.  Stop here and say so. */
+            printf("ABANDONED [%s] at state %zu: a non-reconcilable deviation "
+                   "left the model and the server holding different state\n",
+                   path, i);
+            break;
+        }
     }
     g_post_sdb = NULL;
 
@@ -1871,11 +2083,27 @@ main(
 
     mbt_free_traces(traces, ntraces);
 
+    if (g_nskipped) {
+        printf("# %d of %d trace(s) skipped -- see smb2_mbt_deviations.h "
+               "(smb2_mbt_trace_limits)\n", g_nskipped, ntraces);
+    }
+    if (g_ndeviation) {
+        printf("# %d recorded deviation(s) -- known, cited chimera "
+               "divergences from the model (smb2_mbt_deviations.h)\n",
+               g_ndeviation);
+    }
     if (total) {
         fprintf(stderr, "%d total mismatch(es) across %d trace(s)\n",
                 total, ntraces);
         return 1;
     }
-    printf("ok: %d trace(s) replayed with no mismatches\n", ntraces);
+    if (g_nskipped == ntraces) {
+        /* Nothing was driven.  That is a ctest SKIP, not a pass: a batch this
+        * replayer cannot drive must not read as evidence about the server. */
+        printf("# nothing in this batch is replayable against chimera yet\n");
+        return 77;
+    }
+    printf("ok: %d trace(s) replayed with no unrecorded divergence\n",
+           ntraces - g_nskipped);
     return 0;
 } /* main */


### PR DESCRIPTION
Pairs with chimera-nas/specs#12 (merged). Pins `ext/specs` to `1bc1921`, whose
trace bundle is published, so the quint job fetches the corpus rather than
regenerating it.

> [!IMPORTANT]
> **Draft: one test is red, and it is not chimera's fault.**
> `mbt/batch_memfs` reports **1 mismatch across 72 traces**. I analyzed it, and
> it is a **model** bug — chimera is correct on the wire. It needs a follow-up
> fix in specs plus a pin bump before this can go green; details at the bottom.

ext/specs now generates the SMB2 corpus unconditionally — every instance and
flavor, nothing withheld on account of what any one server does with it. Batches
this replayer used to be protected from *by their simply not existing* now
arrive, so chimera needs somewhere to say what it does with them.

## `smb2_mbt_deviations.h`

That place, and deliberately in chimera rather than in specs. The models encode
MS-SMB2 / MS-FSA, they have other consumers, and a chimera divergence is a fact
about chimera — it belongs next to the code that has to change, not in a shared
corpus that would then quietly stop generating the traces that find it.

Two tables:

- `smb2_mbt_deviations[]` — matches a reply-level divergence by
  `(op, expected, actual)`
- `smb2_mbt_trace_limits[]` — declines a whole batch by trace-name prefix

Every entry carries a citation, a root cause, and the change that would retire
it. A divergence matching an entry is a DEVIATION; **anything else is a MISMATCH
and fails.** Same contract as `posix_deviations.py`.

## Four divergences fixed rather than recorded

| what | where | rule |
| --- | --- | --- |
| FLUSH granted on any open handle | `smb_proc_flush.c` | MS-SMB2 3.3.5.13 — needs `FILE_WRITE_DATA`/`FILE_APPEND_DATA`. Windows fails `FlushFileBuffers` on a read-only handle; so does Samba. |
| LOCK had no access check at all | `smb_proc_lock.c` | MS-SMB2 3.3.5.14 — a DELETE-only or attribute-only handle could lock a range. |
| the attribute-only share bypass swallowed a truncating open's write | `smb_proc_create.c` | see below |
| lease-key binding fired with leasing disabled | `smb_proc_create.c` | MS-SMB2 3.3.5.9.8 conditions RqLs processing on lease support; with `smb_leases` off the context binds nothing, so the binding refused opens no lease was ever granted for. |

The third is the interesting one. A truncating create takes `CHIMERA_CLAIM_W`
transiently so it can arbitrate as the writer it is — and the DesiredAccess
check below it then zeroed `granted`/`denied` for *any* open without data-access
bits, discarding the write bit added three lines earlier, in exactly the case
where the truncate was its only source. Those are now zeroed only for a true
stat open (attribute-only **and** non-truncating), while
`held_granted`/`held_denied` still shrink to nothing once the claim is in —
because what such a handle *retains* really is nothing.

## One deviation recorded, and it loses data

**CD-3** — a truncating CREATE refused with `STATUS_SHARING_VIOLATION` still
truncates. `smb_proc_create.c` passes `CHIMERA_VFS_OPEN_TRUNCATE` to
`chimera_vfs_open_at` *before* the share claim is arbitrated, so the backend has
emptied the file by the time the claim refuses the open. Both sides answer
`SHARING_VIOLATION`, so nothing catches it at the CREATE — it surfaces later as
a read that should have returned data.

Recorded rather than fixed because the fix is an async-chain restructure (open
without TRUNCATE, claim, then truncate, relocating the ARCHIVE / AllocationSize
stamping that currently rides on the create-or-truncate open, plus the
named-stream path). That wants smbtorture / WPTS / pike to validate and does not
belong in the same change as the harness that found it.
`check_refused_create_side_effect()` detects it exactly, by comparing the
model's post-state size against the wire's.

## Three batches declined whole

Each by name, each with the bug that would retire it:

- **CD-1** `smb2Durable` — a parked durable handle outlives the per-trace
  teardown, and `chimera_smb_remove_share()` frees the sharemode table under it.
  Heap-use-after-free in `chimera_smb_sharemode_release()`.
- **CD-4** `smb2Leases` — replay wedges on an ack-required break. The capped
  sibling `smb2ForceL2` (same model, `FORCE_LEVELII_OPLOCK` share, so no break
  is ever ack-required) replays all eight traces to the end, which localizes it
  — but **which side is waiting is not established**, so this is a harness limit
  and not yet a chimera bug. If it turns out to be a server deferral that never
  resumes, this entry should become a CD-numbered deviation with a real root
  cause.
- **CD-2** `smb2Replay` — the Q-13 create reply cache makes affected traces
  nondeterministic, so a result there could not be trusted either way.

The batch ctest reports these as SKIP lines. `SKIP_RETURN_CODE 77` turns a run
where nothing was drivable into a ctest SKIP rather than a false pass, and
TIMEOUT goes to 1800 — the corpus is ~70 traces at depth 300-500 now, not 40 at
240-500.

## The one remaining mismatch — a model bug, not a chimera bug

```
MISMATCH [smb2ForceL2_stepLease_300_0x31_4.itf.json] CREATE 'a' lease epoch: model 2 wire 0
```

Traced through the model's own recorded state:

| state | what happens to lease key 1 |
| --- | --- |
| 14 | `CREATE 'a'` with a **v1** RqLs under key 1 → fid 5, lease granted `st=r`, epoch 0 |
| 15 | a break drops fid 5's lease to **NONE** (`r=w=h=false`) |
| 33 | fid 5 is **still open**, still holding lease key 1, still at NONE |
| 34 | `CREATE 'a'` again — same session 0, same file, same key 1 — now requesting **v2** |

The model answers a fresh v2 lease at epoch 2. Chimera coalesces onto the
existing v1 lease and reports epoch 0.

**Chimera is right.** MS-SMB2 3.3.5.9.8: a lease is identified by (client, lease
key), and a `LeaseState` of NONE does not destroy it while an open still
references it. A second open under that key on that file joins the existing
lease and reports its state and version — and the lease is v1, which carries no
epoch, so 0.

The cause is in `grantUnderKey` (`quint/smb2/smb2_ops.qnt`), whose member filter
carries `not(cachingLevelNone(...))`. That drops a lease the moment it breaks to
NONE, so the key stops binding and the next open under it mints a *new* lease —
a v2 one, under a key already bound to a v1 lease.

It is also self-inconsistent: the model separately enforces that a lease key
binds to exactly one lease per client (the rule whose leasing-disabled gate is
fixed as SD-6 in specs#12), which presupposes the binding survives a break.

This is deliberately **not** recorded as a chimera deviation. The registry is
for divergences where chimera is wrong; recording one where chimera is right
would be the first entry that made the mechanism a place to put things rather
than a record of facts.
