### PR TITLE
ci: make the PR-time gate real, and drop the dead event guards

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,10 +5,10 @@
 name: CI
 
 on:
-  # The full build/test matrix runs ONLY in the merge queue, never on raw PRs
-  # (PR-time required-check placeholders live in pr-checks.yml).  The job-level
-  # `if: github.event_name != 'pull_request'` guards below are now redundant but
-  # left in place as a harmless backstop.
+  # The full build/test matrix runs ONLY in the merge queue, never on raw PRs;
+  # the PR-time half of the gate lives in pr-checks.yml.  There is no
+  # pull_request trigger here, so the jobs below carry no event guards: every
+  # job in this file runs on every event that reaches it.
   merge_group:
   workflow_dispatch:   # allow manual runs
 
@@ -64,7 +64,6 @@ env:
 jobs:
   build-devcontainer:
     name: Build devcontainer ${{ matrix.arch }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -109,7 +108,6 @@ jobs:
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -151,7 +149,6 @@ jobs:
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -193,7 +190,6 @@ jobs:
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -235,7 +231,6 @@ jobs:
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -276,7 +271,6 @@ jobs:
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -322,7 +316,6 @@ jobs:
   test:
     name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -468,7 +461,6 @@ jobs:
   static-analysis:
     name: Analyze ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer, build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -619,7 +611,7 @@ jobs:
   publish-test-results:
     name: Report
     needs: [test, test-dev, macos]
-    if: ${{ always() && github.event_name != 'pull_request' }}
+    if: ${{ always() }}
     runs-on: arc-small
     permissions:
       pull-requests: write
@@ -662,7 +654,6 @@ jobs:
   test-dev:
     name: Test devcontainer ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer]
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -733,7 +724,6 @@ jobs:
   # ---------------------------------------------------------------------------
   macos:
     name: Test macOS ${{ matrix.build_type }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: macos-14
     permissions:
       contents: read
@@ -798,7 +788,6 @@ jobs:
   # container image to wait on, it has no dependencies at all.
   analyze-macos:
     name: Analyze macOS ${{ matrix.build_type }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: macos-14
     permissions:
       contents: read
@@ -871,12 +860,14 @@ jobs:
     steps:
       - name: Verify all build/test jobs passed
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "PR placeholder — the full build/test matrix runs in the merge queue (merge_group)."
-            exit 0
-          fi
-          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
-            echo "One or more build/test jobs did not pass."
-            exit 1
-          fi
-          echo "All build/test jobs passed."
+          # Every dependency must be `success`.  Checking results rather than
+          # using success() means a job that was skipped -- never actually run --
+          # cannot pass this for the wrong reason.
+          results='${{ join(needs.*.result, ' ') }}'
+          echo "dependency results: ${results}"
+          for r in ${results}; do
+            if [ "$r" != "success" ]; then
+              echo "a required job did not succeed"
+              exit 1
+            fi
+          done

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,6 @@ env:
 jobs:
   build-and-push:
     name: Build ${{ matrix.os }} ${{ matrix.platform }} ${{ matrix.build_type }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -150,12 +149,14 @@ jobs:
     steps:
       - name: Verify docker build jobs passed
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "PR placeholder — docker image builds run in the merge queue (merge_group)."
-            exit 0
-          fi
-          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
-            echo "One or more docker build jobs did not pass."
-            exit 1
-          fi
-          echo "All docker build jobs passed."
+          # Every dependency must be `success`.  Checking results rather than
+          # using success() means a job that was skipped -- never actually run --
+          # cannot pass this for the wrong reason.
+          results='${{ join(needs.*.result, ' ') }}'
+          echo "dependency results: ${results}"
+          for r in ${results}; do
+            if [ "$r" != "success" ]; then
+              echo "a required job did not succeed"
+              exit 1
+            fi
+          done

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,11 +7,19 @@ name: PR checks
 # The heavy build/test matrix (build-test.yml) and docker image builds
 # (docker-build.yml) run ONLY in the merge queue (merge_group), not on pull
 # requests -- so a PR's check list isn't cluttered with a wall of skipped
-# matrix jobs.  But the branch-protection ruleset still requires the
-# "CI complete" and "Docker build complete" checks on a PR before it can be
-# added to the queue.  This workflow satisfies them with instant no-op
-# placeholders; the real checks of the same names run in the queue (where the
-# actual matrix and image builds happen).
+# matrix jobs.  The branch-protection ruleset requires "CI complete" and
+# "Docker build complete" on a PR before it can be added to the queue, and the
+# jobs of those names here are what report them at PR time; the real checks of
+# the same names run in the queue.
+#
+# "CI complete" is a real gate, not a placeholder: it depends on every
+# pre-merge job below, so a PR cannot enter the queue until all of them are
+# green.  It used to be a bare echo, which meant the required set went green in
+# about a second and the pre-merge signal -- ten minutes of static analysis and
+# model-based tests -- gated nothing at all.  Queueing early simply skipped it.
+#
+# "Docker build complete" stays a no-op here, because no docker image is built
+# at PR time; that check only carries meaning in the queue.
 #
 # It also carries the pre-merge signal that is cheap enough to be worth having
 # before the queue: clang static analysis on devcontainer and macOS, and the
@@ -49,17 +57,30 @@ env:
 jobs:
   ci-complete:
     name: CI complete
+    needs: [build-devcontainer, analyze-dev, quint-coverage, analyze-macos]
+    if: ${{ always() }}
     runs-on: arc-small
     steps:
-      - name: PR placeholder
-        run: echo "PR placeholder -- the full build/test matrix runs in the merge queue (merge_group)."
+      - name: Verify every pre-merge job succeeded
+        run: |
+          # Every dependency must be `success`.  Checking results rather than
+          # using success() means a job that was skipped -- never actually run --
+          # cannot pass this for the wrong reason.
+          results='${{ join(needs.*.result, ' ') }}'
+          echo "dependency results: ${results}"
+          for r in ${results}; do
+            if [ "$r" != "success" ]; then
+              echo "a required job did not succeed"
+              exit 1
+            fi
+          done
 
   docker-build-complete:
     name: Docker build complete
     runs-on: arc-small
     steps:
       - name: PR placeholder
-        run: echo "PR placeholder -- docker image builds run in the merge queue (merge_group)."
+        run: echo "No docker image is built at PR time; the real check runs in the merge queue."
 
   # ---------------------------------------------------------------------------
   # Pre-merge signal.  The devcontainer image is built once here and consumed by


### PR DESCRIPTION
Two rules, stated plainly:

- everything green before a PR can enter the merge queue
- everything green in the queue before it reaches `main`

The second held. The first did not.

## What was wrong

`protect-main` requires four contexts. At PR time, two of them were bare
echoes:

| required check | PR-time duration |
|---|---|
| `CI complete` | **3s** (echo, exit 0) |
| `Docker build complete` | **4s** (echo, exit 0) |
| `reuse-lint` | ~27s |
| `Check code formatting with uncrustify` | ~31s |

Meanwhile the work that actually says something about the change was **not
required at all**:

| not required | duration |
|---|---|
| `Analyze macOS Release (pre-merge)` | 635s |
| `Analyze devcontainer amd64 Release (pre-merge)` | 281s |
| `Quint coverage devcontainer amd64` | 269s |

So the required set went green inside a minute. Queue at t=40s and ten minutes
of static analysis and model-based tests gated nothing. It wasn't that queueing
*aborted* CI — nothing was ever waiting on it.

## The fix

`CI complete` keeps its name and its two contexts, and grows real dependencies
at PR time. It now means "the CI appropriate to this context passed": the
pre-merge signal on a PR, the full matrix in the queue.

This deliberately reuses the shape that already exists. A required context must
report in **both** the `pull_request` and `merge_group` contexts — a name that
is required but never reported hangs the queue forever, which is what the
ruleset note on the old flake gate was about. `CI complete` already reports in
both, so **no ruleset change is needed**, and the pre-merge set can change later
without touching branch protection.

Cost: a PR can't be queued for ~10.5 min, bounded by `Analyze macOS Release`.

`Docker build complete` stays a no-op at PR time — no docker image is built
there, so there's nothing for it to wait on. **That leaves the user-facing
`Dockerfile` ungated until the queue**, which is a deliberate gap rather than an
oversight; closing it would mean building four images per PR.

## Dead weight removed while here

- **13 job-level `if: github.event_name != 'pull_request'` guards.** Neither
  `build-test.yml` nor `docker-build.yml` has a `pull_request` trigger, so every
  one was always true. They also fed two `if pull_request` branches *inside* the
  aggregate scripts that would have silently passed everything had either
  workflow ever gained that trigger.
- **The aggregates were too lenient.** They asked whether any dependency had
  `failure` or `cancelled`, which lets a **skipped** job through. They now
  require every result to be `success`, so a leg that never ran can't pass for
  the wrong reason.

## Coverage check

Every job is now gated by its aggregate, with two intentional exceptions:

- `publish-test-results` (`Report`) — a reporting job that must not fail the
  build; the test jobs stay the source of truth.
- `merge-manifests` — runs only on `push`, i.e. after the merge, so it can't
  gate a queue check.