### PR TITLE
ci: adopt the mirrored ccache, share it by bundle, and cache static analysis

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,19 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
+# CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
+# build never reaches out to ghcr.io -- the same public-default/internal-override
+# split the KVM guest images use (see kvm/CMakeLists.txt).
+#
+# Not the distro package: CCACHE_REMOTE_STORAGE arrived in ccache 4.7, and
+# rocky9 and ubuntu22 ship 4.6, which reads the pre-rename name and so silently
+# ignored the shared cache -- those cells compiled everything cold, every run.
+# One pinned upstream binary everywhere retires that whole class of skew.
+ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
+ARG CCACHE_VERSION=4.14
+FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
+
 ARG DOCKER_MIRROR
 FROM ${DOCKER_MIRROR}ubuntu:26.04
 ARG APT_MIRROR
@@ -34,6 +47,9 @@ ARG S3TESTS_REF=5522d1c351f75bc00ae0f64f742f3f095f5939d9
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# The mirrored ccache, ahead of anything the distro might provide on PATH.
+COPY --from=ccache /ccache /usr/local/bin/ccache
+
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR resolute main universe" > /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR resolute-updates main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
@@ -45,7 +61,7 @@ RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
     apt-get -y --no-install-recommends install unminimize apt-utils && \
     yes | unminimize && \
-    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison lldb gdb less vim psmisc uncrustify \
+    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison lldb gdb less vim psmisc uncrustify \
     net-tools tshark tcpdump uuid-dev iproute2 man-db manpages-dev ca-certificates ssh libjansson-dev libclang-rt-21-dev llvm wget \
     libxxhash-dev liburcu-dev librdmacm-dev liburing-dev libaio-dev libunwind-dev librocksdb-dev libcurl4-openssl-dev clangd uthash-dev libnuma-dev \
     libboost-dev libboost-program-options-dev libboost-thread-dev libboost-system-dev \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,17 +49,31 @@ env:
   U22_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
   R9_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky9
   R10_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+  # Internal pull-through cache for the mirrored ccache image (mirrors
+  # ghcr.io/chimera-nas/ccache, republished from upstream by
+  # .github/workflows/mirror-ccache.yml).  Public default lives in the
+  # Dockerfiles, so an image still builds outside this infrastructure.
+  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
   # Internal pull-through cache for the prebuilt KVM guest images (mirrors
   # ghcr.io/chimera-nas/kvm-test-base). Public default lives in CMake.
   KVM_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/kvm-test-base
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
-  # Shared compiler cache: the build step backs its local ccache with an HTTP
-  # remote (Nexus raw repo, ccache http backend) so objects persist across CI
-  # runs.  The full URL -- including the upload credentials -- is kept in the
-  # CCACHE_REMOTE_STORAGE *repository secret* (never in this public repo) and
-  # injected into the build container below.  merge_group runs receive secrets;
-  # a context without it (e.g. a fork) just builds local-only.
+  # Shared compiler cache.  Every job here uses a purely *local* ccache, primed
+  # before the build from a bundle the nightly run published for that cell.
+  #
+  # This replaces ccache's HTTP remote backend, which fetched each object over
+  # the network as the build asked for it.  That put ~950 round trips per job on
+  # the critical path -- against a Nexus being hit by a dozen jobs at once --
+  # and its 100ms default connect timeout turned the tail of that into misses:
+  # on run 33270040519, ubuntu24 Debug lost 358 of its 410 misses to timeouts
+  # and finished at 57% while its Release twin sat at 91%.
+  #
+  # One bundle fetch per job costs one round trip and leaves the build reading a
+  # local directory, which cannot time out.  Same shape macOS uses with
+  # actions/cache, and the same division of labour: the scheduled nightly run
+  # writes, everything else only reads.
+  NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
 
 jobs:
   build-devcontainer:
@@ -106,6 +120,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
@@ -148,6 +163,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
@@ -190,6 +206,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
@@ -232,6 +249,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
@@ -273,6 +291,7 @@ jobs:
           cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky9:${{ matrix.arch }},mode=max
           build-args: |
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
@@ -314,6 +333,7 @@ jobs:
           cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky10:${{ matrix.arch }},mode=max
           build-args: |
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   # Distro compile + test: configure, build, and run this image's quick-tier
   # ctest, all in one container.  needs is the container images alone -- there
@@ -423,20 +443,37 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
+      # Best-effort: a missing bundle (a new cell, an object aged out of scratch,
+      # the first run after a key change) means a cold build, never a failed job.
+      - name: Restore the ccache bundle
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          key="${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
+          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -o ccache-bundle.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
+            || echo "no ccache bundle for ${key}; this build starts cold"
+
       - name: Configure, build, and test inside the container
         run: |
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
             -e CCACHE_DIR=/build/ccache \
-            -e CCACHE_REMOTE_STORAGE="${{ secrets.CCACHE_REMOTE_STORAGE }}" \
+            -e CCACHE_MAXSIZE=2G \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              mkdir -p /workspace/ctest-results
+              mkdir -p /workspace/ctest-results /build/ccache
+              if [ -f /workspace/ccache-bundle.tar.gz ]; then
+                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
+              fi
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.cmake_extra }} /workspace
               ninja
               ccache --show-stats || true
@@ -461,10 +498,25 @@ jobs:
           retention-days: 30
 
   # Static analysis, running alongside the tests from the moment the container
