### PR TITLE
tests/quint: name the position when an MBT harness hangs

### DIFF
--- a/src/common/mbt_watchdog.h
+++ b/src/common/mbt_watchdog.h
@@ -1,0 +1,124 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Deadlock backstop for the quint MBT harnesses, with the context intact.
+ *
+ * Every harness runs the whole stack -- server, client and the model oracle
+ * -- in one process, so a server deadlock leaves the driver spinning in its
+ * reply wait forever rather than failing.  Each one therefore arms an alarm
+ * as a backstop.  Left at SIGALRM's default disposition that turns a hang
+ * into a bare "SIGALRM" and nothing else: the harness dies with its stdout
+ * still sitting in a block buffer (stdout is a pipe under ctest, not a tty),
+ * so the per-trace progress it printed on the way in is discarded along with
+ * it.  Three separate CI hangs of nfsaux/batch_memfs reported exactly that
+ * and no more, which is not enough to act on.
+ *
+ * Arming through this header keeps the backstop and the context: stdout is
+ * switched to line buffering so whatever the harness already printed has
+ * escaped, and the handler names the position the alarm caught -- trace and
+ * step where the caller tracks one -- before letting the default disposition
+ * kill the process, so ctest still reports the failure as SIGALRM.
+ *
+ * The handler touches nothing but write(2) and its own sig_atomic_t state.
+ */
+
+#ifndef CHIMERA_MBT_WATCHDOG_H
+#define CHIMERA_MBT_WATCHDOG_H
+
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Position the alarm would report, published by the driver as it advances.
+ * The trace and tag are string literals or long-lived buffers owned by the
+ * caller; the handler only ever reads them. */
+static const char *volatile  mbt_watchdog_trace = NULL;
+static const char *volatile  mbt_watchdog_tag   = NULL;
+static volatile sig_atomic_t mbt_watchdog_step  = -1;
+
+static inline void
+mbt_watchdog_write(const char *s)
+{
+    if (s) {
+        ssize_t rc = write(STDERR_FILENO, s, strlen(s));
+
+        (void) rc;
+    }
+} /* mbt_watchdog_write */
+
+/* Decimal conversion done by hand: snprintf is not async-signal-safe. */
+static inline void
+mbt_watchdog_write_int(long v)
+{
+    char buf[24];
+    int  i = (int) sizeof(buf);
+
+    if (v < 0) {
+        mbt_watchdog_write("?");
+        return;
+    }
+    buf[--i] = '\0';
+    do {
+        buf[--i] = (char) ('0' + (v % 10));
+        v       /= 10;
+    } while (v && i > 0);
+    mbt_watchdog_write(&buf[i]);
+} /* mbt_watchdog_write_int */
+
+static inline void
+mbt_watchdog_on_alarm(int sig)
+{
+    mbt_watchdog_write("\n*** MBT WATCHDOG: no progress before the alarm; the "
+                       "stack is wedged ***\n  trace: ");
+    mbt_watchdog_write(mbt_watchdog_trace ? mbt_watchdog_trace : "(none)");
+    mbt_watchdog_write("\n  step:  ");
+    mbt_watchdog_write_int((long) mbt_watchdog_step);
+    mbt_watchdog_write(" (");
+    mbt_watchdog_write(mbt_watchdog_tag ? mbt_watchdog_tag : "(none)");
+    mbt_watchdog_write(")\n");
+
+    /* Die by SIGALRM after all, so ctest still reports it as such. */
+    signal(sig, SIG_DFL);
+    raise(sig);
+} /* mbt_watchdog_on_alarm */
+
+/*
+ * Arm the backstop for `seconds`.  Idempotent with respect to the handler and
+ * the buffering mode, so the per-trace callers can re-arm freely.
+ */
+static inline void
+mbt_watchdog_arm(unsigned int seconds)
+{
+    static int installed = 0;
+
+    if (!installed) {
+        /* Line buffering so the progress printed before a hang survives it. */
+        setvbuf(stdout, NULL, _IOLBF, 0);
+        signal(SIGALRM, mbt_watchdog_on_alarm);
+        installed = 1;
+    }
+    alarm(seconds);
+} /* mbt_watchdog_arm */
+
+/* Publish the position the watchdog should name if it fires. */
+static inline void
+mbt_watchdog_at(
+    const char *trace,
+    int         step,
+    const char *tag)
+{
+    mbt_watchdog_trace = trace;
+    mbt_watchdog_step  = step;
+    mbt_watchdog_tag   = tag;
+} /* mbt_watchdog_at */
+
+static inline void
+mbt_watchdog_disarm(void)
+{
+    alarm(0);
+    mbt_watchdog_at(NULL, -1, NULL);
+} /* mbt_watchdog_disarm */
+
+#endif /* CHIMERA_MBT_WATCHDOG_H */

