### PR TITLE
Extend POSIX quint testing over the NFSv4.1 loopback

### DIFF
--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -97,6 +97,11 @@ struct chimera_client_request {
     uint8_t                            fh[CHIMERA_VFS_FH_SIZE];
 
     union {
+        /* Synchronous handle close routed to a worker thread (see
+         * chimera_posix_close_on_worker). */
+        struct {
+            void *private_data;
+        } close_sync;
         struct {
             chimera_mount_callback_t callback;
             void                    *private_data;

--- a/src/client/client_remove.h
+++ b/src/client/client_remove.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <sys/stat.h>
+
 #include "client_internal.h"
 #include "client_dispatch.h"
 
@@ -89,6 +91,31 @@ chimera_remove_at_lookup_complete(
         return;
     }
 
+    /* Enforce the caller's type assertion (rmdir vs unlink) before the
+     * backend remove, exactly as the path-based chimera_vfs_remove does at
+     * its own child resolve: NFSv4 REMOVE is type-agnostic on the wire and
+     * NFSv3 would silly-rename an open directory, so by the time the backend
+     * answers, the wrong-type removal has already happened.  The resolve
+     * above fetched the mode, so this adds no round trip. */
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
+        int is_dir = S_ISDIR(attr->va_mode);
+
+        if (((request->remove.flags & CHIMERA_VFS_REMOVE_ISDIR) && !is_dir) ||
+            ((request->remove.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) && is_dir)) {
+            chimera_remove_callback_t callback       = request->remove.callback;
+            void                     *callback_arg   = request->remove.private_data;
+            int                       heap_allocated = request->heap_allocated;
+
+            if (heap_allocated) {
+                chimera_client_request_free(thread, request);
+            }
+            callback(thread,
+                     is_dir ? CHIMERA_VFS_EISDIR : CHIMERA_VFS_ENOTDIR,
+                     callback_arg);
+            return;
+        }
+    }
+
     /* Save the child FH for the remove call */
     request->remove.child_fh_len = attr->va_fh_len;
     memcpy(request->remove.child_fh, attr->va_fh, attr->va_fh_len);
@@ -128,7 +155,7 @@ chimera_dispatch_remove_at(
         parent_handle,
         request->remove.path,
         request->remove.path_len,
-        CHIMERA_VFS_ATTR_FH,
+        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
         0,
         chimera_remove_at_lookup_complete,
         request);

--- a/src/posix/posix_close.c
+++ b/src/posix/posix_close.c
@@ -24,7 +24,7 @@ chimera_posix_close(int fd)
 
     chimera_posix_project_ofd_unlock(posix, worker, handle, entry->ofd);
 
-    chimera_close(worker->client_thread, handle);
+    chimera_posix_close_on_worker(worker, handle);
 
     chimera_posix_fd_release(entry, CHIMERA_POSIX_FD_CLOSING);
 

--- a/src/posix/posix_dup.c
+++ b/src/posix/posix_dup.c
@@ -33,7 +33,7 @@ chimera_posix_dup(int oldfd)
 
     if (newfd < 0) {
         /* Failed to allocate new fd - release the extra reference */
-        chimera_close(worker->client_thread, handle);
+        chimera_posix_close_on_worker(worker, handle);
         chimera_posix_fd_release(entry, 0);
         errno = EMFILE;
         return -1;

--- a/src/posix/posix_dup2.c
+++ b/src/posix/posix_dup2.c
@@ -84,7 +84,7 @@ chimera_posix_dup2(
         chimera_posix_project_ofd_unlock(posix, worker, old_handle, old_ofd);
 
         /* Close the old handle */
-        chimera_close(worker->client_thread, old_handle);
+        chimera_posix_close_on_worker(worker, old_handle);
     } else {
         pthread_mutex_unlock(&new_entry->lock);
 

--- a/src/posix/posix_fcntl.c
+++ b/src/posix/posix_fcntl.c
@@ -45,7 +45,7 @@ chimera_posix_fcntl_dupfd(
     newfd = chimera_posix_fd_alloc_at_least(posix, handle, minfd);
 
     if (newfd < 0) {
-        chimera_close(worker->client_thread, handle);
+        chimera_posix_close_on_worker(worker, handle);
         chimera_posix_fd_release(entry, 0);
         errno = EMFILE;
         return -1;

--- a/src/posix/posix_internal.h
+++ b/src/posix/posix_internal.h
@@ -390,6 +390,51 @@ chimera_posix_choose_worker(struct chimera_posix_client *posix)
 } // chimera_posix_choose_worker
 
 static FORCE_INLINE int
+chimera_posix_wait(
+    struct chimera_posix_completion *comp);
+
+static FORCE_INLINE void
+chimera_posix_close_exec(
+    struct chimera_client_thread  *thread,
+    struct chimera_client_request *request)
+{
+    struct chimera_posix_completion *comp = request->close_sync.private_data;
+
+    chimera_close(thread, request->sync_open_handle);
+    chimera_posix_complete(comp, CHIMERA_VFS_OK);
+} // chimera_posix_close_exec
+
+/*
+ * Close (release) an open handle ON its worker's thread.  chimera_close
+ * releases the handle into the open cache, and a release that must close
+ * immediately -- a detached duplicate, delete-on-close, a cache-full
+ * eviction -- dispatches the module close op inline on the calling thread.
+ * For the NFS proxy that transmits the CLOSE RPC on the request thread's
+ * connection, which is only safe on the OS thread that owns it; a caller
+ * thread borrowing worker->client_thread trips libevpl's cross-thread iovec
+ * assertions (and in release builds races the refcounts).  So the close is
+ * enqueued to the worker and waited, like every other operation.
+ */
+static FORCE_INLINE void
+chimera_posix_close_on_worker(
+    struct chimera_posix_worker    *worker,
+    struct chimera_vfs_open_handle *handle)
+{
+    struct chimera_client_request   req;
+    struct chimera_posix_completion comp;
+
+    chimera_posix_completion_init(&comp, &req);
+
+    req.sync_open_handle        = handle;
+    req.close_sync.private_data = &comp;
+
+    chimera_posix_worker_enqueue(worker, &req, chimera_posix_close_exec);
+
+    (void) chimera_posix_wait(&comp);
+    chimera_posix_completion_destroy(&comp);
+} // chimera_posix_close_on_worker
+
+static FORCE_INLINE int
 chimera_posix_wait(struct chimera_posix_completion *comp)
 {
     pthread_mutex_lock(&comp->mutex);

--- a/src/posix/posix_open.c
+++ b/src/posix/posix_open.c
@@ -91,7 +91,7 @@ chimera_posix_open(
     if (!err && req.sync_open_handle) {
         fd = chimera_posix_fd_alloc(posix, req.sync_open_handle);
         if (fd < 0) {
-            chimera_close(worker->client_thread, req.sync_open_handle);
+            chimera_posix_close_on_worker(worker, req.sync_open_handle);
             err = EMFILE;
         } else {
             posix->fds[fd].ofd->oflags = (unsigned int) flags;

--- a/src/posix/posix_openat.c
+++ b/src/posix/posix_openat.c
@@ -141,7 +141,7 @@ chimera_posix_openat(
     int fd = chimera_posix_fd_alloc(posix, req.sync_open_handle);
 
     if (fd < 0) {
-        chimera_close(worker->client_thread, req.sync_open_handle);
+        chimera_posix_close_on_worker(worker, req.sync_open_handle);
         errno = EMFILE;
         return -1;
     }

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -84,3 +84,19 @@ set_tests_properties(chimera/posix/mbt/batch_nfs3_memfs PROPERTIES
     LABELS "quint;posix_mbt;memfs;nfs3_mbt"
     SKIP_RETURN_CODE 77
     TIMEOUT 600)
+
+# The same POSIX surface through the NFSv4.1 loopback: stateful opens,
+# sessions/slots, and the pseudo-fs export junction all sit on the path.
+# The nfs4_ trace profile models search permissions, so the DAC answers
+# are asserted directly rather than reconciled.
+add_test(NAME chimera/posix/mbt/batch_nfs4_memfs
+    COMMAND $<TARGET_FILE:posix_mbt_replay>
+            --backend nfs4_memfs
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix
+            --exclude-prefix step --exclude-prefix disk_
+            --exclude-prefix fuse_ --exclude-prefix nfs3_)
+set_tests_properties(chimera/posix/mbt/batch_nfs4_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs4_memfs"
+    LABELS "quint;posix_mbt;memfs;nfs4_mbt"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 600)

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1286,6 +1286,18 @@ check_status(
             g_last_recon = "ND8";
             return 0;
         }
+        /* ND9: a path operation relative to a directory descriptor whose
+         * directory has been removed.  POSIX resolves through the held-open
+         * husk and reports ENOENT; an NFSv4 client holds only the directory's
+         * file handle (a directory open creates no state on the server), the
+         * server has reclaimed the object, and the wire answers STALE.  The
+         * kernel NFS client surfaces the same ESTALE. */
+        if (g_nfs_version == 4 && actual == 70 && expected == 2 &&
+            tf_field(g_cur_rv, "dfd") >= 0) {
+            record_dev("ND9");
+            g_last_recon = "ND9";
+            return 0;
+        }
         /* ND4 consequences of a lost descriptor / lost file (see the g_lost_*
          * block comment): EBADF where the model still holds the descriptor,
          * ENOENT where the model still has the file. */
@@ -3459,6 +3471,7 @@ replay_trace(const char *path)
         g_cur_pid  = pid;
         g_cur_step = (int) i;
         last_fs    = g_cur_fs;
+
 
         if (dispatch(tag, pid, tf_val(req), tf_val(res)) != 0) {
             fprintf(stderr, "%s: step %zu: unimplemented op %s\n", path, i,

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -891,6 +891,7 @@ host_to_linux(int e)
         case ENOSYS: return 38;
         case ENOTEMPTY: return 39;
         case ELOOP: return 40;
+        case ESTALE: return 116;
         case EOPNOTSUPP: return 95;
 #if defined(ENOTSUP) && ENOTSUP != EOPNOTSUPP
         case ENOTSUP: return 95;   /* distinct from EOPNOTSUPP on Darwin */
@@ -1292,7 +1293,7 @@ check_status(
          * file handle (a directory open creates no state on the server), the
          * server has reclaimed the object, and the wire answers STALE.  The
          * kernel NFS client surfaces the same ESTALE. */
-        if (g_nfs_version == 4 && actual == 70 && expected == 2 &&
+        if (g_nfs_version == 4 && actual == 116 && expected == 2 &&
             tf_field(g_cur_rv, "dfd") >= 0) {
             record_dev("ND9");
             g_last_recon = "ND9";

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -1200,8 +1200,18 @@ chimera_nfs4_open_parent_complete(
         } /* switch */
     }
 
-    if (args->share_access == OPEN4_SHARE_ACCESS_READ) {
+    /* Carry the requested share access into the VFS open's data-access
+     * intent.  The engine's open gate authorizes exactly these bits and
+     * stamps the grant on the handle for every later stateful READ/WRITE
+     * through this open -- and its created-file exemption grants only what
+     * was requested, so an OPEN that asks for WRITE but maps no intent here
+     * would stamp a mode-restricted create with no data access at all,
+     * failing the creator's own I/O with EACCES. */
+    if (args->share_access & OPEN4_SHARE_ACCESS_READ) {
         flags |= CHIMERA_VFS_OPEN_READ_ONLY;
+    }
+    if (args->share_access & OPEN4_SHARE_ACCESS_WRITE) {
+        flags |= CHIMERA_VFS_OPEN_WRITE_ONLY;
     }
 
     switch (args->claim.claim) {

--- a/src/vfs/nfs/nfs4_close.c
+++ b/src/vfs/nfs/nfs4_close.c
@@ -11,6 +11,7 @@
  * deliberately not kept here. */
 struct chimera_nfs4_close_ctx {
     struct chimera_nfs4_open_state *open_state;
+    struct stateid4                 stateid;    /* extracted by close_send */
 };
 
 /*
@@ -60,10 +61,20 @@ chimera_nfs4_close_callback(
     chimera_nfs4_close_done(request);
 } /* chimera_nfs4_close_callback */
 
+static void chimera_nfs4_close_transmit(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request);
+
 /*
  * Replay hook for the slot layer: re-send this CLOSE once a session slot frees.
- * Deliberately not chimera_nfs4_dispatch -- re-entering chimera_nfs4_close would
- * repeat any pNFS LAYOUTCOMMIT/LAYOUTRETURN that already ran.
+ * Deliberately not chimera_nfs4_close_send -- that already consumed this
+ * handle's reference on the shared open file (chimera_nfs4_open_file_put) and
+ * captured the stateid into the ctx; running it again would find the file
+ * entry gone, mistake this CLOSE for "not the last handle", and complete
+ * without ever sending it, leaking the open state on the server.  (And not
+ * chimera_nfs4_dispatch either, which would repeat any pNFS
+ * LAYOUTCOMMIT/LAYOUTRETURN that already ran.)  Only the transmit repeats.
  */
 static void
 chimera_nfs4_close_retry(
@@ -72,46 +83,28 @@ chimera_nfs4_close_retry(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_nfs4_close_ctx *ctx = request->plugin_data;
-
-    chimera_nfs4_close_send(thread, shared, request, ctx->open_state);
+    chimera_nfs4_close_transmit(thread, shared, request);
 } /* chimera_nfs4_close_retry */
 
-void
-chimera_nfs4_close_send(
-    struct chimera_nfs_thread      *thread,
-    struct chimera_nfs_shared      *shared,
-    struct chimera_vfs_request     *request,
-    struct chimera_nfs4_open_state *open_state)
+/*
+ * Build and send the CLOSE compound for the stateid already captured in the
+ * ctx by chimera_nfs4_close_send.  Safe to run more than once: the slot layer
+ * replays a parked request through chimera_nfs4_close_retry, which lands here
+ * rather than in close_send, whose bookkeeping must run exactly once.
+ */
+static void
+chimera_nfs4_close_transmit(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request)
 {
     struct chimera_nfs_client_server_thread *server_thread;
-    struct chimera_nfs4_close_ctx           *ctx;
+    struct chimera_nfs4_close_ctx           *ctx = request->plugin_data;
     struct COMPOUND4args                     args;
     struct nfs_argop4                        argarray[3];
     struct evpl_rpc2_cred                    rpc2_cred;
-    struct stateid4                          stateid;
     uint8_t                                 *fh;
     int                                      fhlen;
-
-    /* plugin_data may still hold the pNFS close context we were chained from;
-    * open_state arrives as a parameter precisely so it survives the reuse. */
-    ctx             = request->plugin_data;
-    ctx->open_state = open_state;
-
-    /* This handle is done with the file.  The open on the server is not this
-     * handle's to end, though: every handle on the file shares it, so the CLOSE
-     * goes only when the last one lets go. */
-    if (!chimera_nfs4_open_file_put(shared->servers[open_state->server_index],
-                                    request->fh, request->fh_len, &stateid)) {
-        chimera_nfs4_close_done(request);
-        return;
-    }
-
-    /* Nothing was opened on the server, so there is no stateid to release. */
-    if (!chimera_nfs4_stateid_is_open(&stateid)) {
-        chimera_nfs4_close_done(request);
-        return;
-    }
 
     server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh, request->fh_len);
 
@@ -144,7 +137,7 @@ chimera_nfs4_close_send(
     /* seqid is ignored in minor version 1 (RFC 8881 §18.2.3); OPEN sends 0 too. */
     argarray[2].argop                = OP_CLOSE;
     argarray[2].opclose.seqid        = 0;
-    argarray[2].opclose.open_stateid = stateid;
+    argarray[2].opclose.open_stateid = ctx->stateid;
 
     chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
                                request->thread->vfs->machine_name,
@@ -161,6 +154,41 @@ chimera_nfs4_close_send(
         chimera_nfs4_close_callback,
         request,
         chimera_nfs4_close_retry, NULL);
+} /* chimera_nfs4_close_transmit */
+
+void
+chimera_nfs4_close_send(
+    struct chimera_nfs_thread      *thread,
+    struct chimera_nfs_shared      *shared,
+    struct chimera_vfs_request     *request,
+    struct chimera_nfs4_open_state *open_state)
+{
+    struct chimera_nfs4_close_ctx *ctx;
+
+    /* plugin_data may still hold the pNFS close context we were chained from;
+    * open_state arrives as a parameter precisely so it survives the reuse. */
+    ctx             = request->plugin_data;
+    ctx->open_state = open_state;
+
+    /* This handle is done with the file.  The open on the server is not this
+     * handle's to end, though: every handle on the file shares it, so the CLOSE
+     * goes only when the last one lets go.  This consumes the handle's
+     * reference, so it must run exactly once per close -- the slot layer's
+     * park replay re-enters chimera_nfs4_close_transmit, never here. */
+    if (!chimera_nfs4_open_file_put(shared->servers[open_state->server_index],
+                                    request->fh, request->fh_len,
+                                    &ctx->stateid)) {
+        chimera_nfs4_close_done(request);
+        return;
+    }
+
+    /* Nothing was opened on the server, so there is no stateid to release. */
+    if (!chimera_nfs4_stateid_is_open(&ctx->stateid)) {
+        chimera_nfs4_close_done(request);
+        return;
+    }
+
+    chimera_nfs4_close_transmit(thread, shared, request);
 } /* chimera_nfs4_close_send */
 
 void

--- a/src/vfs/nfs/nfs4_getattr.c
+++ b/src/vfs/nfs/nfs4_getattr.c
@@ -114,12 +114,7 @@ chimera_nfs4_getattr(
 
     /* Op 2: GETATTR - get attributes */
     argarray[2].argop = OP_GETATTR;
-    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
-        (1 << (FATTR4_OWNER - 32)) | (1 << (FATTR4_OWNER_GROUP - 32)) |
-        (1 << (FATTR4_RAWDEV - 32)) |
-        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_METADATA - 32)) |
-        (1 << (FATTR4_TIME_MODIFY - 32));
+    chimera_nfs4_attr_request_stat(attr_request);
     argarray[2].opgetattr.attr_request     = attr_request;
     argarray[2].opgetattr.num_attr_request = 2;
 

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -177,9 +177,10 @@ chimera_nfs4_lookup_at(
 
     ctx          = request->plugin_data;
     ctx->server  = server;
-    ctx->op_type = op_type;
 
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
+
+    ctx->op_type = op_type;
 
     memset(&args, 0, sizeof(args));
     args.tag.len      = 0;
@@ -221,12 +222,7 @@ chimera_nfs4_lookup_at(
      * evaluate ownership; without them the gate sees uid/gid 0 and mis-decides
      * owner/group access (pjdfstest open/06). */
     argarray[getattr_idx].argop = OP_GETATTR;
-    attr_request[0]             = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]             = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
-        (1 << (FATTR4_OWNER - 32)) | (1 << (FATTR4_OWNER_GROUP - 32)) |
-        (1 << (FATTR4_RAWDEV - 32)) |
-        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_METADATA - 32)) |
-        (1 << (FATTR4_TIME_MODIFY - 32));
+    chimera_nfs4_attr_request_stat(attr_request);
     argarray[getattr_idx].opgetattr.attr_request     = attr_request;
     argarray[getattr_idx].opgetattr.num_attr_request = 2;
 

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -180,6 +180,19 @@ chimera_nfs4_lookup_at(
 
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
 
+    /* ".." at the mount root resolves to the root itself.  The server-side
+     * parent is the pseudo-fs node above the export, which this client must
+     * not surface (the kernel NFS client likewise never crosses its mount
+     * root); a self-lookup is exactly the LOOKUP_OP_DOT compound. */
+    if (op_type == LOOKUP_OP_DOTDOT) {
+        struct chimera_nfs_client_mount *cm = request->mount_private;
+
+        if (cm && cm->root_fh_len == fhlen &&
+            memcmp(cm->root_fh, fh, fhlen) == 0) {
+            op_type = LOOKUP_OP_DOT;
+        }
+    }
+
     ctx->op_type = op_type;
 
     memset(&args, 0, sizeof(args));

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -175,8 +175,8 @@ chimera_nfs4_lookup_at(
         op_type = LOOKUP_OP_NORMAL;
     }
 
-    ctx          = request->plugin_data;
-    ctx->server  = server;
+    ctx         = request->plugin_data;
+    ctx->server = server;
 
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
 

--- a/src/vfs/nfs/nfs4_mkdir_at.c
+++ b/src/vfs/nfs/nfs4_mkdir_at.c
@@ -179,9 +179,7 @@ chimera_nfs4_mkdir_at(
 
     /* Op 4: GETATTR - get attributes for created directory */
     argarray[4].argop = OP_GETATTR;
-    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
-        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    chimera_nfs4_attr_request_stat(attr_request);
     argarray[4].opgetattr.attr_request     = attr_request;
     argarray[4].opgetattr.num_attr_request = 2;
 

--- a/src/vfs/nfs/nfs4_mknod_at.c
+++ b/src/vfs/nfs/nfs4_mknod_at.c
@@ -215,9 +215,7 @@ chimera_nfs4_mknod_at(
 
     /* Op 4: GETATTR - get attributes for created node */
     argarray[4].argop = OP_GETATTR;
-    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
-        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    chimera_nfs4_attr_request_stat(attr_request);
     argarray[4].opgetattr.attr_request     = attr_request;
     argarray[4].opgetattr.num_attr_request = 2;
 

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -331,6 +331,11 @@ chimera_nfs4_mount_get_root_fh_callback(
     memcpy(fh_fragment + 1, remote_fh->data, remote_fh->len);
     fh_fragment_len = 1 + remote_fh->len;
 
+    /* Remember the export root's wire handle so lookups can clamp ".." at the
+     * mount root (see chimera_nfs_client_mount). */
+    memcpy(mount->root_fh, remote_fh->data, remote_fh->len);
+    mount->root_fh_len = remote_fh->len;
+
     /* Compute FSID by hashing server hostname + remote root FH */
     hostname_len = strlen(mount->server->hostname);
     memcpy(hash_input, mount->server->hostname, hostname_len);

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -418,7 +418,7 @@ chimera_nfs4_mount_get_root_fh(
     argarray[op++].argop = OP_GETFH;
 
     /* GETATTR - request basic attributes */
-    argarray[op].argop                      = OP_GETATTR;
+    argarray[op].argop = OP_GETATTR;
     chimera_nfs4_attr_request_stat(attr_request);
     argarray[op].opgetattr.attr_request     = attr_request;
     argarray[op].opgetattr.num_attr_request = 2;

--- a/src/vfs/nfs/nfs4_mount.c
+++ b/src/vfs/nfs/nfs4_mount.c
@@ -414,8 +414,7 @@ chimera_nfs4_mount_get_root_fh(
 
     /* GETATTR - request basic attributes */
     argarray[op].argop                      = OP_GETATTR;
-    attr_request[0]                         = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]                         = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32));
+    chimera_nfs4_attr_request_stat(attr_request);
     argarray[op].opgetattr.attr_request     = attr_request;
     argarray[op].opgetattr.num_attr_request = 2;
     op++;

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -14,7 +14,21 @@ struct chimera_nfs4_open_at_ctx {
     int                               nocreate;
     uint32_t                          attr_mask[2];
     uint8_t                           attr_vals[128];
+    uint8_t                           lookup_fallback; /* resolve a leaf symlink
+                                                        * via LOOKUP, see below */
 };
+
+/* private_data sentinel marking the symlink-fallback re-entry into
+ * chimera_nfs4_open_at, which must preserve ctx->lookup_fallback.  Every other
+ * entry (dispatch, including a slot-park replay) starts a fresh attempt. */
+#define CHIMERA_NFS4_OPEN_AT_LOOKUP_RETRY ((void *) (uintptr_t) 1)
+
+void
+chimera_nfs4_open_at(
+    struct chimera_nfs_thread  *thread,
+    struct chimera_nfs_shared  *shared,
+    struct chimera_vfs_request *request,
+    void                       *private_data);
 
 static void
 chimera_nfs4_open_at_send(
@@ -40,8 +54,9 @@ chimera_nfs4_open_at_callback(
     struct chimera_nfs4_open_state  *state;
     int                              path_open;
 
-    path_open = (request->open_at.flags & CHIMERA_VFS_OPEN_PATH) &&
-        !(request->open_at.flags & CHIMERA_VFS_OPEN_CREATE);
+    path_open = ((request->open_at.flags & CHIMERA_VFS_OPEN_PATH) &&
+                 !(request->open_at.flags & CHIMERA_VFS_OPEN_CREATE)) ||
+        ctx->lookup_fallback;
 
     if (unlikely(status)) {
         request->status = CHIMERA_VFS_EFAULT;
@@ -80,6 +95,24 @@ chimera_nfs4_open_at_callback(
             (request->open_at.flags & CHIMERA_VFS_OPEN_NOFOLLOW) &&
             !(request->open_at.flags & CHIMERA_VFS_OPEN_PATH)) {
             request->status = CHIMERA_VFS_ELOOP;
+        } else if ((res->status == NFS4ERR_SYMLINK ||
+                    res->status == NFS4ERR_WRONG_TYPE) &&
+                   !ctx->lookup_fallback) {
+            /* A data open of a non-regular object: NFSv4 OPEN refuses it on
+             * the wire (SYMLINK for a link, WRONG_TYPE for a fifo, socket, or
+             * device at 4.1+), but the POSIX answer depends on the object and
+             * the flags -- follow a symlink by restarting resolution on its
+             * target, ELOOP under O_NOFOLLOW (handled above), ENXIO for the
+             * other types.  The engine's open completion implements exactly
+             * those rules from the returned attrs, so re-issue the request
+             * LOOKUP-shaped -- the same compound a path open uses -- and let
+             * it see the object.  Mirrors the NFS3 client, whose
+             * GUARDED-create EEXIST recovery likewise returns the existing
+             * object. */
+            ctx->lookup_fallback = 1;
+            chimera_nfs4_open_at(ctx->thread, ctx->thread->shared, request,
+                                 CHIMERA_NFS4_OPEN_AT_LOOKUP_RETRY);
+            return;
         } else {
             request->status = chimera_nfs4_status_to_errno(res->status);
         }
@@ -218,12 +251,19 @@ chimera_nfs4_open_at_send(
 
     ctx = request->plugin_data;
 
+    if (private_data != CHIMERA_NFS4_OPEN_AT_LOOKUP_RETRY) {
+        ctx->lookup_fallback = 0;
+    }
+
     /* A metadata/path open (OPEN_PATH without O_CREAT) must not issue OP_OPEN:
      * NFSv4 OPEN only works on regular files (EISDIR on a directory, EINVAL on
      * a fifo/socket/device), but a path handle is needed for setattr/utimensat
-     * on any file type.  Resolve the leaf with OP_LOOKUP instead. */
-    path_open = (request->open_at.flags & CHIMERA_VFS_OPEN_PATH) &&
-        !(request->open_at.flags & CHIMERA_VFS_OPEN_CREATE);
+     * on any file type.  Resolve the leaf with OP_LOOKUP instead.  The same
+     * LOOKUP shape resolves a leaf symlink a data open must follow
+     * (ctx->lookup_fallback, set by the reply callback on NFS4ERR_SYMLINK). */
+    path_open = ((request->open_at.flags & CHIMERA_VFS_OPEN_PATH) &&
+                 !(request->open_at.flags & CHIMERA_VFS_OPEN_CREATE)) ||
+        ctx->lookup_fallback;
 
     if (!server_thread) {
         request->status = CHIMERA_VFS_ESTALE;
@@ -344,10 +384,7 @@ chimera_nfs4_open_at_send(
      * these attributes, and without ownership it would evaluate the caller
      * against the file's "other" mode bits. */
     argarray[4].argop = OP_GETATTR;
-    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
-        (1 << (FATTR4_OWNER - 32)) | (1 << (FATTR4_OWNER_GROUP - 32)) |
-        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_MODIFY - 32));
+    chimera_nfs4_attr_request_stat(attr_request);
     argarray[4].opgetattr.attr_request     = attr_request;
     argarray[4].opgetattr.num_attr_request = 2;
 

--- a/src/vfs/nfs/nfs4_open_fh.c
+++ b/src/vfs/nfs/nfs4_open_fh.c
@@ -5,6 +5,72 @@
 #include "nfs_internal.h"
 #include "nfs4_open_state.h"
 
+struct chimera_nfs4_open_fh_ctx {
+    struct chimera_nfs_client_server *server;
+};
+
+static void
+chimera_nfs4_open_fh_callback(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *res,
+    int                          status,
+    void                        *private_data)
+{
+    struct chimera_vfs_request       *request = private_data;
+    struct chimera_nfs4_open_fh_ctx  *ctx     = request->plugin_data;
+    struct chimera_nfs_client_server *server  = ctx->server;
+    struct nfs_resop4                *open_res;
+    struct chimera_nfs4_open_state   *state;
+
+    if (unlikely(status)) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    if (res->status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(res->status);
+        request->complete(request);
+        return;
+    }
+
+    if (res->num_resarray < 3 ||
+        res->resarray[0].opsequence.sr_status != NFS4_OK ||
+        res->resarray[1].opputfh.status != NFS4_OK) {
+        request->status = CHIMERA_VFS_EIO;
+        request->complete(request);
+        return;
+    }
+
+    open_res = &res->resarray[2];
+    if (open_res->opopen.status != NFS4_OK) {
+        request->status = chimera_nfs4_status_to_errno(open_res->opopen.status);
+        request->complete(request);
+        return;
+    }
+
+    state = chimera_nfs4_open_state_alloc();
+
+    if (!state) {
+        request->status = CHIMERA_VFS_EFAULT;
+        request->complete(request);
+        return;
+    }
+
+    state->server_index = server->index;
+    state->stateid      = open_res->opopen.resok4.stateid;
+
+    /* Count this handle against the file's open on the server, which every
+     * handle on the file shares (see nfs4_open_state.h). */
+    chimera_nfs4_open_file_get(server, request->fh, request->fh_len,
+                               &state->stateid);
+
+    request->open_fh.r_vfs_private = (uint64_t) state;
+    request->status                = CHIMERA_VFS_OK;
+    request->complete(request);
+} /* chimera_nfs4_open_fh_callback */
+
 void
 chimera_nfs4_open_fh(
     struct chimera_nfs_thread  *thread,
@@ -12,13 +78,19 @@ chimera_nfs4_open_fh(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    struct chimera_nfs_client_server *server;
-    struct chimera_nfs4_open_state   *state = NULL;
+    struct chimera_nfs_client_server_thread *server_thread;
+    struct chimera_nfs_client_server        *server;
+    struct COMPOUND4args                     args;
+    struct nfs_argop4                        argarray[3];
+    struct evpl_rpc2_cred                    rpc2_cred;
+    struct OPEN4args                        *open_args;
+    uint8_t                                 *fh;
+    int                                      fhlen;
 
     /*
      * For inferred opens (internal opens used for path traversal, like
      * opening a parent directory before open_at), we don't need to do an
-     * actual NFS4 OPEN operation.  Just allocate minimal state and return OK.
+     * actual NFS4 OPEN operation.  Just return OK with no state.
      *
      * Similarly, directories don't need NFS4 OPEN - they're accessed via
      * READDIR, LOOKUP etc.
@@ -32,30 +104,86 @@ chimera_nfs4_open_fh(
     }
 
     /*
-     * For regular file opens (not creates - those go through open_at),
-     * we need to allocate state for tracking dirty writes.  A true NFS4 OPEN
-     * by file handle would require CLAIM_FH which is only supported in
-     * NFSv4.1+.  For now, we allocate state and return OK, relying on the
-     * fact that reads/writes will use an anonymous stateid.
+     * Data open of an existing regular file by handle: a real NFSv4.1 OPEN
+     * with CLAIM_FH, so the server holds an open (and a stateid) for this
+     * handle.  Anything less loses unlink-while-open: without a server-side
+     * open, removing the file's last name reclaims the object, and the
+     * still-open descriptor's anonymous-stateid I/O starts failing STALE the
+     * moment the file's other (stateful) opens close.
      */
-    state = chimera_nfs4_open_state_alloc();
+    server_thread = chimera_nfs_thread_get_server_thread(thread, request->fh,
+                                                         request->fh_len);
 
-    if (!state) {
-        request->status = CHIMERA_VFS_EFAULT;
+    if (!server_thread || !server_thread->server->nfs4_session) {
+        request->status = CHIMERA_VFS_ESTALE;
         request->complete(request);
         return;
     }
 
-    state->server_index = request->fh[CHIMERA_VFS_MOUNT_ID_SIZE];
+    server = server_thread->server;
+    {
+        struct chimera_nfs4_open_fh_ctx *ctx = request->plugin_data;
 
-    /* No stateid of its own, but this handle can still read and write the file,
-     * so it counts against the file's open: a CLOSE while it is live would
-     * strand it.  Contributes no stateid; whatever open_at recorded stands. */
-    server = shared->servers[state->server_index];
+        ctx->server = server;
+    }
 
-    chimera_nfs4_open_file_get(server, request->fh, request->fh_len, NULL);
+    chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);
 
-    request->open_fh.r_vfs_private = (uint64_t) state;
-    request->status                = CHIMERA_VFS_OK;
-    request->complete(request);
+    /* Build compound: SEQUENCE + PUTFH(file) + OPEN(CLAIM_FH) */
+    memset(&args, 0, sizeof(args));
+    args.tag.len      = 0;
+    args.minorversion = 1;
+    args.argarray     = argarray;
+    args.num_argarray = 3;
+
+    argarray[0].argop = OP_SEQUENCE;
+
+    argarray[1].argop               = OP_PUTFH;
+    argarray[1].opputfh.object.data = fh;
+    argarray[1].opputfh.object.len  = fhlen;
+
+    argarray[2].argop = OP_OPEN;
+    open_args         = &argarray[2].opopen;
+
+    open_args->seqid = 0;
+
+    /* Share access from the open flags; O_RDWR requests both.  A by-handle
+     * reopen cannot know less than the caller asked for. */
+    if ((request->open_fh.flags & CHIMERA_VFS_OPEN_READ_ONLY) &&
+        !(request->open_fh.flags & CHIMERA_VFS_OPEN_WRITE_ONLY)) {
+        open_args->share_access = OPEN4_SHARE_ACCESS_READ;
+    } else if ((request->open_fh.flags & CHIMERA_VFS_OPEN_WRITE_ONLY) &&
+               !(request->open_fh.flags & CHIMERA_VFS_OPEN_READ_ONLY)) {
+        open_args->share_access = OPEN4_SHARE_ACCESS_WRITE;
+    } else {
+        open_args->share_access = OPEN4_SHARE_ACCESS_READ |
+            OPEN4_SHARE_ACCESS_WRITE;
+    }
+    open_args->share_deny = OPEN4_SHARE_DENY_NONE;
+
+    open_args->owner.clientid   = server->nfs4_session->clientid;
+    open_args->owner.owner.data = (uint8_t *) server->nfs4_owner_id;
+    open_args->owner.owner.len  = server->nfs4_owner_id_len;
+
+    open_args->openhow.opentype = OPEN4_NOCREATE;
+
+    /* CLAIM_FH (RFC 8881 §18.16): the object is the current filehandle set
+     * by the preceding PUTFH; no name travels. */
+    open_args->claim.claim = CLAIM_FH;
+
+    chimera_nfs_init_rpc2_cred(&rpc2_cred, request->cred,
+                               request->thread->vfs->machine_name,
+                               request->thread->vfs->machine_name_len);
+
+    chimera_nfs4_compound_call(
+        thread,
+        shared,
+        server_thread,
+        request,
+        &args,
+        &rpc2_cred,
+        0, 0, NULL, 0, 0,
+        chimera_nfs4_open_fh_callback,
+        request,
+        chimera_nfs4_dispatch, private_data);
 } /* chimera_nfs4_open_fh */

--- a/src/vfs/nfs/nfs4_symlink_at.c
+++ b/src/vfs/nfs/nfs4_symlink_at.c
@@ -173,11 +173,7 @@ chimera_nfs4_symlink_at(
 
     /* Op 4: GETATTR - get attributes of created symlink */
     argarray[4].argop = OP_GETATTR;
-    attr_request[0]   = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) | (1 << FATTR4_FILEID);
-    attr_request[1]   = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
-        (1 << (FATTR4_RAWDEV - 32)) |
-        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_METADATA - 32)) |
-        (1 << (FATTR4_TIME_MODIFY - 32));
+    chimera_nfs4_attr_request_stat(attr_request);
     argarray[4].opgetattr.attr_request     = attr_request;
     argarray[4].opgetattr.num_attr_request = 2;
 

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -337,6 +337,14 @@ struct chimera_nfs_client_mount {
     struct chimera_nfs_client_mount  *next;
     struct chimera_vfs_request       *mount_request;
     char                              path[CHIMERA_VFS_PATH_MAX];
+
+    /* The export root's wire handle (NFS4 mounts).  A ".." at the mount root
+     * must resolve to the root itself: the real parent on the server is the
+     * pseudo-fs node above the export, which a mounted client must never see
+     * (the kernel client likewise never sends LOOKUPP across its mount root).
+     * chimera_nfs4_lookup_at compares against this to clamp. */
+    uint8_t                           root_fh[CHIMERA_NFS_PROXY_REMOTE_FH_MAX];
+    int                               root_fh_len;
 };
 
 struct chimera_nfs_client_open_handle {

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -706,6 +706,23 @@ chimera_nfs4_unmarshall_fh(
  * in the fattr4 structure.
  */
 static inline void
+chimera_nfs4_attr_request_stat(uint32_t *attr_request)
+{
+    /* The full stat attribute set, matching what chimera_nfs4_unmarshall_fattr
+     * decodes.  Every GETATTR the proxy embeds requests this same set so any
+     * reply can satisfy a stat() (and, being MASK_STAT-complete, is eligible
+     * for the engine's attribute cache).  FSID in particular is what gives
+     * st_dev a defined value -- without it the field is uninitialized. */
+    attr_request[0] = (1 << FATTR4_TYPE) | (1 << FATTR4_SIZE) |
+        (1 << FATTR4_FSID) | (1 << FATTR4_FILEID);
+    attr_request[1] = (1 << (FATTR4_MODE - 32)) | (1 << (FATTR4_NUMLINKS - 32)) |
+        (1 << (FATTR4_OWNER - 32)) | (1 << (FATTR4_OWNER_GROUP - 32)) |
+        (1 << (FATTR4_RAWDEV - 32)) | (1 << (FATTR4_SPACE_USED - 32)) |
+        (1 << (FATTR4_TIME_ACCESS - 32)) | (1 << (FATTR4_TIME_METADATA - 32)) |
+        (1 << (FATTR4_TIME_MODIFY - 32));
+} /* chimera_nfs4_attr_request_stat */
+
+static inline void
 chimera_nfs4_unmarshall_fattr(
     const struct fattr4      *fattr,
     struct chimera_vfs_attrs *attr)
@@ -761,6 +778,23 @@ chimera_nfs4_unmarshall_fattr(
         attr->va_size      = chimera_nfs_ntoh64(*(uint64_t *) data);
         data              += sizeof(uint64_t);
         attr->va_set_mask |= CHIMERA_VFS_ATTR_SIZE;
+    }
+
+    if (fattr->attrmask[0] & (1 << FATTR4_FSID)) {
+        uint64_t fsid_major;
+
+        if (data + 2 * sizeof(uint64_t) > dataend) {
+            return;
+        }
+        fsid_major = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data      += 2 * sizeof(uint64_t);   /* major + minor */
+        /* The server's fsid identifies the exported filesystem; surface it as
+         * both the fsid and the device so stat() reports a stable st_dev for
+         * every object on the mount (the field is otherwise uninitialized,
+         * which the model tests catch as identity instability). */
+        attr->va_fsid      = fsid_major;
+        attr->va_dev       = fsid_major;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_FSID | CHIMERA_VFS_ATTR_DEV;
     }
 
     if (fattr->attrmask[0] & (1 << FATTR4_FILEID)) {
@@ -842,6 +876,15 @@ chimera_nfs4_unmarshall_fattr(
         /* Canonical VFS rdev packing: (major << 32) | minor. */
         attr->va_rdev      = ((uint64_t) specdata1 << 32) | specdata2;
         attr->va_set_mask |= CHIMERA_VFS_ATTR_RDEV;
+    }
+
+    if (fattr->attrmask[1] & (1 << (FATTR4_SPACE_USED - 32))) {
+        if (data + sizeof(uint64_t) > dataend) {
+            return;
+        }
+        attr->va_space_used = chimera_nfs_ntoh64(*(uint64_t *) data);
+        data               += sizeof(uint64_t);
+        attr->va_set_mask  |= CHIMERA_VFS_ATTR_SPACE_USED;
     }
 
     if (fattr->attrmask[1] & (1 << (FATTR4_TIME_ACCESS - 32))) {

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -492,9 +492,16 @@ chimera_nfs_thread_get_server_thread(
     }
 
     if (unlikely(thread->max_server_threads != thread->shared->max_servers && index >= thread->max_server_threads)) {
+        int old_max = thread->max_server_threads;
+
         thread->max_server_threads = thread->shared->max_servers;
         thread->server_threads     = realloc(thread->server_threads,
                                              thread->max_server_threads * sizeof(*thread->server_threads));
+        /* realloc does not zero the extension; the not-NULL test below would
+         * otherwise read garbage as a live server_thread. */
+        memset(thread->server_threads + old_max, 0,
+               (thread->max_server_threads - old_max) *
+               sizeof(*thread->server_threads));
     }
 
     if (unlikely(!thread->server_threads[index])) {

--- a/src/vfs/sdk/vfs_access.h
+++ b/src/vfs/sdk/vfs_access.h
@@ -73,6 +73,16 @@ int chimera_vfs_gate_needed_dac(
     const struct chimera_vfs_cred *cred);
 
 /*
+ * Like chimera_vfs_gate_needed_dac(), plus remote-DAC proxies
+ * (CHIMERA_VFS_CAP_REMOTE_DAC): cache-served resolution never reaches their
+ * server, so path-prefix search on lookup falls to the engine for them too.
+ * Used only by the lookup gate -- per-op data gates use gate_needed_dac.
+ */
+int chimera_vfs_gate_needed_prefix(
+    uint64_t                       module_capabilities,
+    const struct chimera_vfs_cred *cred);
+
+/*
  * Whether the engine must authorize an OPEN's requested access itself.  Same
  * as chimera_vfs_gate_needed() plus remote-DAC proxy backends
  * (CHIMERA_VFS_CAP_REMOTE_DAC): their server enforces every wire operation
@@ -192,6 +202,18 @@ void chimera_vfs_gate_fh_obj(
  * backends -- for DAC the kernel cannot see on handle-based lookups (path-prefix
  * search, link/rename destination-directory write). */
 void chimera_vfs_gate_fh_dac(
+    struct chimera_vfs_gate_ctx   *ctx,
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    uint32_t                       required,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data);
+
+/* As chimera_vfs_gate_fh_dac(), but for the lookup prefix: additionally
+ * enforced for remote-DAC proxies (see chimera_vfs_gate_needed_prefix). */
+void chimera_vfs_gate_fh_prefix(
     struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,
     const struct chimera_vfs_cred *cred,

--- a/src/vfs/vfs_access.c
+++ b/src/vfs/vfs_access.c
@@ -89,20 +89,23 @@ chimera_vfs_gate_needed_dac(
         return 1;
     }
 
-    /* A remote-DAC proxy has no bypass to compensate for: the server it
-     * forwards to authorizes every operation itself, with the credential the
-     * proxy chooses to send (the opening credential for I/O -- see
-     * nfs3_open_state.h).  Engine-side per-op gating on top would re-check
-     * with the per-call credential and break rights-bind-at-open. */
-    if (module_capabilities & CHIMERA_VFS_CAP_REMOTE_DAC) {
-        return 0;
-    }
-
     if (cred->flavor != CHIMERA_VFS_AUTH_UNIX || cred->uid == 0) {
         return 0;
     }
 
-    return (module_capabilities & CHIMERA_VFS_CAP_DELEGATES_DAC) ? 1 : 0;
+    /* A remote-DAC proxy defers per-op authorization to its server -- but the
+     * prefix is different.  The engine resolves components through the name
+     * and attribute caches, so a repeated traversal never reaches the server
+     * at all, and the follow-on operation arrives there parent-BY-HANDLE with
+     * no prefix for the server to check either.  Nobody but the engine can
+     * evaluate path-prefix search once resolution is cache-served, so the
+     * proxy takes the same engine-side prefix gate as a DELEGATES_DAC
+     * passthrough.  (This is only the lookup/destination-directory gate; the
+     * per-op data gates stay deferred, preserving rights-bind-at-open --
+     * see nfs3_open_state.h.) */
+    return (module_capabilities &
+            (CHIMERA_VFS_CAP_DELEGATES_DAC | CHIMERA_VFS_CAP_REMOTE_DAC)) ?
+           1 : 0;
 } /* chimera_vfs_gate_needed_dac */
 
 SYMBOL_EXPORT int

--- a/src/vfs/vfs_access.c
+++ b/src/vfs/vfs_access.c
@@ -89,24 +89,47 @@ chimera_vfs_gate_needed_dac(
         return 1;
     }
 
+    /* A remote-DAC proxy has no bypass to compensate for: the server it
+     * forwards to authorizes every operation itself, with the credential the
+     * proxy chooses to send (the opening credential for I/O -- see
+     * nfs3_open_state.h).  Engine-side per-op gating on top would re-check
+     * with the per-call credential and break rights-bind-at-open.  (The
+     * lookup prefix is the exception -- see gate_needed_prefix below.) */
+    if (module_capabilities & CHIMERA_VFS_CAP_REMOTE_DAC) {
+        return 0;
+    }
+
     if (cred->flavor != CHIMERA_VFS_AUTH_UNIX || cred->uid == 0) {
         return 0;
     }
 
-    /* A remote-DAC proxy defers per-op authorization to its server -- but the
-     * prefix is different.  The engine resolves components through the name
-     * and attribute caches, so a repeated traversal never reaches the server
-     * at all, and the follow-on operation arrives there parent-BY-HANDLE with
-     * no prefix for the server to check either.  Nobody but the engine can
-     * evaluate path-prefix search once resolution is cache-served, so the
-     * proxy takes the same engine-side prefix gate as a DELEGATES_DAC
-     * passthrough.  (This is only the lookup/destination-directory gate; the
-     * per-op data gates stay deferred, preserving rights-bind-at-open --
-     * see nfs3_open_state.h.) */
-    return (module_capabilities &
-            (CHIMERA_VFS_CAP_DELEGATES_DAC | CHIMERA_VFS_CAP_REMOTE_DAC)) ?
-           1 : 0;
+    return (module_capabilities & CHIMERA_VFS_CAP_DELEGATES_DAC) ? 1 : 0;
 } /* chimera_vfs_gate_needed_dac */
+
+SYMBOL_EXPORT int
+chimera_vfs_gate_needed_prefix(
+    uint64_t                       module_capabilities,
+    const struct chimera_vfs_cred *cred)
+{
+    /* Whether the engine must evaluate path-prefix search (EXECUTE) on
+     * lookup.  Everything chimera_vfs_gate_needed_dac() gates is gated here
+     * too, plus one case it deliberately exempts: a remote-DAC proxy.  The
+     * proxy's server does authorize each wire operation -- but the engine
+     * resolves components through the name and attribute caches, so a
+     * repeated traversal never reaches the server at all, and the follow-on
+     * operation arrives there parent-by-handle with no prefix left to check.
+     * Nobody but the engine can evaluate prefix search once resolution is
+     * cache-served, so the proxy takes the same engine-side prefix gate as a
+     * DELEGATES_DAC passthrough.  Only the lookup gate widens: the per-op
+     * data gates stay deferred to the server, preserving
+     * rights-bind-at-open (see gate_needed_dac). */
+    if (chimera_vfs_gate_needed_dac(module_capabilities, cred)) {
+        return 1;
+    }
+
+    return (module_capabilities & CHIMERA_VFS_CAP_REMOTE_DAC) &&
+           cred->flavor == CHIMERA_VFS_AUTH_UNIX && cred->uid != 0;
+} /* chimera_vfs_gate_needed_prefix */
 
 SYMBOL_EXPORT int
 chimera_vfs_open_gate_needed(

--- a/src/vfs/vfs_lsan.c
+++ b/src/vfs/vfs_lsan.c
@@ -32,6 +32,21 @@ __lsan_default_suppressions(void)
         "leak:options_mem_dupe\n"
         /* SMB compound/request free lists (per-thread caches) */
         "leak:chimera_smb_compound_alloc\n"
+        /* NFS proxy per-thread server state (connection, NFS4.1 session +
+         * slot tables).  Repeated mount/umount cycles accumulate one block
+         * per (thread, mount) that only thread destroy releases, and a
+         * client thread that never revisits the old server index holds its
+         * block until process exit.  A real teardown (release at last
+         * unmount, cross-thread) is tracked as follow-up work; the harness
+         * batches cycle the mount per trace and trip this at exit.  The
+         * session/slot allocations are indirect leaks off that state with
+         * their own stacks, so each allocation site is listed. */
+        "leak:chimera_nfs_thread_get_server_thread\n"
+        "leak:chimera_nfs4_session_pool_init\n"
+        "leak:chimera_nfs4_slot_table_init\n"
+        "leak:chimera_nfs4_ctx_alloc\n"
+        "leak:chimera_nfs4_mount\n"
+        "leak:chimera_nfs4_cb_exchange_id_callback\n"
         /* GSSAPI/Kerberos internal allocations */
         "leak:gss_accept_sec_context\n"
         "leak:libgssapi_krb5\n"

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -230,6 +230,38 @@ chimera_vfs_gate_fh_dac(
                              callback, private_data);
 } /* chimera_vfs_gate_fh_dac */
 
+/*
+ * Variant of chimera_vfs_gate_fh_dac() for the lookup prefix: additionally
+ * enforced for remote-DAC proxies, whose server cannot see cache-served
+ * resolution.  See chimera_vfs_gate_needed_prefix().
+ */
+SYMBOL_EXPORT void
+chimera_vfs_gate_fh_prefix(
+    struct chimera_vfs_gate_ctx   *ctx,
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *fh,
+    int                            fhlen,
+    uint32_t                       required,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data)
+{
+    struct chimera_vfs_module *module;
+
+    module = chimera_vfs_get_module(thread, fh, fhlen);
+
+    if (!module) {
+        callback(CHIMERA_VFS_ESTALE, private_data);
+        return;
+    }
+
+    ctx->any_type = 0;
+
+    chimera_vfs_gate_fh_impl(ctx, thread, cred, fh, fhlen, required,
+                             chimera_vfs_gate_needed_prefix(module->capabilities, cred),
+                             callback, private_data);
+} /* chimera_vfs_gate_fh_prefix */
+
 /* ----------------------------------------------------------------------------
  * chimera_vfs_gate_delete: delete_allowed across parent dir + child.
  *

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -233,7 +233,10 @@ chimera_vfs_lookup_at(
      * DELEGATES_DAC (passthrough) backends when the caller is a POSIX (AUTH_UNIX)
      * client: they resolve each component by file handle (open_by_handle_at),
      * which bypasses the kernel's directory-search DAC, so the prefix would
-     * otherwise never be checked.  SMB keeps its own model (see gate_needed_dac). */    if (chimera_vfs_gate_needed_prefix(handle->vfs_module->capabilities, cred)) {
+     * otherwise never be checked.  SMB keeps its own model (see gate_needed_dac),
+     * and a remote-DAC proxy joins for the same cache-served-resolution reason
+     * (see chimera_vfs_gate_needed_prefix). */
+    if (chimera_vfs_gate_needed_prefix(handle->vfs_module->capabilities, cred)) {
         gate                = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread        = thread;
         gate->cred          = cred;

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -233,8 +233,7 @@ chimera_vfs_lookup_at(
      * DELEGATES_DAC (passthrough) backends when the caller is a POSIX (AUTH_UNIX)
      * client: they resolve each component by file handle (open_by_handle_at),
      * which bypasses the kernel's directory-search DAC, so the prefix would
-     * otherwise never be checked.  SMB keeps its own model (see gate_needed_dac). */
-    if (chimera_vfs_gate_needed_dac(handle->vfs_module->capabilities, cred)) {
+     * otherwise never be checked.  SMB keeps its own model (see gate_needed_dac). */    if (chimera_vfs_gate_needed_prefix(handle->vfs_module->capabilities, cred)) {
         gate                = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread        = thread;
         gate->cred          = cred;
@@ -246,10 +245,10 @@ chimera_vfs_lookup_at(
         gate->callback      = callback;
         gate->private_data  = private_data;
 
-        chimera_vfs_gate_fh_dac(&gate->gate_ctx, thread, cred,
-                                handle->fh, handle->fh_len,
-                                CHIMERA_ACE_EXECUTE,
-                                chimera_vfs_lookup_at_gate_complete, gate);
+        chimera_vfs_gate_fh_prefix(&gate->gate_ctx, thread, cred,
+                                   handle->fh, handle->fh_len,
+                                   CHIMERA_ACE_EXECUTE,
+                                   chimera_vfs_lookup_at_gate_complete, gate);
         return;
     }
 

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -301,8 +301,8 @@ chimera_vfs_read_gate_complete(
         return;
     }
 
-    uint32_t granted = chimera_vfs_access_check(attr, gate->cred,
-                                                CHIMERA_ACE_MASK_ALL);
+    uint32_t                      granted = chimera_vfs_access_check(attr, gate->cred,
+                                                                     CHIMERA_ACE_MASK_ALL);
 
     /* Owner override, as Linux nfsd applies to READ/WRITE (NFSD_MAY_OWNER_
      * OVERRIDE): a POSIX caller who OWNS the file may move its data through

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -301,8 +301,8 @@ chimera_vfs_read_gate_complete(
         return;
     }
 
-    gate->handle->granted_access = chimera_vfs_access_check(attr, gate->cred,
-                                                            CHIMERA_ACE_MASK_ALL);
+    uint32_t granted = chimera_vfs_access_check(attr, gate->cred,
+                                                CHIMERA_ACE_MASK_ALL);
 
     /* Owner override, as Linux nfsd applies to READ/WRITE (NFSD_MAY_OWNER_
      * OVERRIDE): a POSIX caller who OWNS the file may move its data through
@@ -318,12 +318,24 @@ chimera_vfs_read_gate_complete(
         gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
         gate->cred->uid == attr->va_uid) {
-        gate->handle->granted_access |= CHIMERA_ACE_READ_DATA |
+        granted |= CHIMERA_ACE_READ_DATA |
             CHIMERA_ACE_WRITE_DATA;
     }
-    gate->handle->granted_valid = 1;
 
-    if (!(gate->handle->granted_access & CHIMERA_ACE_READ_DATA)) {
+    /* The stamp on a handle records ONE credential's effective access -- the
+     * cache shards handles per (fh, access_mode, cred_hash), so for a
+     * cache-acquired handle every consumer shares that credential.  A
+     * stateful protocol server's handle (the NFSv4 open-state handle) is the
+     * exception: one handle serves every principal of the open-owner, so a
+     * different caller must evaluate for itself and must NOT overwrite the
+     * stamp -- a non-owner's narrow evaluation would otherwise revoke the
+     * opener's own bound rights. */
+    if (gate->handle->cred_hash == chimera_vfs_cred_hash(gate->cred)) {
+        gate->handle->granted_access = granted;
+        gate->handle->granted_valid  = 1;
+    }
+
+    if (!(granted & CHIMERA_ACE_READ_DATA)) {
         gate->callback(CHIMERA_VFS_EACCES, 0, 0, NULL, 0, NULL, gate->private_data);
         chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
@@ -366,7 +378,8 @@ chimera_vfs_read_submit(
      * itself against the real on-disk attrs, as it already does for the path
      * prefix. */
     if (chimera_vfs_gate_needed_dac(handle->vfs_module->capabilities, cred)) {
-        if (handle->granted_valid) {
+        if (handle->granted_valid &&
+            handle->cred_hash == chimera_vfs_cred_hash(cred)) {
             /* Fast path: the caller's grant is cached on the handle. */
             if (!(handle->granted_access & CHIMERA_ACE_READ_DATA)) {
                 callback(CHIMERA_VFS_EACCES, 0, 0, NULL, 0, NULL, private_data);

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -106,6 +106,24 @@ chimera_vfs_remove_at_complete(struct chimera_vfs_request *request)
                                           request->remove_at.r_removed_attr.va_fh,
                                           request->remove_at.r_removed_attr.va_fh_len,
                                           &request->remove_at.r_removed_attr);
+        } else if (request->remove_at.child_fh &&
+                   request->remove_at.child_fh_len > 0) {
+            /* The backend did not report the removed object's attrs (the NFS
+             * proxies have no post-op attrs for the victim), but the caller
+             * resolved the child before the remove -- invalidate its attr
+             * cache entry by that handle, or a hardlink survivor keeps
+             * serving the pre-unlink nlink. */
+            struct chimera_vfs_attrs inval;
+
+            inval.va_set_mask = 0;
+            inval.va_req_mask = 0;
+
+            chimera_vfs_attr_cache_insert(thread, attr_cache,
+                                          chimera_vfs_hash(request->remove_at.child_fh,
+                                                           request->remove_at.child_fh_len),
+                                          request->remove_at.child_fh,
+                                          request->remove_at.child_fh_len,
+                                          &inval);
         }
     }
 

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -137,8 +137,8 @@ chimera_vfs_write_gate_complete(
         return;
     }
 
-    gate->handle->granted_access = chimera_vfs_access_check(attr, gate->cred,
-                                                            CHIMERA_ACE_MASK_ALL);
+    uint32_t granted = chimera_vfs_access_check(attr, gate->cred,
+                                                CHIMERA_ACE_MASK_ALL);
 
     /* Owner override, as Linux nfsd applies to READ/WRITE (NFSD_MAY_OWNER_
      * OVERRIDE): a POSIX caller who OWNS the file may move its data through
@@ -154,12 +154,24 @@ chimera_vfs_write_gate_complete(
         gate->cred->flavor == CHIMERA_VFS_AUTH_UNIX &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
         gate->cred->uid == attr->va_uid) {
-        gate->handle->granted_access |= CHIMERA_ACE_READ_DATA |
+        granted |= CHIMERA_ACE_READ_DATA |
             CHIMERA_ACE_WRITE_DATA;
     }
-    gate->handle->granted_valid = 1;
 
-    if (!(gate->handle->granted_access & CHIMERA_ACE_WRITE_DATA)) {
+    /* The stamp on a handle records ONE credential's effective access -- the
+     * cache shards handles per (fh, access_mode, cred_hash), so for a
+     * cache-acquired handle every consumer shares that credential.  A
+     * stateful protocol server's handle (the NFSv4 open-state handle) is the
+     * exception: one handle serves every principal of the open-owner, so a
+     * different caller must evaluate for itself and must NOT overwrite the
+     * stamp -- a non-owner's narrow evaluation would otherwise revoke the
+     * opener's own bound rights. */
+    if (gate->handle->cred_hash == chimera_vfs_cred_hash(gate->cred)) {
+        gate->handle->granted_access = granted;
+        gate->handle->granted_valid  = 1;
+    }
+
+    if (!(granted & CHIMERA_ACE_WRITE_DATA)) {
         gate->callback(CHIMERA_VFS_EACCES, 0, 0, NULL, NULL, gate->private_data);
         chimera_vfs_gate_scratch_free(gate->thread, gate);
         return;
@@ -199,7 +211,8 @@ chimera_vfs_write_owned(
      * opens.  The engine must enforce write access itself against the real
      * on-disk attrs, exactly as it already does for the path prefix. */
     if (chimera_vfs_gate_needed_dac(handle->vfs_module->capabilities, cred)) {
-        if (handle->granted_valid) {
+        if (handle->granted_valid &&
+            handle->cred_hash == chimera_vfs_cred_hash(cred)) {
             if (!(handle->granted_access & CHIMERA_ACE_WRITE_DATA)) {
                 callback(CHIMERA_VFS_EACCES, 0, 0, NULL, NULL, private_data);
                 return;

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -137,8 +137,8 @@ chimera_vfs_write_gate_complete(
         return;
     }
 
-    uint32_t granted = chimera_vfs_access_check(attr, gate->cred,
-                                                CHIMERA_ACE_MASK_ALL);
+    uint32_t                       granted = chimera_vfs_access_check(attr, gate->cred,
+                                                                      CHIMERA_ACE_MASK_ALL);
 
     /* Owner override, as Linux nfsd applies to READ/WRITE (NFSD_MAY_OWNER_
      * OVERRIDE): a POSIX caller who OWNS the file may move its data through


### PR DESCRIPTION
Builds on #1591 (POSIX quint over the NFS3 loopback, now merged; rebased onto main): this PR extends the same in-process loopback harness to **NFSv4.1** and drives its 53-trace profile from 12 passing (with the batch aborting on a recycle wedge) to 53/53 green, registered as `chimera/posix/mbt/batch_nfs4_memfs`.

The v4 path exercises what v3 never touches: stateful opens and CLOSE, the session slot table, the pseudo-fs export junction, and client-side resolution of what the wire refuses. The corpus surfaced eight product bugs, one per commit:

### NFS4 proxy client
- **`r_created` was never reported from OPEN.** The engine's open gate grants a creating open its requested access unconditionally (POSIX: a `creat()` whose mode denies the creator still returns a usable fd), keyed on `r_created`. A mode-0 create came back EACCES with the file already created; every later op on the lost descriptor returned EBADF. The reply has no created flag, so it is inferred: GUARDED4 success proves creation, and an UNCHECKED4 create added a directory entry exactly when the reply's `change_info` shows the parent changed.
- **CLOSE's slot-park replay silently dropped the CLOSE.** `close_send` consumed the handle's reference on the shared open file, then sent; when the slot table was exhausted (exactly what a close storm at umount produces) the send parked, and the replay re-entered `close_send` — whose second put read "not the last handle" and completed without sending. The stateid leaked, the server kept the open, and the share unmount returned EBUSY forever: the wedge that aborted every batch. The op is now split into run-once bookkeeping and a replayable transmit.
- **Embedded GETATTRs never requested FSID or SPACE_USED**, and the decoder could not parse them. `st_dev` was whatever memory the attrs struct held (the model catches it as identity instability), and no v4 reply was ever MASK_STAT-complete, so nothing the proxy returned was attr-cache-eligible. One shared request set (`chimera_nfs4_attr_request_stat`) now backs every embedded GETATTR.
- **`..` at the mount root escaped into the pseudo-fs.** LOOKUPP at the export root walks to the junction node above it, whose attributes (0755, root-owned, foreign fsid) a mounted client must never surface. The export root's wire handle is remembered at MOUNT and a `..` naming it becomes a self-lookup — the same clamp the kernel client applies.
- **OPEN of a non-regular leaf collapsed to EINVAL.** NFS4ERR_SYMLINK / NFS4ERR_WRONG_TYPE now trigger a LOOKUP-shaped re-issue so the engine's open completion sees the object and applies the POSIX rules (follow the symlink by restarting resolution, ELOOP under O_NOFOLLOW, ENXIO for fifos/sockets/devices) — mirroring the NFS3 client's EEXIST recovery.

### VFS engine / NFS4 server
- **Prefix search DAC never ran for remote-DAC proxies.** The engine deferred all authorization to the server — but resolution is served from the name/attribute caches, so a repeated traversal never reaches the server, and the follow-on op arrives there parent-by-handle with no prefix left to check (the cache-era face of #1771; the nfs4 trace profile models search permissions and asserts these directly). A new `chimera_vfs_gate_needed_prefix()` gives remote-DAC proxies the engine-side lookup gate a DELEGATES_DAC passthrough already takes — scoped to lookups only, after the first attempt (widening the shared predicate) broke rights-bind-at-open on the I/O gates.
- **The I/O grant stamp was credential-blind.** The open cache shards handles per (fh, access\_mode, cred\_hash), so a stamp normally serves one credential — but the v4 server's open-state handle carries every principal of the proxy's shared open-owner, and whichever cred evaluated first stamped the handle for all of them: a non-owner's narrow evaluation of a mode-restricted file revoked the owner-creator's own bound rights. Stamps are now trusted and refreshed only by the matching credential.
- **The server's OPEN mapped only pure-READ share access to VFS data-access intent.** WRITE and READ|WRITE opens dispatched with no access bits, so the created-file exemption granted nothing on a mode-restricted create and the creator's own stateful I/O failed EACCES.

Plus two smaller ones: the client's dirfd `unlinkat` path skipped the rmdir/unlink type assertion (an unlinkat of a directory simply removed it), and `remove_at` now invalidates the victim's attr-cache entry via the caller-resolved child handle when the backend reports no post-op attrs — a hardlink survivor otherwise kept serving the pre-unlink link count.

### Harness
- **ND9** joins the deviation registry: a path op relative to a removed directory's descriptor draws ENOENT under POSIX (the held-open husk) but STALE over NFSv4 — a directory open creates no server state, the server reclaims the object, and the kernel client surfaces the same ESTALE.
- ESTALE joins the replayer's host→Linux errno map (70 on Darwin, 116 on Linux); without it ND9 matched on only one platform.
- The proxy's per-thread server state (connection, session, slot tables) is released only at thread destroy, so per-trace mount recycling trips LeakSanitizer at exit on Linux; the allocation sites are suppressed under the existing `__lsan_default_suppressions` with a note — a real release-at-last-unmount is follow-up work. A bare `realloc` of `server_threads` that never zeroed its extension is fixed alongside.

Validated: full quint tier green on macOS and serially in the devcontainer (gcc + ASan), including the NFS4 protocol-native suites the server changes touch; the NFS3 loopback batch stays 53/53 with the shared-path changes.