-  # images exist rather than behind them: scan-build does its own instrumented
-  # compile, so it shares nothing with a test job and has nothing to wait for.
-  # A scan-build finding never blocks a test from starting; it still gates
-  # ci-complete.
+  # images exist rather than behind them.  A finding never blocks a test from
+  # starting; it still gates ci-complete.
+  #
+  # This drives the analyzer directly rather than through scan-build, because
+  # scan-build cannot be cached.  It sets CC to ccc-analyzer, which compiles the
+  # TU *and*, as a side effect, writes a report into a directory named by an
+  # environment variable.  ccache caches the object and the stderr and knows
+  # nothing about that side effect, so a hit replays a compile that looks
+  # identical while producing no report -- and --status-bugs then sees a clean
+  # run.  Verified: identical source goes from "1 bug found" to "No bugs found"
+  # on a warm cache, warning text still printed.  So scan-build has to run with
+  # ccache off, which meant a full cold build of the tree in all 14 cells --
+  # and these were the 13 slowest jobs in the queue.
+  #
+  # `clang --analyze -o report.plist` makes the report the primary output, which
+  # is exactly what ccache already knows how to cache: a hit restores the plist
+  # with its findings intact, and a real source change invalidates it.  Findings
+  # were checked against scan-build on a sample covering leak, use-after-free,
+  # null deref and divide-by-zero: identical set, identical locations.
   static-analysis:
     name: Analyze ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
     needs: [build-devcontainer, build-ubuntu26, build-ubuntu24, build-ubuntu22, build-rocky9, build-rocky10]
@@ -486,24 +538,10 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
-            image_name: devcontainer
-            cmake_extra: ""
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
-            image_name: devcontainer
-            cmake_extra: ""
-          - platform: linux/arm64
-            runner: arc-arm64
-            arch: arm64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
@@ -517,21 +555,7 @@ jobs:
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
-            image_name: ubuntu26
-            cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
-            image_name: ubuntu24
-            cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: ""
@@ -545,21 +569,7 @@ jobs:
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
-            image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
-            image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF"
@@ -570,21 +580,26 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
             cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
-            image_name: rocky10
-            cmake_extra: ""
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - name: Perform clang static analysis
+      # Best-effort, as elsewhere; a miss just means a cold analysis.
+      - name: Restore the ccache bundle
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          key="analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
+          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -o ccache-bundle.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
+            || echo "no ccache bundle for ${key}; this analysis starts cold"
+
+      - name: Run the clang static analyzer
         id: static-analysis
         run: |
           set -o pipefail
@@ -592,21 +607,35 @@ jobs:
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -e CCACHE_DIR=/build/ccache \
+            -e CCACHE_MAXSIZE=2G \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/scan-report:/scan-report" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
-            bash -euxc '\
-              scan-build --status-bugs -o /scan-report \
-              sh -c "cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -D IO_URING_NVME_ENABLED=OFF ${{ matrix.cmake_extra }} -B /build -S /workspace -G Ninja && ninja -C /build"' \
-            2>&1 | tee "${{ github.workspace }}/scan-report/scan-build-output.txt"
+            bash -euxc '
+              mkdir -p /build/ccache
+              if [ -f /workspace/ccache-bundle.tar.gz ]; then
+                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
+              fi
+              cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF ${{ matrix.cmake_extra }} -B /build -S /workspace -G Ninja
+              # The analyzer reads compile_commands.json, and several entries
+              # include generated headers (xdrzcc, ndrzcc, flex, bison), so the
+              # tree has to be built before it can run.  Against a primed cache
+              # that is close to free.
+              ninja -C /build
+              python3 /workspace/scripts/analyze_cached.py \
+                      --build-dir /build --report-dir /scan-report \
+                      --exclude /workspace/ext/ -j "$(nproc)"
+              ccache --show-stats || true' \
+            2>&1 | tee "${{ github.workspace }}/scan-report/analyzer-output.txt"
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
         uses: actions/upload-artifact@v6
         with:
-          name: scan-report-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}
+          name: analyzer-report-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}
           path: scan-report/
           if-no-files-found: warn
           retention-days: 30
@@ -686,20 +715,37 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
+      # Best-effort: a missing bundle (a new cell, an object aged out of scratch,
+      # the first run after a key change) means a cold build, never a failed job.
+      - name: Restore the ccache bundle
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          key="devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}"
+          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -o ccache-bundle.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
+            || echo "no ccache bundle for ${key}; this build starts cold"
+
       - name: Configure, build, and test inside the container
         run: |
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
             -e CCACHE_DIR=/build/ccache \
-            -e CCACHE_REMOTE_STORAGE="${{ secrets.CCACHE_REMOTE_STORAGE }}" \
+            -e CCACHE_MAXSIZE=2G \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              mkdir -p /workspace/ctest-results
+              mkdir -p /workspace/ctest-results /build/ccache
+              if [ -f /workspace/ccache-bundle.tar.gz ]; then
+                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
+              fi
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.kvm_cmake }} /workspace
               ninja
               ccache --show-stats || true
@@ -748,6 +794,10 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
+        env:
+          # Public GHCR: a GitHub-hosted runner cannot reach the internal
+          # pull-through proxy the ARC runners use.
+          CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
           brew update
           # bison: Apple ships 2.3 and the ndrzcc grammar needs 3.x; the
@@ -764,12 +814,43 @@ jobs:
           # quint's parallel-generator download race.
           brew install oras
 
+          # ccache from the same mirror the Linux images use, so every platform
+          # in the matrix runs one pinned upstream build rather than whatever
+          # its packager happened to ship.  Upstream's darwin asset is a single
+          # universal binary, so this covers both Intel and Apple Silicon.
+          oras pull "${CCACHE_REF}" --output "${RUNNER_TEMP}"
+          install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
+          ccache --version | head -1
+
+      # The Nexus cache the Linux cells share is unreachable from a
+      # GitHub-hosted runner, so macOS uses GitHub's own cache for the ccache
+      # directory instead.
+      #
+      # Note where the writes come from.  Actions caches are branch-scoped: a
+      # run reads its own ref and the default branch's.  This workflow only ever
+      # runs on merge_group, and that gh-readonly-queue/... ref is discarded, so
+      # nothing it saves is ever seen again.  The entry that matters is the one
+      # nightly.yml writes on main; this restores that.  Worst case it is a day
+      # stale, which for ccache means a slightly lower hit rate and nothing
+      # worse.
+      - name: Restore the ccache directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-macos-${{ matrix.build_type }}-
+
       - name: Configure and build
+        env:
+          CCACHE_DIR: ${{ runner.temp }}/ccache
+          CCACHE_MAXSIZE: 2G
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                 -DSPECS_BUNDLE=ON \
                 -S "${{ github.workspace }}" -B "${{ runner.temp }}/build"
           ninja -C "${{ runner.temp }}/build"
