### PR TITLE
ci: report coverage of the lines a pull request changed

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -160,6 +160,20 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          # A pull_request checkout is the refs/pull/N/merge commit, whose
+          # first parent is the merge base -- so `git diff HEAD^1 HEAD` is
+          # exactly this PR's diff, and depth 2 is all it takes to have it.
+          # The default depth 1 has no parent at all.
+          fetch-depth: 2
+
+      # Captured on the runner rather than in the container below: the
+      # bind-mounted checkout is not owned by the container's root, so git
+      # there refuses the repository as dubiously owned (the same trap
+      # cmake/SpecsBundle.cmake documents).  -U0 keeps hunk headers to exactly
+      # the changed runs, with no context lines to subtract back out.
+      - name: Capture the pull request diff
+        if: ${{ github.event_name == 'pull_request' }}
+        run: git diff -U0 HEAD^1 HEAD > pr.diff
 
       # oras lets cmake fetch the prebuilt trace bundle for the pinned
       # ext/specs commit instead of regenerating it with quint; the image
@@ -181,11 +195,18 @@ jobs:
       - name: Build instrumented and run the quint suite
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_REPO: ${{ github.repository }}
+          # The PR head, not the merge commit: a link to a merge ref's blob
+          # dies with the ref.  Empty on a non-PR run, which only costs the
+          # uncovered lines their hyperlinks.
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
             -e RUN_URL="$RUN_URL" \
+            -e GH_REPO="$GH_REPO" \
+            -e PR_HEAD_SHA="$PR_HEAD_SHA" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
@@ -203,12 +224,28 @@ jobs:
               LLVM_PROFILE_FILE=/build/coverage/profraw/%m-%p.profraw \
                 ctest -L quint --output-on-failure --no-tests=error \
                       --test-output-size-failed 65536 --timeout 600 -j "$(nproc)"
+              # Which of the changed files are worth an lcov export; empty
+              # (or absent, on a non-PR run) means the export is skipped.
+              : > /workspace/pr-sources.txt
+              if [ -f /workspace/pr.diff ]; then
+                python3 /workspace/scripts/ci_patch_coverage.py \
+                        --sources /workspace/pr.diff \
+                        > /workspace/pr-sources.txt
+              fi
               COVERAGE_JSON=/workspace/coverage-export.json \
+              COVERAGE_LCOV=/workspace/patch-coverage.lcov \
+              COVERAGE_LCOV_SOURCES=/workspace/pr-sources.txt \
                 bash /workspace/etc/coverage-report.sh /build
               # Rendered in here, where the paths in the export still resolve.
               python3 /workspace/scripts/ci_coverage_report.py \
                       /workspace/coverage-export.json /workspace "$RUN_URL" \
-                      > /workspace/coverage-report.md'
+                      > /workspace/coverage-report.md
+              if [ -f /workspace/pr.diff ]; then
+                python3 /workspace/scripts/ci_patch_coverage.py \
+                        /workspace/pr.diff /workspace/patch-coverage.lcov \
+                        /workspace "$GH_REPO" "$PR_HEAD_SHA" \
+                        >> /workspace/coverage-report.md
+              fi'
 
       # Best-effort: a report that cannot be posted is still in the run summary,
       # and a comment API hiccup should not fail an otherwise-green job.

--- a/etc/coverage-report.sh
+++ b/etc/coverage-report.sh
@@ -80,7 +80,14 @@ echo "coverage: merging ${raw_count} raw profile(s) ..."
 # handed an object with no coverage mapping, so we must filter rather than glob.
 objs=()
 while IFS= read -r f; do
