### PR TITLE
tests/quint: run the NFS3 model suite on the linux + io_uring backends

### DIFF
--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -97,6 +97,37 @@ if(CAIRN_ENABLED)
         TIMEOUT 60)
 endif()
 
+# The passthrough backends (linux, io_uring) mount a host directory instead of
+# a named filesystem, and their trees must live on a filesystem that supports
+# name_to_handle_at -- tmpfs and overlayfs do not.  The harness roots its
+# backing store at $CHIMERA_MBT_SCRATCH (default: the working directory) and
+# turns an incapable filesystem into a clean SKIP, so these register
+# unconditionally on capable platforms: in CI the ctest working directory is
+# a docker volume on the runner's ext4, and a local overlayfs build tree
+# skips rather than fails.  The probe additionally guards the
+# exclusive-create-retry-exist deviation, which only a passthrough backend
+# (whose host filesystem touches the atime the exclusive verifier is stashed
+# in) can reproduce.
+if(CHIMERA_LINUX)
+    add_test(NAME chimera/server/nfs/mbt/deviation_probe_linux
+        COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b linux)
+    set_tests_properties(chimera/server/nfs/mbt/deviation_probe_linux PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_probe_linux"
+        LABELS "quint;nfs3_mbt;linux"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 60)
+endif()
+
+if(CHIMERA_VFS_IO_URING)
+    add_test(NAME chimera/server/nfs/mbt/deviation_probe_io_uring
+        COMMAND $<TARGET_FILE:nfs3_mbt_probe> -b io_uring)
+    set_tests_properties(chimera/server/nfs/mbt/deviation_probe_io_uring PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_probe_io_uring"
+        LABELS "quint;nfs3_mbt;io_uring"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 60)
+endif()
+
 # Auxiliary-protocol ground truth: pins which portmap/rpcbind, MOUNT, NLM and
 # NSM procedures chimera registers, and the constants their replies carry --
 # the facts the nfsaux model's configuration gate encodes.  Needs no corpus.
@@ -158,6 +189,35 @@ if(CAIRN_ENABLED)
     set_tests_properties(chimera/server/nfs/mbt/batch_cairn PROPERTIES
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_cairn"
         LABELS "quint;nfs3_mbt;cairn"
+        TIMEOUT 300)
+endif()
+
+# The corpus against the passthrough backends (scratch/skip semantics as for
+# the deviation probes above).  --max-attr-skip-rate is raised: NFS3 post-op
+# attributes are RFC-optional, and the passthrough backends omit them where
+# fetching would cost an extra host round trip -- measured up to ~25% of
+# replies on the step flavors, against ~0% for the in-engine backends.  The
+# model tolerates an omitted optional attribute; the cap only bounds how much
+# of the corpus may go unchecked before the replay is judged vacuous.
+if(CHIMERA_LINUX)
+    add_test(NAME chimera/server/nfs/mbt/batch_linux
+        COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
+                --backend linux --max-attr-skip-rate 0.5)
+    set_tests_properties(chimera/server/nfs/mbt/batch_linux PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_linux"
+        LABELS "quint;nfs3_mbt;linux"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 300)
+endif()
+
+if(CHIMERA_VFS_IO_URING)
+    add_test(NAME chimera/server/nfs/mbt/batch_io_uring
+        COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
+                --backend io_uring --max-attr-skip-rate 0.5)
+    set_tests_properties(chimera/server/nfs/mbt/batch_io_uring PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_io_uring"
+        LABELS "quint;nfs3_mbt;io_uring"
+        SKIP_RETURN_CODE 77
         TIMEOUT 300)
 endif()
 

--- a/src/server/nfs/tests/quint/nfs3_mbt_probe.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_probe.c
@@ -202,9 +202,16 @@ main(
         fprintf(stderr, "MKNOD pd/f failed: %u\n", res->status);
         return 1;
     }