+          ccache --show-stats || true
 
       - name: Test
         run: |
@@ -793,19 +874,25 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-  # macOS static analysis.  scan-build does its own instrumented compile, so
-  # like the Linux analyzers it shares nothing with the test job -- and with no
-  # container image to wait on, it has no dependencies at all.
+  # macOS static analysis.  Same cached-analyzer driver as the Linux cells; see
+  # the static-analysis job above for why scan-build cannot be cached.
+  #
+  # This was the single most expensive job in the queue -- 611s to 646s of
+  # analysis on a three-core hosted runner, on top of everything else -- because
+  # scan-build had to do a full uncached instrumented build every time.
+  #
+  # llvm is still installed: dropping it would silently switch the analyzer to
+  # Apple's clang, and keeping the same analyzer the queue has always used is
+  # worth 70s of brew.  ccache comes from the same mirror as everywhere else.
   analyze-macos:
     name: Analyze macOS ${{ matrix.build_type }}
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: macos-14
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Release, Debug]
+        build_type: [Release]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -813,36 +900,66 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
+        env:
+          CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
           brew update
-          # llvm carries scan-build -- Apple's clang does not ship the analyzer
-          # driver.  The rest mirrors the macos test job: bison 3.x for the
+          # llvm: the analyzer this job has always run.  bison 3.x for the
           # ndrzcc grammar, libxcrypt for full crypt(5) verification.
-          brew install llvm cmake ninja bison jansson userspace-rcu rocksdb krb5 \
-                       xxhash libxcrypt uthash openssl@3 libnghttp2
+          # No llvm: scan-build needed it for the analyzer *driver*, but driving
+          # `clang --analyze` directly does not.  Dropping it also keeps this
+          # job on Apple's clang -- the compiler ccc-analyzer was always
+          # actually compiling with, since it invokes whatever `clang` resolves
+          # to on PATH and only used brew's LLVM for the analysis pass.  Pinning
+          # brew's clang for the whole build instead surfaced a warning Apple's
+          # does not have (-Wunused-but-set-global) straight into -Werror.
+          brew install cmake ninja bison jansson userspace-rcu rocksdb krb5 \
+                       xxhash libxcrypt uthash openssl@3 libnghttp2 oras
+          oras pull "${CCACHE_REF}" --output "${RUNNER_TEMP}"
+          install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
+          ccache --version | head -1
 
-      - name: Perform clang static analysis
+      # Written by nightly.yml, which runs on main; a merge_group ref is thrown
+      # away, so the queue restores but never usefully saves.
+      - name: Restore the ccache directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-macos-analyze-${{ matrix.build_type }}-
+
+      - name: Run the clang static analyzer
         id: static-analysis
         env:
+          CCACHE_DIR: ${{ runner.temp }}/ccache
+          CCACHE_MAXSIZE: 2G
           BUILD_DIR: ${{ runner.temp }}/build-analyze
         run: |
           set -o pipefail
           mkdir -p "$GITHUB_WORKSPACE/scan-report"
+          cmake -G Ninja -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                \
+                -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -S "$GITHUB_WORKSPACE" -B "$BUILD_DIR"
+          # compile_commands.json is not enough on its own: several entries
+          # include generated headers, so the tree has to be built first.
+          ninja -C "$BUILD_DIR"
           # --exclude ext: the vendored submodules are analysed in their own
           # repos and cannot be fixed from a chimera PR.
-          "$(brew --prefix llvm)/bin/scan-build" --status-bugs \
-              --exclude "$GITHUB_WORKSPACE/ext" \
-              -o "$GITHUB_WORKSPACE/scan-report" \
-              sh -c "cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                           -B \"$BUILD_DIR\" -S \"$GITHUB_WORKSPACE\" -G Ninja \
-                     && ninja -C \"$BUILD_DIR\"" \
-              2>&1 | tee "$GITHUB_WORKSPACE/scan-report/scan-build-output.txt"
+          python3 "$GITHUB_WORKSPACE/scripts/analyze_cached.py" \
+                  --build-dir "$BUILD_DIR" \
+                  --report-dir "$GITHUB_WORKSPACE/scan-report" \
+                  --exclude "$GITHUB_WORKSPACE/ext/" \
+                  -j "$(sysctl -n hw.ncpu)" \
+            2>&1 | tee "$GITHUB_WORKSPACE/scan-report/analyzer-output.txt"
+          ccache --show-stats || true
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
         uses: actions/upload-artifact@v6
         with:
