### PR TITLE
vfs/claim: decide a cancel without waiting out the backend confirm

### DIFF
--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -429,10 +429,41 @@ chimera_nfs_nlm4_lock_acquire_cb(
     res.cookie.data = ctx->cookie.data;
 
     if (result == CHIMERA_CLAIM_GRANTED) {
+        bool reaped;
+
         pthread_mutex_lock(&shared->nlm_state.mutex);
-        entry->pending        = false;
-        entry->claim_inserted = true;
+        reaped = entry->reaped;
+        if (reaped) {
+            /* The client was reaped (FREE_ALL, SM_NOTIFY, or its last
+             * connection dropped) while this acquire was in flight, and the
+             * reaper could not claim the ticket, so it left the entry to us.
+             * Granting now would hand a lock to a client we have already
+             * told holds none -- drop it instead.  Still linked, so unlink
+             * under the same mutex the reaper used. */
+            DL_DELETE(ctx->client->locks, entry);
+        } else {
+            entry->pending        = false;
+            entry->claim_inserted = true;
+        }
         pthread_mutex_unlock(&shared->nlm_state.mutex);
+
+        if (reaped) {
+            chimera_nfs_debug(
+                "NLM LOCK: grant landed for reaped client '%s'; releasing",
+                ctx->client->hostname);
+            chimera_vfs_claim_release(vfs_state, entry->file_state,
+                                      &entry->claim);
+            chimera_vfs_state_put(vfs_state, entry->file_state);
+            entry->file_state = NULL;
+            chimera_vfs_release(thread->vfs_thread, entry->handle);
+            nlm_lock_entry_free(entry);
+            /* The original LOCK RPC was already answered with NLM4_BLOCKED
+             * (only blocked entries can still be pending here), so no reply
+             * is owed and no NLM_GRANTED callback is wanted. */
+            free(ctx);
+            return;
+        }
+
         res.stat = NLM4_GRANTED;
 
         /* Monitor the lock holder so we can SM_NOTIFY it to reclaim if we

--- a/src/server/nfs/nfs_nlm_state.c
+++ b/src/server/nfs/nfs_nlm_state.c
@@ -388,16 +388,23 @@ nlm_client_release_all_locks(
          * core (an NLM blocking LOCK not yet granted) must have its ticket
          * cancelled before we free it -- otherwise the pending pump would later
          * fire the acquire callback on freed memory.  chimera_vfs_claim_cancel
-         * is the atomic arbiter: true exactly once if it dequeued the ticket
-         * before the pump claimed it.
+         * is the atomic arbiter: true exactly once if it claimed the ticket
+         * before the callback was invoked.
          *
          *   - cancel == true : the callback will NOT fire; WE own the entry.
          *     Its original LOCK RPC already received NLM4_BLOCKED, so no reply is
          *     owed; free the acquire ctx the callback would have freed.
-         *   - cancel == false: the acquire callback is firing concurrently and
-         *     will DL_DELETE + free this entry itself -- leave it linked, skip. */
+         *   - cancel == false: the acquire callback has been invoked and may be
+         *     RUNNING right now, blocked on the mutex we hold.  It will
+         *     DL_DELETE + free this entry itself, so leave it linked and skip --
+         *     but mark it reaped first, so that when it does get the mutex it
+         *     tears the lock down instead of granting a lock to a client we have
+         *     just declared lock-free.  The flag is the whole hand-off: cancel
+         *     must not block here (it once spun until the callback returned,
+         *     deadlocking against the very mutex we hold). */
         if (entry->pending && !entry->claim_inserted && entry->file_state) {
             if (!chimera_vfs_claim_cancel(vfs_state, &entry->ticket)) {
+                entry->reaped = true;
                 continue;
             }
             free(entry->ticket.private_data);

--- a/src/server/nfs/nfs_nlm_state.h
+++ b/src/server/nfs/nfs_nlm_state.h
@@ -55,6 +55,11 @@ struct nlm_lock_entry {
     struct chimera_vfs_pending_acquire ticket;
     struct chimera_vfs_file_state     *file_state;
     bool                               claim_inserted; /* claim present in claim core */
+    /* Set under nlm_state.mutex by nlm_client_release_all_locks when it
+     * could not claim a still-in-flight acquire: the client is gone, so the
+     * acquire callback must tear the entry down instead of completing it.
+     * Exactly one of the reaper and the callback frees the entry. */
+    bool                               reaped;
     struct nlm_lock_entry             *next;
     struct nlm_lock_entry             *prev;
 };

--- a/src/vfs/tests/vfs_claim_test.c
+++ b/src/vfs/tests/vfs_claim_test.c
@@ -26,6 +26,7 @@
 #include <assert.h>
 
 #include "vfs/vfs_claim.h"
+#include "vfs/vfs_claim_internal.h"
 #include "vfs/vfs_internal.h"
 #include "common/logging.h"
 
@@ -856,6 +857,92 @@ test_async_acquire_cancel(void)
     chimera_vfs_state_put(state, file);
     chimera_vfs_state_destroy(state);
 } /* test_async_acquire_cancel */
+
+/* Test 14b: the backend RANGE confirm lane ------------------------- */
+
+/* A projectable RANGE grant does not complete when the pump runs: its
+ * ticket rides the service work FIFO awaiting the backend confirm.  Both
+ * points at which a cancel can still claim such a ticket are tested here,
+ * and BOTH must answer without blocking -- chimera_vfs_claim_cancel used
+ * to spin until the confirm's callback returned, which deadlocked any
+ * caller holding a lock that callback also takes (NLM client teardown
+ * cancelling under nlm_state.mutex against the confirm's NLM4_GRANTED
+ * callback).  There is no backend here: forcing lease_capable is what puts
+ * the core on the projecting path, which is otherwise reachable only with
+ * a real CAP_LEASE module attached. */
+static void
+test_backend_confirm_lane_cancel(void)
+{
+    struct chimera_vfs_state          *state;
+    struct chimera_vfs_file_state     *file;
+    struct chimera_vfs_claim           held, want;
+    struct chimera_claim_owner         owner;
+    struct chimera_vfs_pending_acquire ticket;
+    struct chimera_vfs_bl_range_op     op;
+    struct acquire_recorder            rec = { 0 };
+    bool                               cancelled;
+
+    fprintf(stderr, "\ntest_backend_confirm_lane_cancel\n");
+
+    state = chimera_vfs_state_init();
+    /* Pretend a CAP_LEASE backend is attached (short-circuits the lazy
+     * module probe, which needs a real vfs). */
+    state->lease_probed  = 1;
+    state->lease_capable = 1;
+
+    file = get_file(state, 2);
+
+    /* A holds [0,100) exclusively; B blocks behind it. */
+    init_owner(&owner, CHIMERA_CLAIM_PROTO_NLM, 0xC, 1);
+    chimera_vfs_claim_init_range(&held, true, false, 0, 100, &owner);
+    chimera_vfs_claim_try_acquire(state, file, &held, NULL);
+
+    init_owner(&owner, CHIMERA_CLAIM_PROTO_NLM, 0xD, 2);
+    chimera_vfs_claim_init_range(&want, true, false, 0, 100, &owner);
+    chimera_vfs_claim_acquire(NULL, state, file, &want, &ticket, true, true,
+                              recording_acquire_cb, NULL, &rec);
+    CHECK(ticket.queued == true, "blocking range ticket queues");
+
+    /* Releasing A pumps B.  B is granted locally but, being projectable,
+     * is handed to the service lane instead of completing. */
+    chimera_vfs_claim_release(state, file, &held);
+    CHECK(rec.fired == 0, "pump defers a projectable grant to the lane");
+    CHECK(state->work_head != NULL, "ticket is queued on the work FIFO");
+
+    /* Still on the FIFO: the cancel yanks it outright. */
+    cancelled = chimera_vfs_claim_cancel(state, &ticket);
+    CHECK(cancelled == true, "cancel claims a ticket queued for confirm");
+    CHECK(state->work_head == NULL, "cancel removed the FIFO entry");
+    CHECK(rec.fired == 0, "cancelled ticket never fires its callback");
+
+    /* Already dispatched: the confirm is in flight and its op is linked,
+     * so the cancel claims the op instead and the completion will skip the
+     * callback.  It must decide immediately rather than wait the confirm
+     * out. */
+    memset(&op, 0, sizeof(op));
+    op.state               = state;
+    op.file                = file;
+    op.ticket              = &ticket;
+    op.serial_lane         = true;
+    state->confirm_head    = &op;
+    state->work_confirming = true;
+
+    cancelled = chimera_vfs_claim_cancel(state, &ticket);
+    CHECK(cancelled == true, "cancel claims a confirm already in flight");
+    CHECK(op.cancelled == true, "the in-flight confirm is marked cancelled");
+
+    /* Once the completion has unlinked its op -- which it does before
+     * invoking the callback -- the callback owns the ticket and the cancel
+     * must say so instead of blocking. */
+    state->confirm_head    = NULL;
+    state->work_confirming = false;
+
+    cancelled = chimera_vfs_claim_cancel(state, &ticket);
+    CHECK(cancelled == false, "cancel yields once the callback owns the ticket");
+
+    chimera_vfs_state_put(state, file);
+    chimera_vfs_state_destroy(state);
+} /* test_backend_confirm_lane_cancel */
 
 /* Test 15: release pumps pending queue ----------------------------- */
 static void
@@ -1705,6 +1792,7 @@ main(
     test_async_acquire_immediate();
     test_async_acquire_wait_then_ack();
     test_async_acquire_cancel();
+    test_backend_confirm_lane_cancel();
     test_release_pumps_pending();
     test_lease_test();
     test_breakable_share_recall();

--- a/src/vfs/vfs_claim.c
+++ b/src/vfs/vfs_claim.c
@@ -1654,18 +1654,19 @@ chimera_vfs_claim_acquire(
     /* A locally-granted byte-range lock on a CAP_LEASE file is confirmed
      * with the backend BEFORE the callback fires: optimistic local insert,
      * rollback + DENIED on refusal (binding claims are all-or-nothing at
-     * the arbiter, never recallable).  Dispatched on the CALLER's thread:
-     * a CAP_LEASE arbiter completes lease ops inline (it must not be
-     * CAP_BLOCKING-delegated), so the callback still fires synchronously
-     * for FAIL_IMMEDIATELY-style callers.  Unlock-then-relock ordering is
-     * preserved by program order because the release paths with a thread
-     * dispatch their backend release synchronously too
-     * (chimera_vfs_claim_release_ranged); only threadless teardown
-     * releases ride the queued lane. */
+     * the arbiter, never recallable).  Dispatched on the CALLER's thread,
+     * so the callback fires synchronously for FAIL_IMMEDIATELY-style
+     * callers whenever the backend answers inline -- which is the common
+     * case but NOT guaranteed (async delegation, and eventually a
+     * clustered arbiter, both answer later), so this is not something a
+     * caller may depend on.  Unlock-then-relock ordering is preserved by
+     * program order because the release paths with a thread dispatch their
+     * backend release synchronously too (chimera_vfs_claim_release_ranged);
+     * only threadless teardown releases ride the queued lane. */
     if (result == CHIMERA_CLAIM_GRANTED &&
         claim->klass == CHIMERA_CLAIM_CLASS_RANGE &&
         chimera_vfs_claim_backend_range_projects(state, file, thread)) {
-        chimera_vfs_claim_backend_project_range(thread, state, ticket);
+        chimera_vfs_claim_backend_project_range(thread, state, ticket, false);
         return;
     }
 
@@ -1777,15 +1778,14 @@ chimera_vfs_claim_cancel(
         return true;
     }
 
-    /* Not on the pending queue.  A pump-granted projectable lock is NOT
-     * complete yet: its ticket sits in the service work FIFO awaiting the
-     * backend confirm (chimera_vfs_claim_backend_defer_ticket), callback
-     * unfired.  Yank it so the service thread never touches a ticket whose
-     * owner is tearing it down -- and roll back the pump's optimistic local
-     * insert, releasing the range for other waiters.  When the yank misses
-     * because the confirm is executing right now, ticket_cancel waits it
-     * out, so false keeps its contract: the callback HAS fired (smbtorture
-     * smb2.lock cancel-by-teardown vs deferred-grant UAF). */
+    /* Not on the pending queue.  A projectable lock granted locally is NOT
+     * complete yet: its ticket is either queued for the backend confirm
+     * (chimera_vfs_claim_backend_defer_ticket) or has one in flight, with
+     * the callback unfired either way.  Claim it so nothing ever completes
+     * a ticket whose owner is tearing it down, and roll back the optimistic
+     * local insert, releasing the range for other waiters.  ticket_cancel
+     * never blocks: when it cannot claim the ticket the callback has
+     * already been invoked, and false hands ownership to that callback. */
     if (state && chimera_vfs_claim_backend_ticket_cancel(state, ticket)) {
         chimera_vfs_claim_release(state, file, ticket->claim);
         return true;

--- a/src/vfs/vfs_claim.h
+++ b/src/vfs/vfs_claim.h
@@ -122,41 +122,52 @@ enum chimera_vfs_backend_lease_state {
     CHIMERA_VFS_BL_RELEASING,
 };
 
+struct chimera_vfs_bl_range_op;
+
 struct chimera_vfs_state {
-    struct chimera_vfs_state_shard      shards[CHIMERA_VFS_STATE_NUM_SHARDS];
-    uint32_t                            default_break_deadline_ms;
-    uint32_t                            implicit_idle_ms;
+    struct chimera_vfs_state_shard  shards[CHIMERA_VFS_STATE_NUM_SHARDS];
+    uint32_t                        default_break_deadline_ms;
+    uint32_t                        implicit_idle_ms;
 
     /* Backend lease projection service: work is posted here from any thread
      * and drained on the service thread (the VFS close thread), which owns
      * every backend lease dispatch for AGGREGATE tokens.  lease_capable is
      * false when no registered module declares CHIMERA_VFS_CAP_LEASE, making
      * every projection hook a cheap no-op. */
-    uint8_t                             lease_capable;
-    uint8_t                             lease_probed;  /* modules scanned (lazy: the
+    uint8_t                         lease_capable;
+    uint8_t                         lease_probed;      /* modules scanned (lazy: the
                                                        * close thread attaches
                                                        * before modules register) */
-    struct chimera_vfs                 *vfs;
-    struct chimera_claim_owner          node_owner;  /* this node's wire identity */
-    pthread_mutex_t                     service_lock;
-    struct chimera_vfs_file_state      *service_head;
-    struct chimera_vfs_file_state      *service_tail;
-    struct chimera_vfs_thread          *service_thread;
-    struct evpl_doorbell               *service_doorbell;
+    struct chimera_vfs             *vfs;
+    struct chimera_claim_owner      node_owner;      /* this node's wire identity */
+    pthread_mutex_t                 service_lock;
+    struct chimera_vfs_file_state  *service_head;
+    struct chimera_vfs_file_state  *service_tail;
+    struct chimera_vfs_thread      *service_thread;
+    struct evpl_doorbell           *service_doorbell;
     /* ONE ordered FIFO for every backend RANGE operation (acquire confirms
      * and token releases alike), drained in arrival order on the service
      * thread.  Ordering is load-bearing: an unlock's token release queued
      * before a subsequent lock's confirm MUST reach the backend first, or
      * the confirm collides with the stale record (smb2.lock.stacking /
      * unlock / zerobytelength, pynfs LOCK13). */
-    struct chimera_vfs_bl_work         *work_head;
-    struct chimera_vfs_bl_work         *work_tail;
-    /* The TICKET the service thread is confirming RIGHT NOW (popped from the
-     * FIFO but its callback not yet returned); guarded by service_lock.
-     * chimera_vfs_claim_cancel waits on this so "cancel returned false"
-     * strictly means the ticket's callback has fired -- the contract the
-     * teardown paths (SMB abort-parked, NLM client reap) free memory on. */
-    struct chimera_vfs_pending_acquire *work_active_ticket;
+    struct chimera_vfs_bl_work     *work_head;
+    struct chimera_vfs_bl_work     *work_tail;
+    /* Set while a TICKET popped from the FIFO has a backend confirm in
+     * flight; guarded by service_lock.  The lane is strictly serial: the
+     * drain stops here and is resumed by the confirm's completion, so an
+     * unlock's queued token release can never overtake -- or be overtaken
+     * by -- the confirm ahead of it, whether the backend answers inline or
+     * from a delegation thread. */
+    bool                            work_confirming;
+    /* Every backend RANGE confirm currently in flight, lane-dispatched or
+     * inline.  chimera_vfs_claim_cancel arbitrates against these instead of
+     * waiting for one to finish: the op is CORE-owned memory, so a cancel
+     * that claims one can return immediately and let its caller free the
+     * ticket, and the completion learns it lost without ever dereferencing
+     * a ticket the caller may already have freed.  Guarded by service_lock;
+     * opaque here (defined in vfs_claim_backend.c). */
+    struct chimera_vfs_bl_range_op *confirm_head;
 };
 
 enum chimera_vfs_bl_work_type {
@@ -352,8 +363,21 @@ chimera_vfs_claim_test(
     const struct chimera_vfs_claim    *probe,
     struct chimera_vfs_claim_conflict *conflict_out);
 
-/* Exactly-once cancel of a queued ticket: true = dequeued, cb never fires;
- * false = the cb owns the entry (fired or firing). */
+/* Exactly-once cancel of a pending or backend-confirming ticket.  Never
+ * blocks, and never re-enters the caller: safe to call with the caller's
+ * own state lock held.
+ *
+ *   true  -- WE own the ticket.  The acquire callback will NEVER be
+ *            invoked; the optimistic local grant has been rolled back and
+ *            the caller may free the ticket's containing memory.
+ *   false -- the acquire CALLBACK owns the completion.  It has been
+ *            invoked and may still be RUNNING on another thread, so the
+ *            caller must neither free what the callback uses nor assume
+ *            the callback's side effects are visible yet: arbitrate with
+ *            the callback through the caller's own lock (both sides take
+ *            it), never by waiting here.
+ *
+ * The core itself reads nothing from the ticket once false is returned. */
 bool
 chimera_vfs_claim_cancel(
     struct chimera_vfs_state           *state,

--- a/src/vfs/vfs_claim_backend.c
+++ b/src/vfs/vfs_claim_backend.c
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
-#include <sched.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -530,11 +529,26 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
      * in exactly the order the local state changed.  Entries are popped ONE
      * AT A TIME under service_lock -- never spliced -- so a concurrent
      * chimera_vfs_claim_cancel can always find (and yank) a still-pending
-     * TICKET in the FIFO; a popped TICKET is published as work_active_ticket
-     * for the duration of its confirm so cancel can wait out the inline
-     * completion instead of freeing the ticket under the confirm's feet. */
+     * TICKET in the FIFO.
+     *
+     * The lane is STRICTLY SERIAL across a confirm: dispatching a TICKET
+     * sets work_confirming and the drain stops until that confirm
+     * completes.  Nothing here may assume the backend answers inline --
+     * chimera_vfs_dispatch routes a module's op to a delegation thread
+     * whenever async delegation is configured, and a clustered arbiter will
+     * never answer inline -- and if the next entry dispatched anyway, an
+     * unlock's token release could reach the backend BEFORE the confirm it
+     * was queued behind, which is exactly the collision this FIFO exists to
+     * prevent.  When the backend does answer inline the completion clears
+     * the gate before project_range returns, so this loop keeps draining
+     * without a doorbell round trip. */
     for (;;) {
         pthread_mutex_lock(&state->service_lock);
+        if (state->work_confirming) {
+            /* A confirm is in flight; its completion resumes the drain. */
+            pthread_mutex_unlock(&state->service_lock);
+            break;
+        }
         w = state->work_head;
         if (w) {
             state->work_head = w->next;
@@ -543,7 +557,7 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
             }
             w->next = NULL;
             if (w->type == CHIMERA_VFS_BL_WORK_TICKET) {
-                state->work_active_ticket = w->ticket;
+                state->work_confirming = true;
             }
         }
         pthread_mutex_unlock(&state->service_lock);
@@ -554,15 +568,8 @@ chimera_vfs_claim_backend_service(struct chimera_vfs_state *state)
 
         switch (w->type) {
             case CHIMERA_VFS_BL_WORK_TICKET:
-                /* The confirm completes inline (a CAP_LEASE arbiter must not
-                 * be CAP_BLOCKING-delegated), so the ticket's callback has
-                 * fired by the time project_range returns and the active
-                 * marker can drop. */
                 chimera_vfs_claim_backend_project_range(state->service_thread,
-                                                        state, w->ticket);
-                pthread_mutex_lock(&state->service_lock);
-                state->work_active_ticket = NULL;
-                pthread_mutex_unlock(&state->service_lock);
+                                                        state, w->ticket, true);
                 break;
             case CHIMERA_VFS_BL_WORK_RELEASE:
                 chimera_vfs_lease_release_backend(state->service_thread,
@@ -615,12 +622,6 @@ chimera_vfs_claim_backend_detach(struct chimera_vfs_state *state)
 /* RANGE projection                                                   */
 /* ------------------------------------------------------------------ */
 
-struct chimera_vfs_bl_range_op {
-    struct chimera_vfs_state           *state;
-    struct chimera_vfs_file_state      *file;
-    struct chimera_vfs_pending_acquire *ticket;
-};
-
 static void
 chimera_vfs_bl_range_complete(
     enum chimera_vfs_error error_code,
@@ -628,19 +629,70 @@ chimera_vfs_bl_range_complete(
     uint64_t               token,
     void                  *private_data)
 {
-    struct chimera_vfs_bl_range_op     *op     = private_data;
-    struct chimera_vfs_state           *state  = op->state;
-    struct chimera_vfs_file_state      *file   = op->file;
-    struct chimera_vfs_pending_acquire *ticket = op->ticket;
-    struct chimera_vfs_claim           *claim  = ticket->claim;
+    struct chimera_vfs_bl_range_op  *op          = private_data;
+    struct chimera_vfs_state        *state       = op->state;
+    struct chimera_vfs_file_state   *file        = op->file;
+    struct chimera_vfs_claim        *claim       = op->claim;
+    chimera_vfs_claim_acquire_cb_t   cb          = op->cb;
+    void                            *cb_private  = op->cb_private;
+    bool                             cancelled   = false;
+    bool                             serial_lane = op->serial_lane;
+    struct chimera_vfs_bl_range_op **pp;
+
+    /* Only a LANE confirm is visible to a canceller, so only a lane confirm
+     * needs the lock here: the inline path keeps its original cost. */
+    if (serial_lane) {
+        pthread_mutex_lock(&state->service_lock);
+
+        /* Unlink first: past this point a cancel for our ticket can no
+         * longer find us, so it correctly reports that the callback owns
+         * the ticket. */
+        for (pp = &state->confirm_head; *pp; pp = &(*pp)->next) {
+            if (*pp == op) {
+                *pp = op->next;
+                break;
+            }
+        }
+        cancelled = op->cancelled;
+
+        /* Resume the serial lane.  When the backend answered inline the
+         * drain loop below us simply continues; otherwise the doorbell is
+         * what restarts it, and the drain is idempotent so the redundant
+         * wake in the inline case costs one empty pass. */
+        state->work_confirming = false;
+        if (state->work_head && state->service_doorbell) {
+            evpl_ring_doorbell(state->service_doorbell);
+        }
+        pthread_mutex_unlock(&state->service_lock);
+    }
+
+    free(op);
+
+    if (cancelled) {
+        /* A cancel claimed the ticket while we were in flight: it has
+         * already rolled the optimistic local grant back and its caller may
+         * have freed the ticket AND its claim, so touch neither.  A record
+         * the backend did grant is now referenced by nothing -- we hold the
+         * only copy of its token -- so drop it.
+         *
+         * It goes to the FRONT of the FIFO: the local release happened when
+         * the cancel won, which is BEFORE any acquire that could have taken
+         * these bytes, so every overlapping confirm queued behind us must
+         * still see the record gone.  Nothing already ahead of us can
+         * overlap (the range was locally held until the cancel). */
+        if (error_code == CHIMERA_VFS_OK && granted && token) {
+            chimera_vfs_claim_backend_release_token_front(state, file, token);
+        }
+        chimera_vfs_state_put(state, file);
+        return;
+    }
 
     if (error_code == CHIMERA_VFS_OK && granted) {
         pthread_mutex_lock(&file->lock);
         claim->backend_token = token;
         pthread_mutex_unlock(&file->lock);
 
-        ticket->cb(CHIMERA_CLAIM_GRANTED, claim, NULL,
-                   ticket->private_data);
+        cb(CHIMERA_CLAIM_GRANTED, claim, NULL, cb_private);
     } else {
         struct chimera_vfs_claim_conflict conflict;
 
@@ -651,23 +703,24 @@ chimera_vfs_bl_range_complete(
         memset(&conflict, 0, sizeof(conflict));
         conflict.offset = 0;
         conflict.length = UINT64_MAX;
-        ticket->cb(CHIMERA_CLAIM_DENIED, NULL, &conflict,
-                   ticket->private_data);
+        cb(CHIMERA_CLAIM_DENIED, NULL, &conflict, cb_private);
     }
 
     chimera_vfs_state_put(state, file);
-    free(op);
 } /* chimera_vfs_bl_range_complete */
 
 /* Confirm a locally-granted RANGE claim with the backend before its
  * callback fires.  `thread` must be the calling vfs thread.  Fires the
  * ticket's callback on completion (GRANTED with the token recorded, or
- * DENIED after rollback). */
+ * DENIED after rollback), unless a concurrent cancel claims the ticket
+ * first.  `serial_lane` is true only for the service drain's dispatch, so
+ * the completion knows whether to release the lane gate. */
 void
 chimera_vfs_claim_backend_project_range(
     struct chimera_vfs_thread          *thread,
     struct chimera_vfs_state           *state,
-    struct chimera_vfs_pending_acquire *ticket)
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                serial_lane)
 {
     struct chimera_vfs_claim       *claim = ticket->claim;
     struct chimera_vfs_file_state  *file  = ticket->file;
@@ -676,10 +729,31 @@ chimera_vfs_claim_backend_project_range(
     /* Any queued releases for this file's records must land first. */
     chimera_vfs_claim_backend_drain_releases(thread, state, file);
 
-    op         = calloc(1, sizeof(*op));
-    op->state  = state;
-    op->file   = file;
-    op->ticket = ticket;
+    op              = calloc(1, sizeof(*op));
+    op->state       = state;
+    op->file        = file;
+    op->ticket      = ticket;
+    op->serial_lane = serial_lane;
+    /* Snapshot the ticket now, while it is unambiguously ours: from the
+     * moment a cancel claims this op the ticket is the canceller's to free
+     * and the completion must not read it. */
+    op->claim      = claim;
+    op->cb         = ticket->cb;
+    op->cb_private = ticket->private_data;
+
+    /* Publish BEFORE dispatching so a cancel racing the backend can find
+     * this op no matter how fast the module answers -- but only for the
+     * LANE.  An inline confirm runs under chimera_vfs_claim_acquire on the
+     * acquiring thread, where claiming the ticket would suppress a callback
+     * the caller is still waiting on and swallow the reply that callback
+     * owes; there a cancel keeps reporting false ("the callback owns it"),
+     * exactly as it did before this lane existed. */
+    if (serial_lane) {
+        pthread_mutex_lock(&state->service_lock);
+        op->next            = state->confirm_head;
+        state->confirm_head = op;
+        pthread_mutex_unlock(&state->service_lock);
+    }
 
     chimera_vfs_state_get(state, file->fh, file->fh_len, file->fh_hash, false);
 
@@ -769,24 +843,39 @@ chimera_vfs_claim_backend_drain_releases(
     }
 } /* chimera_vfs_claim_backend_drain_releases */
 
-/* Cancel a pump-deferred RANGE acquire confirm (a CHIMERA_VFS_BL_WORK_TICKET
- * queued by chimera_vfs_claim_backend_defer_ticket whose callback has not
- * fired).  Returns true when the ticket was yanked from the FIFO -- the
- * callback will NEVER fire and the caller must roll back the optimistic
- * local grant.  Returns false only once the ticket's callback has FIRED:
- * if the service thread is mid-confirm on this very ticket (popped but the
- * callback not yet returned), this waits out the inline completion first,
- * so the teardown paths can free the ticket's containing memory on a false
- * return exactly as they did before the deferred lane existed (R21). */
+/* Cancel a RANGE acquire confirm whose callback has not been invoked yet.
+ * NEVER blocks: a ticket is claimable in exactly two states, and both are
+ * decided under service_lock in O(queue).
+ *
+ *   queued on the work FIFO  -- yank the entry; the confirm never starts.
+ *   lane confirm in flight   -- mark the (core-owned) op cancelled; the
+ *                               completion skips the callback and drops
+ *                               whatever the backend granted.
+ *
+ * Both return true: the callback will NEVER fire, and the caller owns the
+ * ticket -- chimera_vfs_claim_cancel rolls the optimistic local grant back
+ * and the caller may free the ticket's containing memory immediately.
+ *
+ * False means the callback owns the ticket: it has been invoked, or it is
+ * an inline confirm under the acquiring thread that is about to invoke it.
+ * Either way it may be RUNNING: the caller must arbitrate with its own
+ * callback through its own lock rather than waiting here.  This used to
+ * spin on sched_yield() until the callback returned, which turned any
+ * caller holding a lock its callback also takes into a deadlock -- an NLM
+ * client teardown cancelling under nlm_state.mutex against the confirm's
+ * NLM4_GRANTED callback wanting the same mutex. */
 bool
 chimera_vfs_claim_backend_ticket_cancel(
     struct chimera_vfs_state           *state,
     struct chimera_vfs_pending_acquire *ticket)
 {
-    struct chimera_vfs_bl_work *w, **pp;
-    bool                        busy;
+    struct chimera_vfs_bl_work     *w, **pp;
+    struct chimera_vfs_bl_work     *yanked = NULL;
+    struct chimera_vfs_bl_range_op *op;
+    bool                            claimed = false;
 
     pthread_mutex_lock(&state->service_lock);
+
     pp = &state->work_head;
     while ((w = *pp)) {
         if (w->type == CHIMERA_VFS_BL_WORK_TICKET && w->ticket == ticket) {
@@ -801,49 +890,72 @@ chimera_vfs_claim_backend_ticket_cancel(
                     }
                 }
             }
-            pthread_mutex_unlock(&state->service_lock);
-            free(w);
-            return true;
+            yanked  = w;
+            claimed = true;
+            break;
         }
         pp = &w->next;
     }
+
+    if (!claimed) {
+        /* Not queued: it may be confirming right now.  The op is linked
+         * from the moment project_range publishes it until the completion
+         * unlinks it -- and the completion unlinks it BEFORE invoking the
+         * callback, so finding it here proves the callback has not fired. */
+        for (op = state->confirm_head; op; op = op->next) {
+            if (op->ticket == ticket) {
+                op->cancelled = true;
+                claimed       = true;
+                break;
+            }
+        }
+    }
+
     pthread_mutex_unlock(&state->service_lock);
 
-    /* Not in the FIFO: either it was never deferred, its callback already
-     * ran, or the service thread popped it and its inline confirm is in
-     * flight right now.  Wait that confirm out -- the loop reads only
-     * state memory, never the ticket (whose containing struct the caller
-     * will free once we return false). */
-    for (;;) {
-        pthread_mutex_lock(&state->service_lock);
-        busy = (state->work_active_ticket == ticket);
-        pthread_mutex_unlock(&state->service_lock);
-        if (!busy) {
-            return false;
-        }
-        sched_yield();
-    }
+    free(yanked);
+
+    return claimed;
 } /* chimera_vfs_claim_backend_ticket_cancel */
 
-/* Append one entry to the ordered backend-RANGE work FIFO. */
+/* Add one entry to the ordered backend-RANGE work FIFO.  `front` jumps the
+ * queue and is used only by a cancelled confirm's rollback, whose logical
+ * position is where the cancel won -- ahead of everything queued since. */
 static void
-chimera_vfs_bl_work_enqueue(
+chimera_vfs_bl_work_enqueue_at(
     struct chimera_vfs_state   *state,
-    struct chimera_vfs_bl_work *work)
+    struct chimera_vfs_bl_work *work,
+    bool                        front)
 {
     pthread_mutex_lock(&state->service_lock);
-    work->next = NULL;
-    if (state->work_tail) {
-        state->work_tail->next = work;
-    } else {
+    if (front) {
+        work->next       = state->work_head;
         state->work_head = work;
+        if (!state->work_tail) {
+            state->work_tail = work;
+        }
+    } else {
+        work->next = NULL;
+        if (state->work_tail) {
+            state->work_tail->next = work;
+        } else {
+            state->work_head = work;
+        }
+        state->work_tail = work;
     }
-    state->work_tail = work;
     /* Ring under service_lock: see chimera_vfs_bl_post. */
     if (state->service_doorbell) {
         evpl_ring_doorbell(state->service_doorbell);
     }
     pthread_mutex_unlock(&state->service_lock);
+} /* chimera_vfs_bl_work_enqueue_at */
+
+static void
+chimera_vfs_bl_work_enqueue(
+    struct chimera_vfs_state   *state,
+    struct chimera_vfs_bl_work *work)
+{
+    chimera_vfs_bl_work_enqueue_at(state, work, false);
 } /* chimera_vfs_bl_work_enqueue */
 
 /* Fire-and-forget release of a projected RANGE token.  Ordered behind every
@@ -870,6 +982,32 @@ chimera_vfs_claim_backend_release_token(
 
     chimera_vfs_bl_work_enqueue(state, work);
 } /* chimera_vfs_claim_backend_release_token */
+
+/* Release a token whose confirm was cancelled mid-flight.  Identical to
+ * chimera_vfs_claim_backend_release_token but jumps the FIFO: the local
+ * range was freed when the cancel won, so any overlapping confirm queued
+ * since MUST still find the backend record gone. */
+void
+chimera_vfs_claim_backend_release_token_front(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    uint64_t                       token)
+{
+    struct chimera_vfs_bl_work *work;
+
+    if (!state || !token || !chimera_vfs_claim_backend_capable(state)) {
+        return;
+    }
+
+    work       = calloc(1, sizeof(*work));
+    work->type = CHIMERA_VFS_BL_WORK_RELEASE;
+    memcpy(work->fh, file->fh, file->fh_len);
+    work->fh_len  = file->fh_len;
+    work->fh_hash = file->fh_hash;
+    work->token   = token;
+
+    chimera_vfs_bl_work_enqueue_at(state, work, true);
+} /* chimera_vfs_claim_backend_release_token_front */
 
 /* Queue a projectable RANGE acquire confirm on the same ordered lane. */
 void

--- a/src/vfs/vfs_claim_internal.h
+++ b/src/vfs/vfs_claim_internal.h
@@ -227,11 +227,30 @@ chimera_vfs_claim_backend_capable(
 /* Confirm a locally-granted RANGE claim with the backend before its ticket
  * callback fires; `thread` must be the CALLING vfs thread (its request pool
  * is per-thread and unlocked). */
+/* One in-flight backend RANGE confirm.  Core-owned, linked on
+ * state->confirm_head for the duration, and carrying a SNAPSHOT of
+ * everything the completion needs out of the ticket: once a cancel claims
+ * this op the ticket may be freed under us, so nothing here dereferences
+ * it afterwards -- `ticket` is an identity key compared only under
+ * service_lock while the op is still linked. */
+struct chimera_vfs_bl_range_op {
+    struct chimera_vfs_state           *state;
+    struct chimera_vfs_file_state      *file;
+    struct chimera_vfs_pending_acquire *ticket; /* identity only           */
+    struct chimera_vfs_claim           *claim;
+    chimera_vfs_claim_acquire_cb_t      cb;
+    void                               *cb_private;
+    bool                                serial_lane;
+    bool                                cancelled;
+    struct chimera_vfs_bl_range_op     *next;
+};
+
 void
 chimera_vfs_claim_backend_project_range(
     struct chimera_vfs_thread          *thread,
     struct chimera_vfs_state           *state,
-    struct chimera_vfs_pending_acquire *ticket);
+    struct chimera_vfs_pending_acquire *ticket,
+    bool                                serial_lane);
 
 bool
 chimera_vfs_claim_backend_range_projects(
@@ -261,6 +280,14 @@ chimera_vfs_claim_backend_drain_releases(
  * service_lock, matching reeval->bl_post). */
 void
 chimera_vfs_claim_backend_release_token(
+    struct chimera_vfs_state      *state,
+    struct chimera_vfs_file_state *file,
+    uint64_t                       token);
+
+/* As above, but placed at the FRONT of the FIFO: the rollback of a confirm
+ * that a cancel claimed mid-flight, whose local release already happened. */
+void
+chimera_vfs_claim_backend_release_token_front(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file,
     uint64_t                       token);


### PR DESCRIPTION
`chimera_vfs_claim_cancel` could not answer while the service thread was confirming the very ticket being cancelled, so it spun on `sched_yield()` until that confirm's callback returned. The callback runs protocol code, and every caller of cancel is a teardown walking its own list under its own lock, so the wait closes a cycle:

- **Thread A** — NLM client reap (`nlm_client_release_all_locks`) holds `nlm_state.mutex` and spins in `chimera_vfs_claim_backend_ticket_cancel`.
- **Thread B** — the confirm it is waiting for, blocked on `pthread_mutex_lock(&shared->nlm_state.mutex)` inside `chimera_nfs_nlm4_lock_acquire_cb`.

Neither moves, and the spin burns a core, so it presents as a hang rather than a stall. This is the `chimera/server/nfs/mbtaux/batch_memfs` timeout at 180s that started appearing once #1574 made the quick tier run on every OS (run 33273945653, and the three hangs recorded in #1581). Reproduced locally under concurrency with the harness alarm disabled; the backtrace has both threads on the same ticket and the same claim state.

The reap path is not exotic — besides `FREE_ALL` and `SM_NOTIFY` it runs whenever a client's last connection drops (`nfs.c:856`), so any client disconnecting with a blocking lock outstanding can hit it.

## What changed

**Arbitrate instead of waiting.** An in-flight confirm is published as a core-owned op on `state->confirm_head` for exactly the window before its callback is invoked. A cancel that finds one claims it: the callback never fires, the caller owns the ticket, and the completion drops the record the backend granted. Because the op is the core's memory and carries a snapshot of what the completion needs, cancel can return the instant it decides and let its caller free the ticket — the completion never dereferences it again.

`false` now means *the callback owns the completion and may still be running*, rather than *the callback has returned*. Callers arbitrate with their own callback through their own lock rather than through this one.

**Only the deferred (service-lane) confirm is published.** An inline confirm runs under `chimera_vfs_claim_acquire` on the acquiring thread, where claiming the ticket would suppress a callback that thread is still waiting on and swallow the reply it owes. There cancel keeps reporting `false` exactly as before.

**The lane no longer assumes the backend answers inline.** It never had to: `chimera_vfs_dispatch` routes an op to a delegation thread whenever async delegation is configured (a supported, documented knob), and a clustered arbiter will never answer inline. With the old code that would have cleared the active marker before the callback fired — turning cancel's contract into a use-after-free — and let a queued token release overtake the confirm ahead of it. Dispatching a confirm now gates the drain until it completes; when the answer comes inline the gate clears before `project_range` returns, so the drain continues without a doorbell round trip.

**NLM (first commit).** When the cancel loses, the reaper used to leave the entry for the callback, which then took the GRANTED path and handed a lock to a client just told it holds none. Both sides already take `nlm_state.mutex`, so a flag is a complete hand-off. That branch is unreachable today — the wait means the callback has finished by the time the flag would be set — which is why it goes first: removing the wait is what makes it live.

## Notes for the reviewer

- **The deferred lane had no unit coverage at all.** The claim tests build a state with no vfs, which leaves the projecting path unreachable, so nothing exercised the FIFO or the cancel interaction. The new test forces the capability and drives both points at which a cancel can still claim a ticket, plus the point at which it must yield.
- **A separate, pre-existing hole in the same lane.** `nfstest_lock_memfs_nfs4.1` intermittently fails "Locking byte range on second process should be granted: got error EAGAIN" right after the holder unlocks — a stale backend record. `chimera_vfs_claim_backend_drain_releases` is supposed to close that by dispatching matching releases before a confirm, but it cannot find a release the service thread has already popped, and that release then races an inline confirm on another thread. This change does not fix it (it makes entries dwell longer in the FIFO where the drain can find them, if anything). Worth its own issue.
- **SMB's abort-vs-deferred-grant window is pre-existing and unchanged in kind.** `chimera_smb_lock_abort_parked` reads `resume_status` and unlinks from `lock_resume_head` on the `false` path, which assumes the callback finished. That assumption is already wrong on every backend except memfs, because a non-CAP_LEASE pump fires the callback directly and the wait never covered it. On memfs this narrows from "fully covered" to a few instructions; the durable fix is a flag under `lease_break_lock`, which both sides already take, and belongs with SMB lock teardown ownership rather than here.

## Verified

- All 30 in-process quint/MBT suites pass, including `mbtaux/batch_memfs`.
- 12 concurrent runs of the aux batch with no hang (it previously wedged within ~12).
- `vfs/claim_test`: 155 checks pass, including the 9 new ones.
- `smb/mbt/batch_memfs` and `vfs/zerorange_diskfs_io_uring` fail identically on clean `upstream/main` in this environment; pynfs and the KVM suites need privileges the local container lacks.