+    /* The engine backends answer ISDIR (a non-directory moved onto a
+     * directory); the passthrough backends surface the host kernel's
+     * reading, which reports the non-empty target first (NOTEMPTY).  Both
+     * are status-only precedence choices on the same refusal -- what F2
+     * actually guards is that the parent-alias case answers at all instead
+     * of deadlocking. */
     expect("RENAME child onto a name resolving to its parent",
            mbt_rename(env, &pd, "f", 1, &root, "pd", 2)->status,
-           NFS3ERR_ISDIR);
+           mbt_module_is_passthrough(env->module) ? NFS3ERR_NOTEMPTY
+                                                  : NFS3ERR_ISDIR);
 
     printf("F6 a filehandle whose object is gone -> STALE:\n");
     {

--- a/src/server/nfs/tests/quint/nfs3_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_replay.c
@@ -1752,7 +1752,7 @@ main(
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
                         "[--block-size N] [--max-attr-skip-rate F] "
-                        "[--backend memfs|diskfs|cairn] "
+                        "[--backend memfs|diskfs|cairn|linux|io_uring] "
                         "[--dry-run] [--verbose]\n", argv[0]);
                 mbt_free_traces(traces, ntraces);
                 return 2;

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1324,10 +1324,24 @@ chimera_io_uring_readdir(
     dup_fd = openat(fd, ".", O_RDONLY | O_DIRECTORY);
 
     if (dup_fd < 0) {
+        struct stat dead_st;
+        int         open_errno = errno;
+
+        /* A handle names an object, not a path: when the directory behind
+         * this handle is gone (removed since the handle was minted), the
+         * answer is ESTALE whatever errno the kernel chose for the re-open
+         * -- kernels disagree across versions (ENOENT historically; newer
+         * ones answer differently, which surfaced as SERVERFAULT from the
+         * unmapped-errno fallback on ubuntu26).  The portable test is the
+         * fd itself: it stays fstat-able on a deleted directory, with a
+         * zero link count. */
+        if (fstat(fd, &dead_st) == 0 && dead_st.st_nlink == 0) {
+            open_errno = ESTALE;
+        }
         chimera_io_uring_error("io_uring_readdir: openat() failed: %s",
-                               strerror(errno));
+                               strerror(open_errno));
         chimera_restore_privilege(request->cred);
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(open_errno);
         request->complete(request);
         return;
     }

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1456,7 +1456,7 @@ chimera_io_uring_open_fh(
                 request->status = CHIMERA_VFS_ENOTDIR;
             }
         } else {
-            request->status = chimera_linux_errno_to_status(errno);
+            request->status = chimera_linux_handle_open_status(errno);
         }
         request->complete(request);
         return;
@@ -2258,7 +2258,7 @@ chimera_io_uring_rename_at(
                                   O_PATH | O_RDONLY | O_NOFOLLOW);
 
     if (old_fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }
