### PR TITLE
ci: mirror the quint toolchain into GHCR

### DIFF
--- a/.github/workflows/mirror-quint.yml
+++ b/.github/workflows/mirror-quint.yml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+
+name: Mirror quint
+
+# Build the node + quint toolchain once and publish it to GHCR, so the CI images
+# install it with a COPY --from instead of reaching nodejs.org and the npm
+# registry on every image build.  Same arrangement as Mirror ccache, and it is
+# proxied inside ARC by the repository.mdh.quantum.com:5009 pull-through the
+# same way.
+#
+# Why this matters beyond build time: without quint on PATH, libevpl's
+# Core/HTTP/RPC2 conformance suites and its quint_model checks disable
+# themselves.  They have only ever run in the devcontainer -- every other image
+# reported "conformance test disabled (needs quint and python3 on PATH)" and
+# ran zero libevpl quint tests.  chimera's own MBT suites are unaffected: they
+# replay the prebuilt specs bundle and need no quint at all.
+#
+# Manual, not on push: the toolchain moves when someone bumps a version, and
+# the images pin QUINT_VERSION, so nothing changes under CI on its own.
+#
+# KEEP the default in sync with ext/specs/.quint-version and the pin in
+# .devcontainer/Dockerfile.  Trace generation is seeded and reproducible for a
+# given quint release, but different releases sample the state space
+# differently, which is why ext/specs records the version it generated against.
+on:
+  workflow_dispatch:
+    inputs:
+      quint_version:
+        description: quint release to package (e.g. 0.32.0)
+        required: true
+        default: "0.32.0"
+      node_version:
+        description: Node release to package it against
+        required: true
+        default: "20.18.1"
+
+jobs:
+  mirror:
+    name: Mirror quint ${{ inputs.quint_version }} to GHCR
+    runs-on: arc-amd64
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker-container
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # One tag, two architectures: a consumer names
+      # ghcr.io/chimera-nas/quint:<version> and buildkit resolves the leg
+      # matching the image being built.  The Rust evaluator is architecture
+      # specific, so each leg warms its own.
+      - name: Build and push the multi-arch quint image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.quint
+          target: linux-image
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/chimera-nas/quint:${{ inputs.quint_version }}
+          build-args: |
+            QUINT_VERSION=${{ inputs.quint_version }}
+            NODE_VERSION=${{ inputs.node_version }}
+          annotations: |
+            index:org.opencontainers.image.source=https://github.com/chimera-nas/chimera
+            index:org.opencontainers.image.description=node ${{ inputs.node_version }} + quint ${{ inputs.quint_version }} with a warmed Rust evaluator, for the CI images
+
+      # macOS cannot use the image above -- it holds Linux binaries -- but only
+      # the Rust evaluator is actually platform specific; quint itself is
+      # JavaScript.  So the darwin payload is the same JS tree plus both darwin
+      # evaluators, published as an OCI artifact the way the ccache darwin
+      # binary is.  With it the macOS jobs reach neither the npm registry nor
+      # the GitHub releases endpoint -- and that second one is what a
+      # merge-queue run has already died on, rate-limited.
+      - name: Build the darwin payload
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.quint
+          target: darwin-bundle
+          platforms: linux/amd64
+          push: false
+          outputs: type=local,dest=darwin-out
+
+      - name: Install oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Push the darwin payload as an OCI artifact
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          mv darwin-out/quint-darwin.tar.gz .
+          oras push "ghcr.io/chimera-nas/quint:${{ inputs.quint_version }}-darwin" \
+              --annotation "org.opencontainers.image.source=https://github.com/chimera-nas/chimera" \
+              quint-darwin.tar.gz:application/gzip

