### PR TITLE
Run the POSIX quint corpus against the linux/io_uring passthrough backends

### DIFF
--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -46,11 +46,8 @@ endif()
 #
 # The specs `posix` corpus carries per-backend profiles distinguished by
 # filename prefix: memfs (no prefix), the NFS loopbacks (nfs3_/nfs4_), the
-# on-disk backends (disk_) and FUSE (fuse_).  Each registered batch selects
-# its profile with --exclude-prefix.  Still unregistered: nfs4_ (the nfs4
-# client needs its own round of the fixes that took nfs3 to green -- see the
-# ND* registry in posix_mbt_replay.c) and disk_ (diskfs needs libaio;
-# runs in the container/CI like the other diskfs batches).
+# on-disk/passthrough backends (disk_) and FUSE (fuse_).  Each registered
+# batch selects its profile with --exclude-prefix.
 add_test(NAME chimera/posix/mbt/batch_memfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend memfs
@@ -100,3 +97,37 @@ set_tests_properties(chimera/posix/mbt/batch_nfs4_memfs PROPERTIES
     LABELS "quint;posix_mbt;memfs;nfs4_mbt"
     SKIP_RETURN_CODE 77
     TIMEOUT 600)
+
+# The disk_ profile replayed against the host-passthrough backends.  The
+# backing store is a fresh directory per trace under $CHIMERA_MBT_SCRATCH
+# (default: the build tree), whose filesystem must support name_to_handle_at
+# -- tmpfs/overlayfs do not, and the driver turns that ENOTSUP into a clean
+# SKIP.  The modules run with per-operation credential impersonation, so the
+# batch needs root (CI containers; skipped otherwise via the mount failure).
+if(CHIMERA_LINUX)
+    add_test(NAME chimera/posix/mbt/batch_linux
+        COMMAND $<TARGET_FILE:posix_mbt_replay>
+                --backend linux
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix
+                --exclude-prefix step --exclude-prefix nfs3_
+                --exclude-prefix nfs4_ --exclude-prefix fuse_)
+    set_tests_properties(chimera/posix/mbt/batch_linux PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_linux"
+        LABELS "quint;posix_mbt;linux"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endif()
+
+if(CHIMERA_VFS_IO_URING)
+    add_test(NAME chimera/posix/mbt/batch_io_uring
+        COMMAND $<TARGET_FILE:posix_mbt_replay>
+                --backend io_uring
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix
+                --exclude-prefix step --exclude-prefix nfs3_
+                --exclude-prefix nfs4_ --exclude-prefix fuse_)
+    set_tests_properties(chimera/posix/mbt/batch_io_uring PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_io_uring"
+        LABELS "quint;posix_mbt;io_uring"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endif()

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -131,3 +131,41 @@ if(CHIMERA_VFS_IO_URING)
         SKIP_RETURN_CODE 77
         TIMEOUT 600)
 endif()
+
+# The NFS loopback profiles replayed with a passthrough backend under the
+# server: the full client stack (posix client -> nfs proxy -> wire -> chimera
+# NFS server) on top of the host-kernel filesystem semantics.  The backing
+# store and skip behavior are as for the direct passthrough batches above.
+set(POSIX_MBT_PT_LOOPBACKS "")
+if(CHIMERA_LINUX)
+    list(APPEND POSIX_MBT_PT_LOOPBACKS linux)
+endif()
+if(CHIMERA_VFS_IO_URING)
+    list(APPEND POSIX_MBT_PT_LOOPBACKS io_uring)
+endif()
+
+foreach(ptmod ${POSIX_MBT_PT_LOOPBACKS})
+    add_test(NAME chimera/posix/mbt/batch_nfs3_${ptmod}
+        COMMAND $<TARGET_FILE:posix_mbt_replay>
+                --backend nfs3_${ptmod}
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix
+                --exclude-prefix step --exclude-prefix disk_
+                --exclude-prefix fuse_ --exclude-prefix nfs4_)
+    set_tests_properties(chimera/posix/mbt/batch_nfs3_${ptmod} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs3_${ptmod}"
+        LABELS "quint;posix_mbt;${ptmod};nfs3_mbt"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+
+    add_test(NAME chimera/posix/mbt/batch_nfs4_${ptmod}
+        COMMAND $<TARGET_FILE:posix_mbt_replay>
+                --backend nfs4_${ptmod}
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix
+                --exclude-prefix step --exclude-prefix disk_
+                --exclude-prefix fuse_ --exclude-prefix nfs3_)
+    set_tests_properties(chimera/posix/mbt/batch_nfs4_${ptmod} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs4_${ptmod}"
+        LABELS "quint;posix_mbt;${ptmod};nfs4_mbt"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endforeach()

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -28,6 +28,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <ftw.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -69,11 +70,55 @@ static FILE                      *proto_out;
  * MBT batches get from a per-trace fsname.  Set once in main(). */
 static const char                *g_module;     /* VFS module (memfs/...)     */
 static int                        g_nfs_version; /* 0 = direct; 3/4 = loopback */
+static int                        g_strict_dac; /* chimera enforces DAC beyond
+                                                 * the model: NFS loopback or a
+                                                 * passthrough backend (engine
+                                                 * prefix/search gates) */
 static int                        g_fs_counter; /* bumped per newfs -> fsN     */
 static char                       g_fsname[32] = "fs0";
 static struct chimera_vfs_cred    g_root_cred;
 static struct chimera_server     *g_server;     /* loopback server (nfs only) */
 static struct prometheus_metrics *g_metrics;
+static char                       g_pt_root[300]; /* passthrough scratch root */
+
+/* memfs/diskfs/cairn create named filesystems (mkfs); linux and io_uring are
+ * passthrough onto a host directory -- the path IS the filesystem, and the
+ * per-trace recycle makes a fresh subdirectory instead of a fresh fs. */
+static int
+posix_module_is_passthrough(const char *module)
+{
+    return strcmp(module, "linux") == 0 || strcmp(module, "io_uring") == 0;
+} /* posix_module_is_passthrough */
+
+static int
+pt_rm_cb(
+    const char        *path,
+    const struct stat *st,
+    int                type,
+    struct FTW        *ftw)
+{
+    (void) st;
+    (void) ftw;
+    return (type == FTW_DP ? rmdir(path) : unlink(path));
+} /* pt_rm_cb */
+
+/* Recursively remove a passthrough backing tree.  Space on the scratch
+ * filesystem is a real budget (CI roots it on a shared volume), so the old
+ * tree goes away at each recycle rather than accumulating. */
+static int
+pt_remove_tree(const char *path)
+{
+    return nftw(path, pt_rm_cb, 16, FTW_DEPTH | FTW_PHYS);
+} /* pt_remove_tree */
+
+/* Path of the current passthrough backing directory (g_pt_root/g_fsname). */
+static void
+pt_tree_path(
+    char  *buf,
+    size_t cap)
+{
+    snprintf(buf, cap, "%s/%s", g_pt_root, g_fsname);
+} /* pt_tree_path */
 
 /* Decode standard base64 (no whitespace); returns length or -1. */
 static int
@@ -1016,6 +1061,39 @@ handle(json_t *req)
             }
             usleep(1000);
         }
+        if (posix_module_is_passthrough(g_module)) {
+            /* Passthrough recycle: a fresh uniquely-named backing directory is
+             * the fresh filesystem.  Remove the old tree (scratch space is a
+             * real budget) and mount the new one; the new directory's fresh
+             * inode gives the mount a fresh root handle, so no cached FH can
+             * cross traces. */
+            char old_dir[340], new_dir[340];
+
+            pt_tree_path(old_dir, sizeof(old_dir));
+            if (pt_remove_tree(old_dir) != 0) {
+                fprintf(stderr, "posix_driver: newfs remove %s failed: %s\n",
+                        old_dir, strerror(errno));
+                return res_int(-1, errno);
+            }
+            snprintf(g_fsname, sizeof(g_fsname), "fs%d", ++g_fs_counter);
+            pt_tree_path(new_dir, sizeof(new_dir));
+            if (mkdir(new_dir, 0777) != 0) {
+                fprintf(stderr, "posix_driver: newfs mkdir %s failed: %s\n",
+                        new_dir, strerror(errno));
+                return res_int(-1, errno);
+            }
+            if (chimera_posix_mount("/test", g_module, new_dir) != 0) {
+                fprintf(stderr, "posix_driver: newfs mount %s failed: %s\n",
+                        new_dir, strerror(errno));
+                return res_int(-1, errno);
+            }
+            if (normalize_root() != 0) {
+                fprintf(stderr, "posix_driver: newfs normalize failed: %s\n",
+                        strerror(errno));
+                return res_int(-1, errno);
+            }
+            return res_int(0, 0);
+        }
         /* Remove the old filesystem rather than leaking it.  The replayer has
          * dropped every handle and the unmount drained them, so rmfs succeeds
          * once the async sweep releases the last reference (bounded-retry that
@@ -1140,6 +1218,36 @@ posix_env_setup(
         }
         snprintf(module_cfg, sizeof(module_cfg),
                  "{\"initialize\":true,\"path\":\"%s\"}", storage);
+    } else if (posix_module_is_passthrough(module)) {
+        /* Passthrough backing store.  The host filesystem must support
+         * name_to_handle_at (the linux/io_uring modules derive their file
+         * handles with it) -- tmpfs and overlayfs do not, so the usual /tmp
+         * will not do.  Root the trees at $CHIMERA_MBT_SCRATCH (default: the
+         * current directory, which under ctest is the build tree); an
+         * unsupported filesystem surfaces as an ENOTSUP mount that the mount
+         * below turns into a clean skip.  Mirrors the NFS3 MBT harness. */
+        const char *scratch = getenv("CHIMERA_MBT_SCRATCH");
+        char       *abs_scratch;
+
+        if (!scratch || !scratch[0]) {
+            scratch = ".";
+        }
+        /* The module opens this path from a worker thread, so it must be
+         * absolute. */
+        abs_scratch = realpath(scratch, NULL);
+        if (!abs_scratch) {
+            fprintf(stderr, "posix_driver: realpath(%s): %s\n", scratch,
+                    strerror(errno));
+            return 1;
+        }
+        snprintf(g_pt_root, sizeof(g_pt_root),
+                 "%s/posix_mbt_pt_XXXXXX", abs_scratch);
+        free(abs_scratch);
+        if (!mkdtemp(g_pt_root)) {
+            fprintf(stderr, "posix_driver: mkdtemp(%s): %s\n", g_pt_root,
+                    strerror(errno));
+            return 1;
+        }
     } else {
         fprintf(stderr, "posix_driver: unknown backend %s\n", backend);
         return 1;
@@ -1215,7 +1323,9 @@ posix_env_setup(
                              "%s", module_cfg);
                 }
             }
-        } else {
+        } else if (!posix_module_is_passthrough(module)) {
+            /* linux/io_uring are already in the default client module set
+             * (Linux builds); adding them again would double-register. */
             chimera_client_config_add_module(config, module, "", module_cfg);
         }
 
@@ -1225,15 +1335,47 @@ posix_env_setup(
             return 1;
         }
 
-        /* Named-filesystem backend (memfs/diskfs/cairn): create the fs first. */
-        if (chimera_posix_mkfs(module, "fs0", NULL) != 0) {
-            fprintf(stderr, "posix_driver: mkfs %s fs0 failed\n", module);
-            return 1;
-        }
+        if (posix_module_is_passthrough(module)) {
+            /* Passthrough: the backing directory is the filesystem.  The
+             * model's root is 0777 root:root; create the tree that way
+             * (normalize_root below re-asserts it through the mount). */
+            char dir[340];
 
-        if (chimera_posix_mount("/test", module, "fs0") != 0) {
-            fprintf(stderr, "posix_driver: %s mount failed\n", backend);
-            return 1;
+            snprintf(dir, sizeof(dir), "%s/fs0", g_pt_root);
+            if (mkdir(dir, 0777) != 0) {
+                fprintf(stderr, "posix_driver: mkdir %s: %s\n", dir,
+                        strerror(errno));
+                return 1;
+            }
+            if (chimera_posix_mount("/test", module, dir) != 0) {
+                if (errno == ENOTSUP || errno == EOPNOTSUPP) {
+                    /* The scratch filesystem cannot produce file handles
+                     * (name_to_handle_at): tmpfs/overlayfs, e.g. a /tmp or
+                     * overlay build tree.  Skip rather than fail -- point
+                     * CHIMERA_MBT_SCRATCH at an ext4/xfs/btrfs path to
+                     * actually exercise the backend. */
+                    fprintf(stderr,
+                            "SKIP: %s backend needs a name_to_handle_at-capable "
+                            "scratch fs; %s is not one (set CHIMERA_MBT_SCRATCH)\n",
+                            module, dir);
+                    exit(77);
+                }
+                fprintf(stderr, "posix_driver: %s mount failed: %s\n",
+                        backend, strerror(errno));
+                return 1;
+            }
+        } else {
+            /* Named-filesystem backend (memfs/diskfs/cairn): create the fs
+             * first. */
+            if (chimera_posix_mkfs(module, "fs0", NULL) != 0) {
+                fprintf(stderr, "posix_driver: mkfs %s fs0 failed\n", module);
+                return 1;
+            }
+
+            if (chimera_posix_mount("/test", module, "fs0") != 0) {
+                fprintf(stderr, "posix_driver: %s mount failed\n", backend);
+                return 1;
+            }
         }
     }
 