@@ -2270,7 +2270,7 @@ chimera_io_uring_rename_at(
 
     if (new_fd < 0) {
         close(old_fd);
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }
@@ -2318,7 +2318,7 @@ chimera_io_uring_link_at(
                               O_PATH | O_RDONLY | O_NOFOLLOW);
 
     if (fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }
@@ -2330,7 +2330,7 @@ chimera_io_uring_link_at(
 
     if (dir_fd < 0) {
         close(fd);
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -662,7 +662,7 @@ chimera_linux_open_fh(
                 request->status = CHIMERA_VFS_ENOTDIR;
             }
         } else {
-            request->status = chimera_linux_errno_to_status(errno);
+            request->status = chimera_linux_handle_open_status(errno);
         }
         request->complete(request);
         return;
@@ -1529,7 +1529,7 @@ chimera_linux_rename_at(
                                   O_PATH | O_RDONLY | O_NOFOLLOW);
 
     if (old_fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }
@@ -1540,7 +1540,7 @@ chimera_linux_rename_at(
                                   O_PATH | O_RDONLY | O_NOFOLLOW);
 
     if (new_fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         close(old_fd);
         return;
@@ -1589,7 +1589,7 @@ chimera_linux_link_at(
                               O_PATH | O_RDONLY | O_NOFOLLOW);
 
     if (fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }
@@ -1601,7 +1601,7 @@ chimera_linux_link_at(
 
     if (dir_fd < 0) {
         close(fd);
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }
@@ -1731,7 +1731,7 @@ chimera_linux_getparent(
                                     request->fh, request->fh_len,
                                     O_PATH | O_NOFOLLOW);
     if (child_fd < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_handle_open_status(errno);
         request->complete(request);
         return;
     }

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -513,10 +513,24 @@ chimera_linux_readdir(
     dup_fd = openat(fd, ".", O_RDONLY | O_DIRECTORY);
 
     if (dup_fd < 0) {
+        struct stat dead_st;
+        int         open_errno = errno;
+
+        /* A handle names an object, not a path: when the directory behind
+         * this handle is gone (removed since the handle was minted), the
+         * answer is ESTALE whatever errno the kernel chose for the re-open
+         * -- kernels disagree across versions (ENOENT historically; newer
+         * ones answer differently, which surfaced as SERVERFAULT from the
+         * unmapped-errno fallback on ubuntu26).  The portable test is the
+         * fd itself: it stays fstat-able on a deleted directory, with a
+         * zero link count. */
+        if (fstat(fd, &dead_st) == 0 && dead_st.st_nlink == 0) {
+            open_errno = ESTALE;
+        }
         chimera_linux_error("linux_readdir: openat() failed: %s",
-                            strerror(errno));
+                            strerror(open_errno));
         chimera_restore_privilege(request->cred);
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(open_errno);
         request->complete(request);
         return;
     }

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -122,6 +122,29 @@ chimera_linux_errno_to_status(int err)
     } /* switch */
 } /* chimera_linux_errno_to_status */
 
+/*
+ * Status for a FAILED open-by-handle.  A file handle names an object, not a
+ * path: when the kernel refuses to re-open one, the handle is STALE unless
+ * the errno names a specific, still-meaningful condition.  Kernels vary in
+ * their choice for a deleted object -- ESTALE, ENOENT, or newer inventions
+ * the errno table does not carry -- and neither a name-flavored NOENT nor
+ * the unmapped-errno fallback (which surfaces as SERVERFAULT on the wire)
+ * is a correct answer for a handle.
+ */
+static inline enum chimera_vfs_error
+chimera_linux_handle_open_status(int err)
+{
+    enum chimera_vfs_error status = chimera_linux_errno_to_status(err);
+
+    switch (status) {
+        case CHIMERA_VFS_ENOENT:
+        case CHIMERA_VFS_UNSET:
+            return CHIMERA_VFS_ESTALE;
+        default:
+            return status;
+    } /* switch */
+} /* chimera_linux_handle_open_status */
+
 static inline void
 chimera_linux_stat_to_attr(
     struct chimera_vfs_attrs *attr,


### PR DESCRIPTION
Registers the NFS3 model suite's deviation probe and corpus batch on the
linux and io_uring passthrough backends — the last piece of the
passthrough enablement effort, everything else from which already
merged: the harness's scratch-rooted passthrough plumbing (clean skip-77
on a `name_to_handle_at`-incapable filesystem), the vfs fixes it drove
(CREATE_REGULAR re-open descriptor, UNCHECKED-create-over-non-regular,
mode-less create default, the per-op DAC gates), the specs model's
search-permission requirement on CREATE resolution, and the two
self-selecting deviations (`create-search-perm-1771` for the mkfs
backends — chimera #1771; `exclusive-create-retry-exist` for
passthrough, whose host filesystem touches the atime the exclusive
verifier is stashed in).

The registration had been parked on "CI has nowhere to run it": the
backing tree needs a `name_to_handle_at`-capable filesystem, and the
devcontainer's checkout is overlayfs. But the CI jobs run ctest from
`/build` — a docker **volume** on the runner's ext4 — so the harness's
default working-directory scratch works there as-is; a local overlayfs
build tree skips 77 instead of failing, and the gates are
`CHIMERA_LINUX` / `CHIMERA_VFS_IO_URING` so non-Linux platforms never
register the tests.

Two small test-side accommodations:

- `--max-attr-skip-rate 0.5` on the passthrough batches: NFS3 post-op
  attributes are RFC-optional, and the passthrough omits them where
  fetching costs an extra host round trip — measured up to ~25% of
  replies on the step flavors, against ~0% for the in-engine backends.
  The cap only bounds how much of the corpus may go attribute-unchecked
  before the replay is judged vacuous.
- The probe's F2 rename-onto-parent status pin is backend-aware now:
  the engine answers ISDIR, the host kernel path reports the non-empty
  target first (NOTEMPTY). Both are precedence readings of the same
  refusal; what F2 guards is answering at all instead of deadlocking.

Measured in an ext4-scratch devcontainer: probe + full corpus green on
both backends, zero unreconciled divergences.
