### PR TITLE
smb/tests: wait out a dropped connection's teardown in the durable probe D6

### DIFF
--- a/src/server/smb/tests/quint/smb2_durable_probe.c
+++ b/src/server/smb/tests/quint/smb2_durable_probe.c
@@ -785,6 +785,57 @@ sec_d5(struct smb2_env *env)
     smb2_quiesce(env);
 } /* sec_d5 */
 
+/* A dropped connection's non-durable open dies with it (MS-SMB2 3.3.7.1), but
+ * the spec does not say WHEN, relative to a request already on its way in on
+ * another connection -- and here the client has nothing to wait on.
+ *
+ * The teardown runs on the dropped connection's own server thread.
+ * smb2_conn_disconnect returns once THIS side has seen the close, which is not
+ * proof the server has run it (that helper says so itself).  smb2_quiesce
+ * cannot cover the gap either: its fixpoint is over CLIENT-OBSERVABLE events,
+ * and a teardown that no live connection is bound to produces none, so its
+ * first pass reports quiet before the teardown has even begun.
+ *
+ * The durable families have wire-observable barriers instead -- wait_parked
+ * above, and server-side, chimera_smb_durable_conn_disconnecting, which makes
+ * a conflicting CREATE retry briefly rather than deny while a durable holder's
+ * connection is on its way out.  Neither reaches a NON-durable holder: it is
+ * in no registry, so the server answers SHARING_VIOLATION at once and the
+ * client has nothing to synchronise against.
+ *
+ * So retry the assertion rather than weaken it.  What is being tested -- that
+ * the open dies with its connection -- is unchanged; what is dropped is the
+ * unstated extra that it dies before the next request from somewhere else.
+ * Same shape as the nfs3 probe's await_stale for diskfs's background inode
+ * reclaim.  The attempt count is reported so a regression here shows up as a
+ * rising number rather than a silent pass, and the cap is a wedge guard, not
+ * a tuning knob: one extra pass has always been enough. */
+#define D6_TEARDOWN_PASSES 64
+
+static uint32_t
+create_await_conn_teardown(
+    struct smb2_env        *env,
+    struct smb2_conn       *c,
+    const char             *name,
+    struct smb2_create_out *out,
+    int                    *passes_out)
+{
+    uint32_t st;
+    int      passes = 0;
+
+    for (;;) {
+        st = smb2_create(c, name, FILE_OPEN, FILE_ALL_ACCESS, 0, NULL, out);
+        if (st != ST_SHARING_VIOLATION || passes >= D6_TEARDOWN_PASSES) {
+            break;
+        }
+        passes++;
+        smb2_quiesce(env);
+    }
+
+    *passes_out = passes;
+    return st;
+} /* create_await_conn_teardown */
+
 /* ------------------------------------------------------------------------
  * D6 -- an open with NO durable request does not survive its connection.
  *
@@ -819,10 +870,18 @@ sec_d6(struct smb2_env *env)
     smb2_conn_disconnect(a);
     smb2_quiesce(env);
 
-    st = smb2_create(b, "d6", FILE_OPEN, FILE_ALL_ACCESS, 0, NULL, &r);
-    EXPECT(st == ST_SUCCESS,
-           "D6 the same open succeeds once the connection is gone (0x%08x)",
-           st);
+    {
+        int passes;
+
+        st = create_await_conn_teardown(env, b, "d6", &r, &passes);
+        if (passes) {
+            NOTE("D6 the reservation cleared after %d extra settle pass(es)",
+                 passes);
+        }
+        EXPECT(st == ST_SUCCESS,
+               "D6 the same open succeeds once the connection is gone (0x%08x)",
+               st);
+    }
     if (st == ST_SUCCESS) {
         smb2_close(b, r.file_id);
     }


### PR DESCRIPTION
`chimera/server/smb/mbt/durable_probe_memfs` fails intermittently with

```
FAIL - D6 the same open succeeds once the connection is gone (0xc0000043)
```

STATUS_SHARING_VIOLATION where SUCCESS was expected. It surfaced on #1585, whose diff is `mirror-ccache.yml` and `Dockerfile.ccache`, so it is a flake by construction. **3 failures in 120 probe runs at 12-way concurrency; 0 in 60 at 6-way** — which is why it only ever appears on a loaded CI machine.

## Why the client cannot see it coming

D6 drops the connection holding a non-durable, share-none open, then has a second connection open the same file. The teardown that releases the reservation runs on the *dropped* connection's own server thread, and nothing the client can send orders against it:

- `smb2_conn_disconnect` returns once **this** side has seen the close. Its own comment says as much: *"It still is not proof the server has PARKED the handle; that needs a separate barrier."*
- `smb2_quiesce` cannot cover the gap. Its fixpoint is over **client-observable** events, and a teardown that no live connection is bound to produces none — so its first pass reports quiet before the teardown has even begun. D6 already calls it, which is exactly why one extra settle pass afterwards always succeeded.

The durable families do have barriers for this — `wait_parked` on the wire, and server-side `chimera_smb_durable_conn_disconnecting`, which makes a conflicting CREATE retry briefly rather than deny while a durable holder's connection is on its way out.

## Why this is a test fix and not a server fix

Neither barrier reaches a **non-durable** holder, and that is deliberate — `smb_proc_create.c` says so: *"Live, persistent, and non-durable holders are left intact, so they still produce a real SHARING_VIOLATION."*

Extending the retry to non-durable holders is not a small change. The yield check is keyed on the durable registry, and resolving an arbitrary persistent id to a non-durable open would need a lookup the server does not have: opens are hashed per-tree by file_id and, as `smb_internal.h` puts it, *"there is currently no global open-instance registry."* The alternative — retrying speculatively whenever the holder is unknown — would add a bounded delay to every genuine SHARING_VIOLATION, which for non-durable opens is the common case rather than the rare one.

I have left that alone. If the behaviour is worth changing (a real client can observe a transient SHARING_VIOLATION after a peer disconnects), it deserves its own decision rather than riding in on a flake fix.

## What changed

D6 retries the assertion instead of weakening it. What it tests — that the open dies with its connection — is unchanged; what it stops requiring is the unstated extra that it dies *before the next request from somewhere else*. This is the same shape as the nfs3 probe's `await_stale` for diskfs's background inode reclaim.

The pass count is reported with `NOTE()`, so a real regression shows up as a rising number rather than a silent pass, and the cap is a wedge guard rather than a tuning knob.

## Verified

144 probe runs at 12-way concurrency against `main`'s `ext/libevpl` pin: 0 failures, one needing a single extra pass. The unfixed probe on the same pin is 2 in 120, matching the 3 in 120 measured earlier. All 30 in-process quint/MBT suites pass; `smb/mbt/batch_memfs` fails identically on clean `main` in this environment.

