### PR TITLE
nfs: verify the krb5i integrity MIC without copying the payload

### DIFF
--- a/src/server/nfs/nfs_gss.c
+++ b/src/server/nfs/nfs_gss.c
@@ -7,7 +7,17 @@
 #include <pwd.h>
 #include <gssapi/gssapi.h>
 #include <gssapi/gssapi_krb5.h>
+/* The IOV extension carries gss_verify_mic_iov, which lets krb5i check the
+ * integrity databody where it already lies in the receive buffers instead of
+ * gathering the whole call -- WRITE payload included -- into one block.
+ * Absent it, the provider leaves verify_mic_iov NULL and rpc2 gathers. */
+#if defined(__has_include)
+#if __has_include(<gssapi/gssapi_ext.h>)
+#include <gssapi/gssapi_ext.h>
+#endif /* __has_include(<gssapi/gssapi_ext.h>) */
+#endif /* defined(__has_include) */
 
+#include "evpl/evpl.h"          /* struct evpl_iovec, for verify_mic_iov */
 #include "nfs_gss.h"
 #include "nfs_internal.h"
 #include "vfs/sdk/vfs_cred.h"
@@ -148,6 +158,57 @@ chimera_nfs_gss_verify_mic(
     return GSS_ERROR(major) ? -1 : 0;
 } /* chimera_nfs_gss_verify_mic */
 
+#ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN
+/* Number of iovecs verified without touching the heap.  A received RPC is a
+ * handful of segments; the malloc path is there for correctness, not speed. */
+#define CHIMERA_GSS_IOV_STACK 16
+
+static int
+chimera_nfs_gss_verify_mic_iov(
+    void                    *arg,
+    void                    *gss_ctx,
+    const struct evpl_iovec *iov,
+    int                      niov,
+    const void              *mic,
+    size_t                   mic_len)
+{
+    OM_uint32            major, minor;
+    gss_qop_t            qop;
+    gss_iov_buffer_desc  stack_biov[CHIMERA_GSS_IOV_STACK];
+    gss_iov_buffer_desc *biov = stack_biov;
+    int                  i, n  = niov + 1;
+    int                  rc;
+
+    (void) arg;
+
+    if (n > CHIMERA_GSS_IOV_STACK) {
+        biov = calloc(n, sizeof(*biov));
+        if (!biov) {
+            return -1;
+        }
+    }
+
+    for (i = 0; i < niov; i++) {
+        biov[i].type          = GSS_IOV_BUFFER_TYPE_DATA;
+        biov[i].buffer.length = iov[i].length;
+        biov[i].buffer.value  = iov[i].data;
+    }
+
+    biov[niov].type          = GSS_IOV_BUFFER_TYPE_MIC_TOKEN;
+    biov[niov].buffer.length = mic_len;
+    biov[niov].buffer.value  = (void *) mic;
+
+    major = gss_verify_mic_iov(&minor, (gss_ctx_id_t) gss_ctx, &qop, biov, n);
+    rc    = GSS_ERROR(major) ? -1 : 0;
+
+    if (biov != stack_biov) {
+        free(biov);
+    }
+
+    return rc;
+} /* chimera_nfs_gss_verify_mic_iov */
+#endif /* GSS_IOV_BUFFER_TYPE_MIC_TOKEN */
+
 static int
 chimera_nfs_gss_wrap(
     void       *arg,
@@ -238,9 +299,12 @@ const struct evpl_rpc2_gss_provider chimera_nfs_gss_provider = {
     .accept     = chimera_nfs_gss_accept,
     .get_mic    = chimera_nfs_gss_get_mic,
     .verify_mic = chimera_nfs_gss_verify_mic,
-    .wrap       = chimera_nfs_gss_wrap,
-    .unwrap     = chimera_nfs_gss_unwrap,
-    .destroy    = chimera_nfs_gss_destroy,
+#ifdef GSS_IOV_BUFFER_TYPE_MIC_TOKEN
+    .verify_mic_iov = chimera_nfs_gss_verify_mic_iov,
+#endif /* GSS_IOV_BUFFER_TYPE_MIC_TOKEN */
+    .wrap    = chimera_nfs_gss_wrap,
+    .unwrap  = chimera_nfs_gss_unwrap,
+    .destroy = chimera_nfs_gss_destroy,
 };
 
 int


### PR DESCRIPTION
Chimera advertises `wtmax`/`wtpref` of 1 MiB (`nfs3_proc_fsinfo.c:24`) and then
rejects any krb5i request whose integrity databody exceeds 128 KiB. That is
what has been failing in the nightly for over a week:
`krb5i_mount_memfs_nfs3` fails on ubuntu2404, ubuntu2404_hwe and ubuntu2204_hwe
in both Debug and Release, while plain `krb5` passes everywhere.

The workload is `dd if=/dev/zero of=/mnt/d/big bs=4k count=64` — a 256 KiB file
that the Linux client flushes as one wsize-sized WRITE. Under RPCSEC_GSS
integrity the databody wraps the *whole* call arguments, payload included, so
the server sees a 256 KiB databody (`reqlen=262240`) and libevpl's unwrap tries
to gather it into the 128 KiB per-message `xdr_dbuf`. `xdr_dbuf_alloc_space`
returns NULL rather than growing, on a path with no debug log of its own, so it
surfaces only as `rpcsec_gss: integrity UNWRAP failed` and a GARBAGE_ARGS reply.

The arena is the wrong home for that body regardless of size — it is scratch
for the small odds and ends of encode/decode. chimera-nas/libevpl#142 stops
gathering: it verifies the MIC over a ref-counted view of the receive buffers
and trims that view past the embedded seq to produce the inner arguments, which
removes both payload copies the integrity path was doing per request.

This side implements the `verify_mic_iov` entry point that requires, with
`gss_verify_mic_iov`. The IOV entry points are a MIT krb5 extension, so the
include and the vtable entry are guarded; on a GSSAPI without them the provider
leaves the hook NULL and libevpl falls back to gathering.

## libevpl pin

chimera-nas/libevpl#142 is merged; `ext/libevpl` is pinned to the libevpl-main
commit `21df5cd`, so CI can resolve it. The landed content is byte-identical to
what was built and tested here.

## CI shard

No merge-queue category selected the kerberos tests: `unit` excludes everything
labelled `kvm`, and the `kvm-*` shards match `/cthon/`, `/xfstests/`, `pnfs`,
`/nfstest/` and `/ltp/`. They ran only in the nightly, which is how this stayed
broken for a week without blocking a merge. A `kvm-kerberos` shard is added on
the same pattern, so the fix is verified pre-merge rather than a day later.

## Verification

Not reproducible locally: no kerberos or GSS test registers on macOS
(`ctest -R "krb|gss|kerberos"` selects nothing), so this is verified by
inspection plus a clean build, and by the new shard once the pin is real. The
guard is confirmed to compile in here — `nm` shows `chimera_nfs_gss_verify_mic_iov`
defined and `gss_verify_mic_iov` referenced against Homebrew MIT krb5.