--- a/Dockerfile.quint
+++ b/Dockerfile.quint
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+#
+# Node, quint and quint's Rust evaluator, packaged as one multi-arch image the
+# CI Dockerfiles COPY --from.  Same arrangement as Dockerfile.ccache: build the
+# toolchain once, mirror it to GHCR, and let every image install from there
+# rather than reach nodejs.org and the npm registry on each build.
+#
+# Node comes from the upstream tarball rather than a distro package or the
+# official node image, and that is a portability requirement rather than a
+# preference: Debian/Ubuntu node packages link against the glibc of the distro
+# that built them, while the upstream tarballs target a much older one, so the
+# same binary runs on ubuntu 22.04 (glibc 2.35) and rocky 9 (2.34) alike.
+# Ubuntu 22.04's own package is node 12, far below what quint needs.
+#
+# Everything lands under a single /opt/quint prefix so a consumer copies one
+# directory and adds one entry to PATH, with no risk of colliding with whatever
+# the base image already keeps in /usr/local.
+
+ARG NODE_VERSION=20.18.1
+ARG QUINT_VERSION=0.32.0
+
+FROM debian:bookworm-slim AS build
+ARG NODE_VERSION
+ARG QUINT_VERSION
+ARG TARGETARCH
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN case "${TARGETARCH}" in \
+        amd64) node_arch=x64 ;; \
+        arm64) node_arch=arm64 ;; \
+        *) echo "unsupported TARGETARCH '${TARGETARCH}'" >&2 ; exit 1 ;; \
+    esac && \
+    mkdir -p /opt/quint && \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.gz" \
+        | tar -xz -C /opt/quint --strip-components=1 \
+              --exclude=CHANGELOG.md --exclude=LICENSE --exclude=README.md && \
+    PATH=/opt/quint/bin:$PATH \
+        npm install -g --prefix /opt/quint @informalsystems/quint@${QUINT_VERSION}
+
+# quint fetches its Rust evaluator on first simulate, into ~/.quint.  The ARC
+# runners reach the network through internal mirrors only, so that download
+# arrives truncated there and every generation fails.  Warming it here bakes the
+# evaluator into the image, and the closing ls fails this build -- where it is
+# fixable -- rather than every downstream job.
+#
+# Double quotes so quint's prime operator (n') needs no escaping: inside single
+# quotes a backslash is literal and would end the string early.
+RUN printf "module warm {\n  var n: int\n  action init = n' = 0\n  action step = n' = n + 1\n}\n" \
+        > /tmp/warm.qnt && \
+    { PATH=/opt/quint/bin:$PATH quint run /tmp/warm.qnt \
+        --max-steps=1 --max-samples=1 > /dev/null 2>&1 || true ; } && \
+    rm -f /tmp/warm.qnt && \
+    ls -d /root/.quint/rust-evaluator-*/quint_evaluator
+
+# The published Linux image is just the two trees.  A consumer copies them and
+# never pays for the download, the npm install, or the evaluator warm-up.
+# Named, because the darwin stages below would otherwise become the default
+# build target.
+FROM scratch AS linux-image
+COPY --from=build /opt/quint  /opt/quint
+COPY --from=build /root/.quint /quint-home
+
+# --------------------------------------------------------------------------
+# The darwin payload.
+#
+# macOS cannot use the image above: it is Linux binaries.  But only one piece
+# of quint is actually platform specific -- the Rust evaluator.  The package
+# itself is JavaScript, so the tree npm installed here runs unchanged on a
+# GitHub-hosted macOS runner against the node it already has.
+#
+# Packaging it here means the macOS jobs stop reaching the npm registry AND
+# stop fetching the evaluator from the GitHub releases endpoint.  That second
+# one is not hypothetical: the release fetch is what a merge-queue run has
+# already died on, and the workaround in build-test.yml exists because quint
+# aborts rather than falling back when the evaluator is missing or half
+# written.
+# --------------------------------------------------------------------------
+FROM build AS darwin
+ARG TARGETARCH
+RUN root=/opt/quint/lib/node_modules/@informalsystems/quint && \
+    ver=$(/opt/quint/bin/node -e \
+        "console.log(require('$root/dist/src/rust/binaryManager').QUINT_EVALUATOR_VERSION)") && \
+    echo "quint evaluator version: $ver" && \
+    mkdir -p "/darwin/rust-evaluator-$ver" && \
+    printf '%s\n' "$ver" > /darwin/evaluator-version && \
+    for a in aarch64 x86_64 ; do \
+        curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+             -o /tmp/ev.tar.gz \
+             "https://github.com/informalsystems/quint/releases/download/evaluator/$ver/quint_evaluator-$a-apple-darwin.tar.gz" && \
+        mkdir -p /tmp/ev && tar -xzf /tmp/ev.tar.gz -C /tmp/ev && \
+        mv /tmp/ev/quint_evaluator "/darwin/rust-evaluator-$ver/quint_evaluator-$a" && \
+        rm -rf /tmp/ev /tmp/ev.tar.gz ; \
+    done && \
+    mkdir -p /darwin/quint/bin && \
+    cp -a /opt/quint/lib /darwin/quint/lib && \
+    cp -a /opt/quint/bin/quint /darwin/quint/bin/quint && \
+    tar -czf /quint-darwin.tar.gz -C /darwin .
+
+FROM scratch AS darwin-bundle
+COPY --from=darwin /quint-darwin.tar.gz /quint-darwin.tar.gz


### PR DESCRIPTION
Groundwork, split out of #1597. This publishes the toolchain; **nothing
installs it yet**.

## Why

libevpl's Core/HTTP/RPC2 conformance suites and its `quint_model` checks detect
quint on `PATH` and disable themselves without it. They have only ever run in
the devcontainer — every other image reports:

```
-- Core conformance test disabled (needs quint and python3 on PATH)
   libevpl quint tests: 0
```

chimera's own model suites are unaffected: they replay the prebuilt specs
bundle and need no quint, which is why ubuntu22 and rocky9 still run 29 MBT
tests apiece while libevpl's run nowhere.

Fixing that means quint in every image, and no image build should have to reach
nodejs.org and the npm registry to get it — so it's mirrored, exactly as the
ccache binaries are, behind the same `:5009` pull-through.

## Two details that are requirements, not preferences

- **Node from the upstream tarball.** Distro node links against the glibc that
  built it; the upstream tarballs target a much older one, so one binary runs on
  ubuntu 22.04 (glibc 2.35) and rocky 9 (2.34) alike. Ubuntu 22.04's own package
  is **node 12**.
- **The Rust evaluator is baked in.** quint fetches it on first simulate, and
  the ARC runners reach the network through internal mirrors only, so that
  download arrives truncated and every generation fails — and quint *aborts*
  rather than falling back to its interpreter. The closing `ls` fails this build
  rather than every downstream job.

A darwin payload rides along as a separate OCI artifact, the way
`ccache:4.14-darwin` does. Only the evaluator is platform-specific — quint
itself is JavaScript.

## Why it lands alone

A consumer in the same change **cannot** work: the mirror job is
`workflow_dispatch`, and dispatch needs the workflow on the default branch, so
the tag cannot exist until this merges. #1597 tried both at once and failed
exactly that way — `500 Internal Server Error` from the pull-through for a tag
with nothing behind it.

After merge: dispatch **Mirror quint** on `main`, then make the new GHCR package
public. #1597 then rebases onto this and becomes just the consumers.