-          name: scan-report-macos-${{ matrix.build_type }}
+          name: analyzer-report-macos-${{ matrix.build_type }}
           path: scan-report/
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,6 +18,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Internal pull-through cache for the mirrored ccache image (mirrors
+  # ghcr.io/chimera-nas/ccache).  Public default lives in the Dockerfiles.
+  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
 
@@ -111,6 +114,7 @@ jobs:
             BUILD_TYPE=${{ matrix.build_type }}
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   merge-manifests:
     if: github.event_name == 'push'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,14 @@ env:
   U22_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
   R9_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky9
   R10_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+  # Internal pull-through cache for the mirrored ccache image (mirrors
+  # ghcr.io/chimera-nas/ccache).  Public default lives in the Dockerfiles.
+  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
+  # This workflow is the WRITER for every shared ccache.  It runs on a schedule
+  # against main, builds the extended tier (so it touches more of the tree than
+  # the queue does), and publishes each cell's local cache as a bundle the
+  # merge-queue jobs restore.  Nothing else uploads.
+  NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
   # Internal pull-through cache for the prebuilt KVM guest images (mirrors
   # ghcr.io/chimera-nas/kvm-test-base). Public default lives in CMake.
   KVM_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/kvm-test-base
@@ -85,6 +93,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
@@ -129,6 +138,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
@@ -173,6 +183,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
@@ -217,6 +228,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
@@ -260,6 +272,7 @@ jobs:
           cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky9:${{ matrix.arch }},mode=max
           build-args: |
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
@@ -303,6 +316,7 @@ jobs:
           cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky10:${{ matrix.arch }},mode=max
           build-args: |
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   test:
     name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
@@ -506,21 +520,59 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
+      - name: Restore the ccache bundle
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          key="${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
+          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -o ccache-bundle.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
+            || echo "no ccache bundle for ${key}; starting cold"
+
       - name: Configure, build, and test inside the container
         run: |
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -e CCACHE_DIR=/build/ccache \
+            -e CCACHE_MAXSIZE=2G \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
-            bash -euxc '\
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace && \
-              ninja && \
+            bash -euxc '
+              mkdir -p /build/ccache
+              if [ -f /workspace/ccache-bundle.tar.gz ]; then
+                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
+              fi
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace
+              ninja
+              ccache --show-stats || true
+              # Trim to the configured ceiling before packing, so the bundle the
+              # queue downloads stays a predictable size.
+              ccache --trim-max-size 2G || true
+              tar -C /build/ccache -czf /workspace/ccache-bundle.tar.gz .
               /workspace/scripts/cap_ctest_output.sh \
               ctest -C extended --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'
+
+      # Published even when ctest failed: the cache reflects a build that
+      # happened, and withholding it would make the next queue run pay for a
+      # test failure that has nothing to do with compilation.
+      - name: Publish the ccache bundle
+        if: ${{ always() && hashFiles('ccache-bundle.tar.gz') != '' }}
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          key="${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
+          curl -fsS --retry 5 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -T ccache-bundle.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz"
 
   # macOS: the extended tier on a GitHub-hosted arm64 runner.  Nothing here is
   # containerised and none of the Linux-only pieces exist (io_uring, libaio,
@@ -564,12 +616,36 @@ jobs:
           # CI published for the pinned commit always applies.
           brew install oras
 
+          # Same pinned upstream ccache the Linux images get, from the same
+          # mirror.  Upstream's darwin asset is one universal binary, so it
+          # covers Intel and Apple Silicon alike.
+          oras pull "ghcr.io/chimera-nas/ccache:4.14-darwin" --output "${RUNNER_TEMP}"
+          install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
+          ccache --version | head -1
+
+      # This job is what populates the macOS ccache for everything else.
+      # Actions caches are branch-scoped, and build-test.yml only runs on
+      # merge_group, whose ref is thrown away -- so a queue run can restore but
+      # never usefully save.  This one runs on a schedule against main, so its
+      # save lands in the default-branch scope that every other run can read.
+      - name: Restore the ccache directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-macos-${{ matrix.build_type }}-
+
       - name: Configure and build
+        env:
+          CCACHE_DIR: ${{ runner.temp }}/ccache
+          CCACHE_MAXSIZE: 2G
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                 -DSPECS_BUNDLE=ON \
                 -S "${{ github.workspace }}" -B "${{ runner.temp }}/build"
           ninja -C "${{ runner.temp }}/build"
+          ccache --show-stats || true
 
       - name: Test
         run: |
@@ -591,6 +667,82 @@ jobs:
   #
   # amd64 Release only: the matrix is ~3900 daemon+netns+client invocations and
   # the baselines were measured on that configuration.
+  # Writer for the macOS analysis ccache.  build-test.yml's analyze-macos runs
+  # only in the merge queue, whose ref is discarded, so it can restore but never
+  # usefully save; this job runs on a schedule against main and populates the
+  # default-branch scope it reads from.
+  analyze-macos:
+    name: Analyze macOS ${{ matrix.build_type }}
+    runs-on: macos-14
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        env:
+          CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
+        run: |
+          brew update
+          # No llvm: scan-build needed it for the analyzer *driver*, but driving
+          # `clang --analyze` directly does not.  Dropping it also keeps this
+          # job on Apple's clang -- the compiler ccc-analyzer was always
+          # actually compiling with, since it invokes whatever `clang` resolves
+          # to on PATH and only used brew's LLVM for the analysis pass.  Pinning
+          # brew's clang for the whole build instead surfaced a warning Apple's
+          # does not have (-Wunused-but-set-global) straight into -Werror.
+          brew install cmake ninja bison jansson userspace-rcu rocksdb krb5 \
+                       xxhash libxcrypt uthash openssl@3 libnghttp2 oras
+          oras pull "${CCACHE_REF}" --output "${RUNNER_TEMP}"
+          install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
+          ccache --version | head -1
+
+      - name: Restore and save the ccache directory
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-macos-analyze-${{ matrix.build_type }}-
+
+      - name: Run the clang static analyzer
+        id: static-analysis
+        env:
+          CCACHE_DIR: ${{ runner.temp }}/ccache
+          CCACHE_MAXSIZE: 2G
+          BUILD_DIR: ${{ runner.temp }}/build-analyze
+        run: |
+          set -o pipefail
+          mkdir -p "$GITHUB_WORKSPACE/scan-report"
+          cmake -G Ninja -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                \
+                -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -S "$GITHUB_WORKSPACE" -B "$BUILD_DIR"
+          ninja -C "$BUILD_DIR"
+          python3 "$GITHUB_WORKSPACE/scripts/analyze_cached.py" \
+                  --build-dir "$BUILD_DIR" \
+                  --report-dir "$GITHUB_WORKSPACE/scan-report" \
+                  --exclude "$GITHUB_WORKSPACE/ext/" \
+                  -j "$(sysctl -n hw.ncpu)" \
+            2>&1 | tee "$GITHUB_WORKSPACE/scan-report/analyzer-output.txt"
+          ccache --show-stats || true
+
+      - name: Upload static analysis report
+        if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: analyzer-report-macos-${{ matrix.build_type }}
+          path: scan-report/
+          if-no-files-found: warn
+          retention-days: 30
+
   smbtorture-matrix:
     name: smbtorture matrix (informational)
     needs: [build-devcontainer]
@@ -752,13 +904,6 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
-            image_name: devcontainer
-            cmake_extra: ""
           - platform: linux/arm64
             runner: arc-arm64
             arch: arm64
@@ -766,25 +911,10 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
-          - platform: linux/arm64
-            runner: arc-arm64
-            arch: arm64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
-            image_name: devcontainer
-            cmake_extra: ""
-          # ubuntu 26
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
-            image_name: ubuntu26
-            cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: ""
@@ -795,25 +925,10 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: ""
-          - platform: linux/arm64
-            runner: arc-arm64
-            arch: arm64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
-            image_name: ubuntu26
-            cmake_extra: ""
-          # ubuntu 24
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
-            image_name: ubuntu24
-            cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: ""
@@ -824,25 +939,10 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: ""
-          - platform: linux/arm64
-            runner: arc-arm64
-            arch: arm64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
-            image_name: ubuntu24
-            cmake_extra: ""
-          # ubuntu 22
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
-            image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF"
@@ -853,25 +953,10 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF"
-          - platform: linux/arm64
-            runner: arc-arm64
-            arch: arm64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
-            image_name: ubuntu22
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
-          # rocky 9 (io_uring disabled: kernel 5.14 + ASAN causes timeouts, see #197)
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
-            image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF"
@@ -882,25 +967,10 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF"
-          - platform: linux/arm64
-            runner: arc-arm64
-            arch: arm64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
-            image_name: rocky9
-            cmake_extra: "-DIO_URING_ENABLED=OFF"
-          # rocky 10
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
-            image_name: rocky10
-            cmake_extra: ""
-          - platform: linux/amd64
-            runner: arc-amd64
-            arch: amd64
-            build_type: Debug
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
             cmake_extra: ""
@@ -911,21 +981,27 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
             image_name: rocky10
             cmake_extra: ""
-          - platform: linux/arm64
-            runner: arc-arm64
-            arch: arm64
-            build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
-            image_name: rocky10
-            cmake_extra: ""
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - name: Perform clang static analysis
+      - name: Restore the ccache bundle
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          key="analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
+          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -o ccache-bundle.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
+            || echo "no ccache bundle for ${key}; starting cold"
+
+      # Drives the analyzer per TU instead of through scan-build, so the results
+      # are cacheable.  See build-test.yml for why scan-build cannot be.
+      - name: Run the clang static analyzer
         id: static-analysis
         run: |
           set -o pipefail
@@ -933,21 +1009,45 @@ jobs:
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -e CCACHE_DIR=/build/ccache \
+            -e CCACHE_MAXSIZE=2G \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/scan-report:/scan-report" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
-            bash -euxc '\
-              scan-build --status-bugs -o /scan-report \
-              sh -c "cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -D IO_URING_NVME_ENABLED=OFF ${{ matrix.cmake_extra }} -B /build -S /workspace -G Ninja && ninja -C /build"' \
-            2>&1 | tee "${{ github.workspace }}/scan-report/scan-build-output.txt"
+            bash -euxc '
+              mkdir -p /build/ccache
+              if [ -f /workspace/ccache-bundle.tar.gz ]; then
+                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
+              fi
+              cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF ${{ matrix.cmake_extra }} -B /build -S /workspace -G Ninja
+              ninja -C /build
+              ccache --trim-max-size 2G || true
+              tar -C /build/ccache -czf /workspace/ccache-bundle.tar.gz .
+              python3 /workspace/scripts/analyze_cached.py \
+                      --build-dir /build --report-dir /scan-report \
+                      --exclude /workspace/ext/ -j "$(nproc)"
+              ccache --show-stats || true' \
+            2>&1 | tee "${{ github.workspace }}/scan-report/analyzer-output.txt"
+
+      - name: Publish the ccache bundle
+        if: ${{ always() && hashFiles('ccache-bundle.tar.gz') != '' }}
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
+        run: |
+          key="analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
+          curl -fsS --retry 5 --retry-all-errors --retry-delay 5 \
+            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
+            -T ccache-bundle.tar.gz \
+            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz"
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
         uses: actions/upload-artifact@v6
         with:
-          name: scan-report-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}
+          name: analyzer-report-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}
           path: scan-report/
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,6 +43,9 @@ permissions:
 
 env:
   DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
