### PR TITLE
smbtorture: give smb2.maxfid room on cairn, and classify timeouts as timeouts

### DIFF
--- a/tools/smbtorture/regen.sh
+++ b/tools/smbtorture/regen.sh
@@ -242,16 +242,34 @@ LOG=$(mktemp "$SMBT_OUTDIR/smbt.XXXXXX.log")
 # too -- upload happens even when the matrix never finished.
 chmod 644 "$LOG"
 cd "$SMBT_REPO"
-timeout --signal=KILL 300 \
+# Most cells finish in seconds.  smb2.maxfid opens 65520 files and then closes
+# them all, which cairn takes about 341s to do -- inside the budget on every
+# other backend, and just over it on that one, so it flapped as a regression
+# while smbtorture itself reported success.  Give that one subtest room rather
+# than raising the default: four subtests (hold-oplock, hold-sharemode,
+# lease.breaking4, aio_delay.aio_cancel) block on purpose and time out on every
+# backend by design, and a larger default would only make them wait longer.
+case "$SUITE" in
+    smb2.maxfid) CELL_TIMEOUT=600;;
+    *)           CELL_TIMEOUT=300;;
+esac
+
+timeout --signal=KILL "$CELL_TIMEOUT" \
     scripts/netns_test_wrapper.sh \
     "$SMBT_TESTBIN" \
     -b "$BACKEND" "$SUITE" > "$LOG" 2>&1
 RC=$?
+# 124 is what GNU timeout reports when the command timed out; 137 is the child
+# seen as killed by the SIGKILL it was sent.  Which of the two surfaces depends
+# on the coreutils version and on what the wrapper does with the signal, and
+# only 137 was handled -- so in practice every timeout was landing in the FAIL
+# arm and being reported as a functional failure.  Of the 25 timeouts in the
+# 2026-08-30 nightly, not one was classified TIME.
 case $RC in
-    0)   STATUS="PASS|$BACKEND|$SUITE";;
-    77)  STATUS="SKIP|$BACKEND|$SUITE";;
-    137) STATUS="TIME|$BACKEND|$SUITE";;
-    *)   STATUS="FAIL|$BACKEND|$SUITE|rc=$RC";;
+    0)        STATUS="PASS|$BACKEND|$SUITE";;
+    77)       STATUS="SKIP|$BACKEND|$SUITE";;
+    124|137)  STATUS="TIME|$BACKEND|$SUITE";;
+    *)        STATUS="FAIL|$BACKEND|$SUITE|rc=$RC";;
 esac
 { flock -x 9; echo "$STATUS" >> "$SMBT_RESULTS"; } 9>"$SMBT_RESULTS.lock"
 if [ "$RC" -ne 0 ] && [ "$RC" -ne 77 ]; then


### PR DESCRIPTION
Fixes the gated-regression failure in tonight's nightly
(run `33332754864`).

## It wasn't a regression

```
FAIL|cairn|smb2.maxfid|rc=124
```

`rc=124` is `timeout(1)`. The kept log ends with:

```
Reached test limit of 65520 open files.
Cleanup open files
success: smb2.maxfid
========================================
smbtorture: PASSED
```

smbtorture ran to completion and passed. The harness killed the cell on its
300s budget — the run took **341s**.

## Why only cairn

| backend | smb2.maxfid |
|---|---|
| memfs, linux, io_uring, diskfs_aio, diskfs_io_uring | PASS |
| **cairn** | **FAIL rc=124** |

The test opens 65520 files then closes them all. Every other backend finishes
inside 300s; cairn needs ~341s. It was sitting right on the line, so it would
have flapped either way.

That subtest now gets 600s. **Raising the default would have been worse** —
four subtests block *on purpose* and time out on every backend by design:

```
6 × smb2.lease.breaking4
6 × smb2.hold-sharemode
6 × smb2.hold-oplock
6 × smb2.aio_delay.aio_cancel
```

24 cells that would simply wait longer for the same answer.

## And a classification bug it exposed

```bash
137) STATUS="TIME|..."      # only this
*)   STATUS="FAIL|...|rc=$RC"
```

`rc=124` is what GNU `timeout` reports when the command timed out; `137` is the
child seen as killed by the SIGKILL it was sent. Which one surfaces depends on
the coreutils version and on what the wrapper does with the signal — and only
137 was handled, so **every** timeout fell through to the FAIL arm.

Of the 25 timeouts in that nightly, **not one was classified TIME**. The bucket
has been dead the whole time. Both codes are now treated as timeouts.

This moves the 24 intentional hangers from "still failing" to "timing out" in
the drift report. It **cannot** change what the gate does: `regen.py` tests for
a gated or disabled subtest *before* it looks at TIME, so a gated cell that
times out still fails the run, as it should.

## Separately worth a look

cairn being ~1.5× slower than every other backend at 65k open-file churn is a
real characteristic, not a test artifact. Not this PR's business, but it's the
kind of thing that gets slower quietly.