### PR TITLE
ci: declare DOCKER_MIRROR before the first FROM so the mirror is honored

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Global scope, ahead of every FROM: an ARG reaches a FROM line only if it is
+# declared before the first FROM.  Below one it belongs to that stage instead
+# and the prefix expands to empty, sending the pull to Docker Hub unmirrored.
+ARG DOCKER_MIRROR
+
 # Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
 # CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
 # build never reaches out to ghcr.io -- the same public-default/internal-override
@@ -15,7 +20,6 @@ ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
 ARG CCACHE_VERSION=4.14
 FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
-ARG DOCKER_MIRROR
 FROM ${DOCKER_MIRROR}ubuntu:26.04
 ARG APT_MIRROR
 ARG ENABLE_XLIO=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Global scope, ahead of every FROM: an ARG reaches a FROM line only if it is
+# declared before the first FROM.  Below one it belongs to that stage instead
+# and the prefix expands to empty, sending the pull to Docker Hub unmirrored.
+ARG DOCKER_MIRROR
+
 # Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
 # CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
 # build never reaches out to ghcr.io -- the same public-default/internal-override
@@ -15,7 +20,6 @@ ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
 ARG CCACHE_VERSION=4.14
 FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
-ARG DOCKER_MIRROR
 FROM ${DOCKER_MIRROR}ubuntu:26.04 AS build
 ARG BUILD_TYPE=Release
 ARG APT_MIRROR

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Global scope, ahead of every FROM: an ARG reaches a FROM line only if it is
+# declared before the first FROM.  Below one it belongs to that stage instead
+# and the prefix expands to empty, sending the pull to Docker Hub unmirrored.
+ARG DOCKER_MIRROR=""
+
 # Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
 # CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
 # build never reaches out to ghcr.io -- the same public-default/internal-override
@@ -15,7 +20,6 @@ ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
 ARG CCACHE_VERSION=4.14
 FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
-ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}rockylinux/rockylinux:10
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=1

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Global scope, ahead of every FROM: an ARG reaches a FROM line only if it is
+# declared before the first FROM.  Below one it belongs to that stage instead
+# and the prefix expands to empty, sending the pull to Docker Hub unmirrored.
+ARG DOCKER_MIRROR=""
+
 # Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
 # CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
 # build never reaches out to ghcr.io -- the same public-default/internal-override
@@ -15,7 +20,6 @@ ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
 ARG CCACHE_VERSION=4.14
 FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
-ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}rockylinux/rockylinux:9
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=0

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Global scope, ahead of every FROM: an ARG reaches a FROM line only if it is
+# declared before the first FROM.  Below one it belongs to that stage instead
+# and the prefix expands to empty, sending the pull to Docker Hub unmirrored.
+ARG DOCKER_MIRROR=""
+
 # Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
 # CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
 # build never reaches out to ghcr.io -- the same public-default/internal-override
@@ -15,7 +20,6 @@ ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
 ARG CCACHE_VERSION=4.14
 FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
-ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}ubuntu:22.04
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=0

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Global scope, ahead of every FROM: an ARG reaches a FROM line only if it is
+# declared before the first FROM.  Below one it belongs to that stage instead
+# and the prefix expands to empty, sending the pull to Docker Hub unmirrored.
+ARG DOCKER_MIRROR=""
+
 # Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
 # CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
 # build never reaches out to ghcr.io -- the same public-default/internal-override
@@ -15,7 +20,6 @@ ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
 ARG CCACHE_VERSION=4.14
 FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
-ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}ubuntu:24.04
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=1

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Global scope, ahead of every FROM: an ARG reaches a FROM line only if it is
+# declared before the first FROM.  Below one it belongs to that stage instead
+# and the prefix expands to empty, sending the pull to Docker Hub unmirrored.
+ARG DOCKER_MIRROR=""
+
 # Current ccache, mirrored into GHCR by .github/workflows/mirror-ccache.yml.
 # CI overrides CCACHE_REGISTRY to the internal pull-through proxy so an image
 # build never reaches out to ghcr.io -- the same public-default/internal-override
@@ -15,7 +20,6 @@ ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
 ARG CCACHE_VERSION=4.14
 FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
-ARG DOCKER_MIRROR=""
 FROM ${DOCKER_MIRROR}ubuntu:26.04
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=1


### PR DESCRIPTION
`ARG DOCKER_MIRROR` sits below the first `FROM` in seven Dockerfiles, so it is scoped to the ccache build stage and never reaches the `FROM ${DOCKER_MIRROR}...` line beneath it. The prefix expands to empty and the base image is pulled from Docker Hub, unmirrored.

90cbe2a1 ("ci: adopt the mirrored ccache, share it by bundle, and cache static analysis") introduced it: it inserted

```dockerfile
ARG CCACHE_REGISTRY=ghcr.io/chimera-nas/ccache
ARG CCACHE_VERSION=4.14
FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
```

directly above what had until then been a global `ARG DOCKER_MIRROR`. The workflows still pass `--build-arg DOCKER_MIRROR=...`, so the build arg has silently had no effect since.

BuildKit says so itself:

```
$ docker build --check -f Dockerfile.ubuntu26.04 .
WARNING: UndefinedArgInFrom - https://docs.docker.com/go/dockerfile/rule/undefined-arg-in-from/
FROM argument 'DOCKER_MIRROR' is not declared
   19 | >>> FROM ${DOCKER_MIRROR}ubuntu:26.04
```

and resolution confirms it -- with `--build-arg DOCKER_MIRROR=mirror.example.invalid/`, before the fix:

```
#2 [internal] load metadata for docker.io/library/ubuntu:26.04
```

after:

```
#2 [internal] load metadata for mirror.example.invalid/ubuntu:26.04
#3 [internal] load metadata for ghcr.io/chimera-nas/ccache:4.14
```

The fix moves the declaration back into the global scope, above the ccache block, and leaves a comment next to it so the next stage inserted at the top of these files does not push it back down. Files: `Dockerfile`, `Dockerfile.rocky9`, `Dockerfile.rocky10`, `Dockerfile.ubuntu22.04`, `Dockerfile.ubuntu24.04`, `Dockerfile.ubuntu26.04`, `.devcontainer/Dockerfile`.

Notes:

- A global ARG is not injected into the stages' `RUN` environments, so this does not add cache-key churn to the layers below -- the concern recorded in the `ENABLE_QUINT` comment in `.devcontainer/Dockerfile` does not apply here.
- `docker build --check` now reports zero warnings on all seven files.
- With `DOCKER_MIRROR` unset, resolution is unchanged (`docker.io/...`), so public builds behave exactly as before.
- The ccache stage still resolves through `CCACHE_REGISTRY`; it deliberately keeps its own public-default/internal-override split and is untouched.
- `test/ad-integration/samba-ad-dc/Dockerfile`, `ext/libevpl/Dockerfile.*` and `ext/specs/.devcontainer/Dockerfile` use the same prefix pattern and are already correct -- no ccache stage was added above them.