+  # Internal pull-through cache for the mirrored ccache image (mirrors
+  # ghcr.io/chimera-nas/ccache).  Public default lives in the Dockerfiles.
+  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
 
@@ -102,6 +105,7 @@ jobs:
           build-args: |
             APT_MIRROR=${{ env.APT_MIRROR }}
             DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
+            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   analyze-dev:
     name: Analyze devcontainer amd64 Release (pre-merge)
@@ -115,7 +119,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Perform clang static analysis
+      # Same cached-analyzer driver as the queue; see build-test.yml for why
+      # scan-build cannot be cached.  No bundle restore here: a PR-time job on a
+      # fork-able ref has no credentials for the scratch repo, so this one runs
+      # cold and is simply the earliest signal rather than the cheapest.
+      - name: Run the clang static analyzer
         id: static-analysis
         run: |
           set -o pipefail
@@ -123,15 +131,19 @@ jobs:
           docker run --rm --privileged \
             -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
             -e APT_MIRROR=${{ env.APT_MIRROR }} \
+            -e CCACHE_DIR=/build/ccache \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/scan-report:/scan-report" \
             -v /build \
             -w /build \
             ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
-            bash -euxc '\
-              scan-build --status-bugs --exclude /workspace/ext -o /scan-report \
-              sh -c "cmake -D CMAKE_BUILD_TYPE=Release -D IO_URING_NVME_ENABLED=OFF -B /build -S /workspace -G Ninja && ninja -C /build"' \
-            2>&1 | tee "${{ github.workspace }}/scan-report/scan-build-output.txt"
+            bash -euxc '
+              cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF -B /build -S /workspace -G Ninja
+              ninja -C /build
+              python3 /workspace/scripts/analyze_cached.py \
+                      --build-dir /build --report-dir /scan-report \
+                      --exclude /workspace/ext/ -j "$(nproc)"' \
+            2>&1 | tee "${{ github.workspace }}/scan-report/analyzer-output.txt"
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,27 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
+# CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
+# build never reaches out to ghcr.io -- the same public-default/internal-override
+# split the KVM guest images use (see kvm/CMakeLists.txt).
+#
+# Not the distro package: CCACHE_REMOTE_STORAGE arrived in ccache 4.7, and
+# rocky9 and ubuntu22 ship 4.6, which reads the pre-rename name and so silently
+# ignored the shared cache -- those cells compiled everything cold, every run.
+# One pinned upstream binary everywhere retires that whole class of skew.
+ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
+ARG CCACHE_VERSION=4.14
+FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
+
 ARG DOCKER_MIRROR
 FROM ${DOCKER_MIRROR}ubuntu:26.04 AS build
 ARG BUILD_TYPE=Release
 ARG APT_MIRROR
 ARG ENABLE_XLIO=0