--- a/src/server/nfs/tests/quint/nfs3_mbt_probe.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_probe.c
@@ -29,6 +29,7 @@
  */
 
 #include "nfs3_mbt_common.h"
+#include "common/mbt_watchdog.h"
 
 static int failures = 0;
 
@@ -113,7 +114,7 @@ main(
     }
 
     /* A deadlock regression would hang a call forever; die loudly. */
-    alarm(60);
+    mbt_watchdog_arm(60);
 
     memset(&opts, 0, sizeof(opts));
     opts.module = backend;

--- a/src/server/nfs/tests/quint/nfs3_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_replay.c
@@ -34,6 +34,7 @@
 
 #include "nfs3_mbt_common.h"
 #include "common/mbt_trace_dir.h"
+#include "common/mbt_watchdog.h"
 
 #define MBT_MAX_FIDS           16384
 #define MBT_MAX_MISM           16
@@ -1586,7 +1587,7 @@ run_trace(
     /* Backstop for a server deadlock: with everything in one process a
      * hung reply spins in mbt_call_wait forever; SIGALRM's default
      * disposition kills the test with a nonzero status. */
-    alarm(120);
+    mbt_watchdog_arm(120);
 
     o = calloc(1, sizeof(*o));
     mbt_env_fs_setup(env, fsname);
@@ -1636,6 +1637,7 @@ run_trace(
         }
 
         memset(&m, 0, sizeof(m));
+        mbt_watchdog_at(trace_path, (int) idx, tag);
         mbt_set_cred(env, op);
         fn(o, op, fs, &m);
         history_push(o, (int) idx, tag, op, env->res.status);
@@ -1674,7 +1676,7 @@ run_trace(
     free(o->scratch);
     free(o);
     json_decref(root);
-    alarm(0);
+    mbt_watchdog_disarm();
     return failed;
 } /* run_trace */
 

--- a/src/server/nfs/tests/quint/nfs4_deleg_probe.c
+++ b/src/server/nfs/tests/quint/nfs4_deleg_probe.c
@@ -32,6 +32,7 @@
  */
 
 #include "nfs3_mbt_common.h"
+#include "common/mbt_watchdog.h"
 
 #define P_DELAY      10008
 #define P_BLOCK      8192
@@ -508,7 +509,7 @@ main(void)
     int                 i;
 
     setvbuf(stdout, NULL, _IONBF, 0);
-    alarm(60);
+    mbt_watchdog_arm(60);
     mbt_env_start_opts(env, &opts);
     env->nfs_v4_cb.recv_call_CB_COMPOUND = pc_cb_compound;
 

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -36,6 +36,7 @@
 
 #include "nfs3_mbt_common.h"
 #include "common/mbt_trace_dir.h"
+#include "common/mbt_watchdog.h"
 
 #define V4_BLOCK_SIZE       8192
 #define V4_LOCK_BYTES       8
@@ -4075,7 +4076,7 @@ run_trace(
         return 0;
     }
 
-    alarm(150);
+    mbt_watchdog_arm(150);
 
     o = calloc(1, sizeof(*o));
 
@@ -4161,6 +4162,9 @@ run_trace(
         }
         lab = jf_val(lastop);
 
+        /* The v4 step label is the whole compound object, not a tag, so
+         * the trace and step index are what name the position. */
+        mbt_watchdog_at(trace_path, (int) idx, "compound");
         memset(&m, 0, sizeof(m));
         run_compound(o, (int) idx, lab, &m);
         if (o->skip) {
@@ -4216,7 +4220,7 @@ run_trace(
     free(o->scratch);
     free(o);
     json_decref(root);
-    alarm(0);
+    mbt_watchdog_disarm();
     return failed;
 } /* run_trace */
 

--- a/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
@@ -37,6 +37,7 @@
 #include <jansson.h>
 
 #include "nfs_aux_mbt_common.h"
+#include "common/mbt_watchdog.h"
 #include "common/mbt_trace_dir.h"
 
 #define AUX_MAX_MISM     16
@@ -1615,9 +1616,11 @@ run_trace(
     }
 
     /* Backstop for a server deadlock: with everything in one process a hung
-     * reply spins in mbt_call_wait forever; SIGALRM's default disposition
-     * kills the test with a nonzero status. */
-    alarm(180);
+     * reply spins in mbt_call_wait forever.  The watchdog names the trace and
+     * step it caught before letting SIGALRM kill the test, so a hang in CI
+     * arrives with the position attached rather than as a bare signal. */
+    mbt_watchdog_arm(180);
+    mbt_watchdog_at(trace_path, -1, "setup");
 
     o = calloc(1, sizeof(*o));
     /* The aux harness asserts against a fixed "/share" export -- its MNT
@@ -1657,6 +1660,7 @@ run_trace(
         /* The asynchronous log is cleared once per step, here rather than in
          * each handler, so every op is judged only on what its own call
          * provoked. */
+        mbt_watchdog_at(trace_path, (int) idx, tag);
         mbt_aux_async_reset(env);
         fn(o, op, &m);
         if (!m.n && paranoid) {
@@ -1683,7 +1687,7 @@ run_trace(
     }
     free(o);
     json_decref(root);
-    alarm(0);
+    mbt_watchdog_disarm();
     return failed;
 } /* run_trace */
 

--- a/src/server/nfs/tests/quint/nfs_aux_probe.c
+++ b/src/server/nfs/tests/quint/nfs_aux_probe.c
@@ -27,6 +27,7 @@
 #include <getopt.h>
 
 #include "nfs_aux_mbt_common.h"
+#include "common/mbt_watchdog.h"
 
 #define PROBE_EXPORT     "/share"
 #define PROBE_EXPORT2    "/share2"
@@ -750,7 +751,7 @@ main(
 
     /* A hung reply spins forever inside mbt_call_wait with everything in one
      * process; SIGALRM's default disposition turns that into a test failure. */
-    alarm(180);
+    mbt_watchdog_arm(180);
 
     mbt_aux_env_open(&env, &opts);
     /* The aux harness asserts against a fixed "/share" export -- its MNT
@@ -782,7 +783,7 @@ main(
     chimera_server_remove_export(env.server, PROBE_EXPORT2);
     mbt_env_fs_teardown_as(&env, "fs0", "share");
     mbt_env_stop(&env);
-    alarm(0);
+    mbt_watchdog_disarm();
 
     if (failures) {
         fprintf(stderr, "\n%d aux probe expectation(s) failed\n", failures);

--- a/src/server/s3/tests/quint/s3_mbt_probe.c
+++ b/src/server/s3/tests/quint/s3_mbt_probe.c
@@ -11,6 +11,7 @@
  * if a deviation's shape drifts.  Needs no trace corpus. */
 
 #include "s3_mbt_common.h"
+#include "common/mbt_watchdog.h"
 
 static int failures;
 
@@ -100,7 +101,7 @@ main(
     (void) argc;
     (void) argv;
 
-    alarm(120);
+    mbt_watchdog_arm(120);
 
     s3_mbt_env_open(&env);
     s3_mbt_env_fs_setup(&env, "fs0");

--- a/src/server/s3/tests/quint/s3_mbt_replay.c
+++ b/src/server/s3/tests/quint/s3_mbt_replay.c
@@ -36,6 +36,7 @@
 
 #include "s3_mbt_common.h"
 #include "common/mbt_trace_dir.h"
+#include "common/mbt_watchdog.h"
 
 #define MBT_MAX_MISM   16
 #define MBT_MISM_LEN   512
@@ -2499,7 +2500,7 @@ run_trace(
     /* Everything runs in one process, so a request the server never answers
      * would spin in s3_mbt_call forever; SIGALRM's default disposition kills
      * the test with the trace name already printed. */
-    alarm(120);
+    mbt_watchdog_arm(120);
 
     if (verbose) {
         printf("%s: %zu steps\n", trace_path, nstates - 1);
@@ -2540,6 +2541,7 @@ run_trace(
             break;
         }
 
+        mbt_watchdog_at(trace_path, (int) idx, tag);
         memset(&m, 0, sizeof(m));
         fn(o, op, post_bkts, &m);
         history_push(o, (int) idx, tag, env->res.status, op);
@@ -2582,7 +2584,7 @@ run_trace(
     free(o->xml_buf);
     free(o);
     json_decref(trace);
-    alarm(0);
+    mbt_watchdog_disarm();
 
     return rc;
 } /* run_trace */


### PR DESCRIPTION
`chimera/server/nfs/mbtaux/batch_memfs` has now hung three times in CI — the
2026-08-29 nightly (arm64 Debug), #1580's queue run (arm64 Release) and #1574's
(amd64 Release) — and each time the entire report was the word `SIGALRM`:

```
26/26 Test #9: chimera/server/nfs/mbtaux/batch_memfs ...SIGALRM***Exception: 188.09 sec
```

No trace, no step, not even how far the run got. There is nothing in that to
act on, and with the quick tier now gating merges on every OS these hangs eject
unrelated PRs.

## Why nothing survives

Every quint harness runs server, client and model oracle in one process, so a
server deadlock leaves the driver spinning in its reply wait rather than
failing. Each arms `alarm()` as a backstop — at SIGALRM's **default
disposition**. Nothing sets buffering either, and under ctest stdout is a pipe,
so it is block-buffered: when the alarm kills the process, every `N steps
replayed` line it had printed dies in the buffer with it.

Eight harnesses share that pattern; only two set buffering at all.

## What changes

`src/common/mbt_watchdog.h` arms the same backstop but keeps the context:

- stdout switched to line buffering, so progress already printed has escaped;
- a handler that names the position the alarm caught — trace and step, which
  the driver publishes as it advances — then restores the default disposition
  and re-raises, so **ctest still reports the failure as SIGALRM exactly as
  before**;
- the handler touches nothing but `write(2)` and its own `sig_atomic_t` state,
  with the decimal conversion open-coded because `snprintf` is not
  async-signal-safe.

All eight harnesses arm through it; the four replayers publish trace and step
per operation. The v4 replayer's step label is a whole compound object rather
than a tag, so there the trace and index name the position.

Verified by shortening the alarm — it prints

```
*** MBT WATCHDOG: no progress before the alarm; the stack is wedged ***
  trace: .../nfsaux/stepAsync_150_0x4_0.itf.json
  step:  72 (ONlmGranted)
```

and still exits 142, and a normal run is unaffected (all 42 nfsaux traces
complete, every progress line present).

**This fixes no hang.** It makes the next one diagnosable, for every MBT
harness rather than just the one currently misbehaving.

## Note on the underlying bug

#1580's occurrence failed with a model divergence *before* it hung on rerun:
`stepShare_150_0x6_1.itf.json` step 104, an NLM lock denied (`got 1, want 0`)
after `ONlmFreeAll` should have released the conflicting holder. That is the
same shape as the NFSv4 `optest05_023` failure that ejected #1574 earlier — a
release acknowledged while a conflicting claim survives. Both are unfixed and
neither is diagnosed; this change is the prerequisite for doing so.
