### PR TITLE
tests/quint: POSIX model testing over the NFS3 loopback, and the fixes it took

### DIFF
--- a/src/client/client_setattr.h
+++ b/src/client/client_setattr.h
@@ -85,10 +85,16 @@ chimera_dispatch_setattr(
 
     /*
      * Use a real file handle instead of OPEN_PATH when setting size, because
-     * ftruncate() requires a real file descriptor, not an O_PATH handle.
+     * ftruncate() requires a real file descriptor, not an O_PATH handle --
+     * and open it with WRITE intent: truncate(2) by path requires write
+     * permission on the file (unlike ftruncate, whose rights were bound at
+     * its own open), and the open gate is where every backend -- engine-
+     * gated and remote-DAC proxy alike -- enforces exactly that.  The wire
+     * SETATTR cannot make the distinction (which is why servers owner-
+     * override size changes, as nfsd does); the client must.
      */
     if (request->setattr.set_attr.va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
-        open_flags = CHIMERA_VFS_OPEN_INFERRED;
+        open_flags = CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_WRITE_ONLY;
     } else {
         open_flags = CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED;
     }
@@ -120,7 +126,8 @@ chimera_dispatch_lsetattr(
     unsigned int open_flags;
 
     if (request->setattr.set_attr.va_set_mask & CHIMERA_VFS_ATTR_SIZE) {
-        open_flags = CHIMERA_VFS_OPEN_INFERRED;
+        /* Write intent for a size change; see chimera_dispatch_setattr. */
+        open_flags = CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_WRITE_ONLY;
     } else {
         open_flags = CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED;
     }

--- a/src/posix/posix_close.c
+++ b/src/posix/posix_close.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 
@@ -21,6 +21,8 @@ chimera_posix_close(int fd)
     }
 
     handle = entry->handle;
+
+    chimera_posix_project_ofd_unlock(posix, worker, handle, entry->ofd);
 
     chimera_close(worker->client_thread, handle);
 

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -73,10 +73,15 @@ chimera_posix_dup2(
     /* If newfd is open, we need to close it silently */
     if (new_entry->handle && !(new_entry->flags & CHIMERA_POSIX_FD_CLOSED)) {
         struct chimera_vfs_open_handle *old_handle = new_entry->handle;
+        struct chimera_posix_ofd       *old_ofd    = new_entry->ofd;
 
         /* Mark as closed */
         new_entry->flags |= CHIMERA_POSIX_FD_CLOSED;
         pthread_mutex_unlock(&new_entry->lock);
+
+        /* This implicit close can be the description's last: release its
+         * backend byte-range locks first, exactly as close(2) does. */
+        chimera_posix_project_ofd_unlock(posix, worker, old_handle, old_ofd);
 
         /* Close the old handle */
         chimera_close(worker->client_thread, old_handle);

--- a/src/posix/posix_fcntl.c
+++ b/src/posix/posix_fcntl.c
@@ -210,6 +210,19 @@ chimera_posix_fcntl(
         return -1;
     }
 
+    /* fcntl(2) SETLK/SETLKW: a read lock requires a descriptor open for
+     * reading and a write lock one open for writing, else EBADF.  F_GETLK
+     * only queries and F_UNLCK only releases; neither is access-gated. */
+    if (cmd != F_GETLK &&
+        ((lock_type == CHIMERA_VFS_LOCK_READ &&
+          !chimera_posix_fd_may_read(entry)) ||
+         (lock_type == CHIMERA_VFS_LOCK_WRITE &&
+          !chimera_posix_fd_may_write(entry)))) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+
     switch (fl->l_whence) {
         case SEEK_SET: {
             if (fl->l_start < 0) {

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -234,6 +234,14 @@ void chimera_posix_ofd_locks_release(
     struct chimera_posix_client *posix,
     struct chimera_posix_ofd    *ofd);
 
+/* Project a whole-file backend unlock before a description's last close on a
+ * CAP_FS_LOCK backend (see posix_lock_claims.c). */
+void chimera_posix_project_ofd_unlock(
+    struct chimera_posix_client    *posix,
+    struct chimera_posix_worker    *worker,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_posix_ofd       *ofd);
+
 /* Drop an fd entry's reference on its open file description, freeing the
  * description when the last duplicate goes.  Caller holds fd_lock. */
 static FORCE_INLINE void

--- a/src/posix/posix_lock_claims.c
+++ b/src/posix/posix_lock_claims.c
@@ -17,7 +17,11 @@
  * The order fd_lock -> file->lock is used consistently (carve, teardown).
  */
 
+#include <unistd.h>
+
 #include "posix_internal.h"
+#include "vfs/sdk/vfs_module.h"
+#include "../client/client_lock.h"
 
 /* A mid-range carve splits one claim into head and tail fragments, so two
  * spares.  The claim core's interface fixes this: vfs_claim.h declares
@@ -121,6 +125,87 @@ chimera_posix_ofd_locks_release(
         free(node);
     }
 } /* chimera_posix_ofd_locks_release */
+
+static void
+chimera_posix_project_unlock_callback(
+    struct chimera_client_thread *thread,
+    enum chimera_vfs_error        status,
+    uint32_t                      conflict_type,
+    uint64_t                      conflict_offset,
+    uint64_t                      conflict_length,
+    pid_t                         conflict_pid,
+    void                         *private_data)
+{
+    struct chimera_posix_completion *comp = private_data;
+
+    chimera_posix_complete(comp, status);
+} /* chimera_posix_project_unlock_callback */
+
+static void
+chimera_posix_project_unlock_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    chimera_dispatch_lock(thread, request);
+} /* chimera_posix_project_unlock_exec */
+
+/*
+ * Dropping an open file description's last descriptor releases its
+ * byte-range locks.  The local claims go in chimera_posix_ofd_locks_release,
+ * but a backend that arbitrates locks itself (CAP_FS_LOCK: the nfs/smb
+ * proxies projecting to a real lock manager) holds its own state -- and the
+ * NLM server pins the file's open handle for as long as the lock lives, so
+ * an untold backend leaks both.  Project one whole-file unlock for this
+ * owner (the owner IS the open handle) while the handle is still live.
+ * Called from every path that implicitly drops a description's last
+ * reference with the handle still open: close(2) and dup2(2)'s implicit
+ * close of its target.  Best-effort: the caller's close succeeds regardless,
+ * so a failed projection only risks the server holding the lock until the
+ * connection drops.  (OFD-granularity, matching the local release -- see the
+ * CLAIMTODO in chimera_posix_ofd_release_locked.)
+ */
+void
+chimera_posix_project_ofd_unlock(
+    struct chimera_posix_client    *posix,
+    struct chimera_posix_worker    *worker,
+    struct chimera_vfs_open_handle *handle,
+    struct chimera_posix_ofd       *ofd)
+{
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+    int                             project;
+
+    if (!handle ||
+        !(handle->vfs_module->capabilities & CHIMERA_VFS_CAP_FS_LOCK)) {
+        return;
+    }
+
+    pthread_mutex_lock(&posix->fd_lock);
+    project = ofd && ofd->refcnt == 1 && ofd->locks != NULL;
+    pthread_mutex_unlock(&posix->fd_lock);
+
+    if (!project) {
+        return;
+    }
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.opcode            = CHIMERA_CLIENT_OP_LOCK;
+    req.lock.handle       = handle;
+    req.lock.whence       = SEEK_SET;
+    req.lock.offset       = 0;
+    req.lock.length       = 0;   /* 0 = to EOF (whole file) */
+    req.lock.lock_type    = CHIMERA_VFS_LOCK_UNLOCK;
+    req.lock.flags        = 0;
+    req.lock.callback     = chimera_posix_project_unlock_callback;
+    req.lock.private_data = &comp;
+
+    chimera_posix_worker_enqueue(worker, &req,
+                                 chimera_posix_project_unlock_exec);
+
+    (void) chimera_posix_wait(&comp);
+    chimera_posix_completion_destroy(&comp);
+} /* chimera_posix_project_ofd_unlock */
 
 /* -------------------------------------------------------------------- */
 /* F_UNLCK carve                                                        */

--- a/src/posix/posix_lockf.c
+++ b/src/posix/posix_lockf.c
@@ -15,9 +15,28 @@ chimera_posix_lockf(
     int   cmd,
     off_t len)
 {
-    struct flock fl;
-    int          fcntl_cmd;
-    int          rc;
+    struct chimera_posix_client   *posix = chimera_posix_get_global();
+    struct chimera_posix_fd_entry *entry;
+    struct flock                   fl;
+    int                            fcntl_cmd;
+    int                            rc;
+
+    /* lockf(3): "The fildes argument is an open file descriptor ... open for
+     * writing"; every command -- F_ULOCK and F_TEST included -- fails EBADF
+     * on a descriptor without write access.  fcntl below cannot enforce this
+     * (its rules differ: read locks want readability, F_GETLK/F_UNLCK are
+     * ungated), so gate here. */
+    entry = chimera_posix_fd_acquire(posix, fd, 0);
+    if (!entry) {
+        errno = EBADF;
+        return -1;
+    }
+    if (!chimera_posix_fd_may_write(entry)) {
+        chimera_posix_fd_release(entry, 0);
+        errno = EBADF;
+        return -1;
+    }
+    chimera_posix_fd_release(entry, 0);
 
     fl.l_whence = SEEK_CUR;
     fl.l_start  = 0;

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -44,12 +44,13 @@ endif()
 # does not match the backend skip individually; the batch reports SKIP (77) only
 # if every trace skips.
 #
-# TEMPORARY (memfs-only): while the memfs backend is driven to 100%, only its
-# profile is replayed.  The specs `posix` corpus also carries the nfs3_/nfs4_/
-# disk_ profiles; to restore the full backend matrix, add per-backend ctests
-# pointing --trace-dir at ${SPECS_BUNDLE_DIR}/posix with the matching
-# --exclude-prefix set (and route the nfs-loopback backends through
-# posix_replay.py + posix_quint_driver, which keep the filesystem server-side).
+# The specs `posix` corpus carries per-backend profiles distinguished by
+# filename prefix: memfs (no prefix), the NFS loopbacks (nfs3_/nfs4_), the
+# on-disk backends (disk_) and FUSE (fuse_).  Each registered batch selects
+# its profile with --exclude-prefix.  Still unregistered: nfs4_ (the nfs4
+# client needs its own round of the fixes that took nfs3 to green -- see the
+# ND* registry in posix_mbt_replay.c) and disk_ (diskfs needs libaio;
+# runs in the container/CI like the other diskfs batches).
 add_test(NAME chimera/posix/mbt/batch_memfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend memfs
@@ -61,3 +62,25 @@ set_tests_properties(chimera/posix/mbt/batch_memfs PROPERTIES
     LABELS "quint;posix_mbt;memfs"
     SKIP_RETURN_CODE 77
     TIMEOUT 300)
+
+# The same corpus replayed through the NFS loopback: an in-process chimera
+# server exports a memfs filesystem over the inproc transport and the posix
+# client mounts it through the nfs proxy module (src/vfs/nfs) with vers=3 --
+# the whole client stack, wire included, under the POSIX model.  The nfs3_
+# profile pins the NFS-flavored capabilities (strict atime, no copy/clone/
+# seek offload); the client-behavior deviations a real NFS client cannot
+# avoid (silly rename and friends) reconcile in the replayer as the ND*
+# registry.  The per-trace recycle unmounts the client, cycles the
+# server-side filesystem, and remounts, so every trace also exercises the
+# proxy's mount/umount paths.
+add_test(NAME chimera/posix/mbt/batch_nfs3_memfs
+    COMMAND $<TARGET_FILE:posix_mbt_replay>
+            --backend nfs3_memfs
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix
+            --exclude-prefix step --exclude-prefix disk_
+            --exclude-prefix fuse_ --exclude-prefix nfs4_)
+set_tests_properties(chimera/posix/mbt/batch_nfs3_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs3_memfs"
+    LABELS "quint;posix_mbt;memfs;nfs3_mbt"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 600)

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -925,9 +925,83 @@ handle(json_t *req)
             }
         }
         if (g_nfs_version) {
-            /* The NFS loopback path keeps the filesystem server-side; only the
-             * direct backends are batched today (POSIX_MBT_MEMFS_ONLY). */
-            return res_int(-1, ENOSYS);
+            /* Loopback recycle: the filesystem lives server-side, so cycle it
+             * there while the server, client, and RPC connection stay up.
+             * Unmount the client (the proxy's UMNT/session teardown), re-point
+             * the server-side share at a fresh uniquely-named fs, and remount:
+             * the fresh MOUNT/PUTROOTFH hands back a new root FH, so neither
+             * content nor a cached handle can cross traces.  The client umount
+             * races the async close sweep exactly like the direct path below,
+             * and the server-side rmfs races the NFS server's own cached open
+             * handles, so both get the same bounded retry (5s ceiling). */
+            char mount_options[64];
+            int  rc;
+            int  tries = 0;
+
+            /* Unlike the direct path's 1ms spins, each EBUSY attempt here
+             * already waited out the VFS umount's own holder timeout (~1s),
+             * so a small ceiling is already a long real wait -- and on a true
+             * leak every attempt logs the still-open handles at error level,
+             * so a low ceiling keeps the log readable. */
+            while (chimera_posix_umount("/test") != 0) {
+                if (errno != EBUSY || ++tries >= 15) {
+                    fprintf(stderr,
+                            "posix_driver: newfs client umount failed: %s\n",
+                            strerror(errno));
+                    return res_int(-1, errno);
+                }
+                usleep(1000);
+            }
+            tries = 0;
+            while ((rc = chimera_server_unmount(g_server, "share")) != 0) {
+                if (rc != CHIMERA_VFS_EBUSY || ++tries >= 15) {
+                    fprintf(stderr,
+                            "posix_driver: newfs share unmount failed: %d\n",
+                            rc);
+                    return res_int(-1, chimera_posix_errno_from_status(rc));
+                }
+                usleep(1000);
+            }
+            tries = 0;
+            while ((rc = chimera_server_rmfs(g_server, g_module,
+                                             g_fsname)) != 0) {
+                if (rc != CHIMERA_VFS_EBUSY || ++tries >= 15) {
+                    fprintf(stderr,
+                            "posix_driver: newfs server rmfs %s failed: %d\n",
+                            g_fsname, rc);
+                    return res_int(-1, chimera_posix_errno_from_status(rc));
+                }
+                usleep(1000);
+            }
+            snprintf(g_fsname, sizeof(g_fsname), "fs%d", ++g_fs_counter);
+            rc = chimera_server_mkfs(g_server, g_module, g_fsname, NULL);
+            if (rc != 0) {
+                fprintf(stderr, "posix_driver: newfs server mkfs %s failed: %d\n",
+                        g_fsname, rc);
+                return res_int(-1, chimera_posix_errno_from_status(rc));
+            }
+            rc = chimera_server_mount(g_server, "share", g_module, g_fsname,
+                                      NULL);
+            if (rc != 0) {
+                fprintf(stderr, "posix_driver: newfs share mount %s failed: %d\n",
+                        g_fsname, rc);
+                return res_int(-1, chimera_posix_errno_from_status(rc));
+            }
+            snprintf(mount_options, sizeof(mount_options), "vers=%d",
+                     g_nfs_version);
+            if (chimera_posix_mount_with_options("/test", "nfs",
+                                                 "127.0.0.1:/share",
+                                                 mount_options) != 0) {
+                fprintf(stderr, "posix_driver: newfs nfs%d remount failed: %s\n",
+                        g_nfs_version, strerror(errno));
+                return res_int(-1, errno);
+            }
+            if (normalize_root() != 0) {
+                fprintf(stderr, "posix_driver: newfs normalize failed: %s\n",
+                        strerror(errno));
+                return res_int(-1, errno);
+            }
+            return res_int(0, 0);
         }
         /* The replayer has dropped every open fd/dir, but the VFS releases the
          * underlying handles on its async sweep thread, so the mount can stay

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -190,10 +190,15 @@ static int           g_nexempt;
  * inode the model mutated through a lost descriptor.  All tallied, so the
  * masking stays visible per trace; the whole family retires when the specs
  * model grows search-permission semantics. */
-static int g_lost_fd[R_MAXPID][R_MAXFD];
-static int g_lost_sid[R_MAXSID];
-static int g_lost_ino[R_MAXINO];
-static int g_cur_pid;
+static int         g_lost_fd[R_MAXPID][R_MAXFD];
+static int         g_lost_sid[R_MAXSID];
+static int         g_lost_ino[R_MAXINO];
+static int         g_cur_pid;
+static const char *g_last_recon;    /* deviation id check_status last
+                                     * reconciled, or NULL              */
+static int         g_cur_step;      /* ITF state index of the op under replay
+                                     * (0 during the final audit)       */
+static int         g_nquarantine;   /* ND5 quarantine dirs minted this trace */
 
 static void
 state_reset(void)
@@ -218,9 +223,10 @@ state_reset(void)
     memset(g_lost_fd, 0, sizeof(g_lost_fd));
     memset(g_lost_sid, 0, sizeof(g_lost_sid));
     memset(g_lost_ino, 0, sizeof(g_lost_ino));
-    g_nmismatch = 0;
-    g_ndevhits  = 0;
-    g_nexempt   = 0;
+    g_nmismatch   = 0;
+    g_ndevhits    = 0;
+    g_nexempt     = 0;
+    g_nquarantine = 0;
 } /* state_reset */
 
 /* Record a reconciled known deviation for the per-trace summary. */
@@ -251,6 +257,13 @@ record_dev(const char *id)
  * name keeps, 1 where the model says 0 (ND2).  Gated on the nfs3_/nfs4_
  * backends: a direct backend producing a .nfs* name would be a real
  * divergence and still flags. */
+/* An ND5 quarantine directory (see residue_preclear). */
+static int
+is_nd5_quarantine(const char *name)
+{
+    return strncmp(name, ".nd5_q", 6) == 0;
+} /* is_nd5_quarantine */
+
 static int
 is_nfs_silly_name(const char *name)
 {
@@ -326,7 +339,7 @@ mism(
 {
     va_list ap;
 
-    printf("MISMATCH [%s] ", g_trace);
+    printf("MISMATCH [%s] step %d: ", g_trace, g_cur_step);
     va_start(ap, fmt);
     vprintf(fmt, ap);
     va_end(ap);
@@ -694,6 +707,148 @@ apply_cred(int pid)
     chimera_posix_set_cred(&driver_creds[pid]);
     (void) chimera_posix_umask(driver_umasks[pid]);
 } /* apply_cred */
+
+/* ---- root redo for reconciled DAC denials -------------------------------- */
+
+/* Re-execute credential: root, with the failing pid's umask left active so a
+ * creating redo's mode arithmetic is preserved. */
+static void
+apply_root_cred(void)
+{
+    chimera_posix_set_cred(&g_root_cred);
+} /* apply_root_cred */
+
+/* True when check_status just reconciled ND3 (a directory-search DAC denial
+ * the model does not share) on an op the model COMPLETED.  Chimera refused a
+ * mutation the model performed, and the two namespaces are about to drift --
+ * so the caller re-executes the exact operation as root, which passes every
+ * DAC check, and the sides converge again instead of cascading through the
+ * lost-inode machinery. */
+static int
+nd3_redo_wanted(
+    json_t *res_v,
+    int     rc)
+{
+    return rc < 0 && tf_field(res_v, "e") == 0 &&
+           g_last_recon && strcmp(g_last_recon, "ND3") == 0;
+} /* nd3_redo_wanted */
+
+/* A root redo creates nodes owned by root where the model attributes them to
+ * the calling credential: align with the model's post-state.  Compares
+ * before writing so a pre-existing node is untouched -- even a same-owner
+ * chown would bump ctime. */
+static void
+redo_fix_owner(
+    const char *path,
+    json_t     *pth,
+    int         follow)
+{
+    struct stat st;
+    json_t     *node;
+    int64_t     ino, uid, gid;
+
+    if (!g_cur_fs) {
+        return;
+    }
+    ino = path_ino(g_cur_fs, json_object_get(pth, "comps"));
+    if (ino < 0) {
+        return;
+    }
+    node = map_get_int(json_object_get(g_cur_fs, "inodes"), ino);
+    if (!node) {
+        return;
+    }
+    uid = tf_field(node, "uid");
+    gid = tf_field(node, "gid");
+    if ((follow ? chimera_posix_stat(path, &st)
+                : chimera_posix_lstat(path, &st)) != 0) {
+        return;
+    }
+    if ((int64_t) st.st_uid != uid || (int64_t) st.st_gid != gid) {
+        if (follow) {
+            (void) chimera_posix_chown(path, (uid_t) uid, (gid_t) gid);
+        } else {
+            (void) chimera_posix_lchown(path, (uid_t) uid, (gid_t) gid);
+        }
+    }
+} /* redo_fix_owner */
+
+/* True when some exempt path's final component is `name` (see the readdir
+ * ND5 use: only the basename is available there). */
+static int
+exempt_basename(const char *name)
+{
+    int i;
+
+    for (i = 0; i < g_nexempt; i++) {
+        const char *slash = strrchr(g_exempt[i], '/');
+        if (slash && strcmp(slash + 1, name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+} /* exempt_basename */
+
+/* Drop an audit exemption that no longer applies (its residue was cleared
+ * and the name can be audited normally again). */
+static void
+exempt_remove(const char *path)
+{
+    int i;
+
+    for (i = 0; i < g_nexempt; i++) {
+        if (strcmp(g_exempt[i], path) == 0) {
+            g_exempt[i][0] = '\0';
+            snprintf(g_exempt[i], sizeof(g_exempt[i]), "%s",
+                     g_exempt[--g_nexempt]);
+            return;
+        }
+    }
+} /* exempt_remove */
+
+/* ND5 leaves a node chimera-side that the model removed (silly-rename
+ * residue blocked the rmdir).  When a later op CREATES that name, the
+ * residue may have cleared in the meantime -- the offending descriptors
+ * closed, and their silly files with them -- so sweep the leftover as root
+ * before the create instead of failing EEXIST, and drop the audit exemption
+ * once the namespaces agree again.  The caller re-applies its credential
+ * afterwards. */
+static void
+residue_preclear(
+    const char *path,
+    json_t     *pth)
+{
+    json_t *comps = json_object_get(pth, "comps");
+    char    mp[4096];
+    size_t  len = 0, k;
+
+    for (k = 0; comps && k < json_array_size(comps); k++) {
+        const char *c = json_string_value(json_array_get(comps, k));
+        len += (size_t) snprintf(mp + len, sizeof(mp) - len, "/%s",
+                                 c ? c : "");
+    }
+    if (len == 0 || !is_exempt(mp)) {
+        return;
+    }
+    apply_root_cred();
+    if (chimera_posix_rmdir(path) == 0 || chimera_posix_unlink(path) == 0) {
+        exempt_remove(mp);
+        return;
+    }
+    /* Still non-empty: descriptors into it are open and their silly files
+     * with them.  Quarantine instead -- rename the leftover aside so the
+     * name is free for the create; the open descriptors keep working (their
+     * handles are fh-based) and the silly files disappear at close as
+     * usual.  Quarantine names are filtered wherever silly names are. */
+    {
+        char q[64];
+
+        snprintf(q, sizeof(q), "%s/.nd5_q%d", MOUNT, ++g_nquarantine);
+        if (chimera_posix_rename(path, q) == 0) {
+            exempt_remove(mp);
+        }
+    }
+} /* residue_preclear */
 
 /* The model and the deviation registry encode Linux errno numbers; the host
  * libc's errno is identical on Linux but diverges on macOS/BSD for the higher
@@ -1064,12 +1219,14 @@ check_status(
 {
     const char *dev;
 
+    g_last_recon = NULL;
     if (actual == expected) {
         return 1;
     }
     dev = reconcile(g_cur_tag, g_cur_rv, (int) expected, actual);
     if (dev) {
         record_dev(dev);
+        g_last_recon = dev;
         return 0;
     }
     if (g_nfs_version) {
@@ -1082,6 +1239,44 @@ check_status(
         if (actual == 13 && expected != 13 &&
             json_object_get(g_cur_rv, "pth")) {
             record_dev("ND3");
+            g_last_recon = "ND3";
+            return 0;
+        }
+        /* The same gap in the other direction: the model's EACCES masks
+         * what lies behind an unsearchable directory, while chimera (whose
+         * resolution has no search-perm concept) reports the true state --
+         * typically ENOENT for a name that is not there. */
+        if (expected == 13 && actual == 2 &&
+            json_object_get(g_cur_rv, "pth")) {
+            record_dev("ND3");
+            g_last_recon = "ND3";
+            return 0;
+        }
+        /* ND6: EACCES on descriptor I/O the model completed.  NFS3 is
+         * stateless, so the server re-checks DAC per READ/WRITE with the
+         * credential the RPC carries; the proxy sends the OPENING
+         * credential and the server owner-overrides, which covers every
+         * owner case -- what remains is a NON-owner opener whose access
+         * was chmod'ed away after open, where real NFS diverges from
+         * POSIX by design.  Retires if the model grows an nfs-per-op-DAC
+         * capability. */
+        if (actual == 13 && expected != 13 &&
+            !json_object_get(g_cur_rv, "pth") &&
+            json_object_get(g_cur_rv, "fd")) {
+            record_dev("ND6");
+            g_last_recon = "ND6";
+            return 0;
+        }
+        /* ND8: the nfs3 profile pins copyRange=false, which the model
+         * flattens to ENOTSUP for every copy_file_range -- but argument
+         * validation comes first in POSIX and Linux alike, so a same-file
+         * overlapping range draws EINVAL before any backend support check.
+         * Retires when the model orders its argument checks ahead of the
+         * capability answer. */
+        if (actual == 22 && expected == 95 &&
+            strcmp(g_cur_tag, "RCopyRange") == 0) {
+            record_dev("ND8");
+            g_last_recon = "ND8";
             return 0;
         }
         /* ND4 consequences of a lost descriptor / lost file (see the g_lost_*
@@ -1090,6 +1285,7 @@ check_status(
         if (actual == 9 && expected != 9 &&
             fd_lost(g_cur_pid, (int) tf_field(g_cur_rv, "fd"))) {
             record_dev("ND4");
+            g_last_recon = "ND4";
             return 0;
         }
         if (actual == 2 && expected != 2 && g_cur_fs) {
@@ -1097,6 +1293,7 @@ check_status(
                                             "comps");
             if (comps && path_touches_lost(g_cur_fs, comps)) {
                 record_dev("ND4");
+                g_last_recon = "ND4";
                 return 0;
             }
         }
@@ -1199,15 +1396,28 @@ check_time(
         t->sec      = wsec;
         t->nsec     = wnsec;
     } else if (abstract == t->abstract) {
-        if (wsec != t->sec || wnsec != t->nsec) {
-            mism("time: model instant unchanged (%lld) but wire moved "
-                 "%lld.%lld -> %lld.%lld", (long long) abstract,
+        /* The model clock quantizes: several time-setting ops can land on
+         * one abstract instant, each moving the REAL timestamp forward
+         * (e.g. observe, chown, observe within a tick).  Forward motion at
+         * an unchanged instant is therefore legitimate on any backend; only
+         * BACKWARD motion is a bug (a stale attribute served after a newer
+         * one -- the attr-cache class this check exists to catch). */
+        if (wsec < t->sec || (wsec == t->sec && wnsec < t->nsec)) {
+            mism("time: ino %lld %s: model instant unchanged (%lld) but wire "
+                 "went backwards %lld.%lld -> %lld.%lld", (long long) mino,
+                 field == 0 ? "atime" : field == 1 ? "mtime" : "ctime",
+                 (long long) abstract,
                  t->sec, t->nsec, wsec, wnsec);
+        } else {
+            t->sec  = wsec;
+            t->nsec = wnsec;
         }
     } else if (abstract > t->abstract) {
         if (wsec < t->sec || (wsec == t->sec && wnsec < t->nsec)) {
-            mism("time: model advanced but wire went backwards "
-                 "%lld.%lld -> %lld.%lld", t->sec, t->nsec, wsec, wnsec);
+            mism("time: ino %lld %s: model advanced but wire went backwards "
+                 "%lld.%lld -> %lld.%lld", (long long) mino,
+                 field == 0 ? "atime" : field == 1 ? "mtime" : "ctime",
+                 t->sec, t->nsec, wsec, wnsec);
         }
         t->abstract = abstract;
         t->sec      = wsec;
@@ -1263,6 +1473,13 @@ check_statres(
             /* Unlinked-while-open: the silly-renamed name keeps one link
              * alive until the last close (ND2). */
             record_dev("ND2");
+        } else if (g_nfs_version && g_nexempt > 0 &&
+                   strcmp(ftag, "FDir") == 0 &&
+                   (int64_t) st->st_nlink > tf_field(rv, "nlink")) {
+            /* A directory the model shrank still holds ND5 residue (a
+             * subdirectory whose rmdir the silly files blocked), so its
+             * link count runs high until the residue clears. */
+            record_dev("ND5");
         } else {
             mism("nlink: expected %lld, got %llu",
                  (long long) tf_field(rv, "nlink"),
@@ -1404,6 +1621,10 @@ op_open(
 
     apply_cred(pid);
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
+    if (tf_bool(fl, "creat")) {
+        residue_preclear(path, json_object_get(rv, "pth"));
+        apply_cred(pid);
+    }
     if (dfd == -1) {
         rc = chimera_posix_open(path, flags, tf_field(fl, "mode"));
     } else {
@@ -1420,10 +1641,32 @@ op_open(
             }
         }
     } else if (tf_field(res_v, "e") == 0 && rc < 0) {
-        /* The model holds a descriptor chimera never obtained (a reconciled
-        * divergence failed the open on our side): mark it and the file it
-        * names lost, so the consequences reconcile instead of cascading. */
-        lose_fd(pid, tf_field(res_v, "fd"));
+        int redone = -1;
+        if (g_last_recon && strcmp(g_last_recon, "ND3") == 0) {
+            /* A search-permission denial of an open the model completed:
+             * re-execute as root (see nd3_redo_wanted) so the descriptor --
+             * and, for O_CREAT, the file -- exists on both sides.  The
+             * active umask is still the failing pid's, so a creating open's
+             * mode arithmetic is preserved; the owner is aligned with the
+             * model's post-state afterwards.  I/O through the root-opened
+             * descriptor then succeeds, which is exactly what the model
+             * expects of a descriptor it granted. */
+            apply_root_cred();
+            redone = dfd == -1
+                ? chimera_posix_open(path, flags, tf_field(fl, "mode"))
+                : chimera_posix_openat(rfd(pid, dfd), path, flags,
+                                       tf_field(fl, "mode"));
+            if (redone >= 0) {
+                redo_fix_owner(path, json_object_get(rv, "pth"), 1);
+                set_fd(pid, tf_field(res_v, "fd"), redone);
+            }
+        }
+        if (redone < 0) {
+            /* The model holds a descriptor chimera never obtained: mark it
+             * and the file it names lost, so the consequences reconcile
+             * instead of cascading. */
+            lose_fd(pid, tf_field(res_v, "fd"));
+        }
     } else if (tf_field(res_v, "e") != 0 && e == 0 && rc >= 0) {
         /* The model expected this open to fail but chimera minted a
          * descriptor (PD24's EMFILE; over the NFS loopback also opens whose
@@ -1541,6 +1784,16 @@ op_lseek(
         fail = 1;               /* offset divergence on success */
     }
     if (fail) {
+        /* ND7: the nfs3 profile pins seekHole=false, which the model encodes
+         * as EINVAL for SEEK_DATA/SEEK_HOLE; the client instead EMULATES
+         * them over the holes-invisible wire (DATA at the offset, HOLE at
+         * EOF, ENXIO past it) -- strictly more useful than failing.
+         * Reconcile until the model grows a seek-emulated capability. */
+        if (g_nfs_version && exp_e == 22 &&
+            (whence == SEEK_DATA || whence == SEEK_HOLE)) {
+            record_dev("ND7");
+            return;
+        }
         /* PD25: a directory's st_size is unspecified; the model abstracts it
          * as 0 while memfs reports a block, so size-relative seeks (and the
          * ENXIO boundary at that size) legitimately disagree on dir fds. */
@@ -1648,6 +1901,13 @@ op_write_family(
                  (long long) tf_field(res_v, "n"), n);
         }
         shadow_apply(tf_field(res_v, "ino"), off, buf, (size_t) len);
+    } else if (tf_field(res_v, "e") == 0 && n < 0) {
+        /* The model wrote, chimera did not (a reconciled divergence): the
+        * inode's size and content have honestly diverged from here on. */
+        int64_t lost = tf_field(res_v, "ino");
+        if (lost >= 0 && lost < R_MAXINO) {
+            g_lost_ino[lost] = 1;
+        }
     }
     free(buf);
 } /* op_write_family */
@@ -1665,7 +1925,12 @@ op_truncate(
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
     rc = chimera_posix_truncate(path, (off_t) tf_field(rv, "len"));
     e  = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) chimera_posix_truncate(path, (off_t) tf_field(rv, "len"));
+    }
     if (tf_field(res_v, "e") == 0) {
         int64_t ino = path_ino(g_cur_fs, json_object_get(
                                    json_object_get(rv, "pth"), "comps"));
@@ -1787,19 +2052,33 @@ op_mkdir(
 
     apply_cred(pid);
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
+    residue_preclear(path, json_object_get(rv, "pth"));
+    apply_cred(pid);
     rc = dfd == -1
         ? chimera_posix_mkdir(path, (mode_t) tf_field(rv, "mode"))
         : chimera_posix_mkdirat(rfd(pid, dfd), path,
                                 (mode_t) tf_field(rv, "mode"));
     e = ERRV(rc);
-    if (!check_status(tf_field(res_v, "e"), e) &&
-        tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
-        /* The model created this directory behind a reconciled divergence;
-         * chimera did not.  Everything at or under it is lost. */
-        int64_t ino = path_ino(g_cur_fs, json_object_get(
-                                   json_object_get(rv, "pth"), "comps"));
-        if (ino >= 0 && ino < R_MAXINO) {
-            g_lost_ino[ino] = 1;
+    if (!check_status(tf_field(res_v, "e"), e)) {
+        if (nd3_redo_wanted(res_v, rc)) {
+            /* Redo as root; align the owner with the model (op_open). */
+            apply_root_cred();
+            rc = dfd == -1
+                ? chimera_posix_mkdir(path, (mode_t) tf_field(rv, "mode"))
+                : chimera_posix_mkdirat(rfd(pid, dfd), path,
+                                        (mode_t) tf_field(rv, "mode"));
+            if (rc == 0) {
+                redo_fix_owner(path, json_object_get(rv, "pth"), 1);
+            }
+        }
+        if (tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
+            /* The model created this directory behind a reconciled
+             * divergence; chimera did not.  Everything under it is lost. */
+            int64_t ino = path_ino(g_cur_fs, json_object_get(
+                                       json_object_get(rv, "pth"), "comps"));
+            if (ino >= 0 && ino < R_MAXINO) {
+                g_lost_ino[ino] = 1;
+            }
         }
     }
 } /* op_mkdir */
@@ -1829,14 +2108,25 @@ op_mknod(
     }
     apply_cred(pid);
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
+    residue_preclear(path, json_object_get(rv, "pth"));
+    apply_cred(pid);
     rc = chimera_posix_mknod(path, mode, dev);
     e  = ERRV(rc);
-    if (!check_status(tf_field(res_v, "e"), e) &&
-        tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
-        int64_t lost_ino = path_ino(g_cur_fs, json_object_get(
-                                        json_object_get(rv, "pth"), "comps"));
-        if (lost_ino >= 0 && lost_ino < R_MAXINO) {
-            g_lost_ino[lost_ino] = 1;
+    if (!check_status(tf_field(res_v, "e"), e)) {
+        if (nd3_redo_wanted(res_v, rc)) {
+            apply_root_cred();
+            rc = chimera_posix_mknod(path, mode, dev);
+            if (rc == 0) {
+                redo_fix_owner(path, json_object_get(rv, "pth"), 0);
+            }
+        }
+        if (tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
+            int64_t lost_ino = path_ino(g_cur_fs, json_object_get(
+                                            json_object_get(rv, "pth"),
+                                            "comps"));
+            if (lost_ino >= 0 && lost_ino < R_MAXINO) {
+                g_lost_ino[lost_ino] = 1;
+            }
         }
     }
 } /* op_mknod */
@@ -1853,14 +2143,25 @@ op_symlink(
     apply_cred(pid);
     real_target(json_object_get(rv, "tgt"), tgt, sizeof(tgt));
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
+    residue_preclear(path, json_object_get(rv, "pth"));
+    apply_cred(pid);
     rc = chimera_posix_symlink(tgt, path);
     e  = ERRV(rc);
-    if (!check_status(tf_field(res_v, "e"), e) &&
-        tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
-        int64_t lost_ino = path_ino(g_cur_fs, json_object_get(
-                                        json_object_get(rv, "pth"), "comps"));
-        if (lost_ino >= 0 && lost_ino < R_MAXINO) {
-            g_lost_ino[lost_ino] = 1;
+    if (!check_status(tf_field(res_v, "e"), e)) {
+        if (nd3_redo_wanted(res_v, rc)) {
+            apply_root_cred();
+            rc = chimera_posix_symlink(tgt, path);
+            if (rc == 0) {
+                redo_fix_owner(path, json_object_get(rv, "pth"), 0);
+            }
+        }
+        if (tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
+            int64_t lost_ino = path_ino(g_cur_fs, json_object_get(
+                                            json_object_get(rv, "pth"),
+                                            "comps"));
+            if (lost_ino >= 0 && lost_ino < R_MAXINO) {
+                g_lost_ino[lost_ino] = 1;
+            }
         }
     }
 } /* op_symlink */
@@ -1877,11 +2178,21 @@ op_link(
     apply_cred(pid);
     real_path(json_object_get(rv, "pthOld"), o, sizeof(o));
     real_path(json_object_get(rv, "pthNew"), n, sizeof(n));
+    residue_preclear(n, json_object_get(rv, "pthNew"));
+    apply_cred(pid);
     rc = tf_bool(rv, "followOld")
         ? chimera_posix_linkat(AT_FDCWD, o, AT_FDCWD, n, AT_SYMLINK_FOLLOW)
         : chimera_posix_link(o, n);
     e = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) (tf_bool(rv, "followOld")
+                ? chimera_posix_linkat(AT_FDCWD, o, AT_FDCWD, n,
+                                       AT_SYMLINK_FOLLOW)
+                : chimera_posix_link(o, n));
+    }
 } /* op_link */
 
 static void
@@ -1899,7 +2210,13 @@ op_unlink(
     rc = dfd == -1 ? chimera_posix_unlink(path)
                    : chimera_posix_unlinkat(rfd(pid, dfd), path, 0);
     e = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) (dfd == -1 ? chimera_posix_unlink(path)
+                          : chimera_posix_unlinkat(rfd(pid, dfd), path, 0));
+    }
 } /* op_unlink */
 
 static void
@@ -1941,7 +2258,14 @@ op_rmdir(
         }
         return;
     }
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) (dfd == -1
+                ? chimera_posix_rmdir(path)
+                : chimera_posix_unlinkat(rfd(pid, dfd), path, AT_REMOVEDIR));
+    }
 } /* op_rmdir */
 
 static void
@@ -1958,7 +2282,12 @@ op_rename(
     real_path(json_object_get(rv, "pthNew"), n, sizeof(n));
     rc = chimera_posix_rename(o, n);
     e  = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) chimera_posix_rename(o, n);
+    }
 } /* op_rename */
 
 static void
@@ -2009,7 +2338,17 @@ op_opendir(
         }
     } else if (tf_field(res_v, "e") == 0 && !d) {
         int64_t msid = tf_field(res_v, "sid");
-        if (msid >= 0 && msid < R_MAXSID) {
+        if (g_last_recon && strcmp(g_last_recon, "ND3") == 0) {
+            /* Redo as root (see nd3_redo_wanted). */
+            apply_root_cred();
+            d = chimera_posix_opendir(path);
+        }
+        if (d && msid >= 0 && msid < R_MAXSID) {
+            g_dirmap[msid]   = d;
+            g_lost_sid[msid] = 0;
+        } else if (d) {
+            chimera_posix_closedir(d);
+        } else if (msid >= 0 && msid < R_MAXSID) {
             g_lost_sid[msid] = 1;
         }
     } else if (d) {
@@ -2087,6 +2426,14 @@ op_readdir(
         if (!ok) {
             if (is_nfs_silly_name(names[i])) {
                 record_dev("ND1");
+            } else if (is_nd5_quarantine(names[i])) {
+                record_dev("ND5");
+            } else if (exempt_basename(names[i])) {
+                /* ND5 residue (a name the model removed but silly-rename
+                 * kept alive chimera-side) showing in its parent listing;
+                 * matched by basename because a stream id gives no dir
+                 * path.  Cleared by residue_preclear when reused. */
+                record_dev("ND5");
             } else {
                 mism("readdir: unexpected name '%s'", names[i]);
             }
@@ -2286,7 +2633,12 @@ op_chmod(
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
     rc = chimera_posix_chmod(path, (mode_t) tf_field(rv, "mode"));
     e  = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) chimera_posix_chmod(path, (mode_t) tf_field(rv, "mode"));
+    }
 } /* op_chmod */
 
 static void
@@ -2320,7 +2672,14 @@ op_chown(
     rc = tf_bool(rv, "follow") ? chimera_posix_chown(path, u, g)
                                : chimera_posix_lchown(path, u, g);
     e = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) (tf_bool(rv, "follow")
+                ? chimera_posix_chown(path, u, g)
+                : chimera_posix_lchown(path, u, g));
+    }
 } /* op_chown */
 
 static void
@@ -2357,7 +2716,13 @@ op_utimens(
     rc = chimera_posix_utimensat(dfd == -1 ? AT_FDCWD : rfd(pid, dfd),
                                  path, times, 0);
     e = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        nd3_redo_wanted(res_v, rc)) {
+        /* Redo as root (see nd3_redo_wanted). */
+        apply_root_cred();
+        (void) chimera_posix_utimensat(dfd == -1 ? AT_FDCWD : rfd(pid, dfd),
+                                       path, times, 0);
+    }
 } /* op_utimens */
 
 static void
@@ -2868,6 +3233,8 @@ final_audit(json_t *fs)
                 snprintf(ep, sizeof(ep), "%.4095s/%.255s", e.path, names[k]);
                 if (is_nfs_silly_name(names[k])) {
                     record_dev("ND1");
+                } else if (is_nd5_quarantine(names[k])) {
+                    record_dev("ND5");
                 } else if (!is_exempt(ep)) {   /* PD24 residue */
                     mism("audit: dir %s: unexpected entry '%s'",
                          e.path[0] ? e.path : "/", names[k]);
@@ -2949,9 +3316,15 @@ final_audit(json_t *fs)
                      (long long) tf_field(cnode, "gid"));
             }
             if ((int64_t) st.st_nlink != tf_field(cnode, "nlink")) {
-                mism("audit: %s: nlink %llu != %lld", cpath,
-                     (unsigned long long) st.st_nlink,
-                     (long long) tf_field(cnode, "nlink"));
+                if (g_nfs_version && g_nexempt > 0 &&
+                    strcmp(ftag, "FDir") == 0 &&
+                    (int64_t) st.st_nlink > tf_field(cnode, "nlink")) {
+                    record_dev("ND5");   /* residue subdir (see check_statres) */
+                } else {
+                    mism("audit: %s: nlink %llu != %lld", cpath,
+                         (unsigned long long) st.st_nlink,
+                         (long long) tf_field(cnode, "nlink"));
+                }
             }
             if (cino >= 0 && cino < R_MAXINO && g_inomap[cino].present) {
                 if (g_inomap[cino].dev != (long long) st.st_dev ||
@@ -3072,12 +3445,13 @@ replay_trace(const char *path)
         res = json_object_get(v, "res");
         tag = tf_tag(req);
 
-        g_cur_fs  = state_get(st, "fs");
-        g_cur_ps  = state_get(st, "ps");
-        g_cur_tag = tag;
-        g_cur_rv  = tf_val(req);
-        g_cur_pid = pid;
-        last_fs   = g_cur_fs;
+        g_cur_fs   = state_get(st, "fs");
+        g_cur_ps   = state_get(st, "ps");
+        g_cur_tag  = tag;
+        g_cur_rv   = tf_val(req);
+        g_cur_pid  = pid;
+        g_cur_step = (int) i;
+        last_fs    = g_cur_fs;
 
         if (dispatch(tag, pid, tf_val(req), tf_val(res)) != 0) {
             fprintf(stderr, "%s: step %zu: unimplemented op %s\n", path, i,

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -179,6 +179,22 @@ static int           g_ndevhits;
 static char          g_exempt[64][256];
 static int           g_nexempt;
 
+/* NFS-loopback divergence containment (ND3/ND4).  When a reconciled
+ * divergence makes chimera fail an op the model completed (today: EACCES
+ * from the server's directory-search enforcement, which neither the model
+ * nor chimera's own resolution -- issue #1771 -- implements), the two sides
+ * fall out of sync: a descriptor, stream, or whole file exists on one side
+ * only.  Rather than drown the trace in follow-on mismatches, the harness
+ * marks what was lost and reconciles exactly the consequences: EBADF on a
+ * lost descriptor, ENOENT on a lost file, and attribute/content checks on an
+ * inode the model mutated through a lost descriptor.  All tallied, so the
+ * masking stays visible per trace; the whole family retires when the specs
+ * model grows search-permission semantics. */
+static int g_lost_fd[R_MAXPID][R_MAXFD];
+static int g_lost_sid[R_MAXSID];
+static int g_lost_ino[R_MAXINO];
+static int g_cur_pid;
+
 static void
 state_reset(void)
 {
@@ -199,6 +215,9 @@ state_reset(void)
         g_shadow[i].buf = NULL;
         g_shadow[i].len = g_shadow[i].cap = 0;
     }
+    memset(g_lost_fd, 0, sizeof(g_lost_fd));
+    memset(g_lost_sid, 0, sizeof(g_lost_sid));
+    memset(g_lost_ino, 0, sizeof(g_lost_ino));
     g_nmismatch = 0;
     g_ndevhits  = 0;
     g_nexempt   = 0;
@@ -222,6 +241,32 @@ record_dev(const char *id)
         g_ndevhits++;
     }
 } /* record_dev */
+
+/* NFS-client deviation (ND1/ND2): the loopback's nfs proxy, like every NFS
+ * client, implements unlink-of-an-open-file as a silly rename (".nfs" + hex
+ * of the file handle) that lingers in the directory until the last close.
+ * The model implements the POSIX reading -- the name is gone, the file lives
+ * on anonymously -- so the artifact name is invisible to it: filter it from
+ * readdir and audit listings (ND1) and accept the link count the lingering
+ * name keeps, 1 where the model says 0 (ND2).  Gated on the nfs3_/nfs4_
+ * backends: a direct backend producing a .nfs* name would be a real
+ * divergence and still flags. */
+static int
+is_nfs_silly_name(const char *name)
+{
+    int i;
+
+    if (!g_nfs_version || strncmp(name, ".nfs", 4) != 0 || name[4] == '\0') {
+        return 0;
+    }
+    for (i = 4; name[i]; i++) {
+        char c = name[i];
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
+            return 0;
+        }
+    }
+    return 1;
+} /* is_nfs_silly_name */
 
 static void
 exempt_add(const char *path)
@@ -263,7 +308,8 @@ set_fd(
     int real)
 {
     if (pid >= 0 && pid < R_MAXPID && mfd >= 0 && mfd < R_MAXFD) {
-        g_fdmap[pid][mfd] = real;
+        g_fdmap[pid][mfd]   = real;
+        g_lost_fd[pid][mfd] = 0;
     }
 } /* set_fd */
 
@@ -422,6 +468,39 @@ model_ino_of_fd(
     return tf_field(node, "ino");
 } /* model_ino_of_fd */
 
+static int
+fd_lost(
+    int pid,
+    int mfd)
+{
+    return pid >= 0 && pid < R_MAXPID && mfd >= 0 && mfd < R_MAXFD &&
+           g_lost_fd[pid][mfd];
+} /* fd_lost */
+
+static int
+ino_lost(int64_t ino)
+{
+    return ino >= 0 && ino < R_MAXINO && g_lost_ino[ino];
+} /* ino_lost */
+
+/* Mark a model descriptor chimera never obtained (or lost), along with the
+ * inode the model reaches through it -- everything the model does via this
+ * descriptor is invisible to chimera from here on. */
+static void
+lose_fd(
+    int pid,
+    int mfd)
+{
+    int64_t ino = model_ino_of_fd(pid, mfd);
+
+    if (pid >= 0 && pid < R_MAXPID && mfd >= 0 && mfd < R_MAXFD) {
+        g_lost_fd[pid][mfd] = 1;
+    }
+    if (ino >= 0 && ino < R_MAXINO) {
+        g_lost_ino[ino] = 1;
+    }
+} /* lose_fd */
+
 /* True when (pid, model fd) maps to a directory inode in the post-state fs. */
 static int
 fd_is_model_dir(
@@ -467,6 +546,43 @@ path_ino(
     }
     return ino;
 } /* path_ino */
+
+/* True when the model path (component list) resolves through or to a lost
+ * inode in the post-state fs: the leaf, or any directory on the way, exists
+ * only model-side (or has honestly diverged) behind a reconciled divergence. */
+static int
+path_touches_lost(
+    json_t *fs,
+    json_t *comps)
+{
+    json_t *inodes = json_object_get(fs, "inodes");
+    int64_t ino    = 0;   /* ROOT */
+    size_t  i;
+
+    if (!json_is_array(comps)) {
+        return 0;
+    }
+    if (ino_lost(ino)) {
+        return 1;
+    }
+    for (i = 0; i < json_array_size(comps); i++) {
+        json_t     *node = map_get_int(inodes, ino);
+        const char *name = json_string_value(json_array_get(comps, i));
+        json_t     *nx;
+        if (!node || !name) {
+            return 0;
+        }
+        nx = map_get_str(json_object_get(node, "ents"), name);
+        if (!nx) {
+            return 0;
+        }
+        ino = tf_i64(nx);
+        if (ino_lost(ino)) {
+            return 1;
+        }
+    }
+    return 0;
+} /* path_touches_lost */
 
 /* ---- path materialization ------------------------------------------------ */
 
@@ -956,6 +1072,35 @@ check_status(
         record_dev(dev);
         return 0;
     }
+    if (g_nfs_version) {
+        /* ND3: EACCES from the server's directory-search enforcement on the
+         * loopback's component-by-component resolution.  Neither the posix
+         * model nor chimera's own resolution (issue #1771) implements search
+         * permission, so any path-taking op can draw an EACCES the model maps
+         * to another outcome.  Retires when the model grows search-perm
+         * semantics (which also unblocks the nfs3 passthrough batches). */
+        if (actual == 13 && expected != 13 &&
+            json_object_get(g_cur_rv, "pth")) {
+            record_dev("ND3");
+            return 0;
+        }
+        /* ND4 consequences of a lost descriptor / lost file (see the g_lost_*
+         * block comment): EBADF where the model still holds the descriptor,
+         * ENOENT where the model still has the file. */
+        if (actual == 9 && expected != 9 &&
+            fd_lost(g_cur_pid, (int) tf_field(g_cur_rv, "fd"))) {
+            record_dev("ND4");
+            return 0;
+        }
+        if (actual == 2 && expected != 2 && g_cur_fs) {
+            json_t *comps = json_object_get(json_object_get(g_cur_rv, "pth"),
+                                            "comps");
+            if (comps && path_touches_lost(g_cur_fs, comps)) {
+                record_dev("ND4");
+                return 0;
+            }
+        }
+    }
     mism("errno: expected %lld, got %d", (long long) expected, actual);
     return 0;
 } /* check_status */
@@ -1082,8 +1227,16 @@ check_statres(
     const char   *want_ft = ftype_of(ftag);
     const char   *got_ft  = ftype_from_mode(st->st_mode);
     int64_t       mino    = tf_field(rv, "ino");
-    long long     dev     = (long long) st->st_dev;
-    long long     ino     = (long long) st->st_ino;
+
+    if (ino_lost(mino)) {
+        /* The model mutated this inode through a descriptor chimera never
+         * had (or created it behind a reconciled divergence); its attributes
+         * have honestly diverged. */
+        record_dev("ND4");
+        return;
+    }
+    long long     dev = (long long) st->st_dev;
+    long long     ino = (long long) st->st_ino;
     struct ident *known;
 
     if (strcmp(got_ft, want_ft) != 0) {
@@ -1105,9 +1258,16 @@ check_statres(
              st->st_gid);
     }
     if ((int64_t) st->st_nlink != tf_field(rv, "nlink")) {
-        mism("nlink: expected %lld, got %llu",
-             (long long) tf_field(rv, "nlink"),
-             (unsigned long long) st->st_nlink);
+        if (g_nfs_version && tf_field(rv, "nlink") == 0 &&
+            st->st_nlink == 1) {
+            /* Unlinked-while-open: the silly-renamed name keeps one link
+             * alive until the last close (ND2). */
+            record_dev("ND2");
+        } else {
+            mism("nlink: expected %lld, got %llu",
+                 (long long) tf_field(rv, "nlink"),
+                 (unsigned long long) st->st_nlink);
+        }
     }
     if (strcmp(ftag, "FReg") == 0) {
         int64_t want = tf_field(rv, "sizeB");
@@ -1209,24 +1369,26 @@ open_flags(json_t *fl)
 } /* open_flags */
 
 /*
- * PD24 (EMFILE) leaves us holding a descriptor the model never learned about:
- * its 16-slot table was full, chimera's larger one let the call through.  The
- * model's fd is not set, so the descriptor never reaches g_fdmap and
- * close_live_handles() cannot reach it either -- and one descriptor still open
- * on the mount wedges the newfs() recycle between traces, whose unmount then
- * returns EBUSY for as long as the harness is willing to retry.  Drop it at the
- * op that minted it.  (op_open does its own, because it must also exempt any
- * node O_CREAT minted from the final audit.)
+ * A call the model expected to FAIL that chimera let through leaves us holding
+ * a descriptor the model never learned about (PD24's EMFILE with chimera's
+ * larger fd table; over the NFS loopback also expected-EACCES opens the
+ * server's DAC reading permits).  The model's fd is not set, so the descriptor
+ * never reaches g_fdmap and close_live_handles() cannot reach it either -- and
+ * one descriptor still open on the mount wedges the newfs() recycle between
+ * traces, whose unmount then returns EBUSY for as long as the harness is
+ * willing to retry.  Drop it at the op that minted it, for every
+ * expected-failure flavor.  (op_open does its own, because it must also exempt
+ * any node O_CREAT minted from the final audit.)
  */
 static void
-pd24_drop_stray_fd(
+drop_stray_fd(
     int64_t model_err,
     int     rc)
 {
-    if (model_err == 24 && rc >= 0) {
+    if (model_err != 0 && rc >= 0) {
         chimera_posix_close(rc);
     }
-} /* pd24_drop_stray_fd */
+} /* drop_stray_fd */
 
 static void
 op_open(
@@ -1257,9 +1419,17 @@ op_open(
                 shadow_resize(ino, 0);
             }
         }
-    } else if (tf_field(res_v, "e") == 24 && e == 0 && rc >= 0) {
-        /* PD24 (EMFILE): the model's 16-slot table was full but chimera's
-         * larger table let the open succeed.  Close the stray descriptor. */
+    } else if (tf_field(res_v, "e") == 0 && rc < 0) {
+        /* The model holds a descriptor chimera never obtained (a reconciled
+        * divergence failed the open on our side): mark it and the file it
+        * names lost, so the consequences reconcile instead of cascading. */
+        lose_fd(pid, tf_field(res_v, "fd"));
+    } else if (tf_field(res_v, "e") != 0 && e == 0 && rc >= 0) {
+        /* The model expected this open to fail but chimera minted a
+         * descriptor (PD24's EMFILE; over the NFS loopback also opens whose
+         * expected EACCES the server's DAC reading does not share).  Close
+         * the stray descriptor -- the model never learned of it, so nothing
+         * downstream ever would. */
         chimera_posix_close(rc);
         if (tf_bool(fl, "creat")) {
             json_t *comps = json_object_get(json_object_get(rv, "pth"),
@@ -1298,11 +1468,16 @@ op_close(
     json_t *rv,
     json_t *res_v)
 {
-    int rc = chimera_posix_close(rfd(pid, tf_field(rv, "fd")));
-    int e  = ERRV(rc);
+    int mfd  = tf_field(rv, "fd");
+    int lost = fd_lost(pid, mfd);
+    int rc   = chimera_posix_close(rfd(pid, mfd));
+    int e    = ERRV(rc);
 
-    if (check_status(tf_field(res_v, "e"), e) && tf_field(res_v, "e") == 0) {
-        set_fd(pid, tf_field(rv, "fd"), BADFD);
+    if ((check_status(tf_field(res_v, "e"), e) || lost) &&
+        tf_field(res_v, "e") == 0) {
+        /* set_fd also clears the lost mark: the model no longer holds the
+         * descriptor, so a later model open reusing the number starts clean. */
+        set_fd(pid, mfd, BADFD);
     }
 } /* op_close */
 
@@ -1317,8 +1492,10 @@ op_dup(
 
     if (check_status(tf_field(res_v, "e"), e) && tf_field(res_v, "e") == 0) {
         set_fd(pid, tf_field(res_v, "fd"), rc);
+    } else if (tf_field(res_v, "e") == 0 && rc < 0) {
+        lose_fd(pid, tf_field(res_v, "fd"));
     } else {
-        pd24_drop_stray_fd(tf_field(res_v, "e"), rc);
+        drop_stray_fd(tf_field(res_v, "e"), rc);
     }
 } /* op_dup */
 
@@ -1409,15 +1586,22 @@ op_read_family(
     if (check_status(tf_field(res_v, "e"), e) && tf_field(res_v, "e") == 0) {
         int64_t        count = tf_field(res_v, "n");
         unsigned char *exp   = malloc(count ? count : 1);
-        if (n != count) {
-            mism("read count: expected %lld, got %zd", (long long) count, n);
-        }
-        shadow_read(tf_field(res_v, "ino"), tf_field(res_v, "off"),
-                    (size_t) count, exp);
-        if (n != count || (count && memcmp(buf, exp, count) != 0)) {
-            mism("read data mismatch at ino %lld off %lld len %lld",
-                 (long long) tf_field(res_v, "ino"),
-                 (long long) tf_field(res_v, "off"), (long long) count);
+        if (ino_lost(tf_field(res_v, "ino"))) {
+            /* The model mutated this inode through a descriptor chimera never
+             * had; its size and content have honestly diverged. */
+            record_dev("ND4");
+        } else {
+            if (n != count) {
+                mism("read count: expected %lld, got %zd", (long long) count,
+                     n);
+            }
+            shadow_read(tf_field(res_v, "ino"), tf_field(res_v, "off"),
+                        (size_t) count, exp);
+            if (n != count || (count && memcmp(buf, exp, count) != 0)) {
+                mism("read data mismatch at ino %lld off %lld len %lld",
+                     (long long) tf_field(res_v, "ino"),
+                     (long long) tf_field(res_v, "off"), (long long) count);
+            }
         }
         free(exp);
     }
@@ -1508,6 +1692,11 @@ op_ftruncate(
         int64_t ino = model_ino_of_fd(pid, tf_field(rv, "fd"));
         if (ino >= 0) {
             shadow_resize(ino, tf_field(rv, "len"));
+        }
+        if (rc < 0 && ino >= 0 && ino < R_MAXINO) {
+            /* The model truncated, chimera did not (a reconciled
+             * divergence): size and content have honestly diverged. */
+            g_lost_ino[ino] = 1;
         }
     }
 } /* op_ftruncate */
@@ -1603,7 +1792,16 @@ op_mkdir(
         : chimera_posix_mkdirat(rfd(pid, dfd), path,
                                 (mode_t) tf_field(rv, "mode"));
     e = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
+        /* The model created this directory behind a reconciled divergence;
+         * chimera did not.  Everything at or under it is lost. */
+        int64_t ino = path_ino(g_cur_fs, json_object_get(
+                                   json_object_get(rv, "pth"), "comps"));
+        if (ino >= 0 && ino < R_MAXINO) {
+            g_lost_ino[ino] = 1;
+        }
+    }
 } /* op_mkdir */
 
 static void
@@ -1633,7 +1831,14 @@ op_mknod(
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
     rc = chimera_posix_mknod(path, mode, dev);
     e  = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
+        int64_t lost_ino = path_ino(g_cur_fs, json_object_get(
+                                        json_object_get(rv, "pth"), "comps"));
+        if (lost_ino >= 0 && lost_ino < R_MAXINO) {
+            g_lost_ino[lost_ino] = 1;
+        }
+    }
 } /* op_mknod */
 
 static void
@@ -1650,7 +1855,14 @@ op_symlink(
     real_path(json_object_get(rv, "pth"), path, sizeof(path));
     rc = chimera_posix_symlink(tgt, path);
     e  = ERRV(rc);
-    check_status(tf_field(res_v, "e"), e);
+    if (!check_status(tf_field(res_v, "e"), e) &&
+        tf_field(res_v, "e") == 0 && rc < 0 && g_cur_fs) {
+        int64_t lost_ino = path_ino(g_cur_fs, json_object_get(
+                                        json_object_get(rv, "pth"), "comps"));
+        if (lost_ino >= 0 && lost_ino < R_MAXINO) {
+            g_lost_ino[lost_ino] = 1;
+        }
+    }
 } /* op_symlink */
 
 static void
@@ -1706,6 +1918,29 @@ op_rmdir(
         ? chimera_posix_rmdir(path)
         : chimera_posix_unlinkat(rfd(pid, dfd), path, AT_REMOVEDIR);
     e = ERRV(rc);
+    if (g_nfs_version && e == 39 && tf_field(res_v, "e") == 0) {
+        /* ND5: the directory holds .nfs* silly-rename residue for files
+         * still open, so the server honestly refuses ENOTEMPTY where the
+         * model (whose unlinks truly removed the names) sees empty.  The
+         * model forgets the directory; chimera keeps it until the last
+         * close -- exempt the path so the audit tolerates the leftover. */
+        record_dev("ND5");
+        {
+            json_t *comps = json_object_get(json_object_get(rv, "pth"),
+                                            "comps");
+            char    mp[4096];
+            size_t  len = 0, k;
+            for (k = 0; comps && k < json_array_size(comps); k++) {
+                const char *c = json_string_value(json_array_get(comps, k));
+                len += (size_t) snprintf(mp + len, sizeof(mp) - len, "/%s",
+                                         c ? c : "");
+            }
+            if (len > 0) {
+                exempt_add(mp);
+            }
+        }
+        return;
+    }
     check_status(tf_field(res_v, "e"), e);
 } /* op_rmdir */
 
@@ -1767,9 +2002,15 @@ op_opendir(
     if (check_status(tf_field(res_v, "e"), e) && tf_field(res_v, "e") == 0) {
         int64_t msid = tf_field(res_v, "sid");
         if (msid >= 0 && msid < R_MAXSID) {
-            g_dirmap[msid] = d;
+            g_dirmap[msid]   = d;
+            g_lost_sid[msid] = 0;
         } else {
             chimera_posix_closedir(d);
+        }
+    } else if (tf_field(res_v, "e") == 0 && !d) {
+        int64_t msid = tf_field(res_v, "sid");
+        if (msid >= 0 && msid < R_MAXSID) {
+            g_lost_sid[msid] = 1;
         }
     } else if (d) {
         chimera_posix_closedir(d);
@@ -1791,7 +2032,13 @@ op_readdir(
 
     (void) pid;
     if (!d) {
-        check_status(tf_field(res_v, "e"), EBADF);
+        int64_t msid = tf_field(rv, "sid");
+        if (g_nfs_version && msid >= 0 && msid < R_MAXSID &&
+            g_lost_sid[msid]) {
+            record_dev("ND4");
+        } else {
+            check_status(tf_field(res_v, "e"), EBADF);
+        }
         return;
     }
     if (!check_status(tf_field(res_v, "e"), 0) || tf_field(res_v, "e") != 0) {
@@ -1838,7 +2085,11 @@ op_readdir(
             }
         }
         if (!ok) {
-            mism("readdir: unexpected name '%s'", names[i]);
+            if (is_nfs_silly_name(names[i])) {
+                record_dev("ND1");
+            } else {
+                mism("readdir: unexpected name '%s'", names[i]);
+            }
         }
     }
 } /* op_readdir */
@@ -1855,7 +2106,13 @@ op_dir_simple(
 
     (void) pid;
     if (!d) {
-        check_status(tf_field(res_v, "e"), EBADF);
+        int64_t msid = tf_field(rv, "sid");
+        if (g_nfs_version && msid >= 0 && msid < R_MAXSID &&
+            g_lost_sid[msid]) {
+            record_dev("ND4");
+        } else {
+            check_status(tf_field(res_v, "e"), EBADF);
+        }
         return;
     }
     switch (which) {
@@ -2189,10 +2446,12 @@ op_dup2(
     e = ERRV(rc);
     if (check_status(tf_field(res_v, "e"), e) && tf_field(res_v, "e") == 0) {
         set_fd(pid, nfd, rc);
+    } else if (tf_field(res_v, "e") == 0 && rc < 0) {
+        lose_fd(pid, nfd);
     } else if (minted) {
         /* Only the dup() arm mints a descriptor of its own; the dup2() arm
          * returns one g_fdmap already names, which close_live_handles() owns. */
-        pd24_drop_stray_fd(tf_field(res_v, "e"), rc);
+        drop_stray_fd(tf_field(res_v, "e"), rc);
     }
 } /* op_dup2 */
 
@@ -2222,7 +2481,7 @@ op_fcntl_dupfd(
             }
         }
     } else {
-        pd24_drop_stray_fd(tf_field(res_v, "e"), rc);
+        drop_stray_fd(tf_field(res_v, "e"), rc);
     }
 } /* op_fcntl_dupfd */
 
@@ -2607,7 +2866,9 @@ final_audit(json_t *fs)
             if (!found) {
                 char ep[4400];
                 snprintf(ep, sizeof(ep), "%.4095s/%.255s", e.path, names[k]);
-                if (!is_exempt(ep)) {   /* PD24 residue: chimera-only node */
+                if (is_nfs_silly_name(names[k])) {
+                    record_dev("ND1");
+                } else if (!is_exempt(ep)) {   /* PD24 residue */
                     mism("audit: dir %s: unexpected entry '%s'",
                          e.path[0] ? e.path : "/", names[k]);
                 }
@@ -2634,8 +2895,12 @@ final_audit(json_t *fs)
                 }
             }
             if (!present) {
-                mism("audit: dir %s: model entry '%s' missing",
-                     e.path[0] ? e.path : "/", name);
+                if (ino_lost(cino)) {
+                    record_dev("ND4");
+                } else {
+                    mism("audit: dir %s: model entry '%s' missing",
+                         e.path[0] ? e.path : "/", name);
+                }
                 continue;
             }
 
@@ -2647,6 +2912,21 @@ final_audit(json_t *fs)
 
             memset(&st, 0, sizeof(st));
             rc = chimera_posix_lstat(full, &st);
+            if (ino_lost(cino)) {
+                /* Mutated or created behind a reconciled divergence: its
+                 * attributes and content have honestly diverged (see the
+                 * g_lost_* block comment).  Still descend a directory that
+                 * exists on both sides, so unaffected children get audited. */
+                record_dev("ND4");
+                if (rc == 0 && S_ISDIR(st.st_mode) &&
+                    strcmp(ftag, "FDir") == 0 && sp < 4096) {
+                    stack[sp].ino = cino;
+                    snprintf(stack[sp].path, sizeof(stack[sp].path),
+                             "%.4095s", cpath);
+                    sp++;
+                }
+                continue;
+            }
             if (rc != 0) {
                 mism("audit: lstat %s: errno %d", cpath, errno);
                 continue;
@@ -2796,6 +3076,7 @@ replay_trace(const char *path)
         g_cur_ps  = state_get(st, "ps");
         g_cur_tag = tag;
         g_cur_rv  = tf_val(req);
+        g_cur_pid = pid;
         last_fs   = g_cur_fs;
 
         if (dispatch(tag, pid, tf_val(req), tf_val(res)) != 0) {

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -798,9 +798,16 @@ exempt_remove(const char *path)
 
     for (i = 0; i < g_nexempt; i++) {
         if (strcmp(g_exempt[i], path) == 0) {
-            g_exempt[i][0] = '\0';
-            snprintf(g_exempt[i], sizeof(g_exempt[i]), "%s",
-                     g_exempt[--g_nexempt]);
+            /* Swap-with-last.  memmove, not snprintf: removing the LAST
+             * entry makes source and destination the same slot, which is
+             * fine for memmove and a -Werror=restrict violation for the
+             * string functions (gcc flags it; clang does not). */
+            g_nexempt--;
+            if (i != g_nexempt) {
+                memmove(g_exempt[i], g_exempt[g_nexempt],
+                        sizeof(g_exempt[i]));
+            }
+            g_exempt[g_nexempt][0] = '\0';
             return;
         }
     }

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -584,6 +584,12 @@ chimera_nfs_map_cred(
                                         CHIMERA_VFS_ANON_UID,
                                         CHIMERA_VFS_ANON_GID);
     }
+
+    /* NFS callers are stateless remote clients: their open(2)s happened on
+     * machines this server never saw, so the engine's per-op data gates
+     * apply the nfsd-style owner override for them (see the flag's comment
+     * in vfs_cred.h). */
+    vfs_cred->flags |= CHIMERA_VFS_CRED_FLAG_OWNER_OVERRIDE;
 } /* chimera_nfs_map_cred */
 
 /*

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -10,6 +10,7 @@
 #include "nfs_common.h"
 #include "nfs_internal.h"
 #include "nfs_nlm.h"
+#include "common/format.h"
 #include "nfs_nlm_state.h"
 #include "nfs_nlm_granted.h"
 #include "nfs_nsm.h"
@@ -990,6 +991,12 @@ chimera_nfs_nlm4_do_lock(
                       (unsigned long) args->alock.l_offset,
                       (unsigned long) args->alock.l_len,
                       (int) args->exclusive, (int) args->block, (int) args->reclaim, (int) nm_lock);
+    {
+        char ohhex[2 * 64 + 1];
+        format_hex(ohhex, sizeof(ohhex), args->alock.oh.data,
+                   args->alock.oh.len > 64 ? 64 : args->alock.oh.len);
+        chimera_nfs_debug("NLM LOCK: oh=%s svid=%d", ohhex, args->alock.svid);
+    }
 
     /* Recover the inner VFS handle from the wrapped wire handle for the open
     * below (lock identity keeps the client's wrapped bytes in entry->fh). */
@@ -1286,6 +1293,16 @@ chimera_nfs_nlm4_do_unlock(
                       (unsigned) args->alock.fh.len,
                       (unsigned long) args->alock.l_offset,
                       (unsigned long) args->alock.l_len);
+    {
+        char ohhex[2 * 64 + 1];
+        format_hex(ohhex, sizeof(ohhex), args->alock.oh.data,
+                   args->alock.oh.len > 64 ? 64 : args->alock.oh.len);
+        char argfh[2 * 64 + 1];
+        format_hex(argfh, sizeof(argfh), args->alock.fh.data,
+                   args->alock.fh.len > 64 ? 64 : args->alock.fh.len);
+        chimera_nfs_debug("NLM UNLOCK: oh=%s svid=%d fh=%s", ohhex,
+                          args->alock.svid, argfh);
+    }
 
     pthread_mutex_lock(&shared->nlm_state.mutex);
     HASH_FIND_STR(shared->nlm_state.clients, safe_hostname, client);
@@ -1307,15 +1324,30 @@ chimera_nfs_nlm4_do_unlock(
         return;
     }
 
-    entry = nlm_client_find_lock(client,
-                                 args->alock.oh.data,
-                                 args->alock.oh.len,
-                                 args->alock.svid,
-                                 args->alock.fh.data,
-                                 args->alock.fh.len,
-                                 args->alock.l_offset,
-                                 NLM_TO_POSIX_LEN(args->alock.l_len));
-    if (!entry) {
+    /* Sweep every lock this owner holds within the range: UNLOCK releases
+     * the covered locks (RFC 1813), and clients routinely unlock [0, ~0) at
+     * close(2) to drop everything they still hold on the file.  Exact-match
+     * lookup alone left those locks -- and the open handles pinning their
+     * files -- held forever.  Entries are unhooked under the mutex, chained,
+     * and released outside it (same ownership discipline as the single-entry
+     * path replaced here). */
+    struct nlm_lock_entry *sweep = NULL;
+
+    while ((entry = nlm_client_find_lock_in_range(
+                client,
+                args->alock.oh.data,
+                args->alock.oh.len,
+                args->alock.svid,
+                args->alock.fh.data,
+                args->alock.fh.len,
+                args->alock.l_offset,
+                NLM_TO_POSIX_LEN(args->alock.l_len))) != NULL) {
+        DL_DELETE(client->locks, entry);
+        entry->next = sweep;
+        sweep       = entry;
+    }
+
+    if (!sweep) {
         pthread_mutex_unlock(&shared->nlm_state.mutex);
         chimera_nfs_debug("NLM UNLOCK: lock entry not found -> NLM4_GRANTED");
         /* Lock not found -- treat as already unlocked */
@@ -1333,27 +1365,29 @@ chimera_nfs_nlm4_do_unlock(
         return;
     }
 
-    /* Take exclusive ownership of the entry by removing it from the list
-     * while still holding the mutex, preventing concurrent FREE_ALL or
-     * disconnect handlers from freeing it before the release path runs. */
-    DL_DELETE(client->locks, entry);
     pthread_mutex_unlock(&shared->nlm_state.mutex);
 
-    /* Release the claim (sync), put the file_state ref (sync),
-     * and close the handle (sync).  RFC 1813 requires NLM4_GRANTED. */
-    if (entry->claim_inserted) {
-        chimera_vfs_claim_release_ranged(thread->vfs_thread, vfs_state,
-                                         entry->file_state, &entry->claim);
-        entry->claim_inserted = false;
+    /* Release each swept lock: the claim (sync), the file_state ref (sync),
+     * and the open handle that was held for the lock's lifetime.  RFC 1813
+     * requires NLM4_GRANTED. */
+    while (sweep) {
+        entry = sweep;
+        sweep = entry->next;
+
+        if (entry->claim_inserted) {
+            chimera_vfs_claim_release_ranged(thread->vfs_thread, vfs_state,
+                                             entry->file_state, &entry->claim);
+            entry->claim_inserted = false;
+        }
+        if (entry->file_state) {
+            chimera_vfs_state_put(vfs_state, entry->file_state);
+            entry->file_state = NULL;
+        }
+        if (entry->handle) {
+            chimera_vfs_release(thread->vfs_thread, entry->handle);
+        }
+        nlm_lock_entry_free(entry);
     }
-    if (entry->file_state) {
-        chimera_vfs_state_put(vfs_state, entry->file_state);
-        entry->file_state = NULL;
-    }
-    if (entry->handle) {
-        chimera_vfs_release(thread->vfs_thread, entry->handle);
-    }
-    nlm_lock_entry_free(entry);
 
     res.cookie.len  = args->cookie.len;
     res.cookie.data = args->cookie.data;

--- a/src/server/nfs/nfs_nlm_state.h
+++ b/src/server/nfs/nfs_nlm_state.h
@@ -317,6 +317,58 @@ nlm_client_find_lock(
     return NULL;
 } /* nlm_client_find_lock */
 
+/*
+ * Find a lock entry held by (owner handle, svid) on fh that lies WITHIN the
+ * byte range [offset, offset+length).  UNLOCK per RFC 1813 releases the
+ * owner's locks covered by the range, not only an exactly-equal one -- in
+ * particular every real client unlocks [0, ~0) at close(2) to drop whatever
+ * it still holds on the file.  Containment only: a lock partially straddling
+ * the range would need a carve (split), which no chimera-side caller emits
+ * today.  Callers loop until NULL to sweep multi-lock owners.
+ */
+static inline struct nlm_lock_entry *
+nlm_client_find_lock_in_range(
+    struct nlm_client *client,
+    const uint8_t     *oh,
+    uint32_t           oh_len,
+    int32_t            svid,
+    const uint8_t     *fh,
+    uint32_t           fh_len,
+    uint64_t           offset,
+    uint64_t           length)
+{
+    struct nlm_lock_entry *entry;
+    uint64_t               end;
+
+    /* Lengths here are in NLM's internal POSIX convention: 0 = to EOF
+     * (see NLM_TO_POSIX_LEN). */
+    end = (length == 0 || offset + length < offset)
+        ? UINT64_MAX : offset + length;
+
+    DL_FOREACH(client->locks, entry)
+    {
+        uint64_t entry_end;
+
+        if (entry->pending) {
+            continue;
+        }
+        entry_end = (entry->length == 0 ||
+                     entry->offset + entry->length < entry->offset)
+            ? UINT64_MAX : entry->offset + entry->length;
+
+        if (entry->oh_len == oh_len &&
+            entry->svid == svid &&
+            entry->fh_len == fh_len &&
+            entry->offset >= offset &&
+            entry_end <= end &&
+            memcmp(entry->oh, oh, oh_len) == 0 &&
+            memcmp(entry->fh, fh, fh_len) == 0) {
+            return entry;
+        }
+    }
+    return NULL;
+} /* nlm_client_find_lock_in_range */
+
 /* -------------------------------------------------------------------------
  * Functions implemented in nfs_nlm_state.c
  * ---------------------------------------------------------------------- */

--- a/src/vfs/nfs/CMakeLists.txt
+++ b/src/vfs/nfs/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(chimera_vfs_nfs SHARED
     nfs.c
     nfs3.c
     nfs4.c
+    nfs3_allocate.c
     nfs3_close.c
     nfs3_commit.c
     nfs3_getattr.c

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -406,7 +406,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_nfs = {
      * by its upstream RPC reply (it reassigns request->read.iov), so the VFS
      * core must not pre-allocate buffers for it. */
     .capabilities   = CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_RELATIVE_OP |
-        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS | CHIMERA_VFS_CAP_DELEGATES_DAC,
+        CHIMERA_VFS_CAP_FS_LOCK | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS | CHIMERA_VFS_CAP_DELEGATES_DAC |
+        CHIMERA_VFS_CAP_REMOTE_DAC,
     .init           = chimera_nfs_init,
     .destroy        = chimera_nfs_destroy,
     .thread_init    = chimera_nfs_thread_init,

--- a/src/vfs/nfs/nfs3.c
+++ b/src/vfs/nfs/nfs3.c
@@ -70,6 +70,9 @@ chimera_nfs3_dispatch(
         case CHIMERA_VFS_OP_LINK_AT:
             chimera_nfs3_link_at(thread, shared, request, private_data);
             break;
+        case CHIMERA_VFS_OP_ALLOCATE:
+            chimera_nfs3_allocate(thread, shared, request, private_data);
+            break;
         case CHIMERA_VFS_OP_LOCK:
             chimera_nfs3_lock(thread, shared, request, private_data);
             break;

--- a/src/vfs/nfs/nfs3_allocate.c
+++ b/src/vfs/nfs/nfs3_allocate.c
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * NFS3 has no ALLOCATE/DEALLOCATE on the wire, but both are emulatable with
+ * the calls it does have, which keeps posix_fallocate() and hole punching
+ * usable over the proxy instead of failing ENOTSUP:
+ *
+ *  - ALLOCATE (posix_fallocate: ensure [offset, offset+length) is backed) is
+ *    a size extension when the range reaches past EOF and a no-op otherwise.
+ *    GETATTR for the current size, then SETATTR size = offset+length if that
+ *    grows the file.  Blocks are not really reserved -- no NFS3 client can do
+ *    that -- but the visible POSIX contract (size, readable zeros) holds.
+ *
+ *  - DEALLOCATE (FALLOC_FL_PUNCH_HOLE | KEEP_SIZE) is zero-writes over the
+ *    punched range, clamped to EOF (KEEP_SIZE never extends).  A real hole
+ *    and written zeros are indistinguishable through the proxy: NFS3 has no
+ *    SEEK_HOLE on the wire, so holes are unobservable client-side anyway.
+ *
+ * I/O goes out with the opening credential when the handle has one, exactly
+ * like read/write (see nfs3_open_state.h).
+ */
+
+#include "nfs_internal.h"
+#include "nfs3_open_state.h"
+#include "nfs_common/nfs3_status.h"
+#include "nfs_common/nfs3_attr.h"
+
+#define CHIMERA_NFS3_ALLOCATE_ZERO_CHUNK (64 * 1024)
+
+struct chimera_nfs3_allocate_ctx {
+    struct chimera_nfs_thread *thread;
+    struct chimera_nfs_shared *shared;
+    uint64_t                   cur;        /* next zero-write offset      */
+    uint64_t                   end;        /* zeroing end (EOF-clamped)   */
+    struct evpl_iovec          zero;       /* zeroed chunk; consumed by send */
+};
+
+static void chimera_nfs3_allocate_send_write(
+    struct chimera_vfs_request *request);
+
+static const struct chimera_vfs_cred *
+chimera_nfs3_allocate_cred(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs3_open_state *state =
+        (struct chimera_nfs3_open_state *) request->allocate.handle->vfs_private;
+
+    return (state && state->open_cred_valid) ? &state->open_cred :
+           request->cred;
+} /* chimera_nfs3_allocate_cred */
+
+static void
+chimera_nfs3_allocate_done(
+    struct chimera_vfs_request *request,
+    enum chimera_vfs_error      status)
+{
+    request->status = status;
+    request->complete(request);
+} /* chimera_nfs3_allocate_done */
+
+static void
+chimera_nfs3_allocate_write_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct WRITE3res            *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request       *request = private_data;
+    struct chimera_nfs3_allocate_ctx *ctx     = request->plugin_data;
+
+    if (unlikely(status)) {
+        chimera_nfs3_allocate_done(request, CHIMERA_VFS_EFAULT);
+        return;
+    }
+
+    if (res->status != NFS3_OK) {
+        chimera_nfs3_allocate_done(request,
+                                   nfs3_client_status_to_chimera_vfs_error(
+                                       res->status));
+        return;
+    }
+
+    ctx->cur += res->resok.count;
+
+    if (res->resok.count == 0 || ctx->cur >= ctx->end) {
+        chimera_nfs3_allocate_done(request, CHIMERA_VFS_OK);
+        return;
+    }
+
+    chimera_nfs3_allocate_send_write(request);
+} /* chimera_nfs3_allocate_write_callback */
+
+static void
+chimera_nfs3_allocate_send_write(struct chimera_vfs_request *request)
+{
+    struct chimera_nfs3_allocate_ctx        *ctx = request->plugin_data;
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct WRITE3args                        args;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint64_t                                 len;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    server_thread = chimera_nfs_thread_get_server_thread(ctx->thread,
+                                                         request->fh,
+                                                         request->fh_len);
+    if (!server_thread) {
+        chimera_nfs3_allocate_done(request, CHIMERA_VFS_ESTALE);
+        return;
+    }
+
+    len = ctx->end - ctx->cur;
+    if (len > CHIMERA_NFS3_ALLOCATE_ZERO_CHUNK) {
+        len = CHIMERA_NFS3_ALLOCATE_ZERO_CHUNK;
+    }
+
+    /* One exactly-sized zero iovec per WRITE.  The XDR marshaller MOVES the
+     * args iovecs into the outgoing message (marshall_WRITE3args ->
+     * evpl_iovec_move), so send_call consumes this reference -- the caller
+     * must not release it, and a trimmed stack copy of a longer shared
+     * buffer would be illegal (the iovec canary trips). */
+    if (evpl_iovec_alloc(ctx->thread->evpl, (unsigned int) len, 4096, 1, 0,
+                         &ctx->zero) < 1) {
+        chimera_nfs3_allocate_done(request, CHIMERA_VFS_EFAULT);
+        return;
+    }
+    memset(ctx->zero.data, 0, len);
+
+    chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    args.file.data.data = fh;
+    args.file.data.len  = fhlen;
+    args.offset         = ctx->cur;
+    args.count          = (uint32_t) len;
+    args.stable         = FILE_SYNC;
+    args.data.iov       = &ctx->zero;
+    args.data.niov      = 1;
+    args.data.length    = (uint32_t) len;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, chimera_nfs3_allocate_cred(request),
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    ctx->shared->nfs_v3.send_call_NFSPROC3_WRITE(&ctx->shared->nfs_v3.rpc2,
+                                                 ctx->thread->evpl,
+                                                 server_thread->nfs_conn,
+                                                 &rpc2_cred, &args, 1, 0,
+                                                 NULL, 0, 0,
+                                                 chimera_nfs3_allocate_write_callback,
+                                                 request);
+} /* chimera_nfs3_allocate_send_write */
+
+static void
+chimera_nfs3_allocate_setattr_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct SETATTR3res          *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request *request = private_data;
+
+    if (unlikely(status)) {
+        chimera_nfs3_allocate_done(request, CHIMERA_VFS_EFAULT);
+        return;
+    }
+
+    if (res->status != NFS3_OK) {
+        chimera_nfs3_get_wcc_data(&request->allocate.r_pre_attr,
+                                  &request->allocate.r_post_attr,
+                                  &res->resfail.obj_wcc);
+        chimera_nfs3_allocate_done(request,
+                                   nfs3_client_status_to_chimera_vfs_error(
+                                       res->status));
+        return;
+    }
+
+    chimera_nfs3_get_wcc_data(&request->allocate.r_pre_attr,
+                              &request->allocate.r_post_attr,
+                              &res->resok.obj_wcc);
+
+    chimera_nfs3_allocate_done(request, CHIMERA_VFS_OK);
+} /* chimera_nfs3_allocate_setattr_callback */
+
+static void
+chimera_nfs3_allocate_getattr_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct GETATTR3res          *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request              *request = private_data;
+    struct chimera_nfs3_allocate_ctx        *ctx     = request->plugin_data;
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct chimera_vfs_attrs                 attr;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint64_t                                 size, target;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    if (unlikely(status)) {
+        chimera_nfs3_allocate_done(request, CHIMERA_VFS_EFAULT);
+        return;
+    }
+
+    if (res->status != NFS3_OK) {
+        chimera_nfs3_allocate_done(request,
+                                   nfs3_client_status_to_chimera_vfs_error(
+                                       res->status));
+        return;
+    }
+
+    attr.va_set_mask = 0;
+    attr.va_req_mask = CHIMERA_VFS_ATTR_MASK_STAT;
+    chimera_nfs3_unmarshall_attrs(&res->resok.obj_attributes, &attr);
+    size   = attr.va_size;
+    target = request->allocate.offset + request->allocate.length;
+
+    if (!(request->allocate.flags & CHIMERA_VFS_ALLOCATE_DEALLOCATE)) {
+        /* Allocation is a size extension or nothing. */
+        if (target <= size) {
+            chimera_nfs3_allocate_done(request, CHIMERA_VFS_OK);
+            return;
+        }
+
+        struct chimera_vfs_attrs set_attr;
+        struct SETATTR3args      args;
+
+        set_attr.va_req_mask = 0;
+        set_attr.va_set_mask = CHIMERA_VFS_ATTR_SIZE;
+        set_attr.va_size     = target;
+
+        server_thread = chimera_nfs_thread_get_server_thread(ctx->thread,
+                                                             request->fh,
+                                                             request->fh_len);
+        if (!server_thread) {
+            chimera_nfs3_allocate_done(request, CHIMERA_VFS_ESTALE);
+            return;
+        }
+
+        chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+        args.object.data.data = fh;
+        args.object.data.len  = fhlen;
+        args.guard.check      = 0;
+        chimera_nfs_va_to_sattr3(&args.new_attributes, &set_attr);
+
+        chimera_nfs_init_rpc2_cred(&rpc2_cred,
+                                   chimera_nfs3_allocate_cred(request),
+                                   request->thread->vfs->machine_name,
+                                   request->thread->vfs->machine_name_len);
+
+        ctx->shared->nfs_v3.send_call_NFSPROC3_SETATTR(
+            &ctx->shared->nfs_v3.rpc2, ctx->thread->evpl,
+            server_thread->nfs_conn, &rpc2_cred, &args, 0, 0, NULL, 0, 0,
+            chimera_nfs3_allocate_setattr_callback, request);
+        return;
+    }
+
+    /* Punch: zero [offset, offset+length) clamped to EOF (KEEP_SIZE). */
+    ctx->cur = request->allocate.offset;
+    ctx->end = target < size ? target : size;
+
+    if (ctx->cur >= ctx->end) {
+        chimera_nfs3_allocate_done(request, CHIMERA_VFS_OK);
+        return;
+    }
+
+    chimera_nfs3_allocate_send_write(request);
+} /* chimera_nfs3_allocate_getattr_callback */
+
+void
+chimera_nfs3_allocate(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data)
+{
+    struct chimera_nfs_client_server_thread *server_thread =
+        chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                             request->fh_len);
+    struct chimera_nfs3_allocate_ctx        *ctx;
+    struct GETATTR3args                      args;
+    struct evpl_rpc2_cred                    rpc2_cred;
+    uint8_t                                 *fh;
+    int                                      fhlen;
+
+    if (!server_thread) {
+        request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    ctx         = request->plugin_data;
+    ctx->thread = thread;
+    ctx->shared = shared;
+
+    chimera_nfs3_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    args.object.data.data = fh;
+    args.object.data.len  = fhlen;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, chimera_nfs3_allocate_cred(request),
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    shared->nfs_v3.send_call_NFSPROC3_GETATTR(&shared->nfs_v3.rpc2,
+                                              thread->evpl,
+                                              server_thread->nfs_conn,
+                                              &rpc2_cred, &args, 0, 0, NULL,
+                                              0, 0,
+                                              chimera_nfs3_allocate_getattr_callback,
+                                              request);
+} /* chimera_nfs3_allocate */

--- a/src/vfs/nfs/nfs3_commit.c
+++ b/src/vfs/nfs/nfs3_commit.c
@@ -80,9 +80,21 @@ chimera_nfs3_commit(
     args.file.data.data = fh;
     args.file.data.len  = fhlen;
 
-    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
-                               request->thread->vfs->machine_name,
-                               request->thread->vfs->machine_name_len);
+    {
+        /* I/O goes out with the opening credential when there is one: POSIX
+         * binds I/O rights at open(2), and the stateless server would
+         * otherwise re-check DAC against the per-call credential (see
+         * nfs3_open_state.h). */
+        struct chimera_nfs3_open_state *dac_state =
+            (struct chimera_nfs3_open_state *) request->commit.handle->vfs_private;
+        const struct chimera_vfs_cred  *io_cred =
+            (dac_state && dac_state->open_cred_valid) ?
+            &dac_state->open_cred : request->cred;
+
+        chimera_nfs_init_rpc2_cred(&rpc2_cred, io_cred,
+                                   request->thread->vfs->machine_name,
+                                   request->thread->vfs->machine_name_len);
+    }
 
     shared->nfs_v3.send_call_NFSPROC3_COMMIT(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
                                              &args, 0, 0, NULL, 0, 0, chimera_nfs3_commit_callback, request);

--- a/src/vfs/nfs/nfs3_open_at.c
+++ b/src/vfs/nfs/nfs3_open_at.c
@@ -126,7 +126,11 @@ chimera_nfs3_open_at_lookup_callback(
             return;
         }
 
-        state->server_index            = ctx->server->index;
+        state->server_index = ctx->server->index;
+        if (request->cred) {
+            state->open_cred       = *request->cred;
+            state->open_cred_valid = 1;
+        }
         request->open_at.r_vfs_private = (uint64_t) state;
     } else {
         request->open_at.r_vfs_private = 0;
@@ -161,8 +165,9 @@ chimera_nfs3_open_at_create_callback(
                                   &request->open_at.r_dir_post_attr,
                                   &res->resfail.dir_wcc);
 
-        /* An UNCHECKED create over a name already held by a non-regular
-         * object is NFS3ERR_EXIST on the wire (RFC 1813 3.3.8: CREATE
+        /* A create over a name already held by another object is
+         * NFS3ERR_EXIST on the wire (all creates go out GUARDED; for a
+         * non-regular name RFC 1813 3.3.8's UNCHECKED would say the same: CREATE
          * materializes a regular file and neither follows a symlink nor
          * unlinks what is there).  That is the right answer to send, but it
          * is not the answer POSIX gives the caller: open(O_CREAT) on a
@@ -210,6 +215,12 @@ chimera_nfs3_open_at_create_callback(
 
     chimera_nfs3_get_wcc_data(&request->open_at.r_dir_pre_attr, &request->open_at.r_dir_post_attr, &res->resok.dir_wcc);
 
+    /* A GUARDED success proves the object was created by this call (all
+     * creates go out GUARDED -- see chimera_nfs3_open_at); the engine's open
+     * gate then grants the requested access unconditionally, per POSIX (a
+     * creating open is not subject to the new file's own mode). */
+    request->open_at.r_created = 1;
+
     /* Allocate open state for dirty tracking and silly rename support.
      * Skip for inferred opens (use synthetic handles which don't call close).
      * Always allocate for non-inferred opens since open_at always inserts fresh. */
@@ -222,7 +233,11 @@ chimera_nfs3_open_at_create_callback(
             return;
         }
 
-        state->server_index            = ctx->server->index;
+        state->server_index = ctx->server->index;
+        if (request->cred) {
+            state->open_cred       = *request->cred;
+            state->open_cred_valid = 1;
+        }
         request->open_at.r_vfs_private = (uint64_t) state;
     } else {
         request->open_at.r_vfs_private = 0;
@@ -271,7 +286,15 @@ chimera_nfs3_open_at(
         create_args.where.dir.data.len  = fhlen;
         create_args.where.name.str      = (char *) request->open_at.name;
         create_args.where.name.len      = request->open_at.namelen;
-        create_args.how.mode            = (request->open_at.flags & CHIMERA_VFS_OPEN_EXCLUSIVE) ? GUARDED : UNCHECKED;
+        /* Always GUARDED, even without O_EXCL: a GUARDED success PROVES this
+         * call created the object, which the engine's open gate needs to know
+         * -- POSIX exempts a creating open from the new file's own mode.  An
+         * EXIST answer falls to the LOOKUP recovery below and opens what is
+         * there (the O_CREAT-on-existing half), with the gate then evaluating
+         * the real attributes.  UNCHECKED could not tell the halves apart --
+         * and would also let the server apply our creation sattr to a file we
+         * did not create. */
+        create_args.how.mode = GUARDED;
 
         chimera_nfs_va_to_sattr3(&create_args.how.obj_attributes, request->open_at.set_attr);
 

--- a/src/vfs/nfs/nfs3_open_fh.c
+++ b/src/vfs/nfs/nfs3_open_fh.c
@@ -24,6 +24,10 @@ chimera_nfs3_open_fh(
     }
 
     state->server_index = request->fh[CHIMERA_VFS_MOUNT_ID_SIZE];
+    if (request->cred) {
+        state->open_cred       = *request->cred;
+        state->open_cred_valid = 1;
+    }
 
     /* Store open state pointer for direct access on write/close */
     request->open_fh.r_vfs_private = (uint64_t) state;

--- a/src/vfs/nfs/nfs3_open_state.h
+++ b/src/vfs/nfs/nfs3_open_state.h
@@ -37,6 +37,17 @@ struct chimera_nfs3_open_state {
      * when the file is finally closed.
      */
     struct chimera_vfs_cred silly_remove_cred;
+
+    /*
+     * The credential that opened this handle.  POSIX binds I/O rights at
+     * open(2); NFS3 is stateless and the server re-checks DAC on every READ /
+     * WRITE with whatever credential the RPC carries.  Issuing I/O with the
+     * opening credential (exactly what the Linux kernel client's open context
+     * does) keeps a descriptor usable by the process that legitimately opened
+     * it, regardless of who calls or what chmod happened since.
+     */
+    int                     open_cred_valid;
+    struct chimera_vfs_cred open_cred;
 };
 
 /*

--- a/src/vfs/nfs/nfs3_read.c
+++ b/src/vfs/nfs/nfs3_read.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs3_open_state.h"
 #include "nfs_common/nfs3_status.h"
 #include "nfs_common/nfs3_attr.h"
 
@@ -72,9 +73,21 @@ chimera_nfs3_read(
     args.offset         = request->read.offset;
     args.count          = request->read.length;
 
-    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
-                               request->thread->vfs->machine_name,
-                               request->thread->vfs->machine_name_len);
+    {
+        /* I/O goes out with the opening credential when there is one: POSIX
+         * binds I/O rights at open(2), and the stateless server would
+         * otherwise re-check DAC against the per-call credential (see
+         * nfs3_open_state.h). */
+        struct chimera_nfs3_open_state *dac_state =
+            (struct chimera_nfs3_open_state *) request->read.handle->vfs_private;
+        const struct chimera_vfs_cred  *io_cred =
+            (dac_state && dac_state->open_cred_valid) ?
+            &dac_state->open_cred : request->cred;
+
+        chimera_nfs_init_rpc2_cred(&rpc2_cred, io_cred,
+                                   request->thread->vfs->machine_name,
+                                   request->thread->vfs->machine_name_len);
+    }
 
     /* read_into over RDMA: have the server RDMA-write the reply data straight
      * into the caller's destination buffer (the RPC write chunk) instead of an

--- a/src/vfs/nfs/nfs3_rename_at.c
+++ b/src/vfs/nfs/nfs3_rename_at.c
@@ -197,6 +197,33 @@ chimera_nfs3_rename_at(
     ctx->shared = shared;
     ctx->server = server_thread->server;
 
+    /* POSIX rename(2): when old and new resolve to the SAME existing file,
+     * rename does nothing and succeeds.  Without this, the silly-target
+     * dance below dismantles the source: the open target -- which IS the
+     * source -- gets silly-renamed aside and the wire rename re-links it,
+     * leaving an undead name and link count.  Catch the literal self-rename
+     * (same directory, same name) and, when the VFS resolved both, the
+     * same-file-through-different-names case. */
+    if (request->fh_len == request->rename_at.new_fhlen &&
+        memcmp(request->fh, request->rename_at.new_fh,
+               request->fh_len) == 0 &&
+        request->rename_at.namelen == request->rename_at.new_namelen &&
+        memcmp(request->rename_at.name, request->rename_at.new_name,
+               request->rename_at.namelen) == 0) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+    if (request->rename_at.source_fh_len && request->rename_at.target_fh &&
+        request->rename_at.target_fh_len ==
+        request->rename_at.source_fh_len &&
+        memcmp(request->rename_at.source_fh, request->rename_at.target_fh,
+               request->rename_at.source_fh_len) == 0) {
+        request->status = CHIMERA_VFS_OK;
+        request->complete(request);
+        return;
+    }
+
     /*
      * If no target FH provided, skip silly rename handling entirely.
      * This happens when:

--- a/src/vfs/nfs/nfs3_setattr.c
+++ b/src/vfs/nfs/nfs3_setattr.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs3_open_state.h"
 #include "nfs_common/nfs3_attr.h"
 #include "nfs_common/nfs3_status.h"
 
@@ -66,9 +67,31 @@ chimera_nfs3_setattr(
 
     args.guard.check = 0;
 
-    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
-                               request->thread->vfs->machine_name,
-                               request->thread->vfs->machine_name_len);
+    {
+        /* A size-only setattr through an open handle is ftruncate(2): its
+         * rights were bound at open, so it goes out with the opening
+         * credential like the rest of the I/O family (see nfs3_open_state.h).
+         * Ownership-sensitive attributes (mode/uid/gid/times) keep the
+         * caller's credential -- chmod/chown authorize against the CALLER,
+         * open rights are irrelevant to them. */
+        struct chimera_nfs3_open_state *dac_state = request->setattr.handle ?
+            (struct chimera_nfs3_open_state *)
+            request->setattr.handle->vfs_private : NULL;
+        const struct chimera_vfs_cred  *io_cred = request->cred;
+
+        if (dac_state && dac_state->open_cred_valid &&
+            (request->setattr.set_attr->va_set_mask &
+             CHIMERA_VFS_ATTR_SIZE) &&
+            !(request->setattr.set_attr->va_set_mask &
+              (CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_UID |
+               CHIMERA_VFS_ATTR_GID))) {
+            io_cred = &dac_state->open_cred;
+        }
+
+        chimera_nfs_init_rpc2_cred(&rpc2_cred, io_cred,
+                                   request->thread->vfs->machine_name,
+                                   request->thread->vfs->machine_name_len);
+    }
 
     shared->nfs_v3.send_call_NFSPROC3_SETATTR(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
                                               &args, 0, 0, NULL, 0, 0, chimera_nfs3_setattr_callback, request);

--- a/src/vfs/nfs/nfs3_write.c
+++ b/src/vfs/nfs/nfs3_write.c
@@ -88,9 +88,21 @@ chimera_nfs3_write(
     args.data.niov      = request->write.niov;
     args.data.length    = request->write.length;
 
-    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
-                               request->thread->vfs->machine_name,
-                               request->thread->vfs->machine_name_len);
+    {
+        /* I/O goes out with the opening credential when there is one: POSIX
+         * binds I/O rights at open(2), and the stateless server would
+         * otherwise re-check DAC against the per-call credential (see
+         * nfs3_open_state.h). */
+        struct chimera_nfs3_open_state *dac_state =
+            (struct chimera_nfs3_open_state *) request->write.handle->vfs_private;
+        const struct chimera_vfs_cred  *io_cred =
+            (dac_state && dac_state->open_cred_valid) ?
+            &dac_state->open_cred : request->cred;
+
+        chimera_nfs_init_rpc2_cred(&rpc2_cred, io_cred,
+                                   request->thread->vfs->machine_name,
+                                   request->thread->vfs->machine_name_len);
+    }
 
     shared->nfs_v3.send_call_NFSPROC3_WRITE(&shared->nfs_v3.rpc2, thread->evpl, server_thread->nfs_conn, &rpc2_cred,
                                             &args, 1, 0, NULL, 0, 0, chimera_nfs3_write_callback, request);

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -1010,7 +1010,7 @@ void chimera_nfs4_compound_call(
     struct evpl_iovec                       *write_chunk_iov,
     int                                      write_chunk_niov,
     int                                      max_rdma_reply_chunk,
-    void                                  ( *cb )(
+    void (                                  *cb )(
         struct evpl *,
         const struct evpl_rpc2_verf *,
         struct COMPOUND4res *,

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -1010,7 +1010,7 @@ void chimera_nfs4_compound_call(
     struct evpl_iovec                       *write_chunk_iov,
     int                                      write_chunk_niov,
     int                                      max_rdma_reply_chunk,
-    void (                                  *cb )(
+    void                                  ( *cb )(
         struct evpl *,
         const struct evpl_rpc2_verf *,
         struct COMPOUND4res *,
@@ -1112,6 +1112,12 @@ void chimera_nfs3_read(
     struct chimera_nfs_shared *,
     struct chimera_vfs_request *,
     void *);
+void chimera_nfs3_allocate(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
+
 void chimera_nfs3_write(
     struct chimera_nfs_thread *,
     struct chimera_nfs_shared *,

--- a/src/vfs/sdk/vfs_access.h
+++ b/src/vfs/sdk/vfs_access.h
@@ -159,6 +159,21 @@ void chimera_vfs_gate_fh(
     chimera_vfs_gate_callback_t    callback,
     void                          *private_data);
 
+/* As chimera_vfs_gate_fh(), but evaluated even where gate_needed() would
+ * defer to the backend -- for the few spots where the ENGINE is about to
+ * deny an operation itself and POSIX orders an access denial ahead of it,
+ * on a backend that will never see the op (see the unprivileged
+ * device-mknod EPERM in vfs_proc_mknod_at.c). */
+void chimera_vfs_gate_fh_always(
+    struct chimera_vfs_gate_ctx   *ctx,
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    uint32_t                       required,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data);
+
 /* As chimera_vfs_gate_fh(), but for an object of ANY type: the directory
  * assertion is dropped.  For callers authorizing access to the object itself
  * rather than traversing it -- an open(2) access-mode check, which must be

--- a/src/vfs/sdk/vfs_access.h
+++ b/src/vfs/sdk/vfs_access.h
@@ -73,6 +73,16 @@ int chimera_vfs_gate_needed_dac(
     const struct chimera_vfs_cred *cred);
 
 /*
+ * Whether the engine must authorize an OPEN's requested access itself.  Same
+ * as chimera_vfs_gate_needed() plus remote-DAC proxy backends
+ * (CHIMERA_VFS_CAP_REMOTE_DAC): their server enforces every wire operation
+ * but has no open to enforce, so open(2) semantics fall to the engine.
+ */
+int chimera_vfs_open_gate_needed(
+    uint64_t                       module_capabilities,
+    const struct chimera_vfs_cred *cred);
+
+/*
  * The enforcement decision itself: CHIMERA_VFS_OK if every bit in `required`
  * (canonical CHIMERA_ACE_* mask) is granted to `cred` on the object described
  * by `attr` (which must carry mode/uid/gid and, for a natively-stored ACL, the

--- a/src/vfs/sdk/vfs_cred.h
+++ b/src/vfs/sdk/vfs_cred.h
@@ -54,7 +54,20 @@ struct chimera_vfs_cred {
      * the kernel (the syscall holds the very lock the invalidation needs).
      * NULL everywhere else; not part of the credential identity hash. */
     const void                  *origin;
+
+    /* Behavioral flags the protocol server stamps on the credential; like
+     * origin, NOT part of the credential identity hash. */
+    uint32_t                     flags;
 };
+
+/* The caller is a stateless remote-filesystem client (the NFS server stamps
+ * this): the engine's per-operation data gates apply the owner override
+ * Linux nfsd calls NFSD_MAY_OWNER_OVERRIDE -- the file's owner keeps
+ * READ/WRITE and size-setattr through descriptors whose rights were bound at
+ * an open(2) this server never saw, regardless of the current mode bits.
+ * Local callers (the posix client, the FUSE server) do NOT set it: their
+ * opens are visible, so strict POSIX evaluation stands. */
+#define CHIMERA_VFS_CRED_FLAG_OWNER_OVERRIDE (1U << 0)
 
 /*
  * Compact identity hash for a credential, used to key the open-handle cache so

--- a/src/vfs/sdk/vfs_module.h
+++ b/src/vfs/sdk/vfs_module.h
@@ -204,6 +204,18 @@ struct chimera_vfs_handle_state {
  * enforce; linux/io_uring enforce in-kernel but do not store the rich ACL). */
 #define CHIMERA_VFS_CAP_DELEGATES_DAC         (1U << 21)
 
+/* Refinement of CHIMERA_VFS_CAP_DELEGATES_DAC for PROXY modules (nfs, smb):
+ * the real enforcer is a remote server that authorizes every operation with
+ * the credential each RPC carries -- there is no open_by_handle_at-style
+ * bypass for the engine to compensate for.  The engine therefore skips the
+ * per-operation I/O and path-prefix gates entirely (they would re-evaluate
+ * DAC with the per-call credential, breaking POSIX's rights-bind-at-open),
+ * and instead runs the OPEN-time access gate, which the remote server cannot
+ * provide (NFS3 has no open on the wire) -- the client-side equivalent of a
+ * kernel NFS client's ACCESS check at open(2).  Meaningful only alongside
+ * DELEGATES_DAC. */
+#define CHIMERA_VFS_CAP_REMOTE_DAC            (1U << 29)
+
 /* If set, the module supports named streams (SMB Alternate Data Streams) on
  * regular files via chimera_vfs_open_stream / list_streams / remove_stream.
  * A named stream is an independent data fork addressed by name; it shares the

--- a/src/vfs/vfs_access.c
+++ b/src/vfs/vfs_access.c
@@ -89,12 +89,45 @@ chimera_vfs_gate_needed_dac(
         return 1;
     }
 
+    /* A remote-DAC proxy has no bypass to compensate for: the server it
+     * forwards to authorizes every operation itself, with the credential the
+     * proxy chooses to send (the opening credential for I/O -- see
+     * nfs3_open_state.h).  Engine-side per-op gating on top would re-check
+     * with the per-call credential and break rights-bind-at-open. */
+    if (module_capabilities & CHIMERA_VFS_CAP_REMOTE_DAC) {
+        return 0;
+    }
+
     if (cred->flavor != CHIMERA_VFS_AUTH_UNIX || cred->uid == 0) {
         return 0;
     }
 
     return (module_capabilities & CHIMERA_VFS_CAP_DELEGATES_DAC) ? 1 : 0;
 } /* chimera_vfs_gate_needed_dac */
+
+SYMBOL_EXPORT int
+chimera_vfs_open_gate_needed(
+    uint64_t                       module_capabilities,
+    const struct chimera_vfs_cred *cred)
+{
+    if (chimera_vfs_gate_needed(module_capabilities, cred)) {
+        return 1;
+    }
+
+    /* Remote-DAC proxy: the server enforces per-op but has no open on the
+     * wire to enforce open(2) access against, so the engine gates the open
+     * itself from the looked-up attributes -- what a kernel NFS client's
+     * ACCESS call at open does.  Root and AUTH_NONE stay exempt. */
+    if (!(module_capabilities & CHIMERA_VFS_CAP_REMOTE_DAC)) {
+        return 0;
+    }
+
+    if (cred->flavor != CHIMERA_VFS_AUTH_UNIX || cred->uid == 0) {
+        return 0;
+    }
+
+    return 1;
+} /* chimera_vfs_open_gate_needed */
 
 SYMBOL_EXPORT enum chimera_vfs_error
 chimera_vfs_gate(

--- a/src/vfs/vfs_cred.c
+++ b/src/vfs/vfs_cred.c
@@ -91,6 +91,7 @@ chimera_vfs_cred_init_unix(
     cred->uid    = uid;
     cred->gid    = gid;
     cred->origin = NULL;
+    cred->flags  = 0;
 
     if (ngids > CHIMERA_VFS_CRED_MAX_GIDS) {
         ngids = CHIMERA_VFS_CRED_MAX_GIDS;
@@ -118,6 +119,7 @@ chimera_vfs_cred_init_attr(
     cred->gid    = gid;
     cred->ngids  = 0;
     cred->origin = NULL;
+    cred->flags  = 0;
 } /* chimera_vfs_cred_init_attr */
 
 SYMBOL_EXPORT int

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -165,6 +165,40 @@ chimera_vfs_gate_fh(
 } /* chimera_vfs_gate_fh */
 
 /*
+ * chimera_vfs_gate_fh, but unconditionally: evaluate the mask even where
+ * chimera_vfs_gate_needed() would defer to the backend.  For the few spots
+ * where the ENGINE is about to deny something itself (the unprivileged
+ * device-mknod EPERM) and POSIX orders the parent-access EACCES first: on a
+ * remote-DAC proxy the server never sees the operation, so the engine must
+ * evaluate the parent access from the (faithfully reported) attributes.
+ */
+SYMBOL_EXPORT void
+chimera_vfs_gate_fh_always(
+    struct chimera_vfs_gate_ctx   *ctx,
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    uint32_t                       required,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data)
+{
+    struct chimera_vfs_module *module;
+
+    module = chimera_vfs_get_module(thread, fh, fhlen);
+
+    if (!module) {
+        callback(CHIMERA_VFS_ESTALE, private_data);
+        return;
+    }
+
+    ctx->any_type = 0;
+
+    chimera_vfs_gate_fh_impl(ctx, thread, cred, fh, fhlen, required, 1,
+                             callback, private_data);
+} /* chimera_vfs_gate_fh_always */
+
+/*
  * Variant of chimera_vfs_gate_fh() that also enforces DAC the kernel cannot see
  * on a handle-based passthrough backend for POSIX callers (path-prefix search,
  * link/rename destination-directory write).  See chimera_vfs_gate_needed_dac().

--- a/src/vfs/vfs_proc_mknod_at.c
+++ b/src/vfs/vfs_proc_mknod_at.c
@@ -287,7 +287,19 @@ chimera_vfs_mknod_at(
         return;
     }
 
-    if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
+    /* The engine's create gate normally runs only where the engine is the
+     * DAC authority.  One remote-DAC exception: a DEVICE mknod by an
+     * unprivileged caller is answered EPERM by the engine itself (the
+     * dispatch path below) -- but POSIX/Linux order the parent-write EACCES
+     * first (may_create before CAP_MKNOD), and the remote server can only
+     * deliver that EACCES for an operation we would actually send.  Run the
+     * engine's own create gate for exactly this case so the denials come
+     * out in the right order. */
+    if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred) ||
+        (chimera_vfs_open_gate_needed(handle->vfs_module->capabilities,
+                                      cred) &&
+         (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+         (S_ISBLK(attr->va_mode) || S_ISCHR(attr->va_mode)))) {
         gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;
         gate->cred           = cred;
@@ -301,10 +313,14 @@ chimera_vfs_mknod_at(
         gate->callback       = callback;
         gate->private_data   = private_data;
 
-        chimera_vfs_gate_fh(&gate->gate_ctx, thread, cred,
-                            handle->fh, handle->fh_len,
-                            CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE,
-                            chimera_vfs_mknod_at_gate_complete, gate);
+        /* _always: on a remote-DAC proxy gate_fh would defer to a backend
+         * that will never see this op (the engine denies it below); the
+         * engine must evaluate the parent access itself. */
+        chimera_vfs_gate_fh_always(&gate->gate_ctx, thread, cred,
+                                   handle->fh, handle->fh_len,
+                                   CHIMERA_ACE_WRITE_DATA |
+                                   CHIMERA_ACE_EXECUTE,
+                                   chimera_vfs_mknod_at_gate_complete, gate);
         return;
     }
 

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -120,7 +120,7 @@ chimera_vfs_open_root_complete(
 
 #define CHIMERA_VFS_OPEN_HOPS_SHIFT 24
 #define CHIMERA_VFS_OPEN_HOPS_MASK  (0xffu << CHIMERA_VFS_OPEN_HOPS_SHIFT)
-#define CHIMERA_VFS_OPEN_HOPS(f) (((f) & CHIMERA_VFS_OPEN_HOPS_MASK) >> \
+#define CHIMERA_VFS_OPEN_HOPS(f) (((f)&CHIMERA_VFS_OPEN_HOPS_MASK) >> \
                                   CHIMERA_VFS_OPEN_HOPS_SHIFT)
 #define CHIMERA_VFS_OPEN_SYMLOOP    8
 

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -120,7 +120,7 @@ chimera_vfs_open_root_complete(
 
 #define CHIMERA_VFS_OPEN_HOPS_SHIFT 24
 #define CHIMERA_VFS_OPEN_HOPS_MASK  (0xffu << CHIMERA_VFS_OPEN_HOPS_SHIFT)
-#define CHIMERA_VFS_OPEN_HOPS(f) (((f)&CHIMERA_VFS_OPEN_HOPS_MASK) >> \
+#define CHIMERA_VFS_OPEN_HOPS(f) (((f) & CHIMERA_VFS_OPEN_HOPS_MASK) >> \
                                   CHIMERA_VFS_OPEN_HOPS_SHIFT)
 #define CHIMERA_VFS_OPEN_SYMLOOP    8
 
@@ -401,7 +401,8 @@ chimera_vfs_open_lookup_complete(
         }
 
         /* Authorize the requested read/write access against the file. */
-        if (chimera_vfs_gate_needed(request->module->capabilities, request->cred)) {
+        if (chimera_vfs_open_gate_needed(request->module->capabilities,
+                                         request->cred)) {
             if (chimera_vfs_gate(attr, request->cred,
                                  chimera_vfs_open_required_access(f)) != CHIMERA_VFS_OK) {
                 chimera_vfs_request_free(thread, request);

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -130,8 +130,8 @@ chimera_vfs_open_at_hdl_callback(
                    (f & (CHIMERA_VFS_OPEN_READ_ONLY |
                          CHIMERA_VFS_OPEN_WRITE_ONLY))) {
             status = CHIMERA_VFS_ENXIO;
-        } else if (chimera_vfs_gate_needed(request->module->capabilities,
-                                           request->cred)) {
+        } else if (chimera_vfs_open_gate_needed(request->module->capabilities,
+                                                request->cred)) {
             uint32_t required = chimera_vfs_open_required_access(f);
             uint32_t granted  =
                 chimera_vfs_access_check(&request->open_at.r_attr,

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -303,6 +303,20 @@ chimera_vfs_read_gate_complete(
 
     gate->handle->granted_access = chimera_vfs_access_check(attr, gate->cred,
                                                             CHIMERA_ACE_MASK_ALL);
+
+    /* Owner override, as Linux nfsd applies to READ/WRITE (NFSD_MAY_OWNER_
+     * OVERRIDE): a POSIX caller who OWNS the file may move its data through
+     * an already-open descriptor regardless of the current mode bits --
+     * POSIX binds I/O rights at open(2), and stateless per-op re-checking
+     * would otherwise break every open-then-chmod sequence.  AUTH_UNIX only:
+     * an SMB caller's rights come from the NT security descriptor, where
+     * ownership does not imply data access. */
+    if (gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+        gate->cred->uid == attr->va_uid) {
+        gate->handle->granted_access |= CHIMERA_ACE_READ_DATA |
+            CHIMERA_ACE_WRITE_DATA;
+    }
     gate->handle->granted_valid = 1;
 
     if (!(gate->handle->granted_access & CHIMERA_ACE_READ_DATA)) {

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -308,10 +308,14 @@ chimera_vfs_read_gate_complete(
      * OVERRIDE): a POSIX caller who OWNS the file may move its data through
      * an already-open descriptor regardless of the current mode bits --
      * POSIX binds I/O rights at open(2), and stateless per-op re-checking
-     * would otherwise break every open-then-chmod sequence.  AUTH_UNIX only:
-     * an SMB caller's rights come from the NT security descriptor, where
+     * would otherwise break every open-then-chmod sequence.  Only for
+     * credentials the protocol server stamped as stateless remote callers
+     * (the NFS server; see CHIMERA_VFS_CRED_FLAG_OWNER_OVERRIDE): a local
+     * caller's opens are visible, so strict POSIX evaluation stands, and an
+     * SMB caller's rights come from the NT security descriptor, where
      * ownership does not imply data access. */
-    if (gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+    if ((gate->cred->flags & CHIMERA_VFS_CRED_FLAG_OWNER_OVERRIDE) &&
+        gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
         gate->cred->uid == attr->va_uid) {
         gate->handle->granted_access |= CHIMERA_ACE_READ_DATA |

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -391,6 +391,18 @@ chimera_vfs_setattr_gate_complete(
         if (owner && (m & time_trigger) && !(m & ~owner_exempt)) {
             required = 0;
         }
+
+        /* Owner override for a SIZE change, as Linux nfsd applies to
+         * truncates (NFSD_MAY_OWNER_OVERRIDE covers them like READ/WRITE):
+         * ftruncate(2)/posix_fallocate(2) bound their rights at open, the
+         * stateless wire re-checks per operation, and an owner must not
+         * lose the ability to resize through a descriptor they legitimately
+         * opened.  AUTH_UNIX only, as in the I/O gates -- an SMB caller's
+         * rights come from the security descriptor. */
+        if (owner && gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+            (m & CHIMERA_VFS_ATTR_SIZE)) {
+            required &= ~CHIMERA_ACE_WRITE_DATA;
+        }
     }
 
     /* WRITE_OWNER (the chown/chgrp right) is authorized separately below; gate

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -399,7 +399,9 @@ chimera_vfs_setattr_gate_complete(
          * lose the ability to resize through a descriptor they legitimately
          * opened.  AUTH_UNIX only, as in the I/O gates -- an SMB caller's
          * rights come from the security descriptor. */
-        if (owner && gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+        if (owner &&
+            (gate->cred->flags & CHIMERA_VFS_CRED_FLAG_OWNER_OVERRIDE) &&
+            gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
             (m & CHIMERA_VFS_ATTR_SIZE)) {
             required &= ~CHIMERA_ACE_WRITE_DATA;
         }

--- a/src/vfs/vfs_proc_umount.c
+++ b/src/vfs/vfs_proc_umount.c
@@ -194,6 +194,53 @@ chimera_vfs_umount_sweep_cache(
     return referenced;
 } /* chimera_vfs_umount_sweep_cache */
 
+
+/* Name the handles that keep an umount from completing: walk both caches and
+ * log each still-referenced handle on the mount, with the identity a reader
+ * needs to find the holder.  Diagnostic only -- by the time this runs the
+ * umount has already given up, and "N handle(s) still open" with no identity
+ * cannot be debugged from the log alone. */
+static void
+chimera_vfs_umount_dump_referenced(
+    struct chimera_vfs       *vfs,
+    struct chimera_vfs_mount *mount)
+{
+    struct vfs_open_cache *caches[2];
+    const char            *names[2] = { "file", "path" };
+
+    caches[0] = vfs->vfs_open_file_cache;
+    caches[1] = vfs->vfs_open_path_cache;
+
+    for (int c = 0; c < 2; c++) {
+        struct vfs_open_cache *cache = caches[c];
+
+        for (unsigned int i = 0; i < cache->num_shards; i++) {
+            struct vfs_open_cache_shard    *shard = &cache->shards[i];
+            struct chimera_vfs_open_handle *handle;
+
+            pthread_mutex_lock(&shard->lock);
+            for (handle = shard->handles; handle;
+                 handle = handle->bucket_next) {
+                char fhhex[CHIMERA_VFS_FH_SIZE * 2 + 1];
+
+                if (memcmp(handle->fh, mount->root_fh,
+                           CHIMERA_VFS_MOUNT_ID_SIZE) != 0 ||
+                    !handle->opencnt) {
+                    continue;
+                }
+                format_hex(fhhex, sizeof(fhhex), handle->fh, handle->fh_len);
+                chimera_vfs_error(
+                    "umount %s: still-open handle fh %s (%s cache, "
+                    "opencnt %u, access_mode %u, cred_hash %llx)",
+                    mount->path, fhhex, names[c], handle->opencnt,
+                    handle->access_mode,
+                    (unsigned long long) handle->cred_hash);
+            }
+            pthread_mutex_unlock(&shard->lock);
+        }
+    }
+} /* chimera_vfs_umount_dump_referenced */
+
 /*
  * Drive the umount forward: sweep both caches, and finish once nothing on the
  * mount remains.  Re-entered from a close completion or the poll timer, so it
@@ -259,6 +306,7 @@ chimera_vfs_umount_progress(struct chimera_vfs_request *request)
             "-- the mount stays registered and callers will see EBUSY",
             request->umount.mount->path, referenced,
             wait->waited_us / 1000);
+        chimera_vfs_umount_dump_referenced(vfs, request->umount.mount);
         chimera_vfs_umount_wait_stop(request);
         chimera_vfs_umount_abandon(request);
         return;

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -144,10 +144,14 @@ chimera_vfs_write_gate_complete(
      * OVERRIDE): a POSIX caller who OWNS the file may move its data through
      * an already-open descriptor regardless of the current mode bits --
      * POSIX binds I/O rights at open(2), and stateless per-op re-checking
-     * would otherwise break every open-then-chmod sequence.  AUTH_UNIX only:
-     * an SMB caller's rights come from the NT security descriptor, where
+     * would otherwise break every open-then-chmod sequence.  Only for
+     * credentials the protocol server stamped as stateless remote callers
+     * (the NFS server; see CHIMERA_VFS_CRED_FLAG_OWNER_OVERRIDE): a local
+     * caller's opens are visible, so strict POSIX evaluation stands, and an
+     * SMB caller's rights come from the NT security descriptor, where
      * ownership does not imply data access. */
-    if (gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+    if ((gate->cred->flags & CHIMERA_VFS_CRED_FLAG_OWNER_OVERRIDE) &&
+        gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
         gate->cred->uid == attr->va_uid) {
         gate->handle->granted_access |= CHIMERA_ACE_READ_DATA |

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -139,6 +139,20 @@ chimera_vfs_write_gate_complete(
 
     gate->handle->granted_access = chimera_vfs_access_check(attr, gate->cred,
                                                             CHIMERA_ACE_MASK_ALL);
+
+    /* Owner override, as Linux nfsd applies to READ/WRITE (NFSD_MAY_OWNER_
+     * OVERRIDE): a POSIX caller who OWNS the file may move its data through
+     * an already-open descriptor regardless of the current mode bits --
+     * POSIX binds I/O rights at open(2), and stateless per-op re-checking
+     * would otherwise break every open-then-chmod sequence.  AUTH_UNIX only:
+     * an SMB caller's rights come from the NT security descriptor, where
+     * ownership does not imply data access. */
+    if (gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
+        gate->cred->uid == attr->va_uid) {
+        gate->handle->granted_access |= CHIMERA_ACE_READ_DATA |
+            CHIMERA_ACE_WRITE_DATA;
+    }
     gate->handle->granted_valid = 1;
 
     if (!(gate->handle->granted_access & CHIMERA_ACE_WRITE_DATA)) {


### PR DESCRIPTION
Runs the POSIX model corpus through the full NFS client stack — posix
client → nfs proxy module → wire → in-process server → memfs — as a
standing ctest: `chimera/posix/mbt/batch_nfs3_memfs`, 53/53 traces in
~6s, no network namespace or privileges (inproc transport, like the
other MBT harnesses). This is the first coverage `src/vfs/nfs` has ever
had in CI (previously 1% of lines, reached by nothing).

The loopback plumbing (nfs3_/nfs4_ driver backends, per-profile trace
corpus) has existed since the original quint suite but could never run:
the per-trace filesystem recycle was unimplemented over the loopback,
and the corpus flushed out a series of real defects once it ran. Each is
its own commit; the headline fixes:

- **The nfs3 proxy issued I/O with per-call credentials.** POSIX binds
  I/O rights at open(2); the stateless server re-checks DAC on every
  READ/WRITE with whatever the RPC carries, so every open-then-chmod and
  shared-descriptor sequence broke. The proxy now stores the opening
  credential and issues READ/WRITE/COMMIT/size-SETATTR with it — what
  the Linux kernel client's open context does. Paired with nfsd-style
  owner override on the server's gated read/write and size-setattr
  paths.
- **Nobody enforced open(2) access over the proxy.** New
  `CHIMERA_VFS_CAP_REMOTE_DAC`: the engine skips its per-op I/O and
  path-prefix gates for proxies (the remote server enforces per-op) and
  instead runs an open-time access gate — the engine-side equivalent of
  a kernel client's ACCESS at open. Proxy creates go out GUARDED so a
  success provably created the file (POSIX exempts a creating open from
  the new file's own mode).
- **NLM UNLOCK was exact-match only.** Real clients unlock
  `[0, to-EOF)` at close; the server matched nothing, answered GRANTED,
  and kept the locks and the open handles they pin forever. UNLOCK now
  sweeps every contained lock of the owner. The nfsaux model changes in
  lockstep: chimera-nas/specs#16 (this PR's specs pin includes that
  commit and must be bumped to the specs main SHA once #16 merges,
  before this enters the queue).
- **The posix client never told the backend about locks dropped at
  close.** close(2) and dup2(2)'s implicit close now project a
  whole-file unlock for FS_LOCK backends while the handle is live.
- **Self-rename corrupted files through the proxy.** `rename(x, x)`
  ran the silly-target dance on its own source, leaving an undead name
  and link count. Same-file rename is now the POSIX no-op.
- **`truncate(2)` vs `ftruncate(2)` semantics.** Path-truncate requires
  write permission, fd-truncate rides open rights, and the wire SETATTR
  cannot tell them apart. The client opens the size-setattr resolution
  with write intent (the open gate enforces the path rule on every
  backend); the server owner-overrides SIZE like nfsd.
- Smaller: `lockf` requires a writable descriptor for every command;
  fcntl read/write locks require a matching descriptor access mode;
  device-mknod's EPERM is ordered after the parent-access EACCES on
  remote-DAC backends (new `chimera_vfs_gate_fh_always`); ALLOCATE/
  DEALLOCATE are emulated over nfs3 (size extension / zero-writes) so
  posix_fallocate works; umount's give-up path names each still-open
  handle instead of just counting them.

What a real NFS client cannot make POSIX-shaped reconciles in the
replayer as a tallied ND registry, mirroring the PD registry's design
(visible per trace, retired when the model or chimera moves): silly-
rename artifacts and their consequences (`.nfs*` names, nlink, rmdir
residue), the directory-search-permission semantics neither the model
nor chimera's resolution implements yet (#1771 — reconciled denials are
re-executed as root so the namespaces stay converged), the one per-op
DAC case owner-override cannot cover, and seek/copy_range capability-
versus-argument-priority quirks.

The nfs4_ profile stays unregistered: the nfs4 client needs its own
round of these fixes (it has independent read/write/setattr paths, plus
an inode-identity instability the first measurements surfaced). The
disk_ profile belongs to the container/CI matrix with the other diskfs
batches.

Depends on chimera-nas/specs#16 (merge first; then the specs pin here
gets bumped to the resulting specs main SHA).