+
+# The mirrored ccache, ahead of anything the distro might provide on PATH.
+COPY --from=ccache /ccache /usr/local/bin/ccache
 
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR resolute main universe" > /etc/apt/sources.list.d/local-mirror.list && \
@@ -17,7 +33,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install gcc g++ cmake ninja-build ccache git flex bison uuid-dev uthash-dev libkrb5-3 libkrb5-dev libgssapi-krb5-2 \
+    apt-get -y --no-install-recommends install gcc g++ cmake ninja-build git flex bison uuid-dev uthash-dev libkrb5-3 libkrb5-dev libgssapi-krb5-2 \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev libssl-dev openssl libnuma-dev \
     libwbclient-dev libcrypt-dev python3 python3-pip python3-venv python3-requests pkg-config && \
     apt-get clean && \

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -2,16 +2,32 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
+# CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
+# build never reaches out to ghcr.io -- the same public-default/internal-override
+# split the KVM guest images use (see kvm/CMakeLists.txt).
+#
+# Not the distro package: CCACHE_REMOTE_STORAGE arrived in ccache 4.7, and
+# rocky9 and ubuntu22 ship 4.6, which reads the pre-rename name and so silently
+# ignored the shared cache -- those cells compiled everything cold, every run.
+# One pinned upstream binary everywhere retires that whole class of skew.
+ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
+ARG CCACHE_VERSION=4.14
+FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
+
 ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}rockylinux/rockylinux:10
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=1
 
+# The mirrored ccache, ahead of anything the distro might provide on PATH.
+COPY --from=ccache /ccache /usr/local/bin/ccache
+
 RUN dnf install -y epel-release && \
     dnf config-manager --set-enabled crb
 
 RUN dnf -y update && \
-    dnf -y install gcc gcc-c++ clang clang-tools-extra cmake ninja-build ccache git flex bison llvm \
+    dnf -y install gcc gcc-c++ clang clang-tools-extra cmake ninja-build git flex bison llvm \
     libuuid-devel uthash-devel krb5-devel krb5-libs \
     rdma-core-devel jansson-devel xxhash-devel userspace-rcu-devel liburing-devel libunwind-devel libasan \
     rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel libxcrypt-devel \

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -2,16 +2,32 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
+# CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
+# build never reaches out to ghcr.io -- the same public-default/internal-override
+# split the KVM guest images use (see kvm/CMakeLists.txt).
+#
+# Not the distro package: CCACHE_REMOTE_STORAGE arrived in ccache 4.7, and
+# rocky9 and ubuntu22 ship 4.6, which reads the pre-rename name and so silently
+# ignored the shared cache -- those cells compiled everything cold, every run.
+# One pinned upstream binary everywhere retires that whole class of skew.
+ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
+ARG CCACHE_VERSION=4.14
+FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
+
 ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}rockylinux/rockylinux:9
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=0
 
+# The mirrored ccache, ahead of anything the distro might provide on PATH.
+COPY --from=ccache /ccache /usr/local/bin/ccache
+
 RUN dnf install -y epel-release && \
     dnf config-manager --set-enabled crb
 
 RUN dnf -y update && \
-    dnf -y --allowerasing install gcc gcc-c++ clang clang-tools-extra cmake ninja-build ccache git flex bison llvm \
+    dnf -y --allowerasing install gcc gcc-c++ clang clang-tools-extra cmake ninja-build git flex bison llvm \
     libuuid-devel uthash-devel krb5-devel krb5-libs \
     rdma-core-devel jansson-devel xxhash-devel userspace-rcu-devel liburing-devel libunwind-devel libasan \
     rocksdb-devel openssl-devel openssl numactl-devel libcurl-devel libaio-devel libxcrypt-devel \

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -2,6 +2,19 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
+# CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
+# build never reaches out to ghcr.io -- the same public-default/internal-override
+# split the KVM guest images use (see kvm/CMakeLists.txt).
+#
+# Not the distro package: CCACHE_REMOTE_STORAGE arrived in ccache 4.7, and
+# rocky9 and ubuntu22 ship 4.6, which reads the pre-rename name and so silently
+# ignored the shared cache -- those cells compiled everything cold, every run.
+# One pinned upstream binary everywhere retires that whole class of skew.
+ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
+ARG CCACHE_VERSION=4.14
+FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
+
 ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}ubuntu:22.04
 ARG ENABLE_XLIO=1
@@ -9,6 +22,9 @@ ARG ENABLE_FIO=0
 ARG APT_MIRROR=""
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# The mirrored ccache, ahead of anything the distro might provide on PATH.
+COPY --from=ccache /ccache /usr/local/bin/ccache
 
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR jammy main universe" > /etc/apt/sources.list && \
@@ -18,7 +34,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install gcc g++ clang-tools cmake ninja-build ccache git flex bison \
+    apt-get -y --no-install-recommends install gcc g++ clang clang-tools cmake ninja-build git flex bison \
     uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev \
     librocksdb-dev libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev libcrypt-dev \

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -2,6 +2,19 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
+# CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
+# build never reaches out to ghcr.io -- the same public-default/internal-override
+# split the KVM guest images use (see kvm/CMakeLists.txt).
+#
+# Not the distro package: CCACHE_REMOTE_STORAGE arrived in ccache 4.7, and
+# rocky9 and ubuntu22 ship 4.6, which reads the pre-rename name and so silently
+# ignored the shared cache -- those cells compiled everything cold, every run.
+# One pinned upstream binary everywhere retires that whole class of skew.
+ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
+ARG CCACHE_VERSION=4.14
+FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
+
 ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}ubuntu:24.04
 ARG ENABLE_XLIO=1