-    if readelf -SW "$f" 2>/dev/null | grep -q '__llvm_covmap'; then
+    # Deliberately not `readelf | grep -q`.  grep -q exits at its first match,
+    # readelf then dies of SIGPIPE, and `set -o pipefail` reports the pipeline
+    # as failed -- so the object is silently dropped.  Whether that happens is
+    # a race on how much readelf has already written, so the object set, and
+    # every number derived from it, varied run to run: this tree reported 3,
+    # 14 and 423 instrumented binaries on three consecutive runs.  No pipe,
+    # no race.
+    if [[ "$(readelf -SW "$f" 2>/dev/null)" == *__llvm_covmap* ]]; then
         objs+=("$f")
     fi
 done < <(find "${BUILD_DIR}" -type f \

--- a/etc/coverage-report.sh
+++ b/etc/coverage-report.sh
@@ -124,6 +124,28 @@ if [[ -n "${COVERAGE_JSON:-}" ]]; then
         -summary-only > "${COVERAGE_JSON}"
 fi
 
+# Per-line hit counts for a named handful of sources, as an lcov tracefile.
+# This is the full (non-summary) export, which is why it is restricted: over the
+# whole tree it runs to hundreds of megabytes, but over the files one pull
+# request touched it is tens of kilobytes.  scripts/ci_patch_coverage.py reads
+# it to say which of the lines a PR changed were actually executed.
+#
+# Emitted here rather than from a second llvm-cov invocation elsewhere because
+# collecting the instrumented objects above means readelf'ing every binary in
+# the build tree, which costs more than the export itself.
+#
+# An empty source list means "no sources to measure" and must NOT fall through
+# to a bare `export`: llvm-cov would then happily export the entire tree.
+if [[ -n "${COVERAGE_LCOV:-}" && -s "${COVERAGE_LCOV_SOURCES:-/dev/null}" ]]; then
+    mapfile -t lcov_sources < "${COVERAGE_LCOV_SOURCES}"
+    echo
+    echo "coverage: exporting ${#lcov_sources[@]} source(s) to ${COVERAGE_LCOV} ..."
+    "${COV_TOOL}" export "${objs[0]}" "${object_args[@]}" \
+        -instr-profile="${PROFDATA}" \
+        -ignore-filename-regex="${IGNORE_REGEX}" \
+        --format=lcov --sources "${lcov_sources[@]}" > "${COVERAGE_LCOV}"
+fi
+
 if [[ "${COVERAGE_HTML:-0}" == "1" ]]; then
     HTML_DIR="${COV_DIR}/html"
     echo

--- a/scripts/ci_patch_coverage.py
+++ b/scripts/ci_patch_coverage.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+"""Report how much of what a pull request changed the model suites executed.
+
+Two modes, because the llvm-cov export in between needs to know which files to
+bother with:
+
+    ci_patch_coverage.py --sources <diff>
+        Print the repo-relative paths worth measuring, one per line, for
+        COVERAGE_LCOV_SOURCES.  Empty output means the PR touched no measurable
+        source, and etc/coverage-report.sh then skips the export entirely.
+
+    ci_patch_coverage.py <diff> <lcov> <repo_root> [<repo> <sha>]
+        Render the markdown section.  <repo>/<sha> are optional and only make
+        the uncovered lines clickable.
+
+The overall table answers "how much of chimera do the models reach".  This
+answers "how much of what this PR wrote did they reach", which is the question a
+reviewer actually has and the one the aggregate cannot show: a 300-line addition
+that nothing executes moves the total by a fraction of a point.
+
+Line counts come from `llvm-cov export --format=lcov`, whose DA records give a
+hit count per instrumented line.  A changed line with no DA record is not
+executable -- a declaration, a brace, a comment, a blank -- and is left out of
+the denominator rather than counted as a miss.  Only added and modified lines
+count; deleting code is not a coverage regression.
+
+The exclusions are imported rather than restated.  A patch number computed over
+a different set of files than the aggregate would be a second number in the same
+comment quietly meaning something else.
+"""
+import collections
+import os
+import re
+import sys
+
+from ci_coverage_report import is_model_unreachable, is_test_source
+
+# Sources llvm-cov can have line counts for.  chimera is C; anything else in a
+# diff (CMake, YAML, .qnt models, documentation) has no coverage to report and
+# only lengthens the export command.
+MEASURABLE_SUFFIXES = (".c", ".h")
+
+# Enough uncovered lines to point a reviewer at the gap; past that the list
+# stops being read and the file-level percentage is the signal.
+MAX_UNCOVERED_RUNS = 12
+
+BAR_WIDTH = 10
+
+
+def measurable(rel):
+    return (rel.endswith(MEASURABLE_SUFFIXES)
+            and not is_test_source(rel)
+            and not is_model_unreachable(rel))
+
+
+def changed_lines(diff_path):
+    """{path: set(line)} -- lines a diff adds or modifies, on the new side.
+
+    Reads `git diff -U0`, so each hunk header names exactly the changed run
+    with no context lines to subtract back out.
+    """
+    changed, cur = collections.defaultdict(set), None
+    with open(diff_path, errors="replace") as f:
+        for line in f:
+            if line.startswith("+++ b/"):
+                cur = line[6:].strip()
+            elif line.startswith("+++ /dev/null"):
+                cur = None                      # deletion; nothing to cover
+            elif line.startswith("@@") and cur:
+                m = re.match(r"@@ -\S+ \+(\d+)(?:,(\d+))? @@", line)
+                if m:
+                    start, count = int(m.group(1)), int(m.group(2) or 1)
+                    # count 0 is a pure deletion hunk: no new-side lines.
+                    changed[cur].update(range(start, start + count))
+    return changed
+
+
+def lcov_hits(lcov_path, root):
+    """{path: {line: hits}} from an lcov tracefile, paths relative to root."""
+    hits, cur = collections.defaultdict(dict), None
+    with open(lcov_path, errors="replace") as f:
+        for line in f:
+            if line.startswith("SF:"):
+                path = os.path.realpath(line[3:].strip())
+                rel = os.path.relpath(path, root)
+                cur = None if rel.startswith("..") else rel
+            elif line.startswith("DA:") and cur is not None:
+                num, _, rest = line[3:].strip().partition(",")
+                count = int(rest.split(",")[0])
+                # One line can carry several regions (a && b, a macro); it ran
+                # if any of them did.
+                prev = hits[cur].get(int(num))
+                hits[cur][int(num)] = count if prev is None else max(prev, count)
+    return hits
+
+
+def runs(numbers):
+    """[1,2,3,7,8] -> [(1,3),(7,8)] -- consecutive lines as ranges."""
+    out = []
+    for n in sorted(numbers):
+        if out and n == out[-1][1] + 1:
+            out[-1][1] = n
+        else:
+            out.append([n, n])
+    return [tuple(r) for r in out]
+
+
+def bar(covered, total):
+    filled = int(round(BAR_WIDTH * covered / total))
+    return "`" + "█" * filled + "░" * (BAR_WIDTH - filled) + "`"
+
+
+def link(repo, sha, rel, lo, hi):
+    text = f"{lo}" if lo == hi else f"{lo}–{hi}"
+    if not (repo and sha):
+        return text
+    frag = f"#L{lo}" if lo == hi else f"#L{lo}-L{hi}"
+    return f"[{text}](https://github.com/{repo}/blob/{sha}/{rel}{frag})"
+
+
+def main():
+    if sys.argv[1:2] == ["--sources"]:
+        for rel in sorted(changed_lines(sys.argv[2])):
+            if measurable(rel):
+                print(rel)
+        return
+
+    diff_path, lcov_path = sys.argv[1], sys.argv[2]
+    root = os.path.realpath(sys.argv[3])
+    repo = sys.argv[4] if len(sys.argv) > 4 else ""
+    sha = sys.argv[5] if len(sys.argv) > 5 else ""
+
+    changed = {rel: lines for rel, lines in changed_lines(diff_path).items()
+               if measurable(rel)}
+    out = ["", "### Coverage of this pull request's changes", ""]
+
+    if not changed:
+        print("\n".join(out + ["This pull request changes no instrumented "
+                               "source, so there is nothing to measure."]))
+        return
+
+    # No lcov at all means the export was skipped or failed.  Say which, rather
+    # than render 0% and let it read as a coverage collapse.
+    if not os.path.exists(lcov_path):
+        print("\n".join(out + [
+            f"{len(changed)} changed source file(s), but no coverage export to "
+            "measure them against — treat this as a broken report, not as 0%."]))
+        return
+
+    hits = lcov_hits(lcov_path, root)
+
+    rows, uncovered, tot_cov, tot_exec = [], [], 0, 0
+    for rel in sorted(changed):
+        file_hits = hits.get(rel, {})
+        executable = sorted(changed[rel] & file_hits.keys())
+        if not executable:
+            # Instrumented file, but the change was to comments, declarations
+            # or whitespace.  A row saying 0/0 would read as a miss.
+            rows.append((rel, None, None))
+            continue
+        missed = [n for n in executable if file_hits[n] == 0]
+        covered = len(executable) - len(missed)
+        tot_cov += covered
+        tot_exec += len(executable)
+        rows.append((rel, covered, len(executable)))
+        if missed:
+            uncovered.append((rel, runs(missed)))
+
+    if not tot_exec:
+        print("\n".join(out + ["This pull request changes no executable lines "
+                               "(comments, declarations or build files only)."]))
+        return
+
+    out += [f"**{bar(tot_cov, tot_exec)} {100.0 * tot_cov / tot_exec:.0f}% "
+            f"({tot_cov:,}/{tot_exec:,} changed lines executed)**", "",
+            "| File | Changed lines executed |", "|---|---|"]
+    for rel, covered, total in rows:
+        if total is None:
+            out.append(f"| `{rel}` | no executable lines changed |")
+        else:
+            out.append(f"| `{rel}` | {bar(covered, total)} "
+                       f"{100.0 * covered / total:.0f}% ({covered}/{total}) |")
+
+    if uncovered:
+        shown = 0
+        items = []
+        for rel, spans in uncovered:
+            take = spans[:max(0, MAX_UNCOVERED_RUNS - shown)]
+            if not take:
+                break
+            shown += len(take)
+            items.append("`" + rel + "` "
+                         + ", ".join(link(repo, sha, rel, lo, hi)
+                                     for lo, hi in take))
+        total_runs = sum(len(s) for _, s in uncovered)
+        more = (f" …and {total_runs - shown} more"
+                if total_runs > shown else "")
+        out += ["", "Changed lines the model suites never executed: "
+                + "; ".join(items) + more + "."]
+
+    out += ["", "<sub>Executed by the quint model suites only "
+            "(`ctest -L quint`) — code reached solely by the other suites "
+            "counts as unexecuted here. Lines with no coverage mapping "
+            "(declarations, braces, comments) are excluded rather than counted "
+            "as misses.</sub>"]
+    print("\n".join(out))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked on #1578 (shares `scripts/ci_coverage_report.py`; rebases to a single
commit pair once that merges).