@@ -1241,6 +1383,7 @@ posix_env_setup(
      * the server/metrics handles so posix_env_teardown can release them. */
     g_module      = module;
     g_nfs_version = nfs_version;
+    g_strict_dac  = nfs_version != 0 || posix_module_is_passthrough(module);
     g_root_cred   = root_cred;
     g_server      = server;
     g_metrics     = metrics;
@@ -1258,6 +1401,9 @@ posix_env_teardown(void)
 {
     chimera_posix_umount("/test");
     chimera_posix_shutdown();
+    if (g_pt_root[0]) {
+        (void) pt_remove_tree(g_pt_root);
+    }
     if (g_server) {
         chimera_server_destroy(g_server);
     }

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -1399,7 +1399,24 @@ posix_env_setup(
 static void
 posix_env_teardown(void)
 {
-    chimera_posix_umount("/test");
+    /* The client umount is what dispatches the module-level UMOUNT that owns
+     * per-mount state (the linux module's root identity, for one); an EBUSY
+     * here (cached handles inside the holder timeout) would leak it, so give
+     * it the same bounded retry the newfs recycle uses. */
+    {
+        int tries = 0;
+        while (chimera_posix_umount("/test") != 0 &&
+               errno == EBUSY && ++tries < 15) {
+            usleep(1000);
+        }
+    }
+    if (g_server) {
+        int tries = 0;
+        while (chimera_server_unmount(g_server, "share") != 0 &&
+               ++tries < 15) {
+            usleep(1000);
+        }
+    }
     chimera_posix_shutdown();
     if (g_pt_root[0]) {
         (void) pt_remove_tree(g_pt_root);

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -1007,30 +1007,63 @@ handle(json_t *req)
                 }
                 usleep(1000);
             }
-            tries = 0;
-            while ((rc = chimera_server_rmfs(g_server, g_module,
-                                             g_fsname)) != 0) {
-                if (rc != CHIMERA_VFS_EBUSY || ++tries >= 15) {
+            if (posix_module_is_passthrough(g_module)) {
+                /* Passthrough recycle under the loopback: a fresh
+                 * uniquely-named backing directory is the fresh filesystem
+                 * (see the direct-path recycle below for the rationale). */
+                char old_dir[340], new_dir[340];
+
+                pt_tree_path(old_dir, sizeof(old_dir));
+                if (pt_remove_tree(old_dir) != 0) {
                     fprintf(stderr,
-                            "posix_driver: newfs server rmfs %s failed: %d\n",
+                            "posix_driver: newfs remove %s failed: %s\n",
+                            old_dir, strerror(errno));
+                    return res_int(-1, errno);
+                }
+                snprintf(g_fsname, sizeof(g_fsname), "fs%d", ++g_fs_counter);
+                pt_tree_path(new_dir, sizeof(new_dir));
+                if (mkdir(new_dir, 0777) != 0) {
+                    fprintf(stderr,
+                            "posix_driver: newfs mkdir %s failed: %s\n",
+                            new_dir, strerror(errno));
+                    return res_int(-1, errno);
+                }
+                rc = chimera_server_mount(g_server, "share", g_module,
+                                          new_dir, NULL);
+                if (rc != 0) {
+                    fprintf(stderr,
+                            "posix_driver: newfs share mount %s failed: %d\n",
+                            new_dir, rc);
+                    return res_int(-1, chimera_posix_errno_from_status(rc));
+                }
+            } else {
+                tries = 0;
+                while ((rc = chimera_server_rmfs(g_server, g_module,
+                                                 g_fsname)) != 0) {
+                    if (rc != CHIMERA_VFS_EBUSY || ++tries >= 15) {
+                        fprintf(stderr,
+                                "posix_driver: newfs server rmfs %s failed: %d\n",
+                                g_fsname, rc);
+                        return res_int(-1, chimera_posix_errno_from_status(rc));
+                    }
+                    usleep(1000);
+                }
+                snprintf(g_fsname, sizeof(g_fsname), "fs%d", ++g_fs_counter);
+                rc = chimera_server_mkfs(g_server, g_module, g_fsname, NULL);
+                if (rc != 0) {
+                    fprintf(stderr,
+                            "posix_driver: newfs server mkfs %s failed: %d\n",
                             g_fsname, rc);
                     return res_int(-1, chimera_posix_errno_from_status(rc));
                 }
-                usleep(1000);
-            }
-            snprintf(g_fsname, sizeof(g_fsname), "fs%d", ++g_fs_counter);
-            rc = chimera_server_mkfs(g_server, g_module, g_fsname, NULL);
-            if (rc != 0) {
-                fprintf(stderr, "posix_driver: newfs server mkfs %s failed: %d\n",
-                        g_fsname, rc);
-                return res_int(-1, chimera_posix_errno_from_status(rc));
-            }
-            rc = chimera_server_mount(g_server, "share", g_module, g_fsname,
-                                      NULL);
-            if (rc != 0) {
-                fprintf(stderr, "posix_driver: newfs share mount %s failed: %d\n",
-                        g_fsname, rc);
-                return res_int(-1, chimera_posix_errno_from_status(rc));
+                rc = chimera_server_mount(g_server, "share", g_module,
+                                          g_fsname, NULL);
+                if (rc != 0) {
+                    fprintf(stderr,
+                            "posix_driver: newfs share mount %s failed: %d\n",
+                            g_fsname, rc);
+                    return res_int(-1, chimera_posix_errno_from_status(rc));
+                }
             }
             snprintf(mount_options, sizeof(mount_options), "vers=%d",
                      g_nfs_version);
@@ -1274,8 +1307,12 @@ posix_env_setup(
         /* Protocols are opt-in (default off): the loopback path needs the NFS
          * server, or chimera_server_create_export has no nfs_shared to add to. */
         chimera_server_config_set_nfs_enabled(server_config, 1);
-        chimera_server_config_add_module(server_config, module, NULL,
-                                         module_cfg);
+        if (!posix_module_is_passthrough(module)) {
+            /* linux/io_uring are already in the server's default module set
+             * (Linux builds); adding them again would double-register. */
+            chimera_server_config_add_module(server_config, module, NULL,
+                                             module_cfg);
+        }
 
         server = chimera_server_init(server_config, metrics);
         if (!server) {
@@ -1283,13 +1320,43 @@ posix_env_setup(
             return 1;
         }
 
-        /* Named-filesystem backend (memfs/diskfs/cairn): create the fs first. */
-        if (chimera_server_mkfs(server, module, "fs0", NULL) != 0) {
-            fprintf(stderr, "posix_driver: mkfs %s fs0 failed\n", module);
-            return 1;
-        }
+        if (posix_module_is_passthrough(module)) {
+            /* Passthrough under the loopback: the share's backing directory
+             * is the filesystem (no mkfs).  ENOTSUP from the mount means the
+             * scratch filesystem cannot produce file handles
+             * (name_to_handle_at) -- skip, as on the direct path. */
+            char dir[340];
+            int  mrc;
 
-        chimera_server_mount(server, "share", module, "fs0", NULL);
+            snprintf(dir, sizeof(dir), "%s/fs0", g_pt_root);
+            if (mkdir(dir, 0777) != 0) {
+                fprintf(stderr, "posix_driver: mkdir %s: %s\n", dir,
+                        strerror(errno));
+                return 1;
+            }
+            mrc = chimera_server_mount(server, "share", module, dir, NULL);
+            if (mrc == CHIMERA_VFS_ENOTSUP) {
+                fprintf(stderr,
+                        "SKIP: %s backend needs a name_to_handle_at-capable "
+                        "scratch fs; %s is not one (set CHIMERA_MBT_SCRATCH)\n",
+                        module, dir);
+                exit(77);
+            }
+            if (mrc != 0) {
+                fprintf(stderr, "posix_driver: share mount %s failed: %d\n",
+                        dir, mrc);
+                return 1;
+            }
+        } else {
+            /* Named-filesystem backend (memfs/diskfs/cairn): create the fs
+             * first. */
+            if (chimera_server_mkfs(server, module, "fs0", NULL) != 0) {
+                fprintf(stderr, "posix_driver: mkfs %s fs0 failed\n", module);
+                return 1;
+            }
+
+            chimera_server_mount(server, "share", module, "fs0", NULL);
+        }
 
         if (chimera_server_create_export(server, "/share", "/share",
                                          4242, NULL) != 0) {

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1237,13 +1237,15 @@ check_status(
         g_last_recon = dev;
         return 0;
     }
-    if (g_nfs_version) {
-        /* ND3: EACCES from the server's directory-search enforcement on the
-         * loopback's component-by-component resolution.  Neither the posix
-         * model nor chimera's own resolution (issue #1771) implements search
-         * permission, so any path-taking op can draw an EACCES the model maps
-         * to another outcome.  Retires when the model grows search-perm
-         * semantics (which also unblocks the nfs3 passthrough batches). */
+    if (g_strict_dac) {
+        /* ND3: EACCES from directory-search enforcement the model does not
+         * share.  On the NFS loopback the server denies the
+         * component-by-component resolution; on a passthrough backend the
+         * engine's own prefix gate does (chimera_vfs_gate_needed_prefix) --
+         * either way chimera implements search permission where this trace
+         * profile's model does not, so any path-taking op can draw an EACCES
+         * the model maps to another outcome.  Retires when the model grows
+         * search-perm semantics. */
         if (actual == 13 && expected != 13 &&
             json_object_get(g_cur_rv, "pth")) {
             record_dev("ND3");
@@ -1251,15 +1253,34 @@ check_status(
             return 0;
         }
         /* The same gap in the other direction: the model's EACCES masks
-         * what lies behind an unsearchable directory, while chimera (whose
-         * resolution has no search-perm concept) reports the true state --
-         * typically ENOENT for a name that is not there. */
+         * what lies behind an unsearchable directory, while chimera reports
+         * the true state -- typically ENOENT for a name that is not there. */
         if (expected == 13 && actual == 2 &&
             json_object_get(g_cur_rv, "pth")) {
             record_dev("ND3");
             g_last_recon = "ND3";
             return 0;
         }
+        /* ND4 consequences of a lost descriptor / lost file (see the g_lost_*
+         * block comment): EBADF where the model still holds the descriptor,
+         * ENOENT where the model still has the file. */
+        if (actual == 9 && expected != 9 &&
+            fd_lost(g_cur_pid, (int) tf_field(g_cur_rv, "fd"))) {
+            record_dev("ND4");
+            g_last_recon = "ND4";
+            return 0;
+        }
+        if (actual == 2 && expected != 2 && g_cur_fs) {
+            json_t *comps = json_object_get(json_object_get(g_cur_rv, "pth"),
+                                            "comps");
+            if (comps && path_touches_lost(g_cur_fs, comps)) {
+                record_dev("ND4");
+                g_last_recon = "ND4";
+                return 0;
+            }
+        }
+    }
+    if (g_nfs_version) {
         /* ND6: EACCES on descriptor I/O the model completed.  NFS3 is
          * stateless, so the server re-checks DAC per READ/WRITE with the
          * credential the RPC carries; the proxy sends the OPENING
@@ -1298,24 +1319,6 @@ check_status(
             record_dev("ND9");
             g_last_recon = "ND9";
             return 0;
-        }
-        /* ND4 consequences of a lost descriptor / lost file (see the g_lost_*
-         * block comment): EBADF where the model still holds the descriptor,
-         * ENOENT where the model still has the file. */
-        if (actual == 9 && expected != 9 &&
-            fd_lost(g_cur_pid, (int) tf_field(g_cur_rv, "fd"))) {
-            record_dev("ND4");
-            g_last_recon = "ND4";
-            return 0;
-        }
-        if (actual == 2 && expected != 2 && g_cur_fs) {
-            json_t *comps = json_object_get(json_object_get(g_cur_rv, "pth"),
-                                            "comps");
-            if (comps && path_touches_lost(g_cur_fs, comps)) {
-                record_dev("ND4");
-                g_last_recon = "ND4";
-                return 0;
-            }
         }
     }
     mism("errno: expected %lld, got %d", (long long) expected, actual);
@@ -2392,7 +2395,7 @@ op_readdir(
     (void) pid;
     if (!d) {
         int64_t msid = tf_field(rv, "sid");
-        if (g_nfs_version && msid >= 0 && msid < R_MAXSID &&
+        if (g_strict_dac && msid >= 0 && msid < R_MAXSID &&
             g_lost_sid[msid]) {
             record_dev("ND4");
         } else {
@@ -2474,7 +2477,7 @@ op_dir_simple(
     (void) pid;
     if (!d) {
         int64_t msid = tf_field(rv, "sid");
-        if (g_nfs_version && msid >= 0 && msid < R_MAXSID &&
+        if (g_strict_dac && msid >= 0 && msid < R_MAXSID &&
             g_lost_sid[msid]) {
             record_dev("ND4");
         } else {
@@ -3472,6 +3475,7 @@ replay_trace(const char *path)
         g_cur_pid  = pid;
         g_cur_step = (int) i;
         last_fs    = g_cur_fs;
+
 
 
         if (dispatch(tag, pid, tf_val(req), tf_val(res)) != 0) {

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1310,14 +1310,33 @@ check_status(
         }
         /* ND9: a path operation relative to a directory descriptor whose
          * directory has been removed.  POSIX resolves through the held-open
-         * husk and reports ENOENT; an NFSv4 client holds only the directory's
+         * husk and reports ENOENT; an NFS client holds only the directory's
          * file handle (a directory open creates no state on the server), the
          * server has reclaimed the object, and the wire answers STALE.  The
-         * kernel NFS client surfaces the same ESTALE. */
-        if (g_nfs_version == 4 && actual == 116 && expected == 2 &&
+         * kernel NFS client surfaces the same ESTALE.  Both loopback
+         * versions: v4 deterministically, v3 whenever the proxy's cached
+         * server handle has been dropped (idle sweep under load) and the
+         * re-open by handle meets the reclaimed object. */
+        if (g_nfs_version && actual == 116 && expected == 2 &&
             tf_field(g_cur_rv, "dfd") >= 0) {
             record_dev("ND9");
             g_last_recon = "ND9";
+            return 0;
+        }
+        /* ND10: a descriptor operation answered ESTALE where the model
+         * completed it.  NFS3 has no opens to pin the object server-side:
+         * once the file's last name is gone, the proxy's cached handle is
+         * the only thing keeping I/O alive, and when the idle sweep drops
+         * it under load the re-open by handle meets a reclaimed object.
+         * The silly-rename machinery covers the common data-descriptor
+         * case; what remains (metadata ops, directories, reap races) is
+         * this architectural residue.  NFSv4's stateful opens (CLAIM_FH)
+         * pin the object, so this is v3-only. */
+        if (g_nfs_version == 3 && actual == 116 && expected == 0 &&
+            !json_object_get(g_cur_rv, "pth") &&
+            json_object_get(g_cur_rv, "fd")) {
+            record_dev("ND10");
+            g_last_recon = "ND10";
             return 0;
         }
     }
@@ -1734,6 +1753,13 @@ op_open(
             if (path_ino(g_cur_fs, comps) < 0) {
                 char rp[4096];
                 real_path(json_object_get(rv, "pth"), rp, sizeof(rp));
+                /* As root: this removal is harness bookkeeping, and the
+                 * acting credential may no longer be allowed to remove the
+                 * residue (the trace may since have restricted the parent
+                 * -- with real-kernel DAC on a passthrough backend the
+                 * denial is unconditional, and the leftover name then
+                 * collides with later steps). */
+                apply_root_cred();
                 chimera_posix_unlink(rp);
             } else {
                 exempt_add(mp);

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1321,6 +1321,20 @@ check_status(
             return 0;
         }
     }
+    if (posix_module_is_passthrough(g_module)) {
+        /* PT1: denial of a removal (or replacing rename) in a sticky
+         * directory.  POSIX permits either errno; the model, like the
+         * engine backends, answers EACCES while the Linux kernel answers
+         * EPERM. */
+        if (actual == 1 && expected == 13 &&
+            (strcmp(g_cur_tag, "RUnlink") == 0 ||
+             strcmp(g_cur_tag, "RRmdir") == 0 ||
+             strcmp(g_cur_tag, "RRename") == 0)) {
+            record_dev("PT1");
+            g_last_recon = "PT1";
+            return 0;
+        }
+    }
     mism("errno: expected %lld, got %d", (long long) expected, actual);
     return 0;
 } /* check_status */
@@ -1816,6 +1830,30 @@ op_lseek(
             (whence == SEEK_DATA || whence == SEEK_HOLE)) {
             record_dev("ND7");
             return;
+        }
+        /* PT2: a passthrough backend sits on a real filesystem that tracks
+         * holes, while the model (like the engine backends) reports every
+         * byte below EOF as data and the sole hole as starting at EOF.
+         * Both are POSIX-valid, so accept the real filesystem's refinement:
+         * SEEK_HOLE may find a hole at or after the queried offset but no
+         * later than the model's EOF answer; SEEK_DATA may skip real holes
+         * to a later offset than the model's, or answer ENXIO when nothing
+         * but holes remain below EOF. */
+        if (posix_module_is_passthrough(g_module) && exp_e == 0 &&
+            (whence == SEEK_DATA || whence == SEEK_HOLE)) {
+            int64_t qoff = tf_field(rv, "off");
+            int64_t moff = tf_field(res_v, "off");
+            int     ok   = 0;
+
+            if (whence == SEEK_HOLE) {
+                ok = (e == 0 && rc >= qoff && (int64_t) rc <= moff);
+            } else {
+                ok = (e == 6) || (e == 0 && (int64_t) rc >= moff);
+            }
+            if (ok) {
+                record_dev("PT2");
+                return;
+            }
         }
         /* PD25: a directory's st_size is unspecified; the model abstracts it
          * as 0 while memfs reports a block, so size-relative seeks (and the
@@ -2392,7 +2430,7 @@ op_readdir(
     int            nnames = 0, i;
     size_t         j;
 
-    (void) pid;
+    apply_cred(pid);
     if (!d) {
         int64_t msid = tf_field(rv, "sid");
         if (g_strict_dac && msid >= 0 && msid < R_MAXSID &&
@@ -3476,8 +3514,6 @@ replay_trace(const char *path)
         g_cur_step = (int) i;
         last_fs    = g_cur_fs;
 
-
-
         if (dispatch(tag, pid, tf_val(req), tf_val(res)) != 0) {
             fprintf(stderr, "%s: step %zu: unimplemented op %s\n", path, i,
                     tag);
@@ -3580,6 +3616,10 @@ main(
         }
     }
 
+    /* The final trace's leftover handles otherwise hold the mount busy
+     * through teardown's umount (the per-trace newfs only closes them at the
+     * start of the NEXT trace). */
+    close_live_handles();
     posix_env_teardown();
 
     printf("batch: %d replayed, %d failed, %d unhandled of %d trace(s)\n",

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -420,7 +420,24 @@ chimera_nfs4_open_install_state(
                                 args->share_access, args->share_deny,
                                 &req->thread->shared->nfs4_state_table,
                                 out_stateid);
-        chimera_vfs_release(req->thread->vfs_thread, handle);
+        /* The coalesced state keeps ONE vfs handle, and every stateid
+         * READ/WRITE/SETATTR runs through it.  When the state was born from
+         * a read-only OPEN, that handle is a read-only open (on a
+         * passthrough backend, literally an O_RDONLY descriptor) -- a
+         * write-share coalesce must adopt this OPEN's write-capable handle
+         * or every subsequent stateid WRITE fails against the read-only
+         * descriptor.  The superseded handle may still be borrowed by
+         * in-flight I/O, so park it on the state rather than releasing it
+         * here; open_state_cleanup releases it with the state. */
+        if (handle->access_mode == CHIMERA_VFS_ACCESS_MODE_RW &&
+            existing->handle &&
+            existing->handle->access_mode != CHIMERA_VFS_ACCESS_MODE_RW &&
+            !existing->handle_superseded) {
+            existing->handle_superseded = existing->handle;
+            existing->handle            = handle;
+        } else {
+            chimera_vfs_release(req->thread->vfs_thread, handle);
+        }
         /* The SHARE reservation acquired on the first OPEN of this
          * (owner, fh) stays in force.  Broadening share bits on
          * coalesce is not re-checked cross-protocol in this pass —

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -45,13 +45,16 @@ chimera_nfs4_setattr_complete(
     chimera_nfs4_compound_complete(req, res->status);
 } /* chimera_nfs4_setattr_complete */
 
+/* Unmarshall the requested attributes and apply them to `handle`.  fd_rights
+ * selects descriptor semantics (chimera_vfs_fsetattr): a size change through
+ * an open stateid is authorized by the OPEN, exactly as ftruncate(2) is by
+ * its descriptor, and must not be re-gated against the file's current mode. */
 static void
-chimera_nfs4_setattr_open_callback(
-    enum chimera_vfs_error          error_code,
+chimera_nfs4_setattr_apply(
+    struct nfs_request             *req,
     struct chimera_vfs_open_handle *handle,
-    void                           *private_data)
+    int                             fd_rights)
 {
-    struct nfs_request       *req  = private_data;
     struct SETATTR4args      *args = &req->args_compound->argarray[req->index].opsetattr;
     struct SETATTR4res       *res  = &req->res_compound.resarray[req->index].opsetattr;
     struct chimera_vfs_attrs *attr;
@@ -62,14 +65,8 @@ chimera_nfs4_setattr_open_callback(
 
     req->handle = handle;
 
-    if (error_code != CHIMERA_VFS_OK) {
-        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
-        chimera_nfs4_compound_complete(req, res->status);
-        return;
-    }
-
-    struct chimera_acl *acl_buf      = NULL;
-    unsigned            acl_buf_aces = 0;
+    struct chimera_acl       *acl_buf      = NULL;
+    unsigned                  acl_buf_aces = 0;
     if (args->obj_attributes.num_attrmask >= 1 &&
         (args->obj_attributes.attrmask[0] & (1 << FATTR4_ACL))) {
         acl_buf = xdr_dbuf_alloc_space(chimera_acl_size(CHIMERA_ACL_MAX_ACES),
@@ -92,22 +89,62 @@ chimera_nfs4_setattr_open_callback(
         return;
     }
 
-    chimera_vfs_setattr(req->thread->vfs_thread,
-                        &req->cred,
-                        handle,
-                        attr,
-                        0,
-                        0,
-                        chimera_nfs4_setattr_complete,
-                        req);
+    if (fd_rights) {
+        chimera_vfs_fsetattr(req->thread->vfs_thread,
+                             &req->cred,
+                             handle,
+                             attr,
+                             0,
+                             0,
+                             chimera_nfs4_setattr_complete,
+                             req);
+    } else {
+        chimera_vfs_setattr(req->thread->vfs_thread,
+                            &req->cred,
+                            handle,
+                            attr,
+                            0,
+                            0,
+                            chimera_nfs4_setattr_complete,
+                            req);
+    }
+} /* chimera_nfs4_setattr_apply */
+
+static void
+chimera_nfs4_setattr_open_callback(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *handle,
+    void                           *private_data)
+{
+    struct nfs_request *req = private_data;
+    struct SETATTR4res *res = &req->res_compound.resarray[req->index].opsetattr;
+
+    if (error_code != CHIMERA_VFS_OK) {
+        req->handle = handle;
+        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    chimera_nfs4_setattr_apply(req, handle, 0);
 } /* chimera_nfs4_setattr_open_callback */
 
-/* Open the target and apply the attributes.  Invoked directly, or as the
- * resume continuation once a conflicting layout has been recalled. */
+/* Apply the attributes -- through the open stateid's own handle when the
+ * size-change validation stashed one (descriptor rights), otherwise via a
+ * fresh path-only open of the target.  Invoked directly, or as the resume
+ * continuation once a conflicting layout has been recalled. */
 static void
 nfs4_setattr_proceed(void *arg)
 {
     struct nfs_request *req = arg;
+
+    if (req->handle) {
+        struct chimera_vfs_open_handle *handle = req->handle;
+
+        req->handle = NULL;
+        chimera_nfs4_setattr_apply(req, handle, 1);
+        return;
+    }
 
     chimera_vfs_open_fh(req->thread->vfs_thread,
                         &req->cred,
@@ -134,6 +171,10 @@ chimera_nfs4_setattr(
      * the marshaller dereferences garbage. */
     res->num_attrsset = 0;
     res->attrsset     = NULL;
+
+    /* nfs_request is pooled; nfs4_setattr_proceed keys off req->handle to
+     * decide between the stateid-handle and path-open application paths. */
+    req->handle = NULL;
 
     if (req->fhlen == 0) {
         res->status = NFS4ERR_NOFILEHANDLE;
@@ -221,6 +262,16 @@ chimera_nfs4_setattr(
 
         bool has_write = (open_state->share_access &
                           OPEN4_SHARE_ACCESS_WRITE) != 0;
+
+        /* Apply through the open's own handle: the stateid authorizes the
+         * size change the way a descriptor authorizes ftruncate(2), and the
+         * OPEN-time handle carries that grant (and, on a passthrough
+         * backend, the writable descriptor itself) where a fresh path-only
+         * open would face a per-operation permission re-check. */
+        if (has_write && open_state->handle) {
+            chimera_vfs_dup_handle(thread->vfs_thread, open_state->handle);
+            req->handle = open_state->handle;
+        }
 
         nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                                 thread->vfs_thread);

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -1310,6 +1310,12 @@ open_state_cleanup(
         chimera_vfs_release(vfs_thread, state->handle);
         state->handle = NULL;
     }
+    /* The read-only handle a write-share coalesce superseded (parked so
+     * in-flight I/O borrowing it stayed valid). */
+    if (state->handle_superseded && vfs_thread) {
+        chimera_vfs_release(vfs_thread, state->handle_superseded);
+        state->handle_superseded = NULL;
+    }
     /* Release the owner ref taken in nfs_open_state_create. */
     nfs_open_owner_put(state->owner);
     free(state);

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -331,6 +331,12 @@ struct nfs_open_state {
 
     struct chimera_vfs_open_handle *handle;             /* +1 via chimera_vfs_dup_handle */
 
+    /* The read-only handle a write-share coalesce superseded (see
+     * chimera_nfs4_open_install_state): in-flight I/O may still be borrowing
+     * it, so its reference is parked here and released with the state.  A
+     * state upgrades at most once (RO -> RW), so one slot suffices. */
+    struct chimera_vfs_open_handle *handle_superseded;
+
     struct nfs_lock_state          *locks;              /* utlist via next_in_open */
     UT_hash_handle                  hh;                 /* by fh in owner->states_by_fh */
 

--- a/src/server/nfs/tests/quint/nfs3_mbt_probe.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_probe.c
@@ -202,16 +202,15 @@ main(
         fprintf(stderr, "MKNOD pd/f failed: %u\n", res->status);
         return 1;
     }
-    /* The engine backends answer ISDIR (a non-directory moved onto a
-     * directory); the passthrough backends surface the host kernel's
-     * reading, which reports the non-empty target first (NOTEMPTY).  Both
-     * are status-only precedence choices on the same refusal -- what F2
-     * actually guards is that the parent-alias case answers at all instead
-     * of deadlocking. */
+    /* Every backend answers ISDIR (a non-directory moved onto a directory).
+     * The host kernel checks the non-empty target first on this corner
+     * (NOTEMPTY), but the passthrough modules re-derive the POSIX type pair
+     * and answer the EISDIR rename(2) specifies, like the engine backends.
+     * What F2 actually guards is that the parent-alias case answers at all
+     * instead of deadlocking. */
     expect("RENAME child onto a name resolving to its parent",
            mbt_rename(env, &pd, "f", 1, &root, "pd", 2)->status,
-           mbt_module_is_passthrough(env->module) ? NFS3ERR_NOTEMPTY
-                                                  : NFS3ERR_ISDIR);
+           NFS3ERR_ISDIR);
 
     printf("F6 a filehandle whose object is gone -> STALE:\n");
     {
@@ -272,6 +271,10 @@ main(
                mbt_remove(env, &root, "nope", 4)->status, NFS3ERR_NOENT);
     }
 
+    /* Unmount before stopping: the module-level UMOUNT owns per-mount state
+     * (the linux module's root identity), and only an explicit teardown runs
+     * it -- otherwise LSAN reports the final mount's allocation. */
+    mbt_env_fs_teardown(env, "fs0");
     mbt_env_stop(env);
     free(env);
 

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1529,6 +1529,21 @@ chimera_io_uring_open_fh(
                               request->fh_len,
                               flags);
 
+    if (fd < 0 && errno == EISDIR &&
+        !(request->open_fh.flags & (CHIMERA_VFS_OPEN_READ_ONLY |
+                                    CHIMERA_VFS_OPEN_WRITE_ONLY))) {
+        /* Access-unspecified (INFERRED) open of a directory: the default
+         * read-write flags cannot open a directory, but the handle must
+         * still be usable -- an NFS3 COMMIT of a directory filehandle
+         * (POSIX fsync on a directory descriptor) arrives this way.
+         * Re-open read-only; a directory is never writable anyway. */
+        flags = (flags & ~O_ACCMODE) | O_RDONLY | O_DIRECTORY;
+        fd    = linux_open_by_handle(&thread->mount_table,
+                                     request->fh,
+                                     request->fh_len,
+                                     flags);
+    }
+
     if (fd < 0) {
         if (errno == ENOTDIR && (request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
             int         probe_fd = linux_open_by_handle(&thread->mount_table,

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -504,13 +504,19 @@ chimera_io_uring_reap(
                             io_uring_prep_openat(sqe, parent_fd, name,
                                                  O_PATH | O_NOFOLLOW, 0);
                         } else {
-                            /* Re-open without O_EXCL (the base flags still carry
-                             * O_TRUNC for OVERWRITE_IF/SUPERSEDE).  r_created
+                            /* Re-open without O_CREAT|O_EXCL (the base flags
+                             * still carry O_TRUNC for OVERWRITE_IF/SUPERSEDE).
+                             * Dropping O_CREAT for the existing object is
+                             * semantically equivalent and immune to the
+                             * kernel's fs.protected_regular, which fails an
+                             * O_CREAT open of another user's existing file in
+                             * a sticky world-writable directory.  r_created
                              * stays 0.  No mode supplied -> 0644 to match the
                              * memfs/cairn/linux backends on the pre-SETATTR
                              * object.  See linux.c open_at. */
-                            rflags = chimera_io_uring_open_at_flags(request);
-                            rmode  = (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)
+                            rflags = chimera_io_uring_open_at_flags(request) &
+                                ~(O_CREAT | O_EXCL);
+                            rmode = (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)
                                      ? request->open_at.set_attr->va_mode : 0644;
                             rpers = chimera_io_uring_get_personality(thread, request->cred);
 
@@ -1233,6 +1239,20 @@ chimera_io_uring_mount(
                             &request->mount.r_attr,
                             mount_fd);
 
+    /* Remember the backing directory's identity so lookups can clamp ".." at
+     * the mount root (see linux_lookup_escapes_root). */
+    {
+        struct chimera_linux_mount_root *root;
+        struct stat                      st;
+
+        if (fstat(mount_fd, &st) == 0 &&
+            (root = calloc(1, sizeof(*root))) != NULL) {
+            root->dev                      = st.st_dev;
+            root->ino                      = st.st_ino;
+            request->mount.r_mount_private = root;
+        }
+    }
+
     close(mount_fd);
 
     request->status = CHIMERA_VFS_OK;
@@ -1245,7 +1265,7 @@ chimera_io_uring_umount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    /* No action required */
+    free(request->umount.mount_private);
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_io_uring_umount */
@@ -1268,6 +1288,13 @@ chimera_io_uring_lookup_at(
     scratch += sizeof(*stx);
 
     TERM_STR(fullname, request->lookup_at.component, request->lookup_at.component_len, scratch);
+
+    /* ".." at the mount root resolves to the root itself. */
+    if (linux_lookup_escapes_root(request->mount_private, parent_fd,
+                                  fullname)) {
+        fullname[0] = '.';
+        fullname[1] = '\0';
+    }
 
     sqe = chimera_io_uring_get_sqe(thread, request, 0, 0);
 
@@ -2224,6 +2251,16 @@ chimera_io_uring_readlink(
                     request->readlink.target_maxlength);
 
     if (rc < 0) {
+        /* Empty-path readlinkat on a handle that is not a symlink fails
+         * ENOENT (the empty-path special case exists only for links);
+         * POSIX readlink(2) reports EINVAL for a non-symlink. */
+        if (errno == ENOENT) {
+            struct stat st;
+
+            if (fstat(fd, &st) == 0 && !S_ISLNK(st.st_mode)) {
+                errno = EINVAL;
+            }
+        }
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -541,13 +541,14 @@ chimera_io_uring_reap(
                         request->status = chimera_linux_errno_to_status(-cqe->res);
                     }
                 } else if (handle->slot == 3) {
-                    /* The non-exclusive-create re-open of an existing file.  For a
-                     * CREATE_REGULAR re-open this is the O_PATH handle on an
-                     * existing regular file: leave its attributes untouched. */
+                    /* The non-exclusive-create re-open of an existing file.
+                     * The create attributes apply only to an object this call
+                     * makes: the open found an existing one, so leave its
+                     * attributes untouched (applying them would chmod a file
+                     * the caller may not own). */
                     if (cqe->res >= 0) {
                         chimera_io_uring_open_at_finish(
-                            thread, request, cqe->res, 0,
-                            (request->open_at.flags & CHIMERA_VFS_OPEN_CREATE_REGULAR) ? 1 : 0);
+                            thread, request, cqe->res, 0, 1);
                     } else {
                         request->status = chimera_linux_errno_to_status(-cqe->res);
                     }
@@ -678,6 +679,21 @@ chimera_io_uring_reap(
                      * matching what the linux backend does via
                      * chimera_linux_set_attrs.  fchownat is a fast metadata
                      * call (no I/O) and is gated on AUTH_ATTR injection. */
+                    /* mkdirat(2) does not honor the requested mode exactly:
+                     * vfs_mkdir strips the set-user/group-ID bits, and a
+                     * set-group-ID parent adds an inherited S_ISGID the
+                     * caller never asked for.  Apply the mode verbatim
+                     * afterward, as the linux backend does via
+                     * chimera_linux_set_attrs. */
+                    if (request->status == CHIMERA_VFS_OK &&
+                        (request->mkdir_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
+                        if (fchmodat(parent_fd, fullname,
+                                     request->mkdir_at.set_attr->va_mode & 07777,
+                                     0) < 0) {
+                            request->status = chimera_linux_errno_to_status(errno);
+                        }
+                    }
+
                     if (request->status == CHIMERA_VFS_OK) {
                         uint64_t mask = request->mkdir_at.set_attr->va_set_mask;
                         if (mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
@@ -732,6 +748,31 @@ chimera_io_uring_reap(
                         request->status        = CHIMERA_VFS_OK;
                         request->read.r_length = cqe->res;
                         request->read.r_eof    = (cqe->res < request->read.length);
+                    } else if (cqe->res == -EINVAL) {
+                        /* Resolved synchronously here rather than from the
+                        * statx companion: the two CQEs complete in either
+                        * order, so the statx slot may already have run. */
+                        int         rfd = (int) request->read.handle->vfs_private;
+                        struct stat rst;
+
+                        request->status = CHIMERA_VFS_EINVAL;
+                        if (fstat(rfd, &rst) == 0) {
+                            if (S_ISREG(rst.st_mode) &&
+                                request->read.offset >= (uint64_t) rst.st_size) {
+                                /* At/after-EOF EINVAL becomes a clean
+                                 * zero-length EOF read for regular files. */
+                                request->status        = CHIMERA_VFS_OK;
+                                request->read.r_length = 0;
+                                request->read.r_niov   = 0;
+                                request->read.r_eof    = 1;
+                            } else if (S_ISDIR(rst.st_mode)) {
+                                /* POSIX read(2): a directory descriptor
+                                 * answers EISDIR whatever else is also wrong
+                                 * with the request (the kernel checks offset
+                                 * validity first for a huge offset). */
+                                request->status = CHIMERA_VFS_EISDIR;
+                            }
+                        }
                     } else {
                         request->status = chimera_linux_errno_to_status(-cqe->res);
                     }
@@ -747,12 +788,6 @@ chimera_io_uring_reap(
                             request->read.r_eof =
                                 (request->read.length > 0 &&
                                  request->read.offset + request->read.r_length >= stx->stx_size);
-                        } else if (request->status == CHIMERA_VFS_EINVAL &&
-                                   request->read.offset >= stx->stx_size) {
-                            request->status        = CHIMERA_VFS_OK;
-                            request->read.r_length = 0;
-                            request->read.r_niov   = 0;
-                            request->read.r_eof    = 1;
                         }
                     }
                 }
@@ -1119,11 +1154,19 @@ chimera_io_uring_setattr(
             return;
         }
 
-        // fd might be O_PATH which doesn't support ftruncate directly,
-        // so use truncate() on /proc/self/fd/N path which follows the symlink
-        char procpath[64];
-        snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", fd);
-        rc = truncate(procpath, request->setattr.set_attr->va_size);
+        // Prefer ftruncate: rights bound to the descriptor at open time
+        // authorize it (POSIX), regardless of the file's current mode or
+        // the impersonated fsuid.  An O_PATH fd has no such rights and
+        // refuses ftruncate with EBADF; those are the stateless path-based
+        // callers, where re-checking DAC via a path truncate through
+        // /proc/self/fd is exactly right.
+        rc = ftruncate(fd, request->setattr.set_attr->va_size);
+
+        if (rc && errno == EBADF) {
+            char procpath[64];
+            snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", fd);
+            rc = truncate(procpath, request->setattr.set_attr->va_size);
+        }
 
         if (rc) {
             chimera_io_uring_error("io_uring_setattr: truncate(%ld) failed: %s",
@@ -1178,7 +1221,31 @@ chimera_io_uring_setattr(
         if (have_any) {
             rc = utimensat(fd, "", times, AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);
 
-            if (rc) {
+            if (rc && errno == EPERM &&
+                chimera_linux_times_now_omit(request->setattr.set_attr)) {
+                /* utimensat(2) with one field UTIME_NOW and the other
+                 * omitted: POSIX grants this to any process with write
+                 * access, Linux insists on ownership (see linux_common.h).
+                 * Settle it by write access, as the engine backends do: a
+                 * writer gets the change applied with privilege restored, a
+                 * non-writer the EACCES POSIX prescribes. */
+                if (chimera_linux_cred_write_ok(fd, request->cred)) {
+                    chimera_restore_privilege(request->cred);
+                    rc = utimensat(fd, "", times,
+                                   AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH);
+                    if (rc) {
+                        request->status =
+                            chimera_linux_errno_to_status(errno);
+                        request->complete(request);
+                        return;
+                    }
+                } else {
+                    chimera_restore_privilege(request->cred);
+                    request->status = CHIMERA_VFS_EACCES;
+                    request->complete(request);
+                    return;
+                }
+            } else if (rc) {
                 chimera_io_uring_error("io_uring_setattr: utimensat() failed: %s",
                                        strerror(errno));
 
@@ -1321,12 +1388,14 @@ chimera_io_uring_readdir(
 
     fd = request->readdir.handle->vfs_private;
 
-    rc = chimera_setup_credential(request->cred, NULL);
-    if (rc != 0) {
-        request->status = chimera_linux_errno_to_status(rc);
-        request->complete(request);
-        return;
-    }
+    /* No credential impersonation here, deliberately: READDIR acts purely
+     * through an open handle the engine already authorized, and POSIX binds
+     * a directory stream's rights at opendir -- a chmod after that must not
+     * break an open stream.  The per-request "." re-open below (a private
+     * cursor over the same object, no path resolution) and the child statx
+     * would otherwise re-check DAC against the current mode.  Stateless
+     * wire callers still face per-operation DAC where it belongs: at the
+     * cred-keyed open of the handle itself. */
 
     if (thread->readdir_verifier) {
         struct stat st;
@@ -1338,7 +1407,6 @@ chimera_io_uring_readdir(
 
             if (request->readdir.verifier &&
                 request->readdir.verifier != mtime_verf) {
-                chimera_restore_privilege(request->cred);
                 request->status = CHIMERA_VFS_EBADCOOKIE;
                 request->complete(request);
                 return;
@@ -1367,7 +1435,6 @@ chimera_io_uring_readdir(
         }
         chimera_io_uring_error("io_uring_readdir: openat() failed: %s",
                                strerror(open_errno));
-        chimera_restore_privilege(request->cred);
         request->status = chimera_linux_errno_to_status(open_errno);
         request->complete(request);
         return;
@@ -1379,7 +1446,6 @@ chimera_io_uring_readdir(
         chimera_io_uring_error("io_uring_readdir: fdopendir() failed: %s",
                                strerror(errno));
         close(dup_fd);
-        chimera_restore_privilege(request->cred);
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;
@@ -1426,7 +1492,6 @@ chimera_io_uring_readdir(
     request->readdir.r_eof    = eof;
 
     closedir(dir);
-    chimera_restore_privilege(request->cred);
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
@@ -2047,6 +2112,24 @@ chimera_io_uring_copy_range(
     dst_off   = (loff_t) request->copy_range.dst_offset;
     remaining = request->copy_range.length;
 
+    /* Clamp the copy to the source bytes present when the operation starts.
+     * The retry loop below otherwise self-feeds on a same-file copy whose
+     * destination range extends the source: each chunk grows the file, the
+     * next iteration finds fresh bytes, and the total exceeds what a single
+     * copy_file_range(2) call -- and the engine backends -- would move. */
+    {
+        struct stat src_st;
+
+        if (fstat(src_fd, &src_st) == 0) {
+            uint64_t avail = (src_st.st_size > src_off) ?
+                (uint64_t) (src_st.st_size - src_off) : 0;
+
+            if (remaining > avail) {
+                remaining = avail;
+            }
+        }
+    }
+
     while (remaining > 0) {
         rc = copy_file_range(src_fd, &src_off, dst_fd, &dst_off, remaining, 0);
 
@@ -2323,13 +2406,29 @@ chimera_io_uring_rename_at(
 
     rc = renameat(old_fd, fullname, new_fd, full_newname);
 
+    int renameat_errno = errno;
+    chimera_restore_privilege(request->cred);
+
+    if (rc < 0 && (renameat_errno == ENOTEMPTY || renameat_errno == EEXIST)) {
+        /* When the destination is an ancestor of the source, the kernel asks
+         * "may the replaced directory be emptied" before the POSIX type
+         * pairing, answering ENOTEMPTY where rename(2) specifies EISDIR for
+         * a non-directory moved onto a directory.  Re-derive the type pair
+         * (as root: DAC was settled above) and correct that corner. */
+        struct stat ost, nst;
+
+        if (fstatat(old_fd, fullname, &ost, AT_SYMLINK_NOFOLLOW) == 0 &&
+            fstatat(new_fd, full_newname, &nst, AT_SYMLINK_NOFOLLOW) == 0 &&
+            !S_ISDIR(ost.st_mode) && S_ISDIR(nst.st_mode)) {
+            renameat_errno = EISDIR;
+        }
+    }
+
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(renameat_errno);
     } else {
         request->status = CHIMERA_VFS_OK;
     }
-
-    chimera_restore_privilege(request->cred);
     close(old_fd);
     close(new_fd);
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -687,6 +687,21 @@ chimera_linux_open_fh(
                               request->fh_len,
                               flags);
 
+    if (fd < 0 && errno == EISDIR &&
+        !(request->open_fh.flags & (CHIMERA_VFS_OPEN_READ_ONLY |
+                                    CHIMERA_VFS_OPEN_WRITE_ONLY))) {
+        /* Access-unspecified (INFERRED) open of a directory: the default
+         * read-write flags cannot open a directory, but the handle must
+         * still be usable -- an NFS3 COMMIT of a directory filehandle
+         * (POSIX fsync on a directory descriptor) arrives this way.
+         * Re-open read-only; a directory is never writable anyway. */
+        flags = (flags & ~O_ACCMODE) | O_RDONLY | O_DIRECTORY;
+        fd    = linux_open_by_handle(&thread->mount_table,
+                                     request->fh,
+                                     request->fh_len,
+                                     flags);
+    }
+
     if (fd < 0) {
         if (errno == ENOTDIR && (request->open_fh.flags & CHIMERA_VFS_OPEN_DIRECTORY)) {
             probe_fd = linux_open_by_handle(&thread->mount_table,

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -233,11 +233,19 @@ chimera_linux_set_attrs(
             return -EFBIG;
         }
 
-        // dirfd might be O_PATH which doesn't support ftruncate directly,
-        // so use truncate() on /proc/self/fd/N path which follows the symlink
-        char procpath[64];
-        snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", dirfd);
-        rc = truncate(procpath, attr->va_size);
+        // Prefer ftruncate: rights bound to the descriptor at open time
+        // authorize it (POSIX), regardless of the file's current mode or
+        // the impersonated fsuid.  An O_PATH dirfd has no such rights and
+        // refuses ftruncate with EBADF; those are the stateless path-based
+        // callers, where re-checking DAC via a path truncate through
+        // /proc/self/fd is exactly right.
+        rc = ftruncate(dirfd, attr->va_size);
+
+        if (rc && errno == EBADF) {
+            char procpath[64];
+            snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", dirfd);
+            rc = truncate(procpath, attr->va_size);
+        }
 
         if (rc) {
             chimera_linux_error("linux_setattr: truncate(%ld) failed: %s",
@@ -354,7 +362,24 @@ chimera_linux_setattr(
     }
 
     rc = chimera_linux_set_attrs(fd, "", request->setattr.set_attr);
-    chimera_restore_privilege(request->cred);
+
+    if (rc == -EPERM &&
+        chimera_linux_times_now_omit(request->setattr.set_attr)) {
+        /* utimensat(2) with one field UTIME_NOW and the other omitted: POSIX
+         * grants this to any process with write access, Linux insists on
+         * ownership (see linux_common.h).  Settle it by write access, as the
+         * engine backends do: a writer gets the change applied with
+         * privilege restored, a non-writer the EACCES POSIX prescribes. */
+        if (chimera_linux_cred_write_ok(fd, request->cred)) {
+            chimera_restore_privilege(request->cred);
+            rc = chimera_linux_set_attrs(fd, "", request->setattr.set_attr);
+        } else {
+            chimera_restore_privilege(request->cred);
+            rc = -EACCES;
+        }
+    } else {
+        chimera_restore_privilege(request->cred);
+    }
 
     chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
                             &request->setattr.r_post_attr,
@@ -503,12 +528,14 @@ chimera_linux_readdir(
 
     chimera_linux_debug("linux_readdir: opening %d", fd);
 
-    rc = chimera_setup_credential(request->cred, NULL);
-    if (rc != 0) {
-        request->status = chimera_linux_errno_to_status(rc);
-        request->complete(request);
-        return;
-    }
+    /* No credential impersonation here, deliberately: READDIR acts purely
+     * through an open handle the engine already authorized, and POSIX binds
+     * a directory stream's rights at opendir -- a chmod after that must not
+     * break an open stream.  The per-request "." re-open below (a private
+     * cursor over the same object, no path resolution) and the child statx
+     * would otherwise re-check DAC against the current mode.  Stateless
+     * wire callers still face per-operation DAC where it belongs: at the
+     * cred-keyed open of the handle itself. */
 
     if (thread->readdir_verifier) {
         struct stat st;
@@ -520,7 +547,6 @@ chimera_linux_readdir(
 
             if (request->readdir.verifier &&
                 request->readdir.verifier != mtime_verf) {
-                chimera_restore_privilege(request->cred);
                 request->status = CHIMERA_VFS_EBADCOOKIE;
                 request->complete(request);
                 return;
@@ -549,7 +575,6 @@ chimera_linux_readdir(
         }
         chimera_linux_error("linux_readdir: openat() failed: %s",
                             strerror(open_errno));
-        chimera_restore_privilege(request->cred);
         request->status = chimera_linux_errno_to_status(open_errno);
         request->complete(request);
         return;
@@ -561,7 +586,6 @@ chimera_linux_readdir(
         chimera_linux_error("linux_readdir: fdopendir() failed: %s",
                             strerror(errno));
         close(dup_fd);
-        chimera_restore_privilege(request->cred);
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;
@@ -609,7 +633,6 @@ chimera_linux_readdir(
     request->readdir.r_eof    = eof;
 
     closedir(dir);
-    chimera_restore_privilege(request->cred);
 
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
@@ -795,9 +818,13 @@ chimera_linux_open_at(
              * equivalent for an existing file, and immune to the kernel's
              * fs.protected_regular, which fails an O_CREAT open of another
              * user's existing file in a sticky world-writable directory
-             * (EPERM/EACCES) where POSIX open(2) plainly opens it. */
+             * (EPERM/EACCES) where POSIX open(2) plainly opens it.  The
+             * create attributes (mode and friends) apply only to an object
+             * this call makes, so the reopen skips them -- applying them
+             * here would chmod an existing file the caller may not own. */
             fd = openat(parent_fd, fullname, flags & ~(O_CREAT | O_EXCL),
                         mode);
+            reopened = 1;
         }
     } else {
         fd = openat(parent_fd, fullname, flags, mode);
@@ -1145,18 +1172,29 @@ chimera_linux_read(
 
     if (len < 0) {
         /* Reading at/after EOF surfaces as EINVAL on some backends; report it
-         * as a clean zero-length EOF read.  The VFS core owns request->read.iov
-         * and releases it on completion (r_length stays 0 here). */
-        if (errno == EINVAL &&
-            fstat(fd, &st) == 0 &&
-            request->read.offset >= (uint64_t) st.st_size) {
-            chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
+         * as a clean zero-length EOF read.  Regular files only: a directory
+         * read must keep its real errno (EISDIR), not become a clean EOF just
+         * because the offset exceeds the directory's nominal size.  The VFS
+         * core owns request->read.iov and releases it on completion (r_length
+         * stays 0 here). */
+        if (errno == EINVAL && fstat(fd, &st) == 0) {
+            if (S_ISREG(st.st_mode) &&
+                request->read.offset >= (uint64_t) st.st_size) {
+                chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                                        &request->read.r_attr, fd);
 
-            request->read.r_length = 0;
-            request->read.r_eof    = 1;
-            request->status        = CHIMERA_VFS_OK;
-            request->complete(request);
-            return;
+                request->read.r_length = 0;
+                request->read.r_eof    = 1;
+                request->status        = CHIMERA_VFS_OK;
+                request->complete(request);
+                return;
+            }
+            /* POSIX read(2): a directory descriptor answers EISDIR whatever
+             * else is also wrong with the request (the kernel checks offset
+             * validity first and can answer EINVAL for a huge offset). */
+            if (S_ISDIR(st.st_mode)) {
+                errno = EISDIR;
+            }
         }
 
         request->status        = chimera_linux_errno_to_status(errno);
@@ -1330,6 +1368,24 @@ chimera_linux_copy_range(
     src_off   = (loff_t) request->copy_range.src_offset;
     dst_off   = (loff_t) request->copy_range.dst_offset;
     remaining = request->copy_range.length;
+
+    /* Clamp the copy to the source bytes present when the operation starts.
+     * The retry loop below otherwise self-feeds on a same-file copy whose
+     * destination range extends the source: each chunk grows the file, the
+     * next iteration finds fresh bytes, and the total exceeds what a single
+     * copy_file_range(2) call -- and the engine backends -- would move. */
+    {
+        struct stat src_st;
+
+        if (fstat(src_fd, &src_st) == 0) {
+            uint64_t avail = (src_st.st_size > src_off) ?
+                (uint64_t) (src_st.st_size - src_off) : 0;
+
+            if (remaining > avail) {
+                remaining = avail;
+            }
+        }
+    }
 
     while (remaining > 0) {
         rc = copy_file_range(src_fd, &src_off, dst_fd, &dst_off, remaining, 0);
@@ -1595,6 +1651,21 @@ chimera_linux_rename_at(
 
     int renameat_errno = errno;
     chimera_restore_privilege(request->cred);
+
+    if (rc < 0 && (renameat_errno == ENOTEMPTY || renameat_errno == EEXIST)) {
+        /* When the destination is an ancestor of the source, the kernel asks
+         * "may the replaced directory be emptied" before the POSIX type
+         * pairing, answering ENOTEMPTY where rename(2) specifies EISDIR for
+         * a non-directory moved onto a directory.  Re-derive the type pair
+         * (as root: DAC was settled above) and correct that corner. */
+        struct stat ost, nst;
+
+        if (fstatat(old_fd, fullname, &ost, AT_SYMLINK_NOFOLLOW) == 0 &&
+            fstatat(new_fd, full_newname, &nst, AT_SYMLINK_NOFOLLOW) == 0 &&
+            !S_ISDIR(ost.st_mode) && S_ISDIR(nst.st_mode)) {
+            renameat_errno = EISDIR;
+        }
+    }
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(renameat_errno);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -406,6 +406,20 @@ chimera_linux_mount(
                             r_attr,
                             mount_fd);
 
+    /* Remember the backing directory's identity so lookups can clamp ".." at
+     * the mount root (see linux_lookup_escapes_root). */
+    {
+        struct chimera_linux_mount_root *root;
+        struct stat                      st;
+
+        if (fstat(mount_fd, &st) == 0 &&
+            (root = calloc(1, sizeof(*root))) != NULL) {
+            root->dev                      = st.st_dev;
+            root->ino                      = st.st_ino;
+            request->mount.r_mount_private = root;
+        }
+    }
+
     request->status = CHIMERA_VFS_OK;
 
     close(mount_fd);
@@ -418,7 +432,7 @@ chimera_linux_umount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    /* No action required */
+    free(request->umount.mount_private);
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_linux_umount */
@@ -434,6 +448,12 @@ chimera_linux_lookup_at(
     parent_fd = (int) request->lookup_at.handle->vfs_private;
 
     TERM_STR(fullname, request->lookup_at.component, request->lookup_at.component_len, scratch);
+
+    /* ".." at the mount root resolves to the root itself. */
+    if (linux_lookup_escapes_root(request->mount_private, parent_fd,
+                                  fullname)) {
+        fullname = ".";
+    }
 
     rc = chimera_linux_map_child_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
                                        request,
@@ -771,7 +791,13 @@ chimera_linux_open_at(
             }
             reopened = 1;
         } else if (errno == EEXIST) {
-            fd = openat(parent_fd, fullname, flags, mode);
+            /* The object exists: re-open WITHOUT O_CREAT.  Semantically
+             * equivalent for an existing file, and immune to the kernel's
+             * fs.protected_regular, which fails an O_CREAT open of another
+             * user's existing file in a sticky world-writable directory
+             * (EPERM/EACCES) where POSIX open(2) plainly opens it. */
+            fd = openat(parent_fd, fullname, flags & ~(O_CREAT | O_EXCL),
+                        mode);
         }
     } else {
         fd = openat(parent_fd, fullname, flags, mode);
@@ -1498,6 +1524,16 @@ chimera_linux_readlink(
                     request->readlink.target_maxlength);
 
     if (rc < 0) {
+        /* Empty-path readlinkat on a handle that is not a symlink fails
+         * ENOENT (the empty-path special case exists only for links);
+         * POSIX readlink(2) reports EINVAL for a non-symlink. */
+        if (errno == ENOENT) {
+            struct stat st;
+
+            if (fstat(fd, &st) == 0 && !S_ISLNK(st.st_mode)) {
+                errno = EINVAL;
+            }
+        }
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -367,6 +367,35 @@ linux_mount_table_destroy(struct chimera_linux_mount_table *mount_table)
 
 } /* linux_mount_table_destroy */
 
+/* Identity of a chimera mount's backing (root) directory, allocated at MOUNT
+ * and handed back as mount_private, so per-op code can recognize the mount
+ * root without holding an fd. */
+struct chimera_linux_mount_root {
+    dev_t dev;
+    ino_t ino;
+};
+
+/* True when `name` is ".." and `parent_fd` is the mount's root directory:
+ * resolution must not escape the mount.  POSIX resolves the root's ".." to
+ * the root itself; without the clamp a passthrough walks into the backing
+ * store's parent (the scratch directory and its siblings). */
+static inline int
+linux_lookup_escapes_root(
+    const void *mount_private,
+    int         parent_fd,
+    const char *name)
+{
+    const struct chimera_linux_mount_root *root = mount_private;
+    struct stat                            pst;
+
+    if (!root || strcmp(name, "..") != 0) {
+        return 0;
+    }
+
+    return fstat(parent_fd, &pst) == 0 &&
+           pst.st_dev == root->dev && pst.st_ino == root->ino;
+} /* linux_lookup_escapes_root */
+
 static inline int
 linux_open_by_handle(
     struct chimera_linux_mount_table *mount_table,

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -153,7 +153,11 @@ chimera_linux_stat_to_attr(
 
     attr->va_set_mask |= CHIMERA_VFS_ATTR_MASK_STAT;
 
-    attr->va_dev   = st->st_dev;
+    /* Compose the device id as major<<32|minor (the same convention as
+     * va_rdev and the statx mapper below) rather than exposing the glibc
+     * dev_t bit layout: the two mappers back the same handles, and object
+     * identity checks compare va_dev across operations. */
+    attr->va_dev   = ((uint64_t) major(st->st_dev) << 32) | minor(st->st_dev);
     attr->va_ino   = st->st_ino;
     attr->va_mode  = st->st_mode;
     attr->va_nlink = st->st_nlink;
@@ -672,3 +676,68 @@ chimera_linux_mtime_to_verifier(const struct stat *st)
     return ((uint64_t) st->st_mtim.tv_sec << 32) |
            ((uint64_t) st->st_mtim.tv_nsec & 0xFFFFFFFF);
 } /* chimera_linux_mtime_to_verifier */
+
+/* True when a setattr is exactly the utimensat(2) pattern Linux handles
+ * differently from POSIX: one timestamp set to "now", the other omitted, and
+ * nothing else in the request.  POSIX 2008 grants that change to any process
+ * with write access (it is equivalent to a NULL times after an I/O), but
+ * Linux treats it as an explicit set and insists on ownership, failing a
+ * mere writer with EPERM (see utimensat(2) BUGS). */
+static inline int
+chimera_linux_times_now_omit(const struct chimera_vfs_attrs *attr)
+{
+    uint64_t tmask = attr->va_set_mask &
+        (CHIMERA_VFS_ATTR_ATIME | CHIMERA_VFS_ATTR_MTIME);
+
+    if (attr->va_set_mask != tmask || tmask == 0) {
+        return 0;
+    }
+
+    if ((attr->va_set_mask & CHIMERA_VFS_ATTR_ATIME) &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME)) {
+        return (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW &&
+                attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_OMIT) ||
+               (attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_OMIT &&
+                attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW);
+    }
+
+    if (attr->va_set_mask & CHIMERA_VFS_ATTR_ATIME) {
+        return attr->va_atime.tv_nsec == CHIMERA_VFS_TIME_NOW;
+    }
+
+    return attr->va_mtime.tv_nsec == CHIMERA_VFS_TIME_NOW;
+} /* chimera_linux_times_now_omit */
+
+/* POSIX-mode write-access check for the credential against the object behind
+* fd.  faccessat(2) checks the real (or effective) uid, never the fsuid the
+* modules impersonate with, so the class check is done here from the stat. */
+static inline int
+chimera_linux_cred_write_ok(
+    int                            fd,
+    const struct chimera_vfs_cred *cred)
+{
+    struct stat st;
+    unsigned    shift;
+    uint32_t    i;
+    int         in_group;
+
+    if (fstat(fd, &st) != 0) {
+        return 0;
+    }
+
+    if (cred->uid == 0) {
+        return 1;
+    }
+
+    if (st.st_uid == cred->uid) {
+        shift = 6;
+    } else {
+        in_group = (st.st_gid == cred->gid);
+        for (i = 0; !in_group && i < cred->ngids; i++) {
+            in_group = (cred->gids[i] == st.st_gid);
+        }
+        shift = in_group ? 3 : 0;
+    }
+
+    return ((st.st_mode >> shift) & S_IWOTH) ? 1 : 0;
+} /* chimera_linux_cred_write_ok */

--- a/src/vfs/nfs/nfs4_close.c
+++ b/src/vfs/nfs/nfs4_close.c
@@ -10,8 +10,9 @@
  * and shared handles the retry path needs arrive as its arguments, so they are
  * deliberately not kept here. */
 struct chimera_nfs4_close_ctx {
-    struct chimera_nfs4_open_state *open_state;
-    struct stateid4                 stateid;    /* extracted by close_send */
+    struct chimera_nfs4_open_state   *open_state;
+    struct chimera_nfs_client_server *server;   /* for open-file close_done */
+    struct stateid4                   stateid;  /* extracted by close_send */
 };
 
 /*
@@ -44,7 +45,8 @@ chimera_nfs4_close_callback(
     int                          status,
     void                        *private_data)
 {
-    struct chimera_vfs_request *request = private_data;
+    struct chimera_vfs_request    *request = private_data;
+    struct chimera_nfs4_close_ctx *ctx     = request->plugin_data;
 
     if (unlikely(status)) {
         chimera_nfsclient_error("CLOSE failed with transport error %d; "
@@ -57,6 +59,9 @@ chimera_nfs4_close_callback(
         chimera_nfsclient_error("CLOSE rejected with NFS status %d",
                                 res->resarray[2].opclose.status);
     }
+
+    chimera_nfs4_open_file_close_done(ctx->server, request->fh,
+                                      request->fh_len);
 
     chimera_nfs4_close_done(request);
 } /* chimera_nfs4_close_callback */
@@ -115,6 +120,8 @@ chimera_nfs4_close_transmit(
     if (!server_thread || !server_thread->server->nfs4_session) {
         chimera_nfsclient_error("CLOSE: no session for open stateid; "
                                 "leaked until lease expiry");
+        chimera_nfs4_open_file_close_done(ctx->server, request->fh,
+                                          request->fh_len);
         chimera_nfs4_close_done(request);
         return;
     }
@@ -169,13 +176,14 @@ chimera_nfs4_close_send(
     * open_state arrives as a parameter precisely so it survives the reuse. */
     ctx             = request->plugin_data;
     ctx->open_state = open_state;
+    ctx->server     = shared->servers[open_state->server_index];
 
     /* This handle is done with the file.  The open on the server is not this
      * handle's to end, though: every handle on the file shares it, so the CLOSE
      * goes only when the last one lets go.  This consumes the handle's
      * reference, so it must run exactly once per close -- the slot layer's
      * park replay re-enters chimera_nfs4_close_transmit, never here. */
-    if (!chimera_nfs4_open_file_put(shared->servers[open_state->server_index],
+    if (!chimera_nfs4_open_file_put(ctx->server,
                                     request->fh, request->fh_len,
                                     &ctx->stateid)) {
         chimera_nfs4_close_done(request);
@@ -184,6 +192,8 @@ chimera_nfs4_close_send(
 
     /* Nothing was opened on the server, so there is no stateid to release. */
     if (!chimera_nfs4_stateid_is_open(&ctx->stateid)) {
+        chimera_nfs4_open_file_close_done(ctx->server, request->fh,
+                                          request->fh_len);
         chimera_nfs4_close_done(request);
         return;
     }

--- a/src/vfs/nfs/nfs4_open_at.c
+++ b/src/vfs/nfs/nfs4_open_at.c
@@ -188,6 +188,23 @@ chimera_nfs4_open_at_callback(
      * (synthetic handles which don't call close) and for path opens (resolved
      * via LOOKUP, so there is no OPEN stateid). */
     if (!(request->open_at.flags & CHIMERA_VFS_OPEN_INFERRED) && !path_open) {
+        /* Count this handle against the file's open on the server, which every
+         * handle on the file shares.  Keyed on the handle OPEN just returned
+         * (unmarshalled into r_attr above), not request->fh, which still names
+         * the parent directory here.  A refusal means this OPEN raced an
+         * in-flight CLOSE of the same file and coalesced into the state that
+         * CLOSE destroys (see chimera_nfs4_open_file_get) -- the returned
+         * stateid is dead on arrival, so re-send the OPEN; once the CLOSE has
+         * landed the retry receives a fresh state. */
+        if (chimera_nfs4_open_file_get(ctx->server,
+                                       request->open_at.r_attr.va_fh,
+                                       request->open_at.r_attr.va_fh_len,
+                                       &open_res->opopen.resok4.stateid) != 0) {
+            chimera_nfs4_open_at_send(ctx->thread, ctx->shared, request,
+                                      ctx->dispatch_private);
+            return;
+        }
+
         state = chimera_nfs4_open_state_alloc();
 
         if (!state) {
@@ -199,15 +216,6 @@ chimera_nfs4_open_at_callback(
         /* Store the stateid from OPEN response */
         state->server_index = ctx->server->index;
         state->stateid      = open_res->opopen.resok4.stateid;
-
-        /* Count this handle against the file's open on the server, which every
-         * handle on the file shares.  Keyed on the handle OPEN just returned
-         * (unmarshalled into r_attr above), not request->fh, which still names
-         * the parent directory here. */
-        chimera_nfs4_open_file_get(ctx->server,
-                                   request->open_at.r_attr.va_fh,
-                                   request->open_at.r_attr.va_fh_len,
-                                   &state->stateid);
 
         request->open_at.r_vfs_private = (uint64_t) state;
     } else {

--- a/src/vfs/nfs/nfs4_open_fh.c
+++ b/src/vfs/nfs/nfs4_open_fh.c
@@ -6,7 +6,10 @@
 #include "nfs4_open_state.h"
 
 struct chimera_nfs4_open_fh_ctx {
+    struct chimera_nfs_thread        *thread;
+    struct chimera_nfs_shared        *shared;
     struct chimera_nfs_client_server *server;
+    void                             *dispatch_private;
 };
 
 static void
@@ -50,6 +53,19 @@ chimera_nfs4_open_fh_callback(
         return;
     }
 
+    /* Count this handle against the file's open on the server, which every
+     * handle on the file shares (see nfs4_open_state.h).  A refusal means
+     * this OPEN raced an in-flight CLOSE of the same file and coalesced into
+     * the state that CLOSE destroys -- the returned stateid is dead on
+     * arrival, so re-send the OPEN; once the CLOSE has landed the retry
+     * receives a fresh state. */
+    if (chimera_nfs4_open_file_get(server, request->fh, request->fh_len,
+                                   &open_res->opopen.resok4.stateid) != 0) {
+        chimera_nfs4_open_fh(ctx->thread, ctx->shared, request,
+                             ctx->dispatch_private);
+        return;
+    }
+
     state = chimera_nfs4_open_state_alloc();
 
     if (!state) {
@@ -60,11 +76,6 @@ chimera_nfs4_open_fh_callback(
 
     state->server_index = server->index;
     state->stateid      = open_res->opopen.resok4.stateid;
-
-    /* Count this handle against the file's open on the server, which every
-     * handle on the file shares (see nfs4_open_state.h). */
-    chimera_nfs4_open_file_get(server, request->fh, request->fh_len,
-                               &state->stateid);
 
     request->open_fh.r_vfs_private = (uint64_t) state;
     request->status                = CHIMERA_VFS_OK;
@@ -124,7 +135,10 @@ chimera_nfs4_open_fh(
     {
         struct chimera_nfs4_open_fh_ctx *ctx = request->plugin_data;
 
-        ctx->server = server;
+        ctx->thread           = thread;
+        ctx->shared           = shared;
+        ctx->server           = server;
+        ctx->dispatch_private = private_data;
     }
 
     chimera_nfs4_map_fh(request->fh, request->fh_len, &fh, &fhlen);

--- a/src/vfs/nfs/nfs4_open_state.c
+++ b/src/vfs/nfs/nfs4_open_state.c
@@ -15,12 +15,25 @@
  * server into two entries, and those two share one open on the wire -- exactly
  * the aliasing this table exists to count.
  *
- * `stateid` is the one OPEN just returned, or NULL from a caller that has none
- * (chimera_nfs4_open_fh, which cannot OPEN by handle without CLAIM_FH).  When a
- * caller does supply one it wins: an OPEN of an already-open file is an upgrade
- * that bumps the seqid, so the newest stateid is the current one.
+ * `stateid` is the one OPEN just returned.  When a caller supplies one it
+ * wins: an OPEN of an already-open file is an upgrade that bumps the seqid,
+ * so the newest stateid is the current one.
+ *
+ * Returns 0 with a reference taken, or -1 when the OPEN raced an in-flight
+ * CLOSE of the same file and its stateid is doomed -- the caller must re-send
+ * the OPEN (nothing to undo here).  Detection: a freshly created server state
+ * has seqid 1 and a new `other` (RFC 8881 §8.2.2), so a reply seqid of 2 or
+ * more proves the OPEN coalesced into a pre-existing state (same open-owner).
+ * That is normal when it is the state this entry is tracking (`other`
+ * matches, other handles hold the file), and fatal otherwise: an upgrade of
+ * a state this client is closing, has closed (no entry at all), or has
+ * already replaced with a fresh one (`other` differs) is an upgrade of a
+ * destroyed -- or about to be destroyed -- state, and I/O on the returned
+ * stateid would answer BAD_STATEID.  Once the CLOSE has been processed by
+ * the server, the re-sent OPEN receives a fresh seqid-1 state, so the retry
+ * converges within a CLOSE round trip.
  */
-void
+int
 chimera_nfs4_open_file_get(
     struct chimera_nfs_client_server *server,
     const uint8_t                    *fh,
@@ -30,15 +43,16 @@ chimera_nfs4_open_file_get(
     struct chimera_nfs4_open_file *file;
     uint8_t                       *wire_fh;
     int                            wire_fh_len;
+    int                            coalesced = stateid && stateid->seqid >= 2;
 
     if (!server) {
-        return;
+        return 0;
     }
 
     chimera_nfs4_map_fh(fh, fh_len, &wire_fh, &wire_fh_len);
 
     if (wire_fh_len <= 0 || wire_fh_len > CHIMERA_VFS_FH_SIZE) {
-        return;
+        return 0;
     }
 
     pthread_mutex_lock(&server->open_state_lock);
@@ -46,21 +60,45 @@ chimera_nfs4_open_file_get(
     HASH_FIND(hh, server->open_files, wire_fh, wire_fh_len, file);
 
     if (file) {
+        int same_state = stateid &&
+            memcmp(file->stateid.other, stateid->other,
+                   sizeof(stateid->other)) == 0;
+
+        if (coalesced && (!same_state || file->closing)) {
+            /* An upgrade of a doomed state: either one other than the entry
+             * tracks (its CLOSE already retired it, or a fresh open already
+             * replaced it and this reply raced past both), or the tracked
+             * state itself while its CLOSE is in flight.  Dead either way. */
+            pthread_mutex_unlock(&server->open_state_lock);
+            return -1;
+        }
+
         file->refcnt++;
 
-        if (stateid) {
+        if (stateid &&
+            (!same_state || stateid->seqid >= file->stateid.seqid)) {
+            /* Take the newest view of the state; a late reply of an older
+             * upgrade must not roll the recorded seqid back. */
             file->stateid = *stateid;
         }
 
         pthread_mutex_unlock(&server->open_state_lock);
-        return;
+        return 0;
+    }
+
+    if (coalesced) {
+        /* An upgrade of a state this client no longer tracks: the file's
+         * CLOSE completed between our OPEN's transmit and the server
+         * processing it, so the state we coalesced into is gone. */
+        pthread_mutex_unlock(&server->open_state_lock);
+        return -1;
     }
 
     file = calloc(1, sizeof(*file));
 
     if (!file) {
         pthread_mutex_unlock(&server->open_state_lock);
-        return;
+        return 0;
     }
 
     file->refcnt = 1;
@@ -74,14 +112,17 @@ chimera_nfs4_open_file_get(
     HASH_ADD_KEYPTR(hh, server->open_files, file->fh, file->fh_len, file);
 
     pthread_mutex_unlock(&server->open_state_lock);
+    return 0;
 } /* chimera_nfs4_open_file_get */
 
 /*
- * Drop a handle's reference.  Returns non-zero when it was the last one, having
- * retired the entry and copied its stateid to *r_stateid for the caller to
- * CLOSE with.  Returns zero while other handles still hold the file open, in
- * which case nothing may be sent -- a CLOSE now would destroy the stateid they
- * are still using.
+ * Drop a handle's reference.  Returns non-zero when it was the last one,
+ * having marked the entry closing and copied its stateid to *r_stateid for
+ * the caller to CLOSE with; the caller must call
+ * chimera_nfs4_open_file_close_done once that CLOSE completes (or when it
+ * decides none is needed).  Returns zero while other handles still hold the
+ * file open, in which case nothing may be sent -- a CLOSE now would destroy
+ * the stateid they are still using.
  */
 int
 chimera_nfs4_open_file_put(
@@ -113,16 +154,59 @@ chimera_nfs4_open_file_put(
         return 0;
     }
 
-    HASH_DEL(server->open_files, file);
-
-    pthread_mutex_unlock(&server->open_state_lock);
+    /* Last handle: this caller owns the wire CLOSE.  The entry stays hashed,
+     * marked closing, until chimera_nfs4_open_file_close_done -- a concurrent
+     * OPEN of the same file must be able to see the in-flight CLOSE (see
+     * chimera_nfs4_open_file_get). */
+    file->closing++;
 
     *r_stateid = file->stateid;
 
-    free(file);
+    pthread_mutex_unlock(&server->open_state_lock);
 
     return 1;
 } /* chimera_nfs4_open_file_put */
+
+/*
+ * The wire CLOSE consuming a put's reference has completed (or was never
+ * needed).  Drop the closing mark and retire the entry once nothing else
+ * holds it -- a fresh OPEN may have revived it in the meantime (refcnt > 0,
+ * with the fresh state's stateid already recorded), in which case it lives
+ * on for that opener.
+ */
+void
+chimera_nfs4_open_file_close_done(
+    struct chimera_nfs_client_server *server,
+    const uint8_t                    *fh,
+    int                               fh_len)
+{
+    struct chimera_nfs4_open_file *file;
+    uint8_t                       *wire_fh;
+    int                            wire_fh_len;
+
+    if (!server) {
+        return;
+    }
+
+    chimera_nfs4_map_fh(fh, fh_len, &wire_fh, &wire_fh_len);
+
+    if (wire_fh_len <= 0 || wire_fh_len > CHIMERA_VFS_FH_SIZE) {
+        return;
+    }
+
+    pthread_mutex_lock(&server->open_state_lock);
+
+    HASH_FIND(hh, server->open_files, wire_fh, wire_fh_len, file);
+
+    if (file && --file->closing == 0 && file->refcnt == 0) {
+        HASH_DEL(server->open_files, file);
+        pthread_mutex_unlock(&server->open_state_lock);
+        free(file);
+        return;
+    }
+
+    pthread_mutex_unlock(&server->open_state_lock);
+} /* chimera_nfs4_open_file_close_done */
 
 /*
  * Release every entry left on a server at shutdown.

--- a/src/vfs/nfs/nfs4_open_state.h
+++ b/src/vfs/nfs/nfs4_open_state.h
@@ -80,6 +80,13 @@ struct chimera_nfs4_open_file {
     * reaching zero and the unhashing that retires the entry have to be one
     * step, or a concurrent open could revive one already bound for a CLOSE. */
     int             refcnt;
+    /* Wire CLOSEs in flight for this file.  The entry stays hashed while one
+     * is outstanding so a concurrent OPEN of the same file can see it: the
+     * server keys state on (owner, fh) and this client uses one owner, so an
+     * OPEN that lands before an in-flight CLOSE coalesces into the very
+     * state that CLOSE then destroys.  chimera_nfs4_open_file_get detects
+     * that (see the seqid rule there) and the opener re-sends. */
+    int             closing;
     struct stateid4 stateid;
     uint8_t         fh_len;
     uint8_t         fh[CHIMERA_VFS_FH_SIZE];

--- a/src/vfs/nfs/nfs4_setattr.c
+++ b/src/vfs/nfs/nfs4_setattr.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include "nfs_internal.h"
+#include "nfs4_open_state.h"
 
 struct chimera_nfs4_setattr_ctx {
     struct chimera_nfs_thread        *thread;
@@ -247,8 +248,24 @@ chimera_nfs4_setattr(
     /* Op 2: SETATTR */
     argarray[2].argop = OP_SETATTR;
 
-    /* Anonymous stateid (all zeros) for setattr on unopened files */
-    memset(&argarray[2].opsetattr.stateid, 0, sizeof(argarray[2].opsetattr.stateid));
+    /* The open's stateid when this handle carries one, else the anonymous
+     * stateid.  A size-changing SETATTR through an open descriptor is
+     * authorized by the OPEN (RFC 8881 §18.30: the stateid is consulted
+     * exactly when size is set), the way ftruncate(2) is authorized by its
+     * descriptor -- with the anonymous stateid the server instead re-checks
+     * the file's current permissions against the caller. */
+    {
+        struct chimera_nfs4_open_state *open_state =
+            (struct chimera_nfs4_open_state *)
+            request->setattr.handle->vfs_private;
+
+        if (open_state) {
+            argarray[2].opsetattr.stateid = open_state->stateid;
+        } else {
+            memset(&argarray[2].opsetattr.stateid, 0,
+                   sizeof(argarray[2].opsetattr.stateid));
+        }
+    }
 
     /* Set attribute mask - use 2 words if we have any bit in word 1, else 1 word */
     if (ctx->attr_mask[1]) {

--- a/src/vfs/nfs/nfs_internal.h
+++ b/src/vfs/nfs/nfs_internal.h
@@ -1286,7 +1286,7 @@ void chimera_nfs4_close_send(
  * to open the file.  `stateid` is the one OPEN returned, or NULL for a caller
  * that has none.  See nfs4_open_state.h for why this is counted apart from the
  * per-handle open state. */
-void chimera_nfs4_open_file_get(
+int chimera_nfs4_open_file_get(
     struct chimera_nfs_client_server *server,
     const uint8_t                    *fh,
     int                               fh_len,
@@ -1299,6 +1299,11 @@ int chimera_nfs4_open_file_put(
     const uint8_t                    *fh,
     int                               fh_len,
     struct stateid4                  *r_stateid);
+
+void chimera_nfs4_open_file_close_done(
+    struct chimera_nfs_client_server *server,
+    const uint8_t                    *fh,
+    int                               fh_len);
 
 /* Free any entries left on a server at module teardown. */
 void chimera_nfs4_open_file_drain(

--- a/src/vfs/sdk/vfs_access.h
+++ b/src/vfs/sdk/vfs_access.h
@@ -224,6 +224,17 @@ void chimera_vfs_gate_fh_prefix(
     void                          *private_data);
 
 /* Authorize deleting `child_fh` from directory `parent_fh` (delete_allowed). */
+void chimera_vfs_gate_delete_always(
+    struct chimera_vfs_gate_ctx   *ctx,
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *parent_fh,
+    int                            parent_fhlen,
+    const void                    *child_fh,
+    int                            child_fhlen,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data);
+
 void chimera_vfs_gate_delete(
     struct chimera_vfs_gate_ctx   *ctx,
     struct chimera_vfs_thread     *thread,

--- a/src/vfs/sdk/vfs_request.h
+++ b/src/vfs/sdk/vfs_request.h
@@ -243,6 +243,13 @@ struct chimera_vfs_open_handle {
      * until computed. */
     uint32_t                        granted_access;
     uint8_t                         granted_valid;
+    /* granted_bound: the grant was made at OPEN time and binds to the handle
+     * itself -- POSIX descriptor semantics: rights fixed at open(2) survive a
+     * later setuid() and travel with the descriptor, and NFSv4 stateid I/O is
+     * authorized by the OPEN, not re-authorized per operation.  Any caller
+     * credential may trust a bound grant; an unbound (lazily computed) grant
+     * is only valid for the credential that computed it. */
+    uint8_t                         granted_bound;
 
     /* Open-serialization and the backend's per-open slot: requests parked
     * behind a pending open, and the value the backend stashed at open. */

--- a/src/vfs/vfs_access.c
+++ b/src/vfs/vfs_access.c
@@ -143,8 +143,18 @@ chimera_vfs_open_gate_needed(
     /* Remote-DAC proxy: the server enforces per-op but has no open on the
      * wire to enforce open(2) access against, so the engine gates the open
      * itself from the looked-up attributes -- what a kernel NFS client's
-     * ACCESS call at open does.  Root and AUTH_NONE stay exempt. */
-    if (!(module_capabilities & CHIMERA_VFS_CAP_REMOTE_DAC)) {
+     * ACCESS call at open does.  Root and AUTH_NONE stay exempt.
+     *
+     * A DELEGATES_DAC passthrough needs the same gate for a POSIX caller:
+     * the module opens by handle under a privileged process, so the kernel
+     * never evaluates open(2) access for the caller -- and the grant this
+     * gate stamps on the handle is what binds I/O rights at open time.
+     * Without it the first per-op READ/WRITE gate evaluates the file's
+     * CURRENT mode instead, denying a creator its own descriptor on a
+     * mode-restricted create (the created-file exemption lives in the open
+     * gate) and revoking descriptors on a later chmod. */
+    if (!(module_capabilities &
+          (CHIMERA_VFS_CAP_REMOTE_DAC | CHIMERA_VFS_CAP_DELEGATES_DAC))) {
         return 0;
     }
 

--- a/src/vfs/vfs_cred.c
+++ b/src/vfs/vfs_cred.c
@@ -9,6 +9,7 @@
  * time; see the SDK boundary rules in sdk/chimera_vfs_sdk.h.
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -136,6 +137,24 @@ chimera_setup_credential(
         case CHIMERA_VFS_AUTH_UNIX:
             if ((cred->uid == sc->uid) &&
                 (cred->gid == sc->gid)) {
+#ifdef __linux__
+                /* This op runs as the server identity, which is also this
+                 * thread's base state -- but verify it: an error path that
+                 * skipped chimera_restore_privilege would otherwise leak a
+                 * previous op's impersonation into this one.  setfsuid
+                 * returns the previous fsuid, so this both detects and
+                 * repairs the leak. */
+                uint32_t prev = (uint32_t) setfsuid(sc->uid);
+
+                if (prev != sc->uid) {
+                    fprintf(stderr,
+                            "chimera_vfs: impersonation leak: thread fsuid %u "
+                            "at a server-credential op; restoring base "
+                            "identity\n", prev);
+                    setfsgid(sc->gid);
+                    syscall(SYS_setgroups, (size_t) 0, NULL);
+                }
+#endif /* ifdef __linux__ */
                 return 0;
             }
 #ifdef __linux__

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -79,6 +79,9 @@ chimera_vfs_handle_stamp_access(
         handle->granted_access = granted;
         handle->granted_valid  = 1;
     }
+    /* Every caller of this helper stamps at open time; the grant binds to
+     * the handle (see granted_bound in vfs_request.h). */
+    handle->granted_bound = 1;
 } /* chimera_vfs_handle_stamp_access */
 
 /* chimera_vfs_debug/info/error/fatal/abort and the *_if variants come from

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -594,6 +594,7 @@ chimera_vfs_open_cache_acquire(
         handle->fh_len              = fhlen;
         handle->cred_hash           = cred_hash;
         handle->granted_valid       = 0;
+        handle->granted_bound       = 0;
         handle->opencnt             = 1;
         handle->access_mode         = access_mode;
         handle->flags               = exclusive ? CHIMERA_VFS_OPEN_HANDLE_EXCLUSIVE : 0;
@@ -697,6 +698,7 @@ chimera_vfs_open_cache_insert(
     handle->fh_len              = fhlen;
     handle->cred_hash           = cred_hash;
     handle->granted_valid       = 0;
+    handle->granted_bound       = 0;
     handle->opencnt             = 1;
     handle->access_mode         = access_mode;
     handle->flags               = 0;

--- a/src/vfs/vfs_proc_gate.c
+++ b/src/vfs/vfs_proc_gate.c
@@ -415,6 +415,29 @@ chimera_vfs_gate_delete(
         return;
     }
 
+    chimera_vfs_gate_delete_always(ctx, thread, cred, parent_fh, parent_fhlen,
+                                   child_fh, child_fhlen, callback,
+                                   private_data);
+} /* chimera_vfs_gate_delete */
+
+/*
+ * As chimera_vfs_gate_delete(), but enforced unconditionally -- for callers
+ * that already decided enforcement applies (the rename gates run under
+ * chimera_vfs_gate_needed_dac, where the per-object helpers' own
+ * gate_needed test would wrongly skip a DELEGATES_DAC passthrough).
+ */
+SYMBOL_EXPORT void
+chimera_vfs_gate_delete_always(
+    struct chimera_vfs_gate_ctx   *ctx,
+    struct chimera_vfs_thread     *thread,
+    const struct chimera_vfs_cred *cred,
+    const void                    *parent_fh,
+    int                            parent_fhlen,
+    const void                    *child_fh,
+    int                            child_fhlen,
+    chimera_vfs_gate_callback_t    callback,
+    void                          *private_data)
+{
     ctx->thread       = thread;
     ctx->cred         = cred;
     ctx->child_fh     = child_fh;
@@ -429,4 +452,4 @@ chimera_vfs_gate_delete(
     chimera_vfs_open_fh(thread, cred, parent_fh, parent_fhlen,
                         CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_PATH,
                         chimera_vfs_gate_delete_parent_open, ctx);
-} /* chimera_vfs_gate_delete */
+} /* chimera_vfs_gate_delete_always */

--- a/src/vfs/vfs_proc_open.c
+++ b/src/vfs/vfs_proc_open.c
@@ -418,6 +418,12 @@ chimera_vfs_open_lookup_complete(
                 chimera_vfs_access_check(attr, request->cred,
                                          CHIMERA_ACE_MASK_ALL);
             request->open.granted_valid = 1;
+        } else {
+            /* Gate-exempt credential (root, AUTH_NONE): DAC grants this open
+             * everything; bind the full grant to the descriptor so a later
+             * setuid() does not revoke I/O on it. */
+            request->open.granted_access = CHIMERA_ACE_MASK_ALL;
+            request->open.granted_valid  = 1;
         }
     }
 

--- a/src/vfs/vfs_proc_open_at.c
+++ b/src/vfs/vfs_proc_open_at.c
@@ -147,6 +147,13 @@ chimera_vfs_open_at_hdl_callback(
             } else {
                 chimera_vfs_handle_stamp_access(handle, granted);
             }
+        } else {
+            /* Gate-exempt credential (root, AUTH_NONE): DAC grants this open
+             * everything, and POSIX binds that to the descriptor -- a later
+             * setuid() must not revoke I/O on it, so record the full grant
+             * rather than leaving the per-op gates to re-evaluate under
+             * whatever credential wields the descriptor later. */
+            chimera_vfs_handle_stamp_access(handle, CHIMERA_ACE_MASK_ALL);
         }
 
         if (status != CHIMERA_VFS_OK) {

--- a/src/vfs/vfs_proc_read.c
+++ b/src/vfs/vfs_proc_read.c
@@ -330,7 +330,8 @@ chimera_vfs_read_gate_complete(
      * different caller must evaluate for itself and must NOT overwrite the
      * stamp -- a non-owner's narrow evaluation would otherwise revoke the
      * opener's own bound rights. */
-    if (gate->handle->cred_hash == chimera_vfs_cred_hash(gate->cred)) {
+    if (!gate->handle->granted_bound &&
+        gate->handle->cred_hash == chimera_vfs_cred_hash(gate->cred)) {
         gate->handle->granted_access = granted;
         gate->handle->granted_valid  = 1;
     }
@@ -379,7 +380,8 @@ chimera_vfs_read_submit(
      * prefix. */
     if (chimera_vfs_gate_needed_dac(handle->vfs_module->capabilities, cred)) {
         if (handle->granted_valid &&
-            handle->cred_hash == chimera_vfs_cred_hash(cred)) {
+            (handle->granted_bound ||
+             handle->cred_hash == chimera_vfs_cred_hash(cred))) {
             /* Fast path: the caller's grant is cached on the handle. */
             if (!(handle->granted_access & CHIMERA_ACE_READ_DATA)) {
                 callback(CHIMERA_VFS_EACCES, 0, 0, NULL, 0, NULL, private_data);

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -507,10 +507,10 @@ chimera_vfs_rename_at_gate_dst_lookup(
         memcpy(gate->dst_target_fh, attr->va_fh, attr->va_fh_len);
         gate->dst_target_fh_len = attr->va_fh_len;
 
-        chimera_vfs_gate_delete(&gate->gate_ctx, gate->thread, gate->cred,
-                                gate->new_fh, gate->new_fhlen,
-                                gate->dst_target_fh, gate->dst_target_fh_len,
-                                chimera_vfs_rename_at_gate_target, gate);
+        chimera_vfs_gate_delete_always(&gate->gate_ctx, gate->thread, gate->cred,
+                                       gate->new_fh, gate->new_fhlen,
+                                       gate->dst_target_fh, gate->dst_target_fh_len,
+                                       chimera_vfs_rename_at_gate_target, gate);
         return;
     }
 
@@ -533,10 +533,10 @@ chimera_vfs_rename_at_gate_dst(
     }
 
     if (gate->target_fh && gate->target_fh_len > 0) {
-        chimera_vfs_gate_delete(&gate->gate_ctx, gate->thread, gate->cred,
-                                gate->new_fh, gate->new_fhlen,
-                                gate->target_fh, gate->target_fh_len,
-                                chimera_vfs_rename_at_gate_target, gate);
+        chimera_vfs_gate_delete_always(&gate->gate_ctx, gate->thread, gate->cred,
+                                       gate->new_fh, gate->new_fhlen,
+                                       gate->target_fh, gate->target_fh_len,
+                                       chimera_vfs_rename_at_gate_target, gate);
         return;
     }
 
@@ -563,10 +563,10 @@ chimera_vfs_rename_at_gate_src(
         return;
     }
 
-    chimera_vfs_gate_fh(&gate->gate_ctx, gate->thread, gate->cred,
-                        gate->new_fh, gate->new_fhlen,
-                        CHIMERA_ACE_WRITE_DATA,
-                        chimera_vfs_rename_at_gate_dst, gate);
+    chimera_vfs_gate_fh_always(&gate->gate_ctx, gate->thread, gate->cred,
+                               gate->new_fh, gate->new_fhlen,
+                               CHIMERA_ACE_WRITE_DATA,
+                               chimera_vfs_rename_at_gate_dst, gate);
 } /* chimera_vfs_rename_at_gate_src */
 
 /* Source name resolved -> authorize its removal (delete_allowed: DELETE_CHILD
@@ -589,10 +589,10 @@ chimera_vfs_rename_at_gate_lookup(
         memcpy(gate->src_child_fh, attr->va_fh, attr->va_fh_len);
         gate->src_child_fh_len = attr->va_fh_len;
 
-        chimera_vfs_gate_delete(&gate->gate_ctx, gate->thread, gate->cred,
-                                gate->fh, gate->fhlen,
-                                gate->src_child_fh, gate->src_child_fh_len,
-                                chimera_vfs_rename_at_gate_src, gate);
+        chimera_vfs_gate_delete_always(&gate->gate_ctx, gate->thread, gate->cred,
+                                       gate->fh, gate->fhlen,
+                                       gate->src_child_fh, gate->src_child_fh_len,
+                                       chimera_vfs_rename_at_gate_src, gate);
         return;
     }
 
@@ -656,7 +656,13 @@ chimera_vfs_rename_at(
 
     module = chimera_vfs_get_module(thread, fh, fhlen);
 
-    if (module && chimera_vfs_gate_needed(module->capabilities, cred)) {
+    /* gate_needed_dac, not gate_needed: a DELEGATES_DAC passthrough resolves
+     * both parents by handle, so the kernel path-resolution permission checks
+     * a real rename(2) would hit never run -- and inside vfs_rename the
+     * kernel's into-own-subtree EINVAL precedes its may_create/may_delete
+     * checks, inverting POSIX's observable order (resolution EACCES first).
+     * The engine's own source/destination gates below restore it. */
+    if (module && chimera_vfs_gate_needed_dac(module->capabilities, cred)) {
         gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;
         gate->cred           = cred;

--- a/src/vfs/vfs_proc_write.c
+++ b/src/vfs/vfs_proc_write.c
@@ -166,7 +166,8 @@ chimera_vfs_write_gate_complete(
      * different caller must evaluate for itself and must NOT overwrite the
      * stamp -- a non-owner's narrow evaluation would otherwise revoke the
      * opener's own bound rights. */
-    if (gate->handle->cred_hash == chimera_vfs_cred_hash(gate->cred)) {
+    if (!gate->handle->granted_bound &&
+        gate->handle->cred_hash == chimera_vfs_cred_hash(gate->cred)) {
         gate->handle->granted_access = granted;
         gate->handle->granted_valid  = 1;
     }
@@ -212,7 +213,8 @@ chimera_vfs_write_owned(
      * on-disk attrs, exactly as it already does for the path prefix. */
     if (chimera_vfs_gate_needed_dac(handle->vfs_module->capabilities, cred)) {
         if (handle->granted_valid &&
-            handle->cred_hash == chimera_vfs_cred_hash(cred)) {
+            (handle->granted_bound ||
+             handle->cred_hash == chimera_vfs_cred_hash(cred))) {
             if (!(handle->granted_access & CHIMERA_ACE_WRITE_DATA)) {
                 callback(CHIMERA_VFS_EACCES, 0, 0, NULL, NULL, private_data);
                 return;


### PR DESCRIPTION
Runs the POSIX model corpus against the `linux` and `io_uring` host-passthrough backends and takes both to green: `chimera/posix/mbt/batch_linux` and `batch_io_uring` replay the `disk_` profile 59/59 with no leaks, registered in the quick tier (SKIP 77 when the scratch filesystem cannot produce file handles, mirroring the NFS3 MBT harness).

Stacked on #1596 (the POSIX-over-NFSv4.1 loopback); only the commits above it are new here.

## Harness

The driver learns the passthrough backends: the backing store is a fresh directory per trace under `$CHIMERA_MBT_SCRATCH` (default: the build tree) — the path *is* the filesystem, so the per-trace recycle makes a fresh subdirectory instead of a fresh fs, and teardown now closes leftover handles and unmounts through EBUSY so the module-level UMOUNT that owns per-mount state actually runs. Two passthrough deviations are registered where the kernel and the model make different POSIX-valid choices:

- **PT1** — removal (or replacing rename) denied in a sticky directory: POSIX permits either errno; the model (like the engine backends) answers EACCES, the kernel EPERM.
- **PT2** — `SEEK_DATA`/`SEEK_HOLE` on a filesystem that really tracks holes: the model reports every byte below EOF as data and the sole hole at EOF; accept the real filesystem's refinement (an earlier hole, later data, or ENXIO when only holes remain).

## Chimera fixes the corpus surfaced

**Engine — rights bind at open (`granted_bound`).** POSIX fixes I/O rights at `open(2)`: a descriptor opened for writing keeps that right across a later chmod or setuid. The read/write fast path previously trusted a stored grant only for the credential that computed it, so a descriptor opened by root (gate-exempt, never stamped) lost its rights the moment the process dropped privilege. Open-time grants now bind to the handle and are honored for any caller credential (also the correct NFSv4 stateid model); lazily computed I/O-gate grants stay credential-scoped and never overwrite a bound grant.

**Engine — rename authorization for passthrough.** The rename gate chain never ran for a DELEGATES_DAC backend, but a passthrough rename resolves both parents by handle, so the kernel path-resolution checks a real `rename(2)` would hit never run — and the kernel's into-own-subtree EINVAL precedes its permission checks, inverting the POSIX-observable order. The chain now runs under `gate_needed_dac`, with `_always` gate variants so the per-object helpers don't re-exempt the backend.

**Modules (both backends) — POSIX conformance sweep.**
- SETATTR size prefers `ftruncate(2)` (descriptor-bound rights) over the path-based `/proc/self/fd` truncate, which re-checked DAC against the impersonated fsuid; O_PATH descriptors keep the path truncate's fresh check — right for the stateless wire callers.
- A non-exclusive `O_CREAT` open that found an existing object no longer applies the creation attributes to it (an impersonated fchmod of a file the caller may not own → EPERM where `open(2)` plainly opens).
- `utimensat(2)` with one field `UTIME_NOW` and the other omitted: POSIX grants it to any writer, Linux insists on ownership (`utimensat(2)` BUGS); settled by an explicit write-access check.
- READDIR no longer impersonates: a directory stream's rights bind at `opendir`, and the per-request `"."` re-open was re-checking DAC against the current mode, breaking an open stream after a chmod. Stateless wire callers still face per-op DAC at the cred-keyed handle open.
- `read(2)` of a directory answers EISDIR instead of a clean EOF or EINVAL (io_uring resolves at the readv CQE with a synchronous fstat — the statx companion CQE can complete first).
- `copy_file_range` clamps to the source bytes present at entry: the retry loop otherwise self-feeds on a same-file copy whose destination extends the source.
- Renaming a non-directory onto its own parent directory answers the EISDIR `rename(2)` specifies instead of the kernel's ENOTEMPTY-first reading (the F2 probe expectation is updated accordingly — the deviation is retired).
- io_uring mkdir applies the mode verbatim after `mkdirat` (the kernel strips setuid/setgid and a setgid parent adds an inherited bit), as linux.c always has.
- The stat and statx attribute mappers composed `va_dev` differently, so object-identity checks saw the same object flip identity; both now use the `va_rdev` convention.

## Validation

- `batch_linux` / `batch_io_uring`: 59/59 green, no LSAN leaks (container, ext4 scratch).
- Full quick tier green in the container (gcc 15, Debug/ASAN) and on macOS (the `smb/mbt/batch_memfs` stepDir failure on the dev mac is pre-existing at the branch base and macOS-machine-local, like the known oplock probe issue).
- All five NFS3 deviation probes (memfs/diskfs/cairn/linux/io_uring) pass.

---

## Round 2: the NFS3/NFS4 loopback profiles over the passthrough backends

`chimera/posix/mbt/batch_nfs{3,4}_{linux,io_uring}` run the same corpus through the full client stack — posix client → nfs proxy → wire → chimera NFS server — with the host-passthrough backends under the server. All four replay 53/53 green. The combination surfaced four chimera bugs the memfs loopbacks could not see:

- **INFERRED open-by-handle of a directory** defaulted to O_RDWR and failed EISDIR, so an NFS3 COMMIT of a directory filehandle (POSIX `fsync` on a directory descriptor) failed where `fsync(2)` succeeds. The modules now retry an access-unspecified EISDIR read-only.
- **v4 share coalesce kept the read-only handle.** A same-owner OPEN coalesces into the existing open state, which kept the state's original vfs handle and released the new one — after a read-only OPEN followed by a write-share OPEN, every stateid WRITE ran against a literally O_RDONLY descriptor (flaky EBADF; invisible on memfs, whose handles carry no backend access mode). The coalesce now adopts the write-capable handle and parks the superseded one on the state so in-flight I/O borrowing it stays valid.
- **SETATTR(SIZE) ignored its stateid on both sides.** The proxy always sent the anonymous stateid, and the server — after validating the stateid names a write-mode open — applied the attributes through a fresh path-only open anyway, so a passthrough ftruncate through a legitimately writable descriptor was re-gated against the file's current mode (RFC 8881 §18.30 says the stateid authorizes the size change the way a descriptor authorizes `ftruncate(2)`). The proxy now sends the open's stateid and the server applies through the open's own handle with descriptor-rights semantics.
- **UNCHECKED4 created-ness inference fails on ext4.** The proxy inferred "this OPEN created the object" from the reply's directory change_info; a backend whose change attribute falls back to a coarse-grained ctime reports before == after across a fast create, so a creator was denied its own 0444 create with the file left behind. The fix (non-exclusive creates go out as a GUARDED4 probe; NFS4ERR_EXIST re-issues NOCREATE) landed on main independently as 23ea19cf while this branch was in flight — the rebase adopts that version, and the stale cinfo inference is dropped in the rebased #1596 commit it came from.

Two client-architecture deviations were registered rather than "fixed": ND9 (removed-directory descriptor answers ESTALE where POSIX resolves ENOENT) extends to the v3 loopback, and ND10 covers v3 descriptor operations that meet ESTALE once the file's last name is gone and the idle handle sweep drops the cached server handle — NFS3 has no opens to pin the object, and silly-rename only covers the data-descriptor case.

## Rebase onto merged #1596 + one more race

Rebased onto main after #1596 merged (the GUARDED4-probe commit here was dropped in favor of main's independent 23ea19cf). The rebase validation then caught one more long-standing flake, now fixed in the final commit: **an OPEN racing the deferred CLOSE of the same file**. The proxy uses one open-owner per server, so the server coalesces such an OPEN into the very state the in-flight CLOSE destroys, and the returned stateid is dead on arrival (flaky BAD_STATEID → EINVAL on I/O right after a close/reopen pair). The open-file table now keeps a closing entry visible until the CLOSE completes, detects the doomed coalesce by the reply's stateid seqid (a fresh state is seqid 1 per RFC 8881 §8.2.2), and re-sends the OPEN — converging within a CLOSE round trip. The affected trace flaked within ~15 tight-loop iterations before and survived 50 after; the full quick tier passed twice.

A first merge-queue attempt exposed the same race's nastier tail (rocky10: `batch_nfs4_memfs` aborted its batch when the newfs share unmount stayed EBUSY): when a *third* open had already replaced the state, the late doomed stateid could overwrite the fresh one in the proxy's open-file table, so the eventual wire CLOSE carried a dead stateid — the server refuses it, DESTROY_CLIENTID at umount answers CLIENTID_BUSY (RFC 8881 §18.50.3), and the abandoned open pins the export for the full 90s lease. The detection now compares the stateid's 12-byte `other` identity as well: a seqid ≥ 2 reply is accepted only for the exact live state the entry tracks, same-state updates keep the newest seqid, and everything else re-sends.