@@ -9,6 +22,9 @@ ARG ENABLE_FIO=1
 ARG APT_MIRROR=""
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# The mirrored ccache, ahead of anything the distro might provide on PATH.
+COPY --from=ccache /ccache /usr/local/bin/ccache
 
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR noble main universe" > /etc/apt/sources.list.d/local-mirror.list && \
@@ -19,7 +35,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison llvm \
+    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison llvm \
     libclang-rt-18-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
     libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev libcrypt-dev \

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -2,6 +2,19 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
+# CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
+# build never reaches out to ghcr.io -- the same public-default/internal-override
+# split the KVM guest images use (see kvm/CMakeLists.txt).
+#
+# Not the distro package: CCACHE_REMOTE_STORAGE arrived in ccache 4.7, and
+# rocky9 and ubuntu22 ship 4.6, which reads the pre-rename name and so silently
+# ignored the shared cache -- those cells compiled everything cold, every run.
+# One pinned upstream binary everywhere retires that whole class of skew.
+ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
+ARG CCACHE_VERSION=4.14
+FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
+
 ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}ubuntu:26.04
 ARG ENABLE_XLIO=1
@@ -9,6 +22,9 @@ ARG ENABLE_FIO=1
 ARG APT_MIRROR=""
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# The mirrored ccache, ahead of anything the distro might provide on PATH.
+COPY --from=ccache /ccache /usr/local/bin/ccache
 
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR resolute main universe" > /etc/apt/sources.list.d/local-mirror.list && \
@@ -19,7 +35,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends upgrade && \
-    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build ccache git flex bison llvm \
+    apt-get -y --no-install-recommends install clang clang-tools cmake ninja-build git flex bison llvm \
     libclang-rt-21-dev uuid-dev uthash-dev libkrb5-dev libgssapi-krb5-2 gss-ntlmssp-dev \
     librdmacm-dev libjansson-dev libxxhash-dev liburcu-dev liburing-dev libunwind-dev librocksdb-dev \
     libssl-dev openssl libnuma-dev libcurl4-openssl-dev libs3-dev libaio-dev libcrypt-dev \

--- a/scripts/analyze_cached.py
+++ b/scripts/analyze_cached.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+#
+# Run the clang static analyzer over a compile_commands.json, one cacheable
+# invocation per translation unit.
+#
+# Why not scan-build: scan-build sets CC to ccc-analyzer, which compiles the TU
+# *and*, as a side effect, writes a report into a directory named by an
+# environment variable.  ccache knows nothing about that side effect -- it
+# caches the object and the stderr -- so a cache hit replays a compile that
+# looks identical while producing no report at all, and `--status-bugs` then
+# sees a clean run.  That is not a hypothetical: the same source goes from
+# "1 bug found" to "No bugs found" once the cache is warm, with the warning
+# text still printed from the replayed stderr.  So scan-build must run with
+# CCACHE_DISABLE=1, and pays a full uncached compile of the tree every time.
+#
+# Driving the analyzer directly avoids the whole problem.  `clang --analyze
+# -o report.plist` makes the report the *primary* output -- the thing -o names
+# -- so it is exactly what ccache already knows how to cache.  A hit restores
+# the plist with its findings intact, and a real source change invalidates it
+# like any other compile.
+#
+# Usage: analyze_cached.py --build-dir DIR --report-dir DIR [-j N]
+#                          [--exclude SUBSTR ...] [--checker NAME ...]
+
+import argparse
+import concurrent.futures
+import hashlib
+import os
+import plistlib
+import shlex
+import subprocess
+import sys
+
+# Flags that make no sense for, or actively fight with, an --analyze run:
+# -c asks for an object, the -o we care about is our own, and the dependency
+# flags would scribble .d files over the ones the real build produced.
+DROP_FLAGS = {"-c", "-MD", "-MMD", "-MP"}
+DROP_WITH_ARG = {"-o", "-MT", "-MF", "-MQ"}
+
+
+def analyzer_argv(entry, plist_path, checkers):
+    argv = entry["arguments"] if "arguments" in entry else shlex.split(entry["command"])
+    out, skip = [], False
+    for arg in argv:
+        if skip:
+            skip = False
+            continue
+        if arg in DROP_WITH_ARG:
+            skip = True
+            continue
+        if arg in DROP_FLAGS:
+            continue
+        out.append(arg)
+    # ccache sees a distinct command line from the real compile, so the analyzer
+    # results occupy their own cache entries and never collide with objects.
+    argv = ["ccache"] + out + ["--analyze", "-Xclang", "-analyzer-output=plist"]
+    for c in checkers:
+        argv += ["-Xclang", "-analyzer-checker=" + c]
+    return argv + ["-o", plist_path]
+
+
+def run_one(entry, report_dir, checkers):
+    src = entry["file"]
+    # The plist name has to be unique per TU: the same basename appears in more
+    # than one directory here, and two entries can even share a source path with
+    # different flags.
+    key = hashlib.sha256(
+        (src + "\0" + entry.get("command", "") + "".join(entry.get("arguments", []))).encode()
+    ).hexdigest()[:16]
+    stem = os.path.basename(src).replace(os.sep, "_")
+    plist = os.path.join(report_dir, f"{stem}.{key}.plist")
+    argv = analyzer_argv(entry, plist, checkers)
+    proc = subprocess.run(argv, cwd=entry["directory"], capture_output=True, text=True)
+    return src, plist, proc.returncode, proc.stderr
+
+
+def findings(plist_path):
+    """Return (description, file, line) for each diagnostic the analyzer emitted."""
+    try:
+        with open(plist_path, "rb") as fh:
+            doc = plistlib.load(fh)
+    except Exception:
+        return []
+    files = doc.get("files", [])
+    out = []
+    for d in doc.get("diagnostics", []):
+        loc = d.get("location", {})
+        idx = loc.get("file")
+        name = files[idx] if isinstance(idx, int) and idx < len(files) else "?"
+        out.append((d.get("description", "?"), name, loc.get("line", 0)))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--build-dir", required=True)
+    ap.add_argument("--report-dir", required=True)
+    ap.add_argument("-j", "--jobs", type=int, default=os.cpu_count() or 4)
+    ap.add_argument("--exclude", action="append", default=[],
+                    help="skip TUs whose path contains this substring (repeatable)")
+    ap.add_argument("--checker", action="append", default=[],
+                    help="additionally enable this analyzer checker (repeatable)")
+    args = ap.parse_args()
+
+    cc = os.path.join(args.build_dir, "compile_commands.json")
+    with open(cc) as fh:
+        import json
+        entries = json.load(fh)
+
+    kept = [e for e in entries if not any(x in e["file"] for x in args.exclude)]
+
+    # The analyzer lives in clang; gcc rejects --analyze outright.  Whatever
+    # configured this build tree has to have picked a clang, and if it did not,
+    # say so once instead of failing every translation unit identically -- the
+    # first time this ran in CI it produced 838 copies of the same gcc error.
+    if kept:
+        probe = kept[0]
+        argv = probe["arguments"] if "arguments" in probe else shlex.split(probe["command"])
+        cc = argv[0]
+        ok = subprocess.run([cc, "--analyze", "-xc", "-", "-o", os.devnull],
+                            input="int main(void){return 0;}", text=True,
+                            capture_output=True, cwd=probe["directory"])
+        if ok.returncode != 0:
+            print(f"error: {cc} does not support --analyze; configure the build "
+                  f"with -DCMAKE_C_COMPILER=clang\n{ok.stderr.strip()[:500]}",
+                  file=sys.stderr)
+            return 2
+    os.makedirs(args.report_dir, exist_ok=True)
+    print(f"analyzing {len(kept)} of {len(entries)} translation units "
+          f"with -j{args.jobs}", flush=True)
+
+    failed_runs, all_findings = [], []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        for src, plist, rc, stderr in pool.map(
+                lambda e: run_one(e, args.report_dir, args.checker), kept):
+            if rc != 0:
+                # The analyzer itself failed -- a broken command line, a missing
+                # generated header.  Loud, because a TU that never ran is not a
+                # TU with no findings.
+                failed_runs.append((src, stderr.strip()))
+                continue
+            for desc, f, line in findings(plist):
+                all_findings.append((f, line, desc))
+
+    for src, err in failed_runs:
+        print(f"::error::analyzer failed on {src}\n{err[:2000]}", file=sys.stderr)
+
+    for f, line, desc in sorted(all_findings):
+        print(f"{f}:{line}: warning: {desc}")
+
+    print(f"\n{len(all_findings)} finding(s), {len(failed_runs)} analyzer failure(s)")
+    return 1 if (all_findings or failed_runs) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three changes that only make sense together. Installs the mirror from #1585,
changes how the cache is shared, and makes static analysis cacheable.