The coverage comment answers *"how much of chimera do the models reach"*. It
cannot answer *"how much of what this PR wrote did they reach"* — and that's the
question a reviewer actually has. A 300-line addition that nothing executes
moves the aggregate by a fraction of a point and looks like noise.

So the comment grows a second section, from the same run and the same profile
data. Reports only — no gate. An uncovered error path is often the right answer,
and that's a judgement for the reviewer, not a threshold.

## What it looks like

Real output, generated against this branch's own pNFS PR (#1569) using its
actual profdata:

### Coverage of this pull request's changes

**`██████░░░░` 59% (47/80 changed lines executed)**

| File | Changed lines executed |
|---|---|
| `src/server/nfs/nfs.c` | `██████████` 100% (2/2) |
| `src/server/nfs/nfs4_pnfs.c` | `█████░░░░░` 54% (39/72) |
| `src/vfs/diskfs/diskfs_attr.c` | `██████████` 100% (1/1) |
| `src/vfs/nfs/nfs.c` | `██████████` 100% (5/5) |

Changed lines the model suites never executed: `src/server/nfs/nfs4_pnfs.c`
843–845, 1240–1241, 1296–1299, 1305–1313, 1359–1362, 1367–1377.

Those land exactly on the `error_code != CHIMERA_VFS_OK` bailouts of that PR's
new LAYOUTCOMMIT chain — which is the point. In the comment they're blob links.

