### PR TITLE
ci: fetch the ccache release tarballs as gzip, not xz

### DIFF
--- a/.github/workflows/mirror-ccache.yml
+++ b/.github/workflows/mirror-ccache.yml
@@ -58,11 +58,14 @@ jobs:
             docker_arch="${pair%%:*}"
             rel_arch="${pair##*:}"
             name="ccache-${V}-linux-${rel_arch}-musl-static"
+            # .tar.gz, not the .tar.xz upstream also publishes: the ARC
+            # runners are minimal hosts and carry no xz, so `tar xJf` dies with
+            # "xz: Cannot exec". gzip is always there, and upstream ships both.
             curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
-                 -o "${name}.tar.xz" "${base}/${name}.tar.xz"
-            tar xJf "${name}.tar.xz"
+                 -o "${name}.tar.gz" "${base}/${name}.tar.gz"
+            tar xzf "${name}.tar.gz"
             install -m 0755 "${name}/ccache" "ccache-${docker_arch}"
-            rm -rf "${name}" "${name}.tar.xz"
+            rm -rf "${name}" "${name}.tar.gz"
           done
           # macOS ships one universal binary covering both Intel and Apple
           # Silicon, so there is no per-arch split to make here.  It cannot ride


### PR DESCRIPTION
Fixes the first dispatch of the mirror job added in #1585, which failed
immediately:

```
tar (child): xz: Cannot exec: No such file or directory
tar: Child returned status 2
```

The ARC runners are minimal hosts — git and the runner and not much else — and
`xz` isn't among the "not much else". I validated the download locally on a mac,
where `xz` is present, which is exactly why this got past review.

Upstream publishes every Linux asset as **both** `.tar.gz` and `.tar.xz`, so
this switches to the gzip one and needs nothing installed. Both `.tar.gz` URLs
verified to return HTTP 200. The darwin leg was already `.tar.gz` and would have
extracted fine — the two now agree.

Nothing has been published to `ghcr.io/chimera-nas/ccache` yet; the run died
before the push steps, which were all skipped.