### PR TITLE
scripts: drop the daemon and the SDK example from the coverage report

### DIFF
--- a/scripts/ci_coverage_report.py
+++ b/scripts/ci_coverage_report.py
@@ -26,11 +26,13 @@ What counts is first-party, hand-written, non-test source.  Test sources are out
 because a suite cannot meaningfully cover the other suites; generated marshallers
 and the bundled ext/ projects are out because neither is code this repository is
 asking the models to reach -- one is emitted from a .x file and the other has its
-own repository and its own tests.  The benchmark plugins (src/fio, src/elbencho)
-are out for the same reason: they are driven by fio/elbencho, not by anything a
-protocol model can emit.  etc/coverage-report.sh applies the generated and
-ext/ exclusions (COVERAGE_INCLUDE_GENERATED / COVERAGE_INCLUDE_EXT fold them
-back in); this drops the tests and the benchmark plugins.
+own repository and its own tests.  So are the parts of the first-party tree no
+model can reach: the benchmark engines (src/fio, src/elbencho) are driven by fio
+and elbencho, the daemon entry point (src/daemon) is bypassed by harnesses that
+start the server in-process, and examples/vfs_module exists to be read.
+etc/coverage-report.sh applies the generated and ext/ exclusions
+(COVERAGE_INCLUDE_GENERATED / COVERAGE_INCLUDE_EXT fold them back in); this
+drops the tests and the model-unreachable components.
 
 <build_root> is optional, and only useful alongside COVERAGE_INCLUDE_GENERATED:
 generated sources are compiled from under the build tree, which mirrors the
@@ -70,15 +72,24 @@ def component(rel):
     return parts[0]
 
 
-# Benchmark plugins (chimera's fio and elbencho engines): first-party, but not
-# core chimera -- nothing a protocol model emits can reach them, so carrying
-# them as permanent 0% rows would only obscure the components the suite is
-# accountable for.
-BENCH_PLUGINS = ("src/fio", "src/elbencho")
+# First-party code no protocol model can reach, whatever the models grow into.
+# Carrying these as permanent near-0% rows only obscures the components the
+# suite is actually accountable for.
+#
+#   src/fio, src/elbencho  the benchmark engines: driven by fio and elbencho,
+#                          not by anything a model emits.
+#   src/daemon             the daemon entry point -- argument parsing, config
+#                          load, signal handling, the run loop.  Every quint
+#                          harness starts the server in-process through the
+#                          library, so nothing here is on a model's path.
+#   examples/vfs_module    a worked example of the VFS module SDK, built to be
+#                          read and to keep the SDK honest, not to be served.
+MODEL_UNREACHABLE = ("src/fio", "src/elbencho", "src/daemon",
+                     "examples/vfs_module")
 
 
-def is_bench_plugin(rel):
-    return any(rel == p or rel.startswith(p + "/") for p in BENCH_PLUGINS)
+def is_model_unreachable(rel):
+    return any(rel == p or rel.startswith(p + "/") for p in MODEL_UNREACHABLE)
 
 
 def is_test_source(rel):
@@ -127,7 +138,7 @@ def main():
         rel = relative(os.path.realpath(entry["filename"]), (root, build_root))
         # None: compiled from outside the checkout entirely -- the container's
         # own /fio clone, say.  Not code this repository can be measured on.
-        if rel is None or is_test_source(rel) or is_bench_plugin(rel):
+        if rel is None or is_test_source(rel) or is_model_unreachable(rel):
             continue
         summary = entry.get("summary", {})
         if summary.get("lines", {}).get("count", 0) == 0:


### PR DESCRIPTION
`src/daemon` and `examples/vfs_module` are first-party, but nothing a protocol
model emits reaches either. Every quint harness starts the server in-process
through the library, so the daemon's argument parsing, config load and run loop
are never on a trace's path; the example module exists to be read and to keep
the VFS module SDK honest, not to be served. Both sat in the report as
permanent near-0% rows — noise in a table whose whole job is to show whether a
change moved a number the models are accountable for.

Same treatment, and the same list, as the benchmark engines from 62b2c3ec:
`BENCH_PLUGINS` becomes `MODEL_UNREACHABLE`, which is what the set has always
actually meant. No new mechanism.

Checked against a real `ctest -L quint` export: the `examples/vfs_module` row
(0/5 functions, 0/22 lines, 0/2 branches) drops and the table goes from 11 rows
to 10, with every other row byte-identical. The prefix match is segment-exact,
so `src/daemonize.c` and other `examples/` subdirectories are unaffected.