### PR TITLE
diskfs: a block device on macOS, and its quint suites with it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,20 @@ else()
     message(STATUS "LIBAIO not found")
 endif()
 
+# Which libevpl block backend diskfs's test harnesses put in their device
+# config.  io_uring and libaio are Linux-only; libevpl's pread backend drives a
+# device from its own service thread and needs nothing beyond POSIX, so it is
+# what is left on macOS -- or on a Linux host without libaio.  A diskfs device
+# is therefore available everywhere chimera builds, which is why the diskfs
+# test variants are no longer gated on HAVE_LIBAIO.
+if (HAVE_LIBAIO)
+    set(CHIMERA_DISKFS_DEVICE_TYPE "libaio")
+else()
+    set(CHIMERA_DISKFS_DEVICE_TYPE "pread")
+endif()
+message(STATUS "diskfs device type: ${CHIMERA_DISKFS_DEVICE_TYPE}")
+add_definitions(-DCHIMERA_DISKFS_DEVICE_TYPE="${CHIMERA_DISKFS_DEVICE_TYPE}")
+
 if (CAIRN_ENABLED)
     message(STATUS "CAIRN enabled")
     add_definitions(-DHAVE_CAIRN=1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -490,7 +490,7 @@ Each entry of `devices`:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `type` | string | required | `"io_uring"`, `"libaio"`, or `"vfio"`. |
+| `type` | string | required | `"io_uring"`, `"libaio"`, `"vfio"`, or `"pread"`.  The first three are Linux-only; `"pread"` runs the device from a libevpl service thread with blocking pread/pwrite and works anywhere. |
 | `path` | string | required | Device path, file path, or PCI BDF (e.g. `"01:00.0"` for VFIO). |
 | `size` | int | auto | Device size in bytes (auto-detected for file-backed if omitted). |
 | `role` | string | `"local"` | `"local"`, or `"remote"` for a pNFS-only data device. |

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -1057,8 +1057,8 @@ posix_env_setup(
         snprintf(module_cfg, sizeof(module_cfg),
                  "{\"initialize\":true,\"unsafe_async\":true,"
                  "\"intent_log_size\":67108864,"
-                 "\"devices\":[{\"type\":\"libaio\",\"size\":1,\"path\":\"%s\"}]}",
-                 img);
+                 "\"devices\":[{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}]}",
+                 CHIMERA_DISKFS_DEVICE_TYPE, img);
     } else if (strcmp(module, "cairn") == 0) {
         if (!storage) {
             fprintf(stderr, "posix_driver: cairn needs a storage dir\n");

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -83,13 +83,11 @@ set_tests_properties(chimera/server/nfs/mbt/deviation_probe_memfs PROPERTIES
 # each backend's own: they each resolve a handle themselves, and each had to
 # learn to tell a handle that no longer names anything from a name that was
 # never there.
-if(HAVE_LIBAIO)
-    add_test(NAME chimera/server/nfs/mbt/deviation_probe_diskfs
-        COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b diskfs)
-    set_tests_properties(chimera/server/nfs/mbt/deviation_probe_diskfs PROPERTIES
-        LABELS "quint;nfs3_mbt;diskfs"
-        TIMEOUT 60)
-endif()
+add_test(NAME chimera/server/nfs/mbt/deviation_probe_diskfs
+    COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b diskfs)
+set_tests_properties(chimera/server/nfs/mbt/deviation_probe_diskfs PROPERTIES
+    LABELS "quint;nfs3_mbt;diskfs"
+    TIMEOUT 60)
 
 if(CAIRN_ENABLED)
     add_test(NAME chimera/server/nfs/mbt/deviation_probe_cairn
@@ -143,17 +141,15 @@ set_tests_properties(chimera/server/nfs/mbt/batch_memfs PROPERTIES
 # genuine backend deviation from the model memfs already satisfies.  Each
 # replay process self-provisions its scratch (device image / rocksdb dir) under
 # its own mkdtemp session dir, so the batches still run fully parallel and clean
-# up with the temp dir.  Gated on the storage each backend needs: diskfs on
-# libaio (its device type), cairn on rocksdb.
-if(HAVE_LIBAIO)
-    add_test(NAME chimera/server/nfs/mbt/batch_diskfs
-        COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
-                --backend diskfs)
-    set_tests_properties(chimera/server/nfs/mbt/batch_diskfs PROPERTIES
-        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_diskfs"
-        LABELS "quint;nfs3_mbt;diskfs"
-        TIMEOUT 300)
-endif()
+# up with the temp dir.  diskfs takes whichever libevpl block backend the
+# platform has (CHIMERA_DISKFS_DEVICE_TYPE); cairn is gated on rocksdb.
+add_test(NAME chimera/server/nfs/mbt/batch_diskfs
+    COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
+            --backend diskfs)
+set_tests_properties(chimera/server/nfs/mbt/batch_diskfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_diskfs"
+    LABELS "quint;nfs3_mbt;diskfs"
+    TIMEOUT 300)
 
 if(CAIRN_ENABLED)
     add_test(NAME chimera/server/nfs/mbt/batch_cairn

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -313,8 +313,8 @@ mbt_env_open_opts(
         snprintf(cfg, sizeof(cfg),
                  "{\"initialize\":true,\"unsafe_async\":true,"
                  "\"intent_log_size\":67108864,"
-                 "\"devices\":[{\"type\":\"libaio\",\"size\":1,\"path\":\"%s\"}]}",
-                 img);
+                 "\"devices\":[{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}]}",
+                 CHIMERA_DISKFS_DEVICE_TYPE, img);
         chimera_server_config_add_module(config, "diskfs", NULL, cfg);
     } else if (strcmp(env->module, "cairn") == 0) {
         char dir[300], cfg[512];

--- a/src/server/s3/tests/quint/CMakeLists.txt
+++ b/src/server/s3/tests/quint/CMakeLists.txt
@@ -105,34 +105,32 @@ set_tests_properties(chimera/server/s3/mbt/batch_multipart_memfs PROPERTIES
 #    passthrough module, not the cache layer.  Run manually with
 #    --backend linux/io_uring; S3_MBT_KEEP_SCRATCH=1 preserves the backing
 #    tree for post-mortem.
-if(HAVE_LIBAIO)
-    add_test(NAME chimera/server/s3/mbt/batch_diskfs
-        COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
-                --backend diskfs --exclude-prefix stepMultipart_)
-    set_tests_properties(chimera/server/s3/mbt/batch_diskfs PROPERTIES
-        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_diskfs"
-        LABELS "quint;s3_mbt;diskfs"
-        TIMEOUT 300)
+add_test(NAME chimera/server/s3/mbt/batch_diskfs
+    COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+            --backend diskfs --exclude-prefix stepMultipart_)
+set_tests_properties(chimera/server/s3/mbt/batch_diskfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_diskfs"
+    LABELS "quint;s3_mbt;diskfs"
+    TIMEOUT 300)
 
-    # Previously withheld: PutObject's publish could double-fire when the
-    # body drain outran the async metadata xattr chain (or vice versa), and
-    # at multipart scale on diskfs the second link_at's failure path crashed
-    # into the first's completion (~1-in-2 on stepMultipart_64_0x11_1).
-    # Fixed by the exactly-once publish handshake in s3_put.c (meta_pending
-    # gate + published latch); debug-level replay made the window wide
-    # enough to pin the real cause, which was never diskfs's completion
-    # threading.
-    add_test(NAME chimera/server/s3/mbt/batch_multipart_diskfs
-        COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
-                --backend diskfs --block-size 5242880
-                --exclude-prefix step_ --exclude-prefix stepData_
-                --exclude-prefix stepList_ --exclude-prefix stepBucket_
-                --exclude-prefix stepTag_)
-    set_tests_properties(chimera/server/s3/mbt/batch_multipart_diskfs PROPERTIES
-        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_multipart_diskfs"
-        LABELS "quint;s3_mbt;diskfs"
-        TIMEOUT 300)
-endif()
+# Previously withheld: PutObject's publish could double-fire when the
+# body drain outran the async metadata xattr chain (or vice versa), and
+# at multipart scale on diskfs the second link_at's failure path crashed
+# into the first's completion (~1-in-2 on stepMultipart_64_0x11_1).
+# Fixed by the exactly-once publish handshake in s3_put.c (meta_pending
+# gate + published latch); debug-level replay made the window wide
+# enough to pin the real cause, which was never diskfs's completion
+# threading.
+add_test(NAME chimera/server/s3/mbt/batch_multipart_diskfs
+    COMMAND $<TARGET_FILE:s3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/s3
+            --backend diskfs --block-size 5242880
+            --exclude-prefix step_ --exclude-prefix stepData_
+            --exclude-prefix stepList_ --exclude-prefix stepBucket_
+            --exclude-prefix stepTag_)
+set_tests_properties(chimera/server/s3/mbt/batch_multipart_diskfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=s3_batch_multipart_diskfs"
+    LABELS "quint;s3_mbt;diskfs"
+    TIMEOUT 300)
 
 if(CAIRN_ENABLED)
     add_test(NAME chimera/server/s3/mbt/batch_cairn

--- a/src/server/s3/tests/quint/s3_mbt_common.h
+++ b/src/server/s3/tests/quint/s3_mbt_common.h
@@ -628,8 +628,8 @@ s3_mbt_env_open_module(
         snprintf(cfg, sizeof(cfg),
                  "{\"initialize\":true,\"unsafe_async\":true,"
                  "\"intent_log_size\":67108864,"
-                 "\"devices\":[{\"type\":\"libaio\",\"size\":1,\"path\":\"%s\"}]}",
-                 img);
+                 "\"devices\":[{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}]}",
+                 CHIMERA_DISKFS_DEVICE_TYPE, img);
         chimera_server_config_add_module(config, "diskfs", NULL, cfg);
     } else if (strcmp(env->module, "cairn") == 0) {
         char dir[300], cfg[512];

--- a/src/vfs/diskfs/diskfs_mount.c
+++ b/src/vfs/diskfs/diskfs_mount.c
@@ -984,6 +984,11 @@ diskfs_init(
             protocol_id = EVPL_BLOCK_PROTOCOL_LIBAIO;
         } else if (strcmp(protocol_name, "vfio") == 0) {
             protocol_id = EVPL_BLOCK_PROTOCOL_VFIO;
+        } else if (strcmp(protocol_name, "pread") == 0) {
+            /* Blocking pread/pwrite on a libevpl-owned service thread per
+             * device.  Slower than the async backends and the only one that
+             * exists off Linux, so it is what diskfs runs on there. */
+            protocol_id = EVPL_BLOCK_PROTOCOL_PREAD;
         } else {
             chimera_diskfs_abort("Unsupported protocol: %s", protocol_name);
         }


### PR DESCRIPTION
Depends on chimera-nas/libevpl#143 — the submodule is pinned at the fork commit and needs re-pinning once that merges.

diskfs keeps its filesystem on a libevpl block device, and every backend libevpl had was Linux-only. So the diskfs variants of the model-based suites were gated on `HAVE_LIBAIO` and simply did not exist on macOS:

- `chimera/server/nfs/mbt/deviation_probe_diskfs`
- `chimera/server/nfs/mbt/batch_diskfs`
- `chimera/server/s3/mbt/batch_diskfs`
- `chimera/server/s3/mbt/batch_multipart_diskfs`

Four ctests a developer there could not run before pushing, on a backend whose whole job is to differ from memfs.

libevpl's new pread backend services a device from its own thread with blocking pread/pwrite and needs nothing beyond POSIX, so there is now a block device everywhere.

## What changes

- diskfs learns the `"pread"` device type.
- `CHIMERA_DISKFS_DEVICE_TYPE` is picked at configure time — `libaio` where CMake found it, `pread` otherwise — and the three quint harnesses that hardcoded `"libaio"` in their device config use it. Linux is unchanged.
- The `HAVE_LIBAIO` gates come off the four diskfs quint ctests. A Linux host without libaio gains them too, running on pread rather than not existing.

## Verification

All four pass on macOS in Release, and under the Debug build's ASan:

```
chimera/server/nfs/mbt/deviation_probe_diskfs ...   Passed
chimera/server/nfs/mbt/batch_diskfs .............   Passed
chimera/server/s3/mbt/batch_diskfs ..............   Passed
chimera/server/s3/mbt/batch_multipart_diskfs ....   Passed
```