## How

- **`coverage-report.sh`** gains `COVERAGE_LCOV` / `COVERAGE_LCOV_SOURCES`: a
  second `llvm-cov export --format=lcov` restricted to named sources. It's the
  full per-line export, which is why it's restricted — whole-tree that's the
  hundreds of megabytes the existing comment warns about; over the four files a
  PR touched it's **70 KB and a few seconds**. Emitted there rather than from a
  separate invocation because collecting the instrumented objects means
  `readelf`ing the whole build tree, which costs more than the export itself.
  An empty source list skips the export rather than falling through to a bare
  `export` of everything.

- **`ci_patch_coverage.py`** intersects `git diff -U0` hunks with the lcov `DA`
  records. A changed line with no `DA` record isn't executable — a declaration,
  a brace, a comment — and leaves the denominator rather than counting as a
  miss. Only the new side counts; deleting code isn't a coverage regression. It
  *imports* the report's exclusions rather than restating them, so both numbers
  in one comment cover the same file set.

- **`pr-checks.yml`** captures the diff on the runner (git inside the container
  refuses the bind-mounted checkout as dubiously owned — the trap
  `cmake/SpecsBundle.cmake` already documents) and needs `fetch-depth: 2`: a
  `pull_request` checkout is the `refs/pull/N/merge` commit whose first parent
  is the merge base, so `git diff HEAD^1 HEAD` is exactly this PR. No full-history
  fetch.

Unlike [GitHub's own coverage feature](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage)
this works on **pull requests from forks**, which is 15 of the 18 currently
open. That feature also needs Team/Enterprise Cloud (this org is on `free`),
accepts only Cobertura (llvm-cov exports text/html/lcov), and reports line
coverage only.

## The first commit is a bug fix you'll want regardless

`coverage-report.sh` runs under `set -o pipefail` and probed each binary with
`readelf -SW "$f" | grep -q __llvm_covmap`. `grep -q` exits at its first match,
`readelf` then dies of SIGPIPE, and pipefail reports the pipeline as failed — so
the object was dropped. Whether that happened was a race on how much `readelf`
had written.

Three consecutive runs over one unchanged build tree collected **3, 14 and 423**
instrumented binaries, out of 423 that carry a coverage mapping. Every number
the report has produced was computed over whichever subset survived the race
that time. It's why the empty patch export was the first thing I hit building
this, and why the aggregate has been quietly unreproducible.

## Verified

Each path exercised against real profdata from a `ctest -L quint` run: a PR
touching instrumented sources (above), one touching only `scripts/` ("changes no
instrumented source"), one touching only lines with no coverage mapping
("changes no executable lines"), a missing export (says the report is broken
rather than rendering 0%), and a file deletion (not attributed). Uncovered lines
cross-checked against `llvm-cov show` — 1240–1243 and 1296–1299 are count 0,
1237 is 120, and blank 1238 correctly carries no record.
