### PR TITLE
ci: rename the nightly workflow to Extended, and run it every six hours

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ on:
 #   - static analysis on every image, and on macOS
 #
 # The extended tier -- pynfs, pjdfstest, cthon, ltp, pike, smbtorture, wpts,
-# KVM -- runs in .github/workflows/nightly.yml, one job per platform.  It is
+# KVM -- runs in .github/workflows/extended.yml, one job per platform.  It is
 # too slow to sit in front of a merge, and the queue is the wrong place to
 # discover that a KVM guest image moved.
 #
@@ -60,7 +60,7 @@ env:
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
   DOCKER_MIRROR: repository.mdh.quantum.com/
   # Shared compiler cache.  Every job here uses a purely *local* ccache, primed
-  # before the build from a bundle the nightly run published for that cell.
+  # before the build from a bundle the Extended workflow published for that cell.
   #
   # This replaces ccache's HTTP remote backend, which fetched each object over
   # the network as the build asked for it.  That put ~950 round trips per job on
@@ -71,7 +71,7 @@ env:
   #
   # One bundle fetch per job costs one round trip and leaves the build reading a
   # local directory, which cannot time out.  Same shape macOS uses with
-  # actions/cache, and the same division of labour: the scheduled nightly run
+  # actions/cache, and the same division of labour: the scheduled Extended run
   # writes, everything else only reads.
   NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
 
@@ -346,7 +346,7 @@ jobs:
           # NOTE: the devcontainer has its own test-dev job below -- it is the
           # one image built for both arches, and it configures KVM on; it is
           # not part of this distro matrix.
-          # ubuntu 26 (amd64 only on PR; arm64 runs in nightly)
+          # ubuntu 26 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
@@ -361,7 +361,7 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: "-DKVM_TESTING=OFF"
-          # ubuntu 24 (amd64 only on PR; arm64 runs in nightly)
+          # ubuntu 24 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
@@ -376,7 +376,7 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: "-DKVM_TESTING=OFF"
-          # ubuntu 22 (amd64 only on PR; arm64 runs in nightly)
+          # ubuntu 22 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
@@ -406,7 +406,7 @@ jobs:
             image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
-          # rocky 10 (amd64 only on PR; arm64 runs in nightly)
+          # rocky 10 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
             runner: arc-amd64
             arch: amd64
@@ -691,7 +691,7 @@ jobs:
   # `test` job above, on the one image built for both arches.
   #
   # KVM guest images are not fetched (KVM_FETCH_IMAGES=OFF): the KVM suites are
-  # extended-tier and run in the nightly, so the queue wants the KVM CMake path
+  # extended-tier and run in the extended workflow, so the queue wants the KVM CMake path
   # configured but not the multi-gigabyte guest images behind it.  KVM is
   # x86-only in the devcontainer, so arm64 configures with it off entirely.
   test-dev:
@@ -841,7 +841,7 @@ jobs:
       # run reads its own ref and the default branch's.  This workflow only ever
       # runs on merge_group, and that gh-readonly-queue/... ref is discarded, so
       # nothing it saves is ever seen again.  The entry that matters is the one
-      # nightly.yml writes on main; this restores that.  Worst case it is a day
+      # extended.yml writes on main; this restores that.  Worst case it is a few
       # stale, which for ccache means a slightly lower hit rate and nothing
       # worse.
       - name: Restore the ccache directory
@@ -1001,7 +1001,7 @@ jobs:
           install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
           ccache --version | head -1
 
-      # Written by nightly.yml, which runs on main; a merge_group ref is thrown
+      # Written by extended.yml, which runs on main; a merge_group ref is thrown
       # away, so the queue restores but never usefully saves.
       - name: Restore the ccache directory
         uses: actions/cache@v4

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -2,11 +2,19 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-name: Nightly
+name: Extended
 
 on:
   schedule:
-    - cron: '0 7 * * *'  # 07:00 UTC daily
+    # Every six hours rather than once a day.  This workflow is the sole writer
+    # of every shared ccache, and a bundle is only as useful as it is fresh: a
+    # PR builds the merge of its branch with current main, so once main has
+    # moved past what the bundle was built from, every translation unit that
+    # includes a changed header misses.  Measured on the same macOS analysis
+    # job either side of four merges to main, two of them touching headers:
+    # 100% hits and 113s against 60% and 464s.  Running four times a day keeps
+    # the caches within a few hours of the tip instead of up to a day behind.
+    - cron: '0 1,7,13,19 * * *'  # 01:00, 07:00, 13:00, 19:00 UTC
   workflow_dispatch:     # allow manual runs
     # Scope the smbtorture matrix for a manual run.  All three default to the
     # full matrix, so the scheduled run is unaffected; they exist so the job can

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,7 +54,7 @@ env:
   # Internal pull-through cache for the mirrored ccache image (mirrors
   # ghcr.io/chimera-nas/ccache).  Public default lives in the Dockerfiles.
   CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
-  # Where the nightly publishes ccache bundles.  Not a secret -- the same
+  # Where the Extended workflow publishes ccache bundles.  Not a secret -- the same
   # literal is in build-test.yml -- so a fork PR can at least attempt a read.
   NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
   APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
@@ -196,7 +196,7 @@ jobs:
                 tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
               fi
               # Zero the counters the bundle brought with it, so --show-stats
-              # below describes this run rather than this run plus the nightly
+              # below describes this run rather than this run plus the Extended run
               # that produced the cache.
               ccache -z > /dev/null
               cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF -B /build -S /workspace -G Ninja