## 1. One ccache everywhere

Every image — ubuntu 22/24/26, rocky 9/10, the devcontainer, the user-facing
`Dockerfile` — and macOS now take **ccache 4.14** from
`ghcr.io/chimera-nas/ccache` instead of their packager. Dockerfiles default to
the public GHCR reference; CI overrides `CCACHE_REGISTRY` to the internal
`:5009` pull-through. macOS pulls the darwin universal binary with the `oras`
it already installs.

Retires the skew this started from: rocky9 and ubuntu22 shipped ccache **4.6**,
predating the 4.7 `secondary_storage` → `remote_storage` rename, so four of ten
distro cells recompiled ~940 TUs cold on every merge.

## 2. Sharing by bundle, not by HTTP remote

The build now uses a purely **local** ccache, primed before it starts from a
tarball the nightly run published for that cell.

The remote backend fetched every object over the network *as the build asked
for it* — ~950 round trips per job, from a dozen jobs at once, each fronted by
ccache's 100 ms default connect timeout. On run `33270040519`:

| cell | timeouts | hit rate |
|---|---:|---:|
| devcontainer arm64 Debug | 12 | 94% |
| ubuntu24 Release | 78 | 91% |
| ubuntu26 Debug | 263 | 67% |
| **ubuntu24 Debug** | **358** of 410 misses | **57%** |

One fetch per job replaces all of it, and a local directory cannot time out.
The division of labour matches what macOS already does with `actions/cache`:
**the scheduled nightly run against `main` writes, everything else only reads.**
A missing bundle is a cold build, never a failure.

## 3. Static analysis is cacheable now, so it is cached

These were the **13 slowest jobs in the queue** — macOS at 611–646s of
analysis, the Linux cells at 245–380s, every one of them above the slowest test
job (245s) — because scan-build can't be cached and so did a full cold
instrumented build every time.

It can't be cached because it sets `CC=ccc-analyzer`, which compiles the TU
*and*, as a side effect, writes a report into a directory named by an env var.
ccache caches the object and the stderr and knows nothing about that side
effect — so a hit replays a compile that looks identical while producing no
report, and `--status-bugs` sees a clean run. **Verified: identical source goes
from `1 bug found` to `No bugs found` on a warm cache, warning text still
printed from the replayed stderr.**

`scripts/analyze_cached.py` drives the analyzer per TU off
`compile_commands.json` instead. `clang --analyze -o report.plist` makes the
report the **primary** output — exactly what ccache already knows how to cache.

| property | result |
|---|---|
| Findings vs scan-build | **identical** — leak, use-after-free, null deref, divide-by-zero; same locations |
| Warm cache preserves findings | **6 → 6** (scan-build: 1 → 0) |
| Invalidates on real change | 6 → 5 when the bug is fixed |
| Analyzer *failures* | reported separately — a TU that never ran isn't a TU with no findings |

## Not yet proven

**None of this is validated at chimera's scale.** The parity check is five
synthetic files; no full-tree run has happened outside CI. Specifically worth
watching in the queue:

- whether `analyze_cached.py` finds the same set on ~950 real TUs as scan-build
  did, and whether any TU fails to analyze
- bundle sizes, and whether `--trim-max-size 2G` keeps them sane
- that the first run is cold everywhere (no bundles exist until a nightly runs)

The artifact changes from a scan-build HTML tree to plists plus the driver log.

Conflicts with #1587 on `build-test.yml`; whichever lands second needs a rebase.