### PR TITLE
Fix the nightly static-analysis findings

### DIFF
--- a/src/posix/posix_lock_claims.c
+++ b/src/posix/posix_lock_claims.c
@@ -19,6 +19,11 @@
 
 #include "posix_internal.h"
 
+/* A mid-range carve splits one claim into head and tail fragments, so two
+ * spares.  The claim core's interface fixes this: vfs_claim.h declares
+ * spare[2]. */
+#define POSIX_LOCK_CARVE_SPARES 2
+
 static FORCE_INLINE struct chimera_vfs_state *
 chimera_posix_vfs_state(struct chimera_posix_client *posix)
 {
@@ -160,8 +165,8 @@ chimera_posix_ofd_lock_carve(
     uint64_t                        length)
 {
     struct chimera_vfs_state           *state = chimera_posix_vfs_state(posix);
-    struct chimera_posix_ofd_lock      *spare_nodes[2];
-    struct chimera_vfs_claim           *spare[2];
+    struct chimera_posix_ofd_lock      *spare_nodes[POSIX_LOCK_CARVE_SPARES];
+    struct chimera_vfs_claim           *spare[POSIX_LOCK_CARVE_SPARES];
     struct chimera_posix_lock_carve_ctx ctx        = { .freed = NULL };
     int                                 spare_used = 0;
     struct chimera_vfs_file_state      *file;
@@ -182,8 +187,21 @@ chimera_posix_ofd_lock_carve(
      * spare (offset/length rewritten) and links it, so the claim needs no
      * init here; each spare carries its own anchor reference in case it is
      * inserted. */
-    for (i = 0; i < 2; i++) {
-        spare_nodes[i]       = calloc(1, sizeof(*spare_nodes[i]));
+    for (i = 0; i < POSIX_LOCK_CARVE_SPARES; i++) {
+        spare_nodes[i] = calloc(1, sizeof(*spare_nodes[i]));
+
+        if (!spare_nodes[i]) {
+            /* Drop the spares already built and skip the carve.  Leaving the
+             * claim unsplit holds more of the range than was asked for, which
+             * is a far better failure than dereferencing NULL. */
+            while (i-- > 0) {
+                chimera_vfs_state_put(state, spare_nodes[i]->file);
+                free(spare_nodes[i]);
+            }
+            chimera_vfs_state_put(state, file);
+            return;
+        }
+
         spare_nodes[i]->file = chimera_vfs_state_get(state,
                                                      handle->fh,
                                                      (uint8_t) handle->fh_len,
@@ -199,6 +217,14 @@ chimera_posix_ofd_lock_carve(
                                     spare, &spare_used,
                                     chimera_posix_lock_carve_released, &ctx);
 
+    /* The core takes at most the spares it was handed -- vfs_claim.h fixes the
+     * array at spare[2] and vfs_claim.c guards with n_spare < 2 -- but it lives
+     * in another translation unit, so bound the count here to keep both loops
+     * below inside spare_nodes[]. */
+    if (spare_used > POSIX_LOCK_CARVE_SPARES) {
+        spare_used = POSIX_LOCK_CARVE_SPARES;
+    }
+
     /* Consumed spares are now inserted head/tail fragments: track them.
      * CLAIMTODO: fragments attribute to the UNLOCKING description even when
      * the split lock was taken through a different description of the same
@@ -211,7 +237,7 @@ chimera_posix_ofd_lock_carve(
 
     pthread_mutex_unlock(&posix->fd_lock);
 
-    for (i = spare_used; i < 2; i++) {
+    for (i = spare_used; i < POSIX_LOCK_CARVE_SPARES; i++) {
         chimera_vfs_state_put(state, spare_nodes[i]->file);
         free(spare_nodes[i]);
     }

--- a/src/posix/tests/pjd_common.h
+++ b/src/posix/tests/pjd_common.h
@@ -644,6 +644,11 @@ pjd_lstat_ctime(
     char        p[PJD_PATHBUF];
     struct stat st;
 
+    /* Leave the output defined even when the stat fails: the pjd cases
+     * use non-fatal expectations and keep running, so a caller can
+     * still read this. */
+    *ts = (struct timespec) { 0, 0 };
+
     if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
         return -1;
     }
@@ -658,6 +663,11 @@ pjd_lstat_mtime(
 {
     char        p[PJD_PATHBUF];
     struct stat st;
+
+    /* Leave the output defined even when the stat fails: the pjd cases
+     * use non-fatal expectations and keep running, so a caller can
+     * still read this. */
+    *ts = (struct timespec) { 0, 0 };
 
     if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
         return -1;
@@ -747,6 +757,11 @@ pjd_stat_ctime(
     char        p[PJD_PATHBUF];
     struct stat st;
 
+    /* Leave the output defined even when the stat fails: the pjd cases
+     * use non-fatal expectations and keep running, so a caller can
+     * still read this. */
+    *ts = (struct timespec) { 0, 0 };
+
     if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
         return -1;
     }
@@ -761,6 +776,11 @@ pjd_stat_mtime(
 {
     char        p[PJD_PATHBUF];
     struct stat st;
+
+    /* Leave the output defined even when the stat fails: the pjd cases
+     * use non-fatal expectations and keep running, so a caller can
+     * still read this. */
+    *ts = (struct timespec) { 0, 0 };
 
     if (chimera_posix_stat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
         return -1;
@@ -827,6 +847,12 @@ pjd_lstat_times(
 {
     char        p[PJD_PATHBUF];
     struct stat st;
+
+    /* Leave the outputs defined even when the stat fails: the pjd cases
+     * use non-fatal expectations and keep running, so a caller can still
+     * read these. */
+    *atime = (struct timespec) { 0, 0 };
+    *mtime = (struct timespec) { 0, 0 };
 
     if (chimera_posix_lstat(pjd_resolve(name, p, sizeof(p)), &st) != 0) {
         return -1;

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -869,7 +869,15 @@ chimera_vfs_open_cache_purge_by_mount(
                 referenced++;
             } else {
                 /* Unreferenced handles sit on pending_close awaiting the idle
-                 * sweep; umount cannot wait out that timer. */
+                 * sweep; umount cannot wait out that timer.  Both detach sites
+                 * unlink from shard->handles before setting DETACHED, so
+                 * anything still walked here is attached and every attached
+                 * handle that reaches opencnt 0 was appended to pending_close.
+                 * utlist's own assert on that is compiled out under NDEBUG,
+                 * which leaves DL_DELETE dereferencing a null head -- say so
+                 * here instead, in every build. */
+                chimera_vfs_abort_if(!shard->pending_close,
+                                     "purge_by_mount: unreferenced handle absent from pending_close");
                 DL_DELETE(shard->pending_close, handle);
                 chimera_vfs_open_cache_shard_remove(shard, handle);
                 shard->open_handles--;


### PR DESCRIPTION
The nightly's static-analysis matrix has been red for at least eight
consecutive runs. In the latest one (run 33253801823) 12 of the 24 `Analyze`
jobs fail, and between them they report five distinct findings. One is already
fixed on main; this fixes the other four.

| finding | reported by |
|---|---|
| `vfs_open_cache.h` — null deref of `pending_close` in `DL_DELETE` | rocky9/10 Release, ubuntu22/24 arm64 Release |
| `posix_lock_claims.c` — dereference of an undefined pointer | ubuntu22/24, all four cells |
| `pjd_common.h` — garbage value in `pjd_timespec_lt` | ubuntu22/24, once per pjd test dir |
| `pjd/utimensat/08.c` — garbage value in `EXPECT_EQ` | ubuntu22/24 |
| `nfs_aux_probe.c` — leak of `env.data_buf` | already fixed on main since the nightly ran |

The last two share one root cause, so the four are three commits.

**`vfs_open_cache.h`** is a true invariant rather than a live bug: both places
that set `OPEN_HANDLE_DETACHED` unlink from `shard->handles` first, so every
handle the umount purge walks is attached, and an attached handle at `opencnt
0` is on `pending_close`. Nothing states that, and utlist's own
`assert((del)->prev != NULL)` is compiled out under `NDEBUG` — which is exactly
why the rocky *Release* analyzers flag it and the *Debug* ones do not. It is
now asserted with `chimera_vfs_abort_if`, which survives `NDEBUG`.

**`posix_lock_claims.c`** has two real defects. `chimera_vfs_claim_range_replace`
is in another translation unit, so nothing visible bounds `spare_used`; if it
exceeded the two spares handed in, the two loops after it would index past
`spare_nodes[]`. The interface does fix the count (`vfs_claim.h` declares
`spare[2]`, `vfs_claim.c` guards with `n_spare < 2`), so that bound is now
named and clamped to. Separately the per-spare `calloc` was unchecked and
dereferenced on the next line; on failure it now drops what it built and skips
the carve, leaving the claim unsplit rather than dereferencing NULL.

**`pjd_common.h`** — five accessors return `-1` without touching their output
when the stat fails, and the pjd cases use non-fatal expectations, so
execution continues and the next line reads an uninitialised `struct timespec`.
Zeroing the outputs up front fixes both reported sites.

## Verification

This PR's own CI cannot confirm these fixes. The pre-merge `Analyze` jobs are
devcontainer and macOS, and both already pass; the analyzers that report these
findings — ubuntu22, ubuntu24, rocky9, rocky10 — run static analysis only in
the nightly. Apple clang 21 does not reproduce them locally either, so the
fixes are argued from the reports rather than from a local red-to-green.

A `workflow_dispatch` run of `nightly.yml` against this branch would exercise
the exact toolchains; otherwise the next scheduled nightly confirms it.

What is verified is that the changes are safe: a native macOS extended-tier run
is 1884/1888. The four failures are `libevpl/unix/bulk_stream_unix_{kqueue,
select}` and `libevpl/rpc2/conformance_STREAM_SOCKET_TCP_{kqueue,select}`,
which fail identically before this change -- `ext/libevpl` is untouched here,
so those binaries are byte-for-byte what main builds, and CI's own macOS job
runs and passes all four. They are a local macOS-native environment problem,
not a regression.

The nightly's other cluster — 5 `Test` job failures, including
`krb5i_mount_memfs_nfs3` failing on three guest variants in both Debug and
Release — is untouched here and wants its own change.