@@ -383,7 +383,7 @@ jobs:
 
       # Unlike the Linux half of this workflow, this needs no secrets: the
       # Actions cache is available to a fork's pull_request run, and a run can
-      # read the default branch's scope.  nightly.yml writes that scope on main,
+      # read the default branch's scope.  extended.yml writes that scope on main,
       # so this restores a cache a PR could never reach through Nexus.
       - name: Restore the ccache directory
         uses: actions/cache@v4
@@ -396,7 +396,7 @@ jobs:
       - name: Run the clang static analyzer
         id: static-analysis
         env:
-          # Must match the directory nightly.yml's analyze-macos builds in.
+          # Must match the directory extended.yml builds analyze-macos in.
           # The producer and the consumer of a ccache have to agree on it:
           # generated headers are reached through -I<build-dir>/... paths, which
           # are part of the command line ccache hashes, so building somewhere
@@ -409,7 +409,7 @@ jobs:
           set -o pipefail
           mkdir -p "$GITHUB_WORKSPACE/scan-report"
           # Zero the counters restored with the cache, so the stats below
-          # describe this run and not the nightly that filled it.
+          # describe this run and not the Extended run that filled it.
           ccache -z > /dev/null
           cmake -G Ninja -D CMAKE_BUILD_TYPE=Release \
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ All testing is done via ctest. Tests are split into two tiers:
   `ctest` runs.
 - **extended** - the quick tier plus everything else: pynfs, pjdfstest, cthon,
   ltp, pike, smbtorture, wpts, the KVM suites, and the unit tests. Selected
-  with `ctest -C extended`, and what the nightly job runs.
+  with `ctest -C extended`, and what the extended workflow runs.
 
 ```bash
 # Quick tier: the model-based tests (default)
@@ -77,7 +77,7 @@ cd build/Release && ctest --output-on-failure -j 8
 the same sweep over the extended tier.
 
 The merge queue runs the quick tier and static analysis on every supported OS,
-so the quick tier is what gates a merge. The extended tier runs nightly. Run it
+so the quick tier is what gates a merge. The extended tier runs in the Extended workflow, four times a day. Run it
 locally as needed - in particular when proving out a fix to one of those tests,
 because a break there will not surface until the next night.
 
@@ -110,7 +110,7 @@ This runs:
 
 `make check` runs the tests at the quick tier, which is what the merge queue
 gates on. `make check_extended` runs the identical sweep with the full test
-suite; only the nightly job runs that, so use it when a change reaches beyond
+suite; only the Extended workflow runs that, so use it when a change reaches beyond
 what the model-based tests cover, or when proving out a fix to an extended
 test.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ endif()
 # tests.  They are cheap and are meant to be a pre-flight proxy for the full
 # suite, so they are what you get when you ask for nothing.  `ctest -C
 # extended` runs the quick tier plus everything else; that is the tier the
-# merge queue and the nightly job use.
+# merge queue and the Extended workflow use.
 #
 # CTest can only withhold a test from the default run through the
 # CONFIGURATIONS keyword of add_test().  The CONFIGURATIONS *test property* is

--- a/tools/smbtorture/regen.py
+++ b/tools/smbtorture/regen.py
@@ -331,7 +331,7 @@ def main():
     c.add_argument("--subs", help="restrict the catalog to this list")
     c.add_argument("--format", choices=("text","markdown"), default="text")
     c.add_argument("--fail-on-newly-failing", action="store_true",
-                   help="exit 1 if a gated test regressed (nightly gate)")
+                   help="exit 1 if a gated test regressed (extended-workflow gate)")
     c.add_argument("--quiet-buckets", default="", type=lambda s: set(filter(None, s.split(","))),
                    help="comma separated bucket names to summarize but not list")
     c.set_defaults(func=do_compare)


### PR DESCRIPTION
Two changes, one reason.

## The name

This workflow hasn't been about the time of day since the suite was split into
tiers. It's the thing that runs the **extended tier** — the half too slow to sit
in front of a merge — and "Nightly" describes its old cadence rather than what
it does.

`nightly.yml` → `extended.yml`, `Nightly` → `Extended`, and the references in
`build-test.yml`, `CLAUDE.md`, `CMakeLists.txt` and `regen.py` follow. No
`nightly` mentions remain under `.github/`.

## The cadence — the part that matters

This workflow is the **sole writer of every shared ccache**, and a bundle is
only worth as much as it is fresh. A PR builds the merge of its branch with
current `main`, so once `main` moves past whatever the bundle was built from,
every TU that includes a changed header misses.

That's measured, not theoretical. The same macOS analysis job, either side of
four merges to `main` (two touching headers):

| | hits | job |
|---|---|---|
| bundle built from the same tree | **100%** | **113s** |
| after `main` moved | 60% | 464s |

Both runs restored their cache correctly — the second simply had less of it that
still applied.

A once-a-day writer means a PR opened in the evening works against a cache up to
**24 hours** behind the tip. Four runs a day — 01:00, 07:00, 13:00, 19:00 UTC,
keeping the existing 07:00 slot — puts the worst case at **6 hours**.

## Cost

The extended tier isn't cheap and this is a real increase in runner time. It
buys back more than it costs: the queue and every PR read a cache close to the
tip, and the compile half has already been measured at 99.8% hits, 383s → 52s.

If the runner budget won't take 4×, the fallback is publishing from the merge
queue as well — every merge would refresh the cache it just invalidated — but
that's a larger change and worth doing separately.

## Conflicts

Rebased onto #1594 (merged). No conflicts.