### PR TITLE
tests/quint: the duplicate-request-cache suite, the POSIX corpus on diskfs, and what they found

### DIFF
--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -60,6 +60,34 @@ set_tests_properties(chimera/posix/mbt/batch_memfs PROPERTIES
     SKIP_RETURN_CODE 77
     TIMEOUT 300)
 
+# The memfs-profile corpus against diskfs: a chimera-native backend
+# (model-conformant DAC, no host-kernel deviations), so it replays the memfs
+# profile rather than the disk_ one, and the per-trace newfs recycle
+# mkfs-cycles it exactly like memfs.  The replay process self-provisions its
+# scratch device image under its own mkdtemp session dir (posix_env_setup) and
+# takes whichever libevpl block backend the platform has
+# (CHIMERA_DISKFS_DEVICE_TYPE).  Five traces are declined BY NAME in
+# posix_mbt_declines (posix_mbt_replay.c), each naming the diskfs bug that
+# retires the entry.
+#
+# cairn is deliberately NOT registered yet: the same corpus fails ~12 traces
+# across most flavors there (SEEK_DATA/SEEK_HOLE at rocksdb block granularity,
+# clone_file_range unsupported, dup'd-fd shared-offset drift, and the same
+# removed-directory create gate diskfs misses), which is a backend work list,
+# not a decline list.  The driver already speaks cairn (--backend cairn), so
+# registering it later is this same block again.
+add_test(NAME chimera/posix/mbt/batch_diskfs
+    COMMAND $<TARGET_FILE:posix_mbt_replay>
+            --backend diskfs
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix
+            --exclude-prefix nfs3_ --exclude-prefix nfs4_ --exclude-prefix disk_
+            --exclude-prefix fuse_)
+set_tests_properties(chimera/posix/mbt/batch_diskfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_diskfs"
+    LABELS "quint;posix_mbt;diskfs"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 600)
+
 # The same corpus replayed through the NFS loopback: an in-process chimera
 # server exports a memfs filesystem over the inproc transport and the posix
 # client mounts it through the nfs proxy module (src/vfs/nfs) with vers=3 --

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -1193,6 +1193,7 @@ posix_env_setup(
     const char                   *module      = backend;
     int                           nfs_version = 0;
     char                          module_cfg[4096];
+    char                          session_dir[256];
 
     /* The VFS releases closed handles on an async sweep thread, so a filesystem
      * stays EBUSY for a window after its last close.  A fast sweep keeps the
@@ -1217,6 +1218,25 @@ posix_env_setup(
     } else if (strncmp(backend, "nfs4_", 5) == 0) {
         nfs_version = 4;
         module      = backend + 5;
+    }
+
+    /* diskfs/cairn need real scratch storage.  The interactive driver takes
+     * it as argv[2]; the batched replayer passes NULL and the store is
+     * self-provisioned under a fresh temp dir instead, the way the NFS MBT
+     * harness provisions its per-process session dir.  The paths land inside
+     * module_cfg below, so the buffer can be local. */
+    if (!storage &&
+        (strcmp(module, "diskfs") == 0 || strcmp(module, "cairn") == 0)) {
+        const char *tmp = getenv("TMPDIR");
+
+        snprintf(session_dir, sizeof(session_dir), "%s/posix_mbt_%s.XXXXXX",
+                 tmp && tmp[0] ? tmp : "/tmp", module);
+        if (!mkdtemp(session_dir)) {
+            fprintf(stderr, "posix_driver: mkdtemp(%s): %s\n", session_dir,
+                    strerror(errno));
+            return 1;
+        }
+        storage = session_dir;
     }
 
     /* Backend module configuration, shared by the direct-mount and

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -161,6 +161,54 @@ static struct tent g_timemap[R_MAXINO][3];  /* [mino][atime|mtime|ctime]      */
 struct shadow { unsigned char *buf; size_t len, cap; };
 static struct shadow g_shadow[R_MAXINO];    /* model ino -> byte content      */
 
+/* Traces declined BY NAME for a specific backend, each with the chimera bug
+ * that retires the entry -- the posix analog of the SMB corpus's
+ * smb2_mbt_trace_limits.  A declined trace is reported as a SKIP line and not
+ * replayed, so the batch stays green while the bug is open and regains the
+ * trace the moment its entry is removed. */
+static const struct {
+    const char *backend;    /* driver backend name the decline applies to */
+    const char *trace;      /* trace file basename */
+    const char *why;
+} posix_mbt_declines[] = {
+    /* diskfs truncate of a file whose extents are shared with a clone walks
+     * the refcount btree off a freed node (ASAN SEGV: diskfs_bt_run <-
+     * diskfs_refcount_dec <- diskfs_setattr_trunc_process). */
+    { "diskfs", "stepData_128_0x1_3.itf.json",
+      "truncate over cloned extents crashes the refcount walk" },
+    /* diskfs copy_file_range copies and answers block-rounded byte counts
+     * past the source EOF (1024 requested at EOF-1024 -> 4096 copied), and
+     * the destination grows to match. */
+    { "diskfs", "stepData_128_0x1_2.itf.json",
+      "copy_file_range over-copies past source EOF" },
+    { "diskfs", "step_256_0x100_1.itf.json",
+      "copy_file_range over-copies past source EOF" },
+    { "diskfs", "step_256_0x100_2.itf.json",
+      "copy_file_range over-copies past source EOF" },
+    /* diskfs mkdirat under a directory that has been removed (still open via
+     * dirfd) creates the entry instead of answering ENOENT. */
+    { "diskfs", "stepFds_128_0x1_3.itf.json",
+      "create under a removed directory succeeds" },
+};
+
+static const char *
+posix_mbt_declined(const char *path)
+{
+    const char *base = strrchr(path, '/');
+    size_t      i;
+
+    base = base ? base + 1 : path;
+    for (i = 0;
+         i < sizeof(posix_mbt_declines) / sizeof(posix_mbt_declines[0]);
+         i++) {
+        if (strcmp(posix_mbt_declines[i].backend, g_module) == 0 &&
+            strcmp(posix_mbt_declines[i].trace, base) == 0) {
+            return posix_mbt_declines[i].why;
+        }
+    }
+    return NULL;
+} /* posix_mbt_declined */
+
 static int           g_strict_atime;        /* from the trace LInit caps      */
 static int           g_nmismatch;           /* per-trace mismatch tally       */
 static const char   *g_trace;               /* current trace path (messages)  */
@@ -3737,7 +3785,13 @@ main(
     }
 
     for (i = 0; i < ntraces; i++) {
-        int rc;
+        int         rc;
+        const char *declined = posix_mbt_declined(traces[i]);
+
+        if (declined) {
+            fprintf(stderr, "SKIP (declined): %s: %s\n", traces[i], declined);
+            continue;
+        }
         if (ran > 0 && !newfs()) {
             fprintf(stderr, "newfs reset failed before %s\n", traces[i]);
             failures++;

--- a/src/server/nfs/nfs3_drc.c
+++ b/src/server/nfs/nfs3_drc.c
@@ -103,6 +103,84 @@ nfs3_drc_checksum_iov(
     return h;
 } /* nfs3_drc_checksum_iov */
 
+/*
+ * Fold the caller's identity into a request checksum.
+ *
+ * The iovecs a dispatcher is handed begin after the RPC header, so they do not
+ * cover the credential: two users sending byte-identical procedure arguments
+ * produce the same checksum.  With the address (NFSv3) or the connection
+ * (NFSv4.0) as the only other scope, that is enough for one user's request to
+ * be answered from another's entry -- and the second user is told its
+ * non-idempotent operation succeeded when nothing of the sort ran.  Two users
+ * on one machine, or on one container host behind a NAT, are all it takes.
+ *
+ * RFC 8881 Section 2.10.6.1.3.1 states the rule for the NFSv4.1 reply cache: a
+ * retry "that uses a different principal in the RPC request's credential field
+ * that translates to a different user" is a false retry, and if the replier
+ * determines the users differ it MUST NOT answer from the cache.  Neither
+ * RFC 1813 nor RFC 7530 discusses a reply cache at all, so neither says
+ * anything either way -- but the hazard is the same one, and the fix is to make
+ * the identity part of what the key compares.
+ *
+ * The decoded credential is folded rather than the raw bytes, because the
+ * AUTH_SYS stamp is free to vary between a call and its own retransmission and
+ * folding it would mean nothing ever matched.  Squashing is deliberately not
+ * applied first: it happens later, per export, and two credentials that would
+ * squash together simply miss and re-execute, which costs work but is never
+ * wrong.
+ */
+uint64_t
+nfs3_drc_checksum_cred(
+    uint64_t                     h,
+    const struct evpl_rpc2_cred *cred)
+{
+    uint32_t flavor = cred ? cred->flavor : 0;
+    uint32_t i;
+
+    h = nfs3_drc_fnv_accum(h, (const uint8_t *) &flavor, sizeof(flavor));
+
+    if (!cred) {
+        return h;
+    }
+
+    switch (cred->flavor) {
+        case EVPL_RPC2_AUTH_SYS:
+            h = nfs3_drc_fnv_accum(h, (const uint8_t *) &cred->authsys.uid,
+                                   sizeof(cred->authsys.uid));
+            h = nfs3_drc_fnv_accum(h, (const uint8_t *) &cred->authsys.gid,
+                                   sizeof(cred->authsys.gid));
+            for (i = 0; i < cred->authsys.num_gids && cred->authsys.gids; i++) {
+                h = nfs3_drc_fnv_accum(h,
+                                       (const uint8_t *) &cred->authsys.gids[i],
+                                       sizeof(cred->authsys.gids[i]));
+            }
+            /* The machine name is part of the identity an AUTH_SYS credential
+             * asserts: the same uid on two hosts is two users. */
+            if (cred->authsys.machinename && cred->authsys.machinename_len > 0) {
+                h = nfs3_drc_fnv_accum(h,
+                                       (const uint8_t *) cred->authsys.machinename,
+                                       (uint32_t) cred->authsys.machinename_len);
+            }
+            break;
+
+        case EVPL_RPC2_AUTH_RPCSEC_GSS:
+            h = nfs3_drc_fnv_accum(h, (const uint8_t *) &cred->gss.service,
+                                   sizeof(cred->gss.service));
+            if (cred->gss.principal) {
+                h = nfs3_drc_fnv_accum(h, (const uint8_t *) cred->gss.principal,
+                                       (uint32_t) strlen(cred->gss.principal));
+            }
+            break;
+
+        default:
+            /* AUTH_NONE and anything unrecognised assert no identity beyond
+             * the flavor, which is already folded in. */
+            break;
+    } /* switch */
+
+    return h;
+} /* nfs3_drc_checksum_cred */
+
 /* Source IP with the ephemeral port stripped (stable across the reconnect a
  * retransmit rides in on).  Returns the address length written into out. */
 uint8_t
@@ -716,7 +794,8 @@ nfs3_drc_dispatch(
     key.addr_len = nfs3_drc_client_addr(conn, key.addr);
     key.proc     = proc;
     key.xid      = encoding->xid;
-    key.cksum    = nfs3_drc_checksum_iov(iov, niov);
+    key.cksum    = nfs3_drc_checksum_cred(nfs3_drc_checksum_iov(iov, niov),
+                                          cred);
 
     return nfs3_drc_serve(drc, &key, evpl, conn, encoding, proc, program_data,
                           cred, iov, niov, length, private_data);

--- a/src/server/nfs/nfs3_drc.h
+++ b/src/server/nfs/nfs3_drc.h
@@ -29,7 +29,10 @@ struct evpl_rpc2_cred;
  * request checksum}.  The address has its ephemeral port stripped so it stays
  * stable across the reconnect a retransmit rides in on; the checksum guards
  * against a reused xid mapping to a different call (a hit then means the same
- * client re-presenting a byte-identical request).
+ * client re-presenting a byte-identical request).  The checksum covers the
+ * caller's credential too, because the address is shared by everything behind
+ * a NAT or on a multi-user host and two users' identical requests would
+ * otherwise be one key.
  *
  * Only non-idempotent procedures are cached (CREATE/MKDIR/REMOVE/RENAME/...);
  * re-executing an idempotent op is harmless, so those bypass the cache.
@@ -150,6 +153,15 @@ uint64_t
 nfs3_drc_checksum_iov(
     const xdr_iovec *iov,
     int              niov);
+
+/* Fold the caller's identity into a checksum.  The iovecs above begin after the
+ * RPC header and so exclude the credential; without this, two users' identical
+ * requests share a key and one is answered from the other's entry.  Shared with
+ * the NFSv4.0 cache, which has the same gap for the same reason. */
+uint64_t
+nfs3_drc_checksum_cred(
+    uint64_t                     h,
+    const struct evpl_rpc2_cred *cred);
 
 /* Source IP with the ephemeral port stripped; writes addr, returns its len. */
 uint8_t

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -108,7 +108,7 @@ nfs4_rofs_gate(
  * WRITE4args.data, while SETXATTR, SETATTR and CREATE payloads are xdr_opaque
  * in dbuf memory freed with the encoding.
  */
-static void
+void
 nfs4_fail_undispatched_op(
     struct chimera_server_nfs_thread *thread,
     struct nfs_argop4                *argop,

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -7,6 +7,43 @@
 #include "nfs4_state.h"
 #include "nfs4_drc.h"
 
+/*
+ * The SEQUENCE result of a successful slot acquisition.
+ *
+ * RFC 8881 Section 2.10.6.1.1 requires this reply to be cached, and permits a
+ * replier to recompute the slot-usage fields rather than store them; that is
+ * what this does, which is also why the uncached-retry path can call it to
+ * reconstruct the reply the client should have received.
+ */
+static void
+nfs4_sequence_fill_resok(
+    struct SEQUENCE4res  *res,
+    struct nfs4_session  *session,
+    struct SEQUENCE4args *args)
+{
+    res->sr_status = NFS4_OK;
+    memcpy(res->sr_resok4.sr_sessionid, session->nfs4_session_id,
+           NFS4_SESSIONID_SIZE);
+    res->sr_resok4.sr_sequenceid = args->sa_sequenceid;
+    res->sr_resok4.sr_slotid     = args->sa_slotid;
+    /* RFC 5661 18.46.3: sr_highest_slotid is the *maximum slot id*, not
+     * the count.  Linux nfsd returns max_slots - 1. */
+    res->sr_resok4.sr_highest_slotid =
+        session->replay_max_slots ? session->replay_max_slots - 1 : 0;
+    res->sr_resok4.sr_target_highest_slotid = res->sr_resok4.sr_highest_slotid;
+    res->sr_resok4.sr_status_flags          = 0;
+
+    /* RFC 8881 §2.10.6.3 / §18.46.3: signal the client that one or more of its
+     * recallable objects (delegations) have been revoked, so it issues
+     * TEST_STATEID / FREE_STATEID to recover.  Cleared once the client has
+     * freed every revoked delegation. */
+    if (session->client_unified &&
+        atomic_load_explicit(&session->client_unified->revoked_deleg_count,
+                             memory_order_acquire) > 0) {
+        res->sr_resok4.sr_status_flags |= SEQ4_STATUS_RECALLABLE_STATE_REVOKED;
+    }
+} /* nfs4_sequence_fill_resok */
+
 void
 chimera_nfs4_sequence(
     struct chimera_server_nfs_thread *thread,
@@ -53,6 +90,40 @@ chimera_nfs4_sequence(
                                       req,
                                       &is_replay);
 
+    /*
+     * A retry of a request whose reply was not cached.
+     *
+     * RFC 8881 Section 2.10.6.1.1: "When a SEQUENCE or CB_SEQUENCE operation is
+     * successfully executed, its reply MUST always be cached" -- even when the
+     * client did not ask for the rest of the COMPOUND to be.  So a retry has a
+     * SEQUENCE reply to be answered from, and Section 2.10.6.1.3 says what the
+     * rest of the COMPOUND gets: the replier "enters into its reply cache a
+     * reply consisting of the original results to the SEQUENCE ... operation,
+     * and with the next operation in COMPOUND ... having the error
+     * NFS4ERR_RETRY_UNCACHED_REP", and it "MUST NOT return
+     * NFS4ERR_RETRY_UNCACHED_REP in reply to a Sequence operation if the
+     * Sequence operation is the first operation" -- which it always is, since
+     * a COMPOUND that does not begin with SEQUENCE is refused earlier.
+     *
+     * A lone SEQUENCE has no next operation, and nothing but the SEQUENCE reply
+     * to cache, so the cached success is the whole answer.
+     */
+    if (status == NFS4ERR_RETRY_UNCACHED_REP) {
+        nfs4_sequence_fill_resok(res, session, args);
+
+        if (req->args_compound->num_argarray > 1) {
+            req->index = 1;
+            nfs4_fail_undispatched_op(thread,
+                                      &req->args_compound->argarray[1],
+                                      &req->res_compound.resarray[1],
+                                      NFS4ERR_RETRY_UNCACHED_REP);
+            chimera_nfs4_compound_complete(req, NFS4ERR_RETRY_UNCACHED_REP);
+        } else {
+            chimera_nfs4_compound_complete(req, NFS4_OK);
+        }
+        return;
+    }
+
     if (status != NFS4_OK) {
         res->sr_status = status;
         chimera_nfs4_compound_complete(req, status);
@@ -88,27 +159,7 @@ chimera_nfs4_sequence(
         return;
     }
 
-    res->sr_status = NFS4_OK;
-    memcpy(res->sr_resok4.sr_sessionid, session->nfs4_session_id,
-           NFS4_SESSIONID_SIZE);
-    res->sr_resok4.sr_sequenceid = args->sa_sequenceid;
-    res->sr_resok4.sr_slotid     = args->sa_slotid;
-    /* RFC 5661 18.46.3: sr_highest_slotid is the *maximum slot id*, not
-     * the count.  Linux nfsd returns max_slots - 1. */
-    res->sr_resok4.sr_highest_slotid =
-        session->replay_max_slots ? session->replay_max_slots - 1 : 0;
-    res->sr_resok4.sr_target_highest_slotid = res->sr_resok4.sr_highest_slotid;
-    res->sr_resok4.sr_status_flags          = 0;
-
-    /* RFC 8881 §2.10.6.3 / §18.46.3: signal the client that one or more of its
-     * recallable objects (delegations) have been revoked, so it issues
-     * TEST_STATEID / FREE_STATEID to recover.  Cleared once the client has
-     * freed every revoked delegation. */
-    if (session->client_unified &&
-        atomic_load_explicit(&session->client_unified->revoked_deleg_count,
-                             memory_order_acquire) > 0) {
-        res->sr_resok4.sr_status_flags |= SEQ4_STATUS_RECALLABLE_STATE_REVOKED;
-    }
+    nfs4_sequence_fill_resok(res, session, args);
 
     if (args->sa_cachethis &&
         session->nfs4_session_fore_attrs.ca_maxresponsesize_cached &&

--- a/src/server/nfs/nfs4_procs.h
+++ b/src/server/nfs/nfs4_procs.h
@@ -859,6 +859,23 @@ chimera_nfs4_validate_name(const xdr_opaque *name)
     return NFS4_OK;
 } /* chimera_nfs4_validate_name */
 
+/*
+ * Fill in the result of an operation that will not be dispatched, with the
+ * status it is to fail on.  Zeroes the result, sets its discriminant from the
+ * argument, and releases any WRITE payload the XDR unmarshal cloned -- which
+ * nothing else will, because the op never runs.
+ *
+ * Used by the compound dispatcher for an op refused before dispatch, and by the
+ * SEQUENCE handler to place NFS4ERR_RETRY_UNCACHED_REP on the operation after
+ * SEQUENCE, where RFC 8881 Section 2.10.6.1.3 requires it to go.
+ */
+void
+nfs4_fail_undispatched_op(
+    struct chimera_server_nfs_thread *thread,
+    struct nfs_argop4                *argop,
+    struct nfs_resop4                *resop,
+    nfsstat4                          status);
+
 static inline void
 chimera_nfs4_compound_complete(
     struct nfs_request *req,

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1517,7 +1517,7 @@ nfs4_replay_capture_reply(
     void                    *private_data)
 {
     struct nfs_request      *req     = private_data;
-    struct nfs4_session     *session = req->session;
+    struct nfs4_session     *session = req->replay_session;
     struct nfs4_replay_slot *slot    = req->replay_slot;
     uint8_t                 *buf;
     size_t                   offset = 0;
@@ -1681,6 +1681,7 @@ nfs4_replay_slot_acquire(
                 continue;  /* lost the race; re-read and re-evaluate */
             }
             req->replay_slot        = slot;
+            req->replay_session     = session;
             req->replay_slot_id     = slotid;
             req->replay_action      = NFS4_REPLAY_ACTION_NEW;
             slot->in_progress_since = nfs4_slot_now();
@@ -1719,6 +1720,7 @@ nfs4_replay_slot_acquire(
                     }
                 }
                 req->replay_slot        = slot;
+                req->replay_session     = session;
                 req->replay_slot_id     = slotid;
                 req->replay_action      = NFS4_REPLAY_ACTION_NEW;
                 slot->in_progress_since = nfs4_slot_now();
@@ -1776,6 +1778,7 @@ nfs4_replay_slot_acquire(
                         continue;  /* lost the race; re-read and re-evaluate */
                     }
                     req->replay_slot        = slot;
+                    req->replay_session     = session;
                     req->replay_slot_id     = slotid;
                     req->replay_action      = NFS4_REPLAY_ACTION_FROM_CACHE;
                     *out_is_replay          = true;
@@ -1860,7 +1863,7 @@ nfs4_replay_slot_acquire(
 void
 nfs4_replay_slot_finalize(struct nfs_request *req)
 {
-    struct nfs4_session     *session = req->session;
+    struct nfs4_session     *session = req->replay_session;
     struct nfs4_replay_slot *slot    = req->replay_slot;
     uint64_t                 cur;
 

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1582,6 +1582,58 @@ nfs4_replay_arm_capture(struct nfs_request *req)
     }
 } /* nfs4_replay_arm_capture */
 
+/*
+ * A 64-bit FNV-1a over the identity a request was made under.
+ *
+ * The fields are the ones chimera_nfs4_compound already decodes onto the
+ * request: the auth flavor, the AUTH_SYS uid/gid and machine name, or the
+ * RPCSEC_GSS principal (which arrives in the same machinename slot).  Not the
+ * raw credential bytes -- the AUTH_SYS stamp is free to differ between a call
+ * and its own retransmission, so folding it in would make every retry look
+ * false.
+ */
+static uint64_t
+nfs4_replay_fold(
+    uint64_t    h,
+    const void *data,
+    uint32_t    len)
+{
+    const uint8_t *p = data;
+    uint32_t       i;
+
+    for (i = 0; i < len; i++) {
+        h ^= p[i];
+        h *= 1099511628211ULL;   /* FNV-1a prime */
+    }
+    return h;
+} /* nfs4_replay_fold */
+
+/*
+ * A 64-bit FNV-1a over the identity a request was made under.
+ *
+ * The fields are the ones chimera_nfs4_compound already decodes onto the
+ * request: the auth flavor, the AUTH_SYS uid/gid and machine name, or the
+ * RPCSEC_GSS principal (which arrives in the same machinename slot).  Not the
+ * raw credential bytes -- the AUTH_SYS stamp is free to differ between a call
+ * and its own retransmission, so folding it in would make every retry look
+ * false.
+ */
+uint64_t
+nfs4_replay_principal_digest(const struct nfs_request *req)
+{
+    uint64_t h = 1469598103934665603ULL;   /* FNV-1a offset basis */
+
+    h = nfs4_replay_fold(h, &req->principal_flavor,
+                         sizeof(req->principal_flavor));
+    h = nfs4_replay_fold(h, &req->principal_uid, sizeof(req->principal_uid));
+    h = nfs4_replay_fold(h, &req->principal_gid, sizeof(req->principal_gid));
+    if (req->principal_machinename && req->principal_machinename_len) {
+        h = nfs4_replay_fold(h, req->principal_machinename,
+                             req->principal_machinename_len);
+    }
+    return h;
+} /* nfs4_replay_principal_digest */
+
 nfsstat4
 nfs4_replay_slot_acquire(
     struct nfs4_session *session,
@@ -1633,6 +1685,7 @@ nfs4_replay_slot_acquire(
             req->replay_action      = NFS4_REPLAY_ACTION_NEW;
             slot->in_progress_since = nfs4_slot_now();
             slot->last_stuck_report = 0;
+            slot->principal         = nfs4_replay_principal_digest(req);
             if (cachethis) {
                 nfs4_replay_arm_capture(req);
             }
@@ -1670,10 +1723,39 @@ nfs4_replay_slot_acquire(
                 req->replay_action      = NFS4_REPLAY_ACTION_NEW;
                 slot->in_progress_since = nfs4_slot_now();
                 slot->last_stuck_report = 0;
+                slot->principal         = nfs4_replay_principal_digest(req);
                 if (cachethis) {
                     nfs4_replay_arm_capture(req);
                 }
             } else if (seqid == cseq) {
+                /*
+                 * A retry.  Before anything else, is it the same user?
+                 *
+                 * RFC 8881 Section 2.10.6.1.3.1: a retry that "uses a
+                 * different principal in the RPC request's credential field
+                 * that translates to a different user" is a false retry, and
+                 * "if the replier determines the users are different between
+                 * the original request and a retry, then the replier MUST
+                 * return NFS4ERR_SEQ_FALSE_RETRY".  Answering it from the
+                 * cache instead hands one user another user's reply and
+                 * silently drops the operation the second one asked for.
+                 *
+                 * The MUST is conditioned on the replier DETERMINING that the
+                 * users differ, and there is one slot that cannot: one
+                 * reconstructed from the KV store after a restart
+                 * (nfs4_drc_repopulate_slot), whose principal was never
+                 * persisted and reads as zero.  Erroring there would answer
+                 * the rightful owner NFS4ERR_SEQ_FALSE_RETRY on the first
+                 * retransmit after every failover, which is the case the
+                 * persistence exists to serve.  Persisting the digest with
+                 * the reply would close the gap and is a change to the record
+                 * format.
+                 */
+                if (slot->principal &&
+                    slot->principal != nfs4_replay_principal_digest(req)) {
+                    status = NFS4ERR_SEQ_FALSE_RETRY;
+                    break;
+                }
                 /* Retransmit.  A CACHED slot always has a live cached_buf
                  * (finalize promotes to CACHED only when bytes were captured),
                  * so claim it CACHED -> IN_PROGRESS with the *same* CAS the
@@ -1713,10 +1795,24 @@ nfs4_replay_slot_acquire(
              * (true retry) or not (client jumped ahead), we cannot
              * produce a reply yet.  Both paths return errors. */
             if (seqid == cseq) {
-                status = NFS4ERR_RETRY_UNCACHED_REP;
+                /*
+                 * RFC 8881 Section 2.10.6.2: "A retry might be sent while the
+                 * original request is still in progress on the replier.  The
+                 * replier SHOULD deal with the issue by returning NFS4ERR_DELAY
+                 * as the reply to SEQUENCE or CB_SEQUENCE operation, but
+                 * implementations MAY return NFS4ERR_MISORDERED."
+                 *
+                 * NFS4ERR_RETRY_UNCACHED_REP, which this used to answer, is
+                 * neither -- and Section 2.10.6.1.3 forbids it outright as the
+                 * result of a Sequence operation in the first position, which
+                 * SEQUENCE always is.  It is also what made a wedged slot
+                 * invisible: a client retries RETRY_UNCACHED_REP silently
+                 * forever, where NFS4ERR_DELAY makes it back off and retry the
+                 * way the protocol intends.
+                 */
+                status = NFS4ERR_DELAY;
                 /* A retry landing on a slot that has been IN_PROGRESS for many
-                 * seconds means the original compound is wedged server-side;
-                 * the client will retry RETRY_UNCACHED_REP silently forever
+                 * seconds means the original compound is wedged server-side
                  * (observed as fsstress writeback hanging in CI with 14k
                  * errored WRITE RPCs and nothing in the server log).  Make the
                  * wedge visible, rate-limited per slot. */
@@ -1729,7 +1825,7 @@ nfs4_replay_slot_acquire(
                         slot->last_stuck_report = now;
                         chimera_nfs_error(
                             "nfs4 session slot %u seqid %u stuck IN_PROGRESS "
-                            "for %ld sec; replying RETRY_UNCACHED_REP "
+                            "for %ld sec; replying NFS4ERR_DELAY "
                             "(original compound has not completed)",
                             slotid, seqid,
                             (long) (now - slot->in_progress_since));
@@ -1751,7 +1847,11 @@ nfs4_replay_slot_acquire(
         nfs4_replay_metric_inc(req, replay_field_hit);
     } else if (status == NFS4ERR_SEQ_MISORDERED) {
         nfs4_replay_metric_inc(req, replay_field_seq_misordered);
-    } else if (status == NFS4ERR_RETRY_UNCACHED_REP) {
+    } else if (status == NFS4ERR_RETRY_UNCACHED_REP ||
+               status == NFS4ERR_DELAY ||
+               status == NFS4ERR_SEQ_FALSE_RETRY) {
+        /* One counter for "a retry this slot could not replay", whichever of
+         * the three the reason turned out to be. */
         nfs4_replay_metric_inc(req, replay_field_retry_uncached);
     }
     return status;

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -62,6 +62,15 @@ struct nfs4_replay_slot {
     _Atomic uint64_t state_word;       /* (seqid << NFS4_SLOT_SEQID_SHIFT) | state */
     uint32_t         cached_len;       /* bytes in cached_buf (CACHED only) */
     void            *cached_buf;       /* RPC reply (header+body); malloc'd */
+    /* Who sent the request this slot holds.  RFC 8881 Section 2.10.6.1.3.1: a
+     * retry "that uses a different principal in the RPC request's credential
+     * field that translates to a different user" is a false retry, and "if the
+     * replier determines the users are different between the original request
+     * and a retry, then the replier MUST return NFS4ERR_SEQ_FALSE_RETRY".
+     * Without it, one user's reply answers another's request.  Written by the
+     * thread that owns the slot, under the same IN_PROGRESS exclusion as
+     * cached_buf. */
+    uint64_t         principal;
     /* Diagnostics for a wedged compound: when the slot entered IN_PROGRESS
      * and when a stuck-slot report was last logged for it.  Written only by
      * the CAS winner / the retry path observing it, both monotonic-seconds;
@@ -533,6 +542,13 @@ nfs4_create_session(
  * On NFS4_OK the slot pointer and slot id are stashed on req for the
  * compound dispatcher to consume at finalize time.  cachethis is recorded
  * for the in-flight request and consulted only at finalize. */
+/* A digest of the identity a request was made under, for the comparison
+ * above.  Two credentials that translate to the same user may still digest
+ * differently -- squashing happens later, per export -- which costs a
+ * false-retry error where a replay would have done, and never the reverse. */
+uint64_t nfs4_replay_principal_digest(
+    const struct nfs_request *req);
+
 nfsstat4 nfs4_replay_slot_acquire(
     struct nfs4_session *session,
     uint32_t             slotid,

--- a/src/server/nfs/nfs4_v40_drc.c
+++ b/src/server/nfs/nfs4_v40_drc.c
@@ -448,8 +448,12 @@ nfs4_v40_drc_dispatch(
      * nfs4_v40_drc_compound_cacheable), and the key covers a checksum of the
      * whole request, so a read-only COMPOUND's bytes cannot match a cached
      * mutating one's.  A read-only request therefore always misses and executes
-     * for real. */
-    cksum = nfs3_drc_checksum_iov(iov, niov);
+     * for real.
+     *
+     * The checksum covers the credential as well as the body: a connection is
+     * one client but not necessarily one user, and two users' byte-identical
+     * COMPOUNDs are two requests. */
+    cksum = nfs3_drc_checksum_cred(nfs3_drc_checksum_iov(iov, niov), cred);
 
     if (nfs4_v40_drc_cache_lookup(drc, conn, encoding->xid, cksum,
                                   &cached, &cached_len)) {

--- a/src/server/nfs/nfs4_v40_drc.h
+++ b/src/server/nfs/nfs4_v40_drc.h
@@ -45,7 +45,11 @@ struct COMPOUND4args;
  *     than a stale one, so no generation counter is needed either.
  *
  * The checksum guards against a client reusing an xid on one connection for a
- * genuinely different request: same xid, different bytes reads as a miss.
+ * genuinely different request: same xid, different bytes reads as a miss.  It
+ * covers the caller's credential as well as the request body
+ * (nfs3_drc_checksum_cred): a connection can carry more than one user -- a
+ * container host, or any client multiplexing its users over one mount -- and
+ * two users' byte-identical COMPOUNDs are two requests, not a retransmission.
  *
  * Cross-connection replay is deliberately not attempted.  A 4.0 client that
  * reconnects must re-establish through SETCLIENTID / SETCLIENTID_CONFIRM

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -201,6 +201,11 @@ struct nfs_request {
      * at completion time (nfs4_replay_slot_finalize) and on replay
      * short-circuit. */
     struct nfs4_replay_slot          *replay_slot;
+    /* The session that owns replay_slot.  Distinct from req->session, which
+     * a CREATE_SESSION later in the same compound reassigns to the session
+     * it creates -- the reply capture and slot finalize must keep charging
+     * the slot's owner. */
+    struct nfs4_session              *replay_session;
     uint32_t                          replay_slot_id;
     uint8_t                           replay_action;
     /* Continuation parked while nfs4_root_junction_check resolves the "/"
@@ -518,6 +523,7 @@ nfs_request_alloc(
     req->encoding = encoding;
 
     req->replay_slot    = NULL;
+    req->replay_session = NULL;
     req->replay_slot_id = 0;
     req->replay_action  = NFS4_REPLAY_ACTION_NONE;
 

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -9,12 +9,14 @@ set(CHIMERA_TEST_TIER quick)
 # NFS model-based tests: the Quint specifications and their trace generation
 # live in the chimera-nas/specs repo (submodule ext/specs); this directory owns
 # only the C replay harnesses that drive that corpus against the live chimera
-# server.  Three suites:
+# server.  Four suites:
 #
 #   nfs3_mbt_replay.c     NFSv3           (specs corpus nfs3/)
 #   nfs4_mbt_replay.c     NFSv4.0/4.1/4.2 (specs corpus nfs4/)
 #   nfs_aux_mbt_replay.c  the four protocols around NFSv3 -- portmap/rpcbind,
 #                         MOUNT, NLM and NSM (specs corpus nfsaux/)
+#   nfs_drc_mbt_replay.c  the duplicate-request caches of NFSv3 and NFSv4.0
+#                         (specs corpus nfsdrc/)
 #
 # Each embeds the chimera server (memfs backend) in the test process and replays
 # every trace over libevpl's inproc transport, failing on any divergence.  No
@@ -59,10 +61,22 @@ target_include_directories(nfs_aux_probe PRIVATE
 target_link_libraries(nfs_aux_probe
     chimera_server chimera_nfs_common chimera_metrics jansson)
 
+add_executable(nfs_drc_probe nfs_drc_probe.c)
+target_include_directories(nfs_drc_probe PRIVATE
+    ${CMAKE_BINARY_DIR}/src/nfs_common)
+target_link_libraries(nfs_drc_probe
+    chimera_server chimera_nfs_common chimera_metrics jansson)
+
 add_executable(nfs_aux_mbt_replay nfs_aux_mbt_replay.c)
 target_include_directories(nfs_aux_mbt_replay PRIVATE
     ${CMAKE_BINARY_DIR}/src/nfs_common)
 target_link_libraries(nfs_aux_mbt_replay
+    chimera_server chimera_nfs_common chimera_metrics jansson)
+
+add_executable(nfs_drc_mbt_replay nfs_drc_mbt_replay.c)
+target_include_directories(nfs_drc_mbt_replay PRIVATE
+    ${CMAKE_BINARY_DIR}/src/nfs_common)
+target_link_libraries(nfs_drc_mbt_replay
     chimera_server chimera_nfs_common chimera_metrics jansson)
 
 add_executable(nfs4_mbt_replay nfs4_mbt_replay.c)
@@ -140,6 +154,19 @@ add_test(NAME chimera/server/nfs/mbtaux/probe_memfs
 set_tests_properties(chimera/server/nfs/mbtaux/probe_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_probe_memfs"
     LABELS "quint;nfsaux_mbt;memfs"
+    TIMEOUT 120)
+
+# Duplicate-request-cache ground truth: pins the properties the nfsdrc model
+# turns into a corpus -- that a retransmit replays, that a different XID,
+# procedure, connection or principal does not, what a reconnect does to each of
+# the two caches, and the transport facts the model's constants record (one
+# address for every in-process peer, a new filehandle per incarnation).  Needs
+# no corpus.
+add_test(NAME chimera/server/nfs/mbtdrc/probe_memfs
+    COMMAND $<TARGET_FILE:nfs_drc_probe>)
+set_tests_properties(chimera/server/nfs/mbtdrc/probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_probe_memfs"
+    LABELS "quint;nfsdrc_mbt;memfs"
     TIMEOUT 120)
 
 # Delegation policy probe: pins the deterministic grant/recall behavior the
@@ -244,6 +271,35 @@ add_test(NAME chimera/server/nfs/mbtaux/batch_memfs
 set_tests_properties(chimera/server/nfs/mbtaux/batch_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_batch_memfs"
     LABELS "quint;nfsaux_mbt;memfs"
+    TIMEOUT 600)
+
+# The duplicate-request caches, replayed from the nfsdrc corpus.  Two batches
+# because there are two servers: the NFSv3 cache is off by default and on in the
+# other, and "the switch does nothing" and "the switch works" are
+# indistinguishable without a corpus for each.  The NFSv4.0 cache has no switch
+# and is under test in both.
+#
+# --paranoid is on for the same reason the auxiliary suite has it on.  Comparing
+# replies alone cannot see a cache misbehaving for every operation: a replayed
+# SETATTR and a re-executed one both answer NFS3_OK, and the difference is a
+# size in the directory.  The flag re-reads the working directory after every
+# step and compares it against the model's own.
+add_test(NAME chimera/server/nfs/mbtdrc/batch_memfs
+    COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid
+            --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
+            --exclude-prefix nfsdrcNoV3)
+set_tests_properties(chimera/server/nfs/mbtdrc/batch_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_memfs"
+    LABELS "quint;nfsdrc_mbt;memfs"
+    TIMEOUT 600)
+
+add_test(NAME chimera/server/nfs/mbtdrc/batch_nodrc_memfs
+    COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid --no-nfs3-drc
+            --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
+            --exclude-prefix nfsdrcRef)
+set_tests_properties(chimera/server/nfs/mbtdrc/batch_nodrc_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_nodrc_memfs"
+    LABELS "quint;nfsdrc_mbt;memfs"
     TIMEOUT 600)
 
 # SKIP_RETURN_CODE 77 still applies to NFS4: a trace whose capability profile

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -170,6 +170,10 @@ struct mbt_env_opts {
      * (1s).  A suite that unmounts often wants this short, because the wait
      * is per attempt and the handles are dropped by an asynchronous sweep. */
     int         umount_timeout_ms;
+    /* server.nfs3_drc: the NFSv3 duplicate-request cache.  Off by default in
+     * the server and here; the DRC suite is the only caller that turns it on.
+     * The NFSv4.0 cache needs no flag -- it is always installed. */
+    int         nfs3_drc;
 };
 
 struct mbt_env {
@@ -485,6 +489,9 @@ mbt_env_open_opts(
         if (opts->disable_caches) {
             chimera_server_config_set_attr_cache_enabled(config, 0);
             chimera_server_config_set_name_cache_enabled(config, 0);
+        }
+        if (opts->nfs3_drc) {
+            chimera_server_config_set_nfs3_drc(config, 1);
         }
     }
 

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -3704,7 +3704,9 @@ run_compound(
 
             if (c->status != rep.status || c->nres != rep.nres) {
                 mism_add(m, "SEQUENCE replay: reply differs from the "
-                         "original (reply cache violation)");
+                         "original (reply cache violation): "
+                         "original status %u nres %d, replay status %u nres %d",
+                         c->status, c->nres, rep.status, rep.nres);
             } else {
                 for (n = 0; n < rep.nres; n++) {
                     if (c->op[n].status != rep.res[n].status ||

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_common.h
@@ -1,0 +1,569 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * Harness support for the duplicate-request-cache model tests.
+ *
+ * The NFS3/NFS4 suites ask what a request does.  This one asks what a
+ * *repeated* request does, which needs three things the other harnesses have
+ * no reason to offer:
+ *
+ *   - control of the transaction id.  A retransmit is the same call under the
+ *     same XID; an rpc2 client normally picks its own, monotonically, so
+ *     reproducing a call means saying which XID it carries
+ *     (evpl_rpc2_conn_set_next_xid).
+ *   - more than one connection, and the ability to drop and reopen one.  The
+ *     NFSv3 cache is scoped to a source address and must survive a reconnect;
+ *     the NFSv4.0 cache is scoped to a connection and must not.  Only a trace
+ *     that reconnects can tell those two apart.
+ *   - more than one credential.  Two users behind one address can send
+ *     byte-identical requests, and whether the server tells them apart is the
+ *     difference between a cache and a way to lose one user's mutations.
+ *
+ * Everything else -- the server, the client event loop, the NFSv3 call
+ * wrappers -- is nfs3_mbt_common.h's.  The NFSv3 wrappers there read
+ * env->nfs_conn and env->cred, so a call on a particular connection under a
+ * particular credential is made by swapping both for the duration of the call
+ * (drc_v3_begin / drc_v3_end).  That is deliberately cheaper than duplicating
+ * a thousand lines of wrappers, and the whole client is single-threaded and
+ * issues one RPC at a time, so there is nothing for the swap to race with.
+ */
+
+#include "nfs3_mbt_common.h"
+
+/* Model connections.  Two is what the suite needs; the extra room costs an
+ * unused pointer each. */
+#define DRC_MAX_CONNS   4
+
+/* Filehandles remembered per (name, incarnation).  A trace of a few hundred
+ * steps over three names creates each of them a few dozen times; 512 is well
+ * clear of that and an overflow is a hard error rather than a silent reuse. */
+#define DRC_MAX_HANDLES 512
+
+#define DRC_NAME_MAX    32
+
+/*
+ * The test directory these traces work in, created fresh per trace inside the
+ * export root.  A directory of its own rather than the export root itself so
+ * its mode can be set without touching the root, and so a listing of it is
+ * exactly the model's `dir` with nothing else in it.
+ */
+#define DRC_DIR_NAME    "d"
+
+/* Both credentials are unprivileged, so that neither is the identity an export
+ * might squash the other onto and the two are genuinely different principals.
+ * The directory and everything created in it is 0777, so the two users are
+ * interchangeable as far as permissions go -- which is the point: any
+ * difference in what they observe is the cache's doing, not the DAC's. */
+#define DRC_MODE        0777
+
+struct drc_conn {
+    struct evpl_rpc2_conn *conn;
+    /*
+     * How many times this connection has been reopened.  The model's cache
+     * keys carry the same counter, because a reconnect must not inherit the
+     * previous connection's entries -- and a server that keyed on a handle it
+     * then recycles would do exactly that.
+     */
+    int                    gen;
+};
+
+/* One remembered filehandle, keyed by the identity the model gives the object
+ * it names.  Objects rather than names, because that is what a handle names: a
+ * hard link shares one, a rename carries one, and a name created again after a
+ * removal gets a different one.
+ *
+ * A handle is kept after its object is gone.  That is the point -- a retransmit
+ * carries the bytes it was built with, and answering it from the cache rather
+ * than re-resolving them is exactly what a duplicate-request cache is for. */
+struct drc_handle {
+    int           id;
+    struct mbt_fh fh;
+};
+
+struct drc_ctx {
+    struct mbt_env        *env;
+
+    struct drc_conn        conns[DRC_MAX_CONNS];
+
+    /* Where the per-trace filesystem is mounted (fs_setup exports each
+     * trace's filesystem under its own name), the export root, and the
+     * per-trace working directory under it. */
+    char                   mntpath[80];
+    struct mbt_fh          root_fh;
+    struct mbt_fh          dir_fh;
+
+    struct drc_handle      handles[DRC_MAX_HANDLES];
+    int                    nhandles;
+
+    /* Saved across a drc_v3_begin/end pair. */
+    struct evpl_rpc2_conn *saved_conn;
+    struct evpl_rpc2_cred  saved_cred;
+};
+
+/* ---- credentials --------------------------------------------------------- */
+
+static inline void
+drc_cred_init(
+    struct evpl_rpc2_cred *cred,
+    uint32_t               uid)
+{
+    memset(cred, 0, sizeof(*cred));
+    cred->flavor                  = EVPL_RPC2_AUTH_SYS;
+    cred->authsys.uid             = uid;
+    cred->authsys.gid             = uid;
+    cred->authsys.num_gids        = 0;
+    cred->authsys.gids            = NULL;
+    cred->authsys.machinename     = "quintdrc";
+    cred->authsys.machinename_len = 8;
+} /* drc_cred_init */
+
+/* ---- connections --------------------------------------------------------- */
+
+static inline struct evpl_rpc2_conn *
+drc_conn_open(struct drc_ctx *c)
+{
+    struct evpl_endpoint  *ep;
+    struct evpl_rpc2_conn *conn;
+
+    ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
+                                            "127.0.0.1", 2049);
+    conn = evpl_rpc2_client_connect(c->env->rpc2_thread, EVPL_STREAM_INPROC,
+                                    ep, NULL, 0, NULL);
+    if (!conn) {
+        fprintf(stderr, "drc: failed to open an NFS connection\n");
+        exit(2);
+    }
+    return conn;
+} /* drc_conn_open */
+
+/* The connection for one model connection id, opened on first use. */
+static inline struct evpl_rpc2_conn *
+drc_conn(
+    struct drc_ctx *c,
+    int             id)
+{
+    if (id < 0 || id >= DRC_MAX_CONNS) {
+        fprintf(stderr, "drc: connection id %d out of range\n", id);
+        exit(2);
+    }
+    if (!c->conns[id].conn) {
+        c->conns[id].conn = drc_conn_open(c);
+        c->conns[id].gen  = 1;
+    }
+    return c->conns[id].conn;
+} /* drc_conn */
+
+/* One tick of the drain timer below. */
+struct drc_drain_ctx {
+    struct evpl_timer timer;
+    volatile int      ticks;
+};
+
+#define DRC_DRAIN_TICK_US 1000
+#define DRC_DRAIN_TICKS   20
+
+static void
+drc_drain_tick(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    (void) evpl;
+    ((struct drc_drain_ctx *) timer)->ticks++;
+} /* drc_drain_tick */
+
+/*
+ * Run the client's event loop for a bounded window with nothing outstanding.
+ *
+ * evpl_continue() BLOCKS until something happens, so a bare pump loop with no
+ * traffic in flight waits forever.  A periodic timer gives it something that
+ * always happens, which is what turns "pump a few times" into a bounded wait
+ * rather than a hang.
+ */
+static inline void
+drc_drain(struct drc_ctx *c)
+{
+    struct drc_drain_ctx ctx;
+
+    ctx.ticks = 0;
+    evpl_add_timer(c->env->evpl, &ctx.timer, drc_drain_tick,
+                   DRC_DRAIN_TICK_US);
+    while (ctx.ticks < DRC_DRAIN_TICKS) {
+        evpl_continue(c->env->evpl);
+    }
+    evpl_remove_timer(c->env->evpl, &ctx.timer);
+} /* drc_drain */
+
+/*
+ * Drop a connection and open another in its place.
+ *
+ * The close has to reach the server before the replacement is used, because
+ * what is under test is that the server dropped the old connection's cache --
+ * and the fresh connection may well be handed the memory the old one just
+ * freed, which is precisely the case a server gets wrong.  Nothing in the
+ * client's own event loop reports that the peer has processed a close, so the
+ * loop is drained for a bounded window first; the server is another thread in
+ * this process and an inproc close reaches it immediately, so the window is
+ * generous rather than tight.
+ */
+static inline void
+drc_reconnect(
+    struct drc_ctx *c,
+    int             id)
+{
+    struct evpl_rpc2_conn *old = drc_conn(c, id);
+
+    evpl_rpc2_client_disconnect(c->env->rpc2_thread, old);
+    drc_drain(c);
+
+    c->conns[id].conn = drc_conn_open(c);
+    c->conns[id].gen++;
+} /* drc_reconnect */
+
+static inline void
+drc_conns_close(struct drc_ctx *c)
+{
+    int i;
+
+    for (i = 0; i < DRC_MAX_CONNS; i++) {
+        if (c->conns[i].conn) {
+            evpl_rpc2_client_disconnect(c->env->rpc2_thread, c->conns[i].conn);
+            c->conns[i].conn = NULL;
+        }
+    }
+} /* drc_conns_close */
+
+/* ---- NFSv3 calls on a chosen connection, credential and XID -------------- */
+
+/*
+ * Point the shared NFSv3 wrappers at one connection and credential, and fix
+ * the XID the next call will carry.
+ *
+ * The XID is always set rather than saved and restored: every call this
+ * harness makes takes its XID from the trace, so the connection's own counter
+ * is never read and there is nothing to preserve.  That also keeps the harness
+ * honest -- an XID that appeared by accident rather than by the model's choice
+ * could make a hit or a miss that the model did not predict.
+ */
+static inline void
+drc_v3_begin(
+    struct drc_ctx              *c,
+    int                          conn_id,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid)
+{
+    struct evpl_rpc2_conn *conn = drc_conn(c, conn_id);
+
+    c->saved_conn    = c->env->nfs_conn;
+    c->saved_cred    = c->env->cred;
+    c->env->nfs_conn = conn;
+    c->env->cred     = *cred;
+
+    evpl_rpc2_conn_set_next_xid(conn, xid);
+} /* drc_v3_begin */
+
+static inline void
+drc_v3_end(struct drc_ctx *c)
+{
+    c->env->nfs_conn = c->saved_conn;
+    c->env->cred     = c->saved_cred;
+} /* drc_v3_end */
+
+/* ---- remembered filehandles ---------------------------------------------- */
+
+static inline struct drc_handle *
+drc_handle_find(
+    struct drc_ctx *c,
+    int             id)
+{
+    int i;
+
+    for (i = 0; i < c->nhandles; i++) {
+        if (c->handles[i].id == id) {
+            return &c->handles[i];
+        }
+    }
+    return NULL;
+} /* drc_handle_find */
+
+static inline void
+drc_handle_record(
+    struct drc_ctx      *c,
+    int                  id,
+    const struct mbt_fh *fh)
+{
+    struct drc_handle *h = drc_handle_find(c, id);
+
+    if (!h) {
+        if (c->nhandles >= DRC_MAX_HANDLES) {
+            fprintf(stderr, "drc: filehandle table full (%d)\n",
+                    DRC_MAX_HANDLES);
+            exit(2);
+        }
+        h     = &c->handles[c->nhandles++];
+        h->id = id;
+    }
+    h->fh = *fh;
+} /* drc_handle_record */
+
+static inline void
+drc_handles_reset(struct drc_ctx *c)
+{
+    c->nhandles = 0;
+} /* drc_handles_reset */
+
+/* ---- NFSv4.0 COMPOUNDs --------------------------------------------------- */
+
+/*
+ * The NFSv4 half of this suite stays on the directory handle: every COMPOUND
+ * it sends is PUTFH of the working directory followed by one namespace
+ * operation.  That is enough for every question the v4.0 cache raises -- which
+ * operations are cached, which connection an entry belongs to, when one is
+ * evicted, what a reconnect does -- and none of those turn on which object the
+ * operation names.  Operations that would need a second handle (LINK, SETATTR)
+ * are left to the NFSv3 traces, which already carry them.
+ */
+#define DRC_V4_MAX_OPS 6
+
+struct drc_v4_res {
+    int           done;
+    int           rpc_err;
+    uint32_t      status;                    /* the COMPOUND's status */
+    int           nres;
+    uint32_t      opstatus[DRC_V4_MAX_OPS];  /* per-operation status */
+    uint8_t       resop[DRC_V4_MAX_OPS];     /* which operation each result is */
+    struct mbt_fh fh;                        /* the last GETFH's result */
+
+    /* Session establishment, for the NFSv4.1 checks. */
+    uint64_t      clientid;                  /* EXCHANGE_ID */
+    uint32_t      seqid;                     /* EXCHANGE_ID sequence */
+    uint8_t       sessionid[NFS4_SESSIONID_SIZE];  /* CREATE_SESSION */
+};
+
+struct drc_v4_ctx {
+    struct drc_v4_res *rep;
+};
+
+static void
+drc_v4_cb(
+    struct evpl                 *evpl,
+    const struct evpl_rpc2_verf *verf,
+    struct COMPOUND4res         *reply,
+    int                          status,
+    void                        *private_data)
+{
+    struct drc_v4_ctx *ctx = private_data;
+    uint32_t           i;
+
+    (void) evpl;
+    (void) verf;
+
+    ctx->rep->rpc_err = status;
+    if (status == 0) {
+        ctx->rep->status = reply->status;
+        ctx->rep->nres   = (int) reply->num_resarray;
+        if (ctx->rep->nres > DRC_V4_MAX_OPS) {
+            ctx->rep->nres = DRC_V4_MAX_OPS;
+        }
+        for (i = 0; i < (uint32_t) ctx->rep->nres; i++) {
+            struct nfs_resop4 *r = &reply->resarray[i];
+
+            /* Every result's first field is its status, whatever the arm. */
+            ctx->rep->opstatus[i] = r->opillegal.status;
+            ctx->rep->resop[i]    = (uint8_t) r->resop;
+
+            if (r->resop == OP_GETFH && r->opgetfh.status == NFS4_OK) {
+                mbt_copy_fh(&ctx->rep->fh, &r->opgetfh.resok4.object);
+            }
+            if (r->resop == OP_EXCHANGE_ID &&
+                r->opexchange_id.eir_status == NFS4_OK) {
+                ctx->rep->clientid = r->opexchange_id.eir_resok4.eir_clientid;
+                ctx->rep->seqid    =
+                    r->opexchange_id.eir_resok4.eir_sequenceid;
+            }
+            if (r->resop == OP_CREATE_SESSION &&
+                r->opcreate_session.csr_status == NFS4_OK) {
+                memcpy(ctx->rep->sessionid,
+                       r->opcreate_session.csr_resok4.csr_sessionid,
+                       NFS4_SESSIONID_SIZE);
+            }
+        }
+    }
+    ctx->rep->done = 1;
+} /* drc_v4_cb */
+
+/*
+ * Send one COMPOUND and wait for it.
+ *
+ * The tag is left empty on purpose.  It is part of the request body and so
+ * part of what a cache checksums, and a tag that varied per call -- a step
+ * number, say -- would make every request unique and no retransmit would ever
+ * match.  The model's notion of two requests being identical is exactly
+ * "same operations, same arguments", so the wire form must carry nothing else.
+ */
+static inline void
+drc_v4_call(
+    struct drc_ctx              *c,
+    int                          conn_id,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    struct nfs_argop4           *argarray,
+    int                          nops,
+    uint32_t                     minorversion,
+    struct drc_v4_res           *out)
+{
+    struct evpl_rpc2_conn *conn = drc_conn(c, conn_id);
+    struct COMPOUND4args   args;
+    struct drc_v4_ctx      ctx;
+
+    memset(out, 0, sizeof(*out));
+    ctx.rep = out;
+
+    memset(&args, 0, sizeof(args));
+    args.tag.data     = NULL;
+    args.tag.len      = 0;
+    args.minorversion = minorversion;
+    args.argarray     = argarray;
+    args.num_argarray = (uint32_t) nops;
+
+    evpl_rpc2_conn_set_next_xid(conn, xid);
+
+    c->env->nfs_v4.send_call_NFSPROC4_COMPOUND(&c->env->nfs_v4.rpc2,
+                                               c->env->evpl, conn, cred,
+                                               &args, 0, 0, NULL, 0, 0,
+                                               drc_v4_cb, &ctx);
+
+    while (!out->done) {
+        evpl_continue(c->env->evpl);
+    }
+
+    if (out->rpc_err != 0) {
+        fprintf(stderr, "drc: rpc2 transport error %d on a COMPOUND\n",
+                out->rpc_err);
+        exit(3);
+    }
+} /* drc_v4_call */
+
+static inline void
+drc_v4_putfh(
+    struct nfs_argop4   *a,
+    const struct mbt_fh *fh)
+{
+    a->argop               = OP_PUTFH;
+    a->opputfh.object.data = (void *) fh->data;
+    a->opputfh.object.len  = fh->len;
+} /* drc_v4_putfh */
+
+/* ---- per-trace working directory ----------------------------------------- */
+
+/*
+ * Mount the export, create the working directory inside it, and forget every
+ * filehandle the previous trace remembered.
+ *
+ * The directory is 0777 so both of the model's users can create and remove in
+ * it, and every object created inside it is 0777 for the same reason: any
+ * difference between what the two users observe has to be the cache's doing.
+ */
+static inline void
+drc_trace_setup(struct drc_ctx *c)
+{
+    struct mbt_result *r;
+
+    drc_handles_reset(c);
+
+    r = mbt_mnt(c->env, c->mntpath);
+    if (r->status != MNT3_OK || !r->obj_fh.has) {
+        fprintf(stderr, "drc: MNT %s failed: %u\n", c->mntpath, r->status);
+        exit(2);
+    }
+    c->root_fh = r->obj_fh;
+
+    r = mbt_mkdir(c->env, &c->root_fh, DRC_DIR_NAME,
+                  (uint32_t) strlen(DRC_DIR_NAME), DRC_MODE);
+    if (r->status != NFS3_OK || !r->obj_fh.has) {
+        fprintf(stderr, "drc: MKDIR %s failed: %u\n", DRC_DIR_NAME, r->status);
+        exit(2);
+    }
+    c->dir_fh = r->obj_fh;
+} /* drc_trace_setup */
+
+/* ---- directory snapshot --------------------------------------------------- */
+
+/*
+ * What the working directory holds, as the model describes it: a name, a type
+ * and a size for each entry.
+ *
+ * Read after every step, and the reason the suite can see a cache at all.  A
+ * reply says what the server decided to tell the client; the directory says
+ * what it actually did.  A cache that answers the right status from the wrong
+ * entry, or one that re-executes a request it should have replayed, is
+ * invisible in the first and unmistakable in the second.
+ */
+struct drc_dirent {
+    char     name[DRC_NAME_MAX];
+    uint32_t ftype;
+    uint64_t size;
+};
+
+struct drc_dirsnap {
+    struct drc_dirent ents[64];
+    int               n;
+};
+
+static inline int
+drc_dirent_cmp(
+    const void *a,
+    const void *b)
+{
+    return strcmp(((const struct drc_dirent *) a)->name,
+                  ((const struct drc_dirent *) b)->name);
+} /* drc_dirent_cmp */
+
+static inline void
+drc_dir_snapshot(
+    struct drc_ctx     *c,
+    struct drc_dirsnap *out)
+{
+    struct mbt_result *r;
+    int                i;
+
+    memset(out, 0, sizeof(*out));
+
+    r = mbt_readdirplus(c->env, &c->dir_fh);
+    if (r->status != NFS3_OK) {
+        fprintf(stderr, "drc: READDIRPLUS of the working directory failed: "
+                "%u\n", r->status);
+        exit(2);
+    }
+    if (r->entries_overflow) {
+        fprintf(stderr, "drc: working directory has more entries than the "
+                "snapshot holds\n");
+        exit(2);
+    }
+
+    for (i = 0; i < r->nentries; i++) {
+        struct mbt_entry *e = &r->entries[i];
+
+        if (strcmp(e->name, ".") == 0 || strcmp(e->name, "..") == 0) {
+            continue;
+        }
+        if (out->n >= (int) (sizeof(out->ents) / sizeof(out->ents[0]))) {
+            fprintf(stderr, "drc: too many directory entries\n");
+            exit(2);
+        }
+        /* Names here are the model's own (a few characters); the explicit
+         * precision bounds the copy for gcc's format-truncation checker. */
+        snprintf(out->ents[out->n].name, DRC_NAME_MAX, "%.*s",
+                 DRC_NAME_MAX - 1, e->name);
+        if (e->attrs.has) {
+            out->ents[out->n].ftype = e->attrs.a.type;
+            out->ents[out->n].size  = e->attrs.a.size;
+        }
+        out->n++;
+    }
+
+    qsort(out->ents, (size_t) out->n, sizeof(out->ents[0]), drc_dirent_cmp);
+} /* drc_dir_snapshot */

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
@@ -1,0 +1,956 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Replay a Quint-generated ITF trace of the DUPLICATE-REQUEST CACHES -- the
+ * NFSv3 connectionless one and the NFSv4.0 per-connection one -- against an
+ * in-process chimera server over the libevpl inproc transport.
+ *
+ * Each state of the trace carries a `lastOp` naming one RPC: which connection
+ * carried it, under which transaction id and which credential, what it asked
+ * for, and what the server must answer (see the nfsdrc model in
+ * ext/specs/quint/nfsdrc).  Replaying it needs one thing the other suites do
+ * not: the XID is dictated by the trace rather than chosen by the client, so
+ * that a retransmit is a retransmit and not merely a similar request.
+ *
+ * What is checked, per step:
+ *
+ *   status    what the server answered.  For most of the operations here a
+ *             replay and a re-execution differ in exactly this -- a replayed
+ *             MKDIR is NFS3_OK where a re-executed one is NFS3ERR_EXIST.
+ *   identity  when the model says the reply came from the cache, it names the
+ *             execution that produced it, and the reply must be THAT one --
+ *             the same filehandle, not merely the same status.  A cache that
+ *             answered from the wrong entry passes a status comparison and
+ *             hands the client another request's object.
+ *   the tree  under --paranoid, the working directory after every step.  This
+ *             is what makes a cache visible at all for the operations whose
+ *             status does not distinguish a replay: a SETATTR replayed leaves
+ *             the size alone, and a SETATTR re-executed puts it back.
+ *
+ * ISOLATION.  The NFSv3 cache is keyed by client address and nothing evicts it
+ * on a timescale a test can wait for, so its entries outlive the filesystem a
+ * trace runs on and would be visible to the next trace.  Two measures make a
+ * trace independent of its predecessors; trace_setup() carries the details.
+ */
+
+#include <getopt.h>
+#include <jansson.h>
+
+#include "nfs_drc_mbt_common.h"
+#include "common/mbt_trace_dir.h"
+
+#define DRC_MAX_MISM         16
+#define DRC_MISM_LEN         512
+#define DRC_HISTORY          10
+
+/* One entry per execution the model counts.  A trace is a few hundred steps
+* and not every step executes, so this is comfortably clear of the bound. */
+#define DRC_MAX_TAGS         2048
+
+/* XIDs the harness issues on its own account, for the LOOKUPs that learn a
+ * filehandle.  Far above anything the model's XID set contains, so a
+ * housekeeping call can never collide with a modeled one -- and LOOKUP is
+ * idempotent, so the NFSv3 cache returns before it would even look. */
+#define DRC_HOUSEKEEPING_XID 0x7f000000u
+
+struct mism {
+    int  n;
+    char msg[DRC_MAX_MISM][DRC_MISM_LEN];
+};
+
+static void
+mism_add(
+    struct mism *m,
+    const char  *fmt,
+    ...)
+{
+    va_list ap;
+
+    if (m->n >= DRC_MAX_MISM) {
+        return;
+    }
+    va_start(ap, fmt);
+    vsnprintf(m->msg[m->n], DRC_MISM_LEN, fmt, ap);
+    va_end(ap);
+    m->n++;
+} /* mism_add */
+
+/* What one execution returned, so a replay of it can be checked to be that
+ * reply rather than one that merely agrees on the status. */
+struct tag_reply {
+    int           used;
+    uint32_t      st;
+    struct mbt_fh fh;    /* the created object, where the reply carries one */
+};
+
+struct hist_ent {
+    int   idx;
+    char  tag[32];
+    char *dump;
+};
+
+struct oracle {
+    struct mbt_env  *env;
+    struct drc_ctx   c;
+    int              trace_seq;
+    int              verbose;
+
+    struct tag_reply tags[DRC_MAX_TAGS];
+
+    struct hist_ent  history[DRC_HISTORY];
+    int              nhist;
+};
+
+/*
+ * There is deliberately no known-deviation registry here.
+ *
+ * The NFSv3 suite keeps one because its model asserts RFC-correct replies over
+ * ground chimera diverges on.  This model has no such ground: the one place it
+ * could have had is a FRESH request on a filehandle whose object is gone, and
+ * the traces never ask.  Not because the answer is wrong -- it is
+ * NFS3ERR_STALE, as RFC 1813 Section 3.3 requires -- but because a handle the
+ * server has recently resolved is pinned by its own handle cache and keeps
+ * resolving for a window afterwards, exactly as an unlinked-but-open inode does
+ * on Linux.  Which of the two a live server gives depends on its cache state,
+ * so a corpus that walked into it would be flaky for a reason unrelated to a
+ * reply cache.  The step relation keeps out of it (see actFhLive in the model)
+ * and nfs_drc_probe.c pins both answers directly, where they are
+ * deterministic.
+ */
+
+/* ---- ITF decoding helpers (jansson) -------------------------------------- */
+
+static int64_t
+itf_i64(json_t *v)
+{
+    json_t *big;
+
+    if (json_is_integer(v)) {
+        return json_integer_value(v);
+    }
+    if (json_is_object(v)) {
+        big = json_object_get(v, "#bigint");
+        if (big && json_is_string(big)) {
+            return strtoll(json_string_value(big), NULL, 10);
+        }
+    }
+    return 0;
+} /* itf_i64 */
+
+static int64_t
+op_i64(
+    json_t     *op,
+    const char *key)
+{
+    return itf_i64(json_object_get(op, key));
+} /* op_i64 */
+
+static const char *
+op_str(
+    json_t     *op,
+    const char *key)
+{
+    json_t *v = json_object_get(op, key);
+
+    return (v && json_is_string(v)) ? json_string_value(v) : "";
+} /* op_str */
+
+static int
+op_bool(
+    json_t     *op,
+    const char *key)
+{
+    json_t *v = json_object_get(op, key);
+
+    return v && json_is_true(v);
+} /* op_bool */
+
+static const char *
+jf_tag(json_t *v)
+{
+    json_t *t = v ? json_object_get(v, "tag") : NULL;
+
+    return (t && json_is_string(t)) ? json_string_value(t) : "";
+} /* jf_tag */
+
+static json_t *
+jf_val(json_t *v)
+{
+    return v ? json_object_get(v, "value") : NULL;
+} /* jf_val */
+
+/* A Quint map, which ITF spells as {"#map": [[k, v], ...]}. */
+static json_t *
+itf_map(json_t *v)
+{
+    json_t *inner = v ? json_object_get(v, "#map") : NULL;
+
+    return (inner && json_is_array(inner)) ? inner : NULL;
+} /* itf_map */
+
+static json_t *
+state_var(
+    json_t     *state,
+    const char *name)
+{
+    const char *key;
+    json_t     *val;
+    size_t      n = strlen(name);
+
+    json_object_foreach(state, key, val)
+    {
+        size_t klen = strlen(key);
+
+        if (klen >= n && strcmp(key + klen - n, name) == 0 &&
+            (klen == n || key[klen - n - 1] == ':')) {
+            return val;
+        }
+    }
+    return NULL;
+} /* state_var */
+
+/* ---- issuing one modeled request ----------------------------------------- */
+
+/* The handle the model's object id names, or NULL if the harness never learned
+ * one (which would be a harness bug, not a divergence). */
+static const struct mbt_fh *
+handle_for(
+    struct oracle *o,
+    int            id,
+    struct mism   *m)
+{
+    struct drc_handle *h;
+
+    if (id == 0) {
+        return &o->c.dir_fh;   /* the working directory itself */
+    }
+    h = drc_handle_find(&o->c, id);
+    if (!h) {
+        mism_add(m, "no filehandle learned for object %d", id);
+        return NULL;
+    }
+    return &h->fh;
+} /* handle_for */
+
+/* One NFSv3 request, as the model describes it.  Returns the reply; the
+ * filehandle it carries (when it carries one) is left in *out_fh. */
+static uint32_t
+issue_v3(
+    struct oracle *o,
+    int            conn,
+    uint32_t       xid,
+    uint32_t       uid,
+    json_t        *act,
+    struct mbt_fh *out_fh,
+    struct mism   *m)
+{
+    struct evpl_rpc2_cred cred;
+    struct mbt_result    *r;
+    const char           *tag = jf_tag(act);
+    json_t               *v   = jf_val(act);
+    const struct mbt_fh  *fh;
+    uint32_t              st;
+
+    drc_cred_init(&cred, uid);
+    drc_v3_begin(&o->c, conn, &cred, xid);
+
+    if (strcmp(tag, "ACreate") == 0) {
+        const char *name  = op_str(v, "name");
+        int64_t     ftype = op_i64(v, "ftype");
+
+        if (ftype == 2) {
+            r = mbt_mkdir(o->env, &o->c.dir_fh, name,
+                          (uint32_t) strlen(name), DRC_MODE);
+        } else if (ftype == 5) {
+            r = mbt_symlink(o->env, &o->c.dir_fh, name,
+                            (uint32_t) strlen(name), "t", DRC_MODE);
+        } else {
+            r = mbt_create(o->env, &o->c.dir_fh, name,
+                           (uint32_t) strlen(name), GUARDED, DRC_MODE, NULL);
+        }
+    } else if (strcmp(tag, "ARemove") == 0) {
+        const char *name = op_str(v, "name");
+
+        if (op_bool(v, "asDir")) {
+            r = mbt_rmdir(o->env, &o->c.dir_fh, name, (uint32_t) strlen(name));
+        } else {
+            r = mbt_remove(o->env, &o->c.dir_fh, name, (uint32_t) strlen(name));
+        }
+    } else if (strcmp(tag, "ARename") == 0) {
+        const char *from = op_str(v, "from");
+        const char *to   = op_str(v, "to");
+
+        r = mbt_rename(o->env, &o->c.dir_fh, from, (uint32_t) strlen(from),
+                       &o->c.dir_fh, to, (uint32_t) strlen(to));
+    } else if (strcmp(tag, "ALink") == 0) {
+        const char *to = op_str(v, "to");
+
+        fh = handle_for(o, (int) op_i64(v, "src"), m);
+        if (!fh) {
+            drc_v3_end(&o->c);
+            return 0;
+        }
+        r = mbt_link(o->env, fh, &o->c.dir_fh, to, (uint32_t) strlen(to));
+    } else if (strcmp(tag, "ASetsize") == 0) {
+        fh = handle_for(o, (int) op_i64(v, "fh"), m);
+        if (!fh) {
+            drc_v3_end(&o->c);
+            return 0;
+        }
+        r = mbt_setattr(o->env, fh, -1, op_i64(v, "size"), NULL);
+    } else if (strcmp(tag, "ALookup") == 0) {
+        const char *name = op_str(v, "name");
+
+        r = mbt_lookup(o->env, &o->c.dir_fh, name, (uint32_t) strlen(name));
+    } else if (strcmp(tag, "AGetattr") == 0) {
+        fh = handle_for(o, (int) op_i64(v, "fh"), m);
+        if (!fh) {
+            drc_v3_end(&o->c);
+            return 0;
+        }
+        r = mbt_getattr(o->env, fh);
+    } else {
+        drc_v3_end(&o->c);
+        mism_add(m, "no NFSv3 encoding for action %s", tag);
+        return 0;
+    }
+
+    st = r->status;
+    if (out_fh) {
+        *out_fh = r->obj_fh;
+    }
+    drc_v3_end(&o->c);
+    return st;
+} /* issue_v3 */
+
+/* One NFSv4.0 COMPOUND.  Every one is PUTFH of the working directory followed
+ * by a single namespace operation; see nfs_drc_mbt_common.h for why. */
+static uint32_t
+issue_v4(
+    struct oracle *o,
+    int            conn,
+    uint32_t       xid,
+    uint32_t       uid,
+    json_t        *act,
+    struct mism   *m)
+{
+    struct evpl_rpc2_cred cred;
+    struct nfs_argop4     a[4];
+    struct drc_v4_res     res;
+    const char           *tag       = jf_tag(act);
+    json_t               *v         = jf_val(act);
+    uint32_t              bitmap[2] = { 0, 1U << (FATTR4_MODE - 32) };
+    uint8_t               blob[4];
+    int                   nops;
+
+    /* mode 0777, big-endian, as an NFSv4 attribute value. */
+    blob[0] = 0;
+    blob[1] = 0;
+    blob[2] = (uint8_t) ((DRC_MODE >> 8) & 0xff);
+    blob[3] = (uint8_t) (DRC_MODE & 0xff);
+
+    memset(a, 0, sizeof(a));
+    drc_v4_putfh(&a[0], &o->c.dir_fh);
+
+    if (strcmp(tag, "ACreate") == 0) {
+        const char *name  = op_str(v, "name");
+        int64_t     ftype = op_i64(v, "ftype");
+
+        a[1].argop                 = OP_CREATE;
+        a[1].opcreate.objname.data = (void *) name;
+        a[1].opcreate.objname.len  = (uint32_t) strlen(name);
+        if (ftype == 5) {
+            a[1].opcreate.objtype.type          = NF4LNK;
+            a[1].opcreate.objtype.linkdata.data = (void *) "t";
+            a[1].opcreate.objtype.linkdata.len  = 1;
+        } else if (ftype == 2) {
+            a[1].opcreate.objtype.type = NF4DIR;
+        } else {
+            /* The model's NFSv4 traces never ask for one: CREATE makes
+             * non-regular objects only (RFC 7530 Section 16.4). */
+            mism_add(m, "NFSv4 CREATE cannot make ftype %d", (int) ftype);
+            return 0;
+        }
+        a[1].opcreate.createattrs.num_attrmask   = 2;
+        a[1].opcreate.createattrs.attrmask       = bitmap;
+        a[1].opcreate.createattrs.attr_vals.data = blob;
+        a[1].opcreate.createattrs.attr_vals.len  = 4;
+        nops                                     = 2;
+    } else if (strcmp(tag, "ARemove") == 0) {
+        const char *name = op_str(v, "name");
+
+        a[1].argop                = OP_REMOVE;
+        a[1].opremove.target.data = (void *) name;
+        a[1].opremove.target.len  = (uint32_t) strlen(name);
+        nops                      = 2;
+    } else if (strcmp(tag, "ARename") == 0) {
+        const char *from = op_str(v, "from");
+        const char *to   = op_str(v, "to");
+
+        a[1].argop = OP_SAVEFH;
+        drc_v4_putfh(&a[2], &o->c.dir_fh);
+        a[3].argop                 = OP_RENAME;
+        a[3].oprename.oldname.data = (void *) from;
+        a[3].oprename.oldname.len  = (uint32_t) strlen(from);
+        a[3].oprename.newname.data = (void *) to;
+        a[3].oprename.newname.len  = (uint32_t) strlen(to);
+        nops                       = 4;
+    } else if (strcmp(tag, "ALookup") == 0) {
+        const char *name = op_str(v, "name");
+
+        a[1].argop                 = OP_LOOKUP;
+        a[1].oplookup.objname.data = (void *) name;
+        a[1].oplookup.objname.len  = (uint32_t) strlen(name);
+        nops                       = 2;
+    } else {
+        mism_add(m, "no NFSv4 encoding for action %s", tag);
+        return 0;
+    }
+
+    drc_cred_init(&cred, uid);
+    drc_v4_call(&o->c, conn, &cred, xid, a, nops, 0, &res);
+    return res.status;
+} /* issue_v4 */
+
+/* ---- learning filehandles ------------------------------------------------ */
+
+/*
+ * Make sure the harness holds a handle for every object the model's directory
+ * currently names.
+ *
+ * A handle is learned once, when its object first appears, and kept
+ * afterwards -- including after the object is gone, which is the state a
+ * retransmit carrying it will be in.  An NFSv3 CREATE hands the handle back in
+ * its reply, so the common case costs nothing; anything else (an object a
+ * COMPOUND created) is looked up by name the moment it appears.
+ *
+ * The LOOKUP rides an XID far outside the model's, and LOOKUP is idempotent so
+ * the NFSv3 cache returns before it would consult an entry.  It therefore
+ * cannot make or match a cache entry, and the trace is unaffected by it.
+ */
+static void
+learn_handles(
+    struct oracle *o,
+    json_t        *state,
+    struct mism   *m)
+{
+    struct evpl_rpc2_cred cred;
+    json_t               *entries = itf_map(state_var(state, "dir"));
+    size_t                i;
+
+    if (!entries) {
+        return;
+    }
+
+    drc_cred_init(&cred, 1000);
+
+    for (i = 0; i < json_array_size(entries); i++) {
+        json_t     *pair = json_array_get(entries, i);
+        const char *name;
+        json_t     *obj;
+        int         id;
+
+        if (!json_is_array(pair) || json_array_size(pair) != 2) {
+            continue;
+        }
+        name = json_string_value(json_array_get(pair, 0));
+        obj  = json_array_get(pair, 1);
+        if (!name || !obj) {
+            continue;
+        }
+        id = (int) op_i64(obj, "id");
+        if (drc_handle_find(&o->c, id)) {
+            continue;
+        }
+
+        drc_v3_begin(&o->c, 1, &cred, DRC_HOUSEKEEPING_XID);
+        {
+            struct mbt_result *r = mbt_lookup(o->env, &o->c.dir_fh, name,
+                                              (uint32_t) strlen(name));
+
+            if (r->status == NFS3_OK && r->obj_fh.has) {
+                drc_handle_record(&o->c, id, &r->obj_fh);
+            } else {
+                mism_add(m, "cannot learn a handle for %s (object %d): "
+                         "LOOKUP answered %u", name, id, r->status);
+            }
+        }
+        drc_v3_end(&o->c);
+    }
+} /* learn_handles */
+
+/* ---- checking ------------------------------------------------------------ */
+
+/*
+ * The working directory, against what the model says it holds.
+ *
+ * The reply comparison alone cannot see a cache doing the wrong thing for
+ * every operation.  A replayed SETATTR and a re-executed one both answer
+ * NFS3_OK; the difference is a size, and it is only visible here.  A cache that
+ * answered a MKDIR from another MKDIR's entry likewise agrees on the status and
+ * differs in what is on disk.
+ */
+static void
+check_tree(
+    struct oracle *o,
+    json_t        *state,
+    struct mism   *m)
+{
+    struct drc_dirsnap snap;
+    json_t            *entries = itf_map(state_var(state, "dir"));
+    size_t             want    = entries ? json_array_size(entries) : 0;
+    size_t             i;
+
+    drc_dir_snapshot(&o->c, &snap);
+
+    if ((size_t) snap.n != want) {
+        mism_add(m, "directory holds %d entries, model says %zu",
+                 snap.n, want);
+        return;
+    }
+
+    for (i = 0; i < want; i++) {
+        json_t     *pair = json_array_get(entries, i);
+        const char *name = json_string_value(json_array_get(pair, 0));
+        json_t     *obj  = json_array_get(pair, 1);
+        uint32_t    ftype;
+        uint64_t    size;
+        int         j, found = 0;
+
+        if (!name || !obj) {
+            continue;
+        }
+        ftype = (uint32_t) op_i64(obj, "ftype");
+        size  = (uint64_t) op_i64(obj, "size");
+
+        for (j = 0; j < snap.n; j++) {
+            if (strcmp(snap.ents[j].name, name) != 0) {
+                continue;
+            }
+            found = 1;
+            if (snap.ents[j].ftype != ftype) {
+                mism_add(m, "%s is type %u, model says %u", name,
+                         snap.ents[j].ftype, ftype);
+            }
+            /* Only regular files carry a size the model tracks; a directory's
+             * is the backend's business and a symlink's is its target's
+             * length. */
+            if (ftype == 1 && snap.ents[j].size != size) {
+                mism_add(m, "%s is %llu bytes, model says %llu", name,
+                         (unsigned long long) snap.ents[j].size,
+                         (unsigned long long) size);
+            }
+            break;
+        }
+        if (!found) {
+            mism_add(m, "%s is missing; the model has it", name);
+        }
+    }
+} /* check_tree */
+
+/*
+ * One step's reply.
+ *
+ * A replay is held to more than its status: the model names the execution whose
+ * reply it must be, and where that reply carried a filehandle the replayed one
+ * has to carry the same bytes.  That is what separates "a cache answered" from
+ * "a cache answered from the right entry" -- the two agree on every status a
+ * status comparison can see.
+ */
+static void
+check_reply(
+    struct oracle *o,
+    json_t        *op,
+    uint32_t       got,
+    struct mbt_fh *got_fh,
+    struct mism   *m)
+{
+    uint32_t want     = (uint32_t) op_i64(op, "st");
+    int64_t  tag      = op_i64(op, "tag");
+    int      replayed = strcmp(jf_tag(json_object_get(op, "served")),
+                               "SReplayed") == 0;
+
+    if (tag < 0 || tag >= DRC_MAX_TAGS) {
+        mism_add(m, "reply tag %lld out of range", (long long) tag);
+        return;
+    }
+
+    if (got != want) {
+        mism_add(m, "status %u, model says %u", got, want);
+        return;
+    }
+
+    if (replayed) {
+        struct tag_reply *t = &o->tags[tag];
+
+        if (!t->used) {
+            mism_add(m, "model replays execution %lld, which never ran",
+                     (long long) tag);
+            return;
+        }
+        if (t->fh.has && got_fh && got_fh->has &&
+            !mbt_fh_eq(&t->fh, got_fh)) {
+            mism_add(m, "replay carries a different filehandle from the "
+                     "execution (%lld) the model says it came from",
+                     (long long) tag);
+        }
+        if (t->fh.has && got_fh && !got_fh->has) {
+            mism_add(m, "replay carries no filehandle; execution %lld did",
+                     (long long) tag);
+        }
+    } else {
+        struct tag_reply *t = &o->tags[tag];
+
+        t->used = 1;
+        t->st   = got;
+        if (got_fh) {
+            t->fh = *got_fh;
+        }
+    }
+} /* check_reply */
+
+/* ---- per-trace setup and teardown ---------------------------------------- */
+
+/*
+ * Make a trace independent of the ones before it.
+ *
+ * The NFSv3 cache is the reason this needs saying.  It is keyed by client
+ * address, its entries have no lifetime a test can wait out, and it is shared
+ * by every connection in the process -- so an entry one trace left behind is
+ * visible to the next, and a step that should miss would hit.  Two things
+ * separate them:
+ *
+ *   - every trace gets its own XID band.  The model's XIDs are small integers,
+ *     so trace N offsets them by N << 16: no two traces can present the same
+ *     {address, procedure, XID} triple, whatever their arguments.
+ *   - every trace gets fresh connections.  The NFSv4.0 cache is keyed by
+ *     connection, so closing them is all its isolation needs, and starting each
+ *     trace with the connection generations at a known point is what makes the
+ *     model's reconnect counting line up.
+ *
+ * The filesystem is fresh per trace already (mbt_env_fs_setup), which is what
+ * makes the directory comparison meaningful.
+ */
+static uint32_t
+trace_xid(
+    struct oracle *o,
+    int64_t        model_xid)
+{
+    return (uint32_t) ((o->trace_seq + 1) << 16) + (uint32_t) model_xid;
+} /* trace_xid */
+
+static int
+trace_setup(struct oracle *o)
+{
+    drc_conns_close(&o->c);
+    memset(o->c.conns, 0, sizeof(o->c.conns));
+    memset(o->tags, 0, sizeof(o->tags));
+
+    drc_trace_setup(&o->c);
+    return 0;
+} /* trace_setup */
+
+static void
+trace_teardown(struct oracle *o)
+{
+    drc_conns_close(&o->c);
+} /* trace_teardown */
+
+/* ---- divergence reporting ------------------------------------------------ */
+
+static void
+history_push(
+    struct oracle *o,
+    int            idx,
+    const char    *tag,
+    json_t        *op)
+{
+    struct hist_ent *h;
+
+    if (o->nhist == DRC_HISTORY) {
+        free(o->history[0].dump);
+        memmove(&o->history[0], &o->history[1],
+                sizeof(o->history[0]) * (DRC_HISTORY - 1));
+        o->nhist--;
+    }
+    h      = &o->history[o->nhist++];
+    h->idx = idx;
+    snprintf(h->tag, sizeof(h->tag), "%s", tag);
+    h->dump = op ? json_dumps(op, JSON_COMPACT | JSON_SORT_KEYS) : NULL;
+} /* history_push */
+
+static void
+report_divergence(
+    const char    *path,
+    struct oracle *o,
+    int            idx,
+    const char    *tag,
+    json_t        *op,
+    struct mism   *m)
+{
+    char *dump = op ? json_dumps(op, JSON_INDENT(2) | JSON_SORT_KEYS) : NULL;
+    int   i;
+
+    fprintf(stderr, "\nDIVERGENCE at %s step %d (%s)\n", path, idx, tag);
+    for (i = 0; i < m->n; i++) {
+        fprintf(stderr, "  - %s\n", m->msg[i]);
+    }
+    if (dump) {
+        fprintf(stderr, "\nstep:\n%s\n", dump);
+        free(dump);
+    }
+    fprintf(stderr, "\nlast steps before the failure:\n");
+    for (i = 0; i < o->nhist; i++) {
+        fprintf(stderr, "  [%4d] %-12s %s\n", o->history[i].idx,
+                o->history[i].tag,
+                o->history[i].dump ? o->history[i].dump : "");
+    }
+} /* report_divergence */
+
+/* ---- the trace loop ------------------------------------------------------- */
+
+static int paranoid;
+
+static int
+run_trace(
+    struct mbt_env *env,
+    const char     *trace_path,
+    const char     *fsname,
+    int             trace_seq,
+    int             verbose,
+    int             dry_run)
+{
+    json_error_t   jerr;
+    json_t        *root, *states, *state, *last_op, *op;
+    const char    *tag;
+    struct oracle *o;
+    size_t         idx, nstates;
+    int            failed = 0;
+    struct mism    m;
+
+    root = json_load_file(trace_path, 0, &jerr);
+    if (!root) {
+        fprintf(stderr, "%s: JSON parse error: %s (line %d)\n", trace_path,
+                jerr.text, jerr.line);
+        return 1;
+    }
+    states = json_object_get(root, "states");
+    if (!states || !json_is_array(states) || !json_object_get(root, "vars")) {
+        fprintf(stderr, "%s: not an ITF trace\n", trace_path);
+        json_decref(root);
+        return 1;
+    }
+    nstates = json_array_size(states);
+
+    if (dry_run) {
+        printf("%s: %zu steps, format OK\n", trace_path, nstates - 1);
+        json_decref(root);
+        return 0;
+    }
+
+    /* Backstop for a server deadlock: with everything in one process a hung
+     * reply spins in the pump forever; SIGALRM's default disposition kills the
+     * test with a nonzero status. */
+    alarm(180);
+
+    o = calloc(1, sizeof(*o));
+    mbt_env_fs_setup(env, fsname);
+
+    o->env   = env;
+    o->c.env = env;
+    snprintf(o->c.mntpath, sizeof(o->c.mntpath), "/%s", fsname);
+    o->verbose   = verbose;
+    o->trace_seq = trace_seq;
+
+    if (trace_setup(o)) {
+        failed = 1;
+        goto out;
+    }
+
+    for (idx = 1; idx < nstates; idx++) {
+        struct mbt_fh got_fh;
+        uint32_t      got;
+
+        state   = json_array_get(states, idx);
+        last_op = state_var(state, "lastOp");
+        if (!last_op) {
+            fprintf(stderr, "%s: state %zu has no lastOp\n", trace_path, idx);
+            failed = 1;
+            goto out;
+        }
+        tag = jf_tag(last_op);
+        op  = jf_val(last_op);
+
+        memset(&m, 0, sizeof(m));
+        memset(&got_fh, 0, sizeof(got_fh));
+
+        if (strcmp(tag, "OV3") == 0) {
+            got = issue_v3(o, (int) op_i64(op, "conn"),
+                           trace_xid(o, op_i64(op, "xid")),
+                           (uint32_t) op_i64(op, "cred"),
+                           json_object_get(op, "act"), &got_fh, &m);
+            if (!m.n) {
+                check_reply(o, op, got, &got_fh, &m);
+            }
+        } else if (strcmp(tag, "OV4") == 0) {
+            got = issue_v4(o, (int) op_i64(op, "conn"),
+                           trace_xid(o, op_i64(op, "xid")),
+                           (uint32_t) op_i64(op, "cred"),
+                           json_object_get(op, "act"), &m);
+            if (!m.n) {
+                check_reply(o, op, got, NULL, &m);
+            }
+        } else if (strcmp(tag, "OReconnect") == 0) {
+            drc_reconnect(&o->c, (int) op_i64(op, "conn"));
+        } else if (strcmp(tag, "ONull") == 0) {
+            struct evpl_rpc2_cred cred;
+
+            drc_cred_init(&cred, 1000);
+            drc_v3_begin(&o->c, (int) op_i64(op, "conn"), &cred,
+                         DRC_HOUSEKEEPING_XID);
+            mbt_null(o->env);
+            drc_v3_end(&o->c);
+        } else {
+            fprintf(stderr, "%s: step %zu: no handler for %s\n", trace_path,
+                    idx, tag);
+            failed = 1;
+            goto out;
+        }
+
+        if (!m.n) {
+            learn_handles(o, state, &m);
+        }
+        if (!m.n && paranoid) {
+            check_tree(o, state, &m);
+        }
+
+        history_push(o, (int) idx, tag, op);
+        if (verbose) {
+            printf("  [%4zu] %s\n", idx, tag);
+        }
+        if (m.n) {
+            report_divergence(trace_path, o, (int) idx, tag, op, &m);
+            failed = 1;
+            goto out;
+        }
+    }
+
+    printf("%s: %zu steps replayed\n", trace_path, nstates - 1);
+
+ out:
+    trace_teardown(o);
+    mbt_env_fs_teardown(env, fsname);
+    while (o->nhist) {
+        free(o->history[--o->nhist].dump);
+    }
+    free(o);
+    json_decref(root);
+    alarm(0);
+    return failed;
+} /* run_trace */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    /* *INDENT-OFF* */
+    /* uncrustify 0.78.1 does not converge on this aligned initializer: each
+     * pass pushes the last column further right than the one before.  Pin a
+     * stable manual alignment. */
+    static struct option long_options[] = {
+        { "trace",          required_argument, 0, 't' },
+        { "trace-dir",      required_argument, 0, 'D' },
+        { "exclude-prefix", required_argument, 0, 'X' },
+        { "dry-run",        no_argument,       0, 'n' },
+        { "verbose",        no_argument,       0, 'v' },
+        { "paranoid",       no_argument,       0, 'p' },
+        { "no-nfs3-drc",    no_argument,       0, 'N' },
+        { "backend",        required_argument, 0, 'B' },
+        { 0,                0,                 0, 0   },
+    };
+    /* *INDENT-ON* */
+    char              **traces;
+    int                 ntraces  = 0;
+    int                 dry_run  = 0;
+    int                 verbose  = 0;
+    int                 nfs3_drc = 1;
+    const char         *backend  = "memfs";
+    int                 failures = 0;
+    int                 c, i;
+    struct mbt_env      env;
+    struct mbt_env_opts opts;
+
+    umask(0);
+
+    traces = mbt_collect_traces(argc, argv, &ntraces);
+
+    while ((c = getopt_long(argc, argv, "t:D:X:nvpNB:", long_options,
+                            NULL)) != -1) {
+        switch (c) {
+            case 't':
+            case 'D':
+            case 'X':
+                break;   /* handled by mbt_collect_traces */
+            case 'n':
+                dry_run = 1;
+                break;
+            case 'v':
+                verbose = 1;
+                break;
+            case 'p':
+                paranoid = 1;
+                break;
+            case 'N':
+                nfs3_drc = 0;
+                break;
+            case 'B':
+                backend = optarg;
+                break;
+            default:
+                fprintf(stderr,
+                        "usage: %s [--trace FILE ...] [--trace-dir DIR] "
+                        "[--backend memfs|diskfs|cairn] [--no-nfs3-drc] "
+                        "[--dry-run] [--verbose] [--paranoid]\n", argv[0]);
+                mbt_free_traces(traces, ntraces);
+                return 2;
+        } /* switch */
+    }
+
+    if (ntraces == 0) {
+        fprintf(stderr, "%s: at least one --trace or --trace-dir is required\n",
+                argv[0]);
+        mbt_free_traces(traces, ntraces);
+        return 2;
+    }
+
+    if (!dry_run) {
+        memset(&opts, 0, sizeof(opts));
+        opts.module = backend;
+        /* The corpus generated from the nfsdrcNoV3 profile is replayed with the
+         * NFSv3 cache off, which is the server's own default; everything else
+         * needs it on.  The NFSv4.0 cache has no switch. */
+        opts.nfs3_drc = nfs3_drc;
+        /* Exact comparison of the directory after every step cannot tolerate a
+         * stale attribute cache. */
+        opts.disable_caches = 1;
+        mbt_env_open_opts(&env, &opts);
+    }
+
+    for (i = 0; i < ntraces; i++) {
+        char fsname[32];
+
+        snprintf(fsname, sizeof(fsname), "fs_%d", i);
+        failures += run_trace(dry_run ? NULL : &env, traces[i], fsname, i,
+                              verbose, dry_run);
+    }
+
+    if (!dry_run) {
+        mbt_env_stop(&env);
+    }
+
+    mbt_free_traces(traces, ntraces);
+    return failures ? 1 : 0;
+} /* main */

--- a/src/server/nfs/tests/quint/nfs_drc_probe.c
+++ b/src/server/nfs/tests/quint/nfs_drc_probe.c
@@ -1,0 +1,985 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Ground truth for the duplicate-request-cache model.
+ *
+ * The nfsdrc model says what a correct cache does.  Several of its
+ * configuration constants are not statements about correctness at all but
+ * about the server and the transport this harness runs against -- whether two
+ * in-process connections look like one client, whether a re-created name gets
+ * a new filehandle, whether the NFSv4 and NFSv3 handle bytes agree.  A wrong
+ * guess at any of those makes every trace fail for a reason that has nothing
+ * to do with the cache.
+ *
+ * This probe measures them, one narrow question at a time, so the model's
+ * constants are recorded rather than assumed.  It doubles as the regression
+ * test for the cache behaviour the traces then exercise in bulk: each check
+ * below is a property, stated in the terms the model uses, that a correct
+ * server has to satisfy.
+ *
+ * Run with --dump to print what was observed even for the checks that passed.
+ */
+
+#include "nfs_drc_mbt_common.h"
+
+static int dump      = 0;
+static int no_caches = 0;
+static int failures  = 0;
+
+static void
+report(
+    const char *name,
+    int         ok,
+    const char *fmt,
+    ...)
+{
+    va_list ap;
+
+    if (!ok) {
+        failures++;
+    }
+    if (ok && !dump) {
+        printf("ok   %s\n", name);
+        return;
+    }
+    printf("%-4s %s: ", ok ? "ok" : "FAIL", name);
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    printf("\n");
+} /* report */
+
+/* One observed status against the one the model predicts. */
+static void
+check_status(
+    const char *name,
+    uint32_t    got,
+    uint32_t    want)
+{
+    report(name, got == want, "status=%u, model says %u", got, want);
+} /* check_status */
+
+/* ---- NFSv3 helpers, parameterised by connection / credential / xid ------- */
+
+static uint32_t
+v3_mkdir(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name,
+    struct mbt_fh               *out_fh)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_mkdir(c->env, &c->dir_fh, name, (uint32_t) strlen(name), DRC_MODE);
+    drc_v3_end(c);
+    if (out_fh && r->obj_fh.has) {
+        *out_fh = r->obj_fh;
+    }
+    return r->status;
+} /* v3_mkdir */
+
+static uint32_t
+v3_remove(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_remove(c->env, &c->dir_fh, name, (uint32_t) strlen(name));
+    drc_v3_end(c);
+    return r->status;
+} /* v3_remove */
+
+static uint32_t
+v3_rmdir(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_rmdir(c->env, &c->dir_fh, name, (uint32_t) strlen(name));
+    drc_v3_end(c);
+    return r->status;
+} /* v3_rmdir */
+
+static uint32_t
+v3_lookup(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_lookup(c->env, &c->dir_fh, name, (uint32_t) strlen(name));
+    drc_v3_end(c);
+    return r->status;
+} /* v3_lookup */
+
+static uint32_t
+v3_getattr_st(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const struct mbt_fh         *fh)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_getattr(c->env, fh);
+    drc_v3_end(c);
+    return r->status;
+} /* v3_getattr_st */
+
+static uint32_t
+v3_setsize(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const struct mbt_fh         *fh,
+    int64_t                      size)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_setattr(c->env, fh, -1, size, NULL);
+    drc_v3_end(c);
+    return r->status;
+} /* v3_setsize */
+
+static uint32_t
+v3_create(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name,
+    struct mbt_fh               *out_fh)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_create(c->env, &c->dir_fh, name, (uint32_t) strlen(name), GUARDED,
+                   DRC_MODE, NULL);
+    drc_v3_end(c);
+    if (out_fh && r->obj_fh.has) {
+        *out_fh = r->obj_fh;
+    }
+    return r->status;
+} /* v3_create */
+
+static uint32_t
+v3_symlink(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_symlink(c->env, &c->dir_fh, name, (uint32_t) strlen(name), "t",
+                    DRC_MODE);
+    drc_v3_end(c);
+    return r->status;
+} /* v3_symlink */
+
+static uint32_t
+v3_rename(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *from,
+    const char                  *to)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_rename(c->env, &c->dir_fh, from, (uint32_t) strlen(from),
+                   &c->dir_fh, to, (uint32_t) strlen(to));
+    drc_v3_end(c);
+    return r->status;
+} /* v3_rename */
+
+static uint32_t
+v3_link(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const struct mbt_fh         *src,
+    const char                  *to)
+{
+    struct mbt_result *r;
+
+    drc_v3_begin(c, conn, cred, xid);
+    r = mbt_link(c->env, src, &c->dir_fh, to, (uint32_t) strlen(to));
+    drc_v3_end(c);
+    return r->status;
+} /* v3_link */
+
+/* ---- NFSv4.0 helpers ------------------------------------------------------ */
+
+static uint32_t
+v4_create_dir(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name)
+{
+    struct nfs_argop4 a[2];
+    struct drc_v4_res res;
+    uint32_t          bitmap[2] = { 0, 1U << (FATTR4_MODE - 32) };
+    uint8_t           blob[4]   = { 0, 0, 0x01, 0xff };  /* mode 0777 */
+
+    memset(a, 0, sizeof(a));
+    drc_v4_putfh(&a[0], &c->dir_fh);
+    a[1].argop                               = OP_CREATE;
+    a[1].opcreate.objtype.type               = NF4DIR;
+    a[1].opcreate.objname.data               = (void *) name;
+    a[1].opcreate.objname.len                = (uint32_t) strlen(name);
+    a[1].opcreate.createattrs.num_attrmask   = 2;
+    a[1].opcreate.createattrs.attrmask       = bitmap;
+    a[1].opcreate.createattrs.attr_vals.data = blob;
+    a[1].opcreate.createattrs.attr_vals.len  = 4;
+
+    drc_v4_call(c, conn, cred, xid, a, 2, 0, &res);
+    return res.status;
+} /* v4_create_dir */
+
+static uint32_t
+v4_remove(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name)
+{
+    struct nfs_argop4 a[2];
+    struct drc_v4_res res;
+
+    memset(a, 0, sizeof(a));
+    drc_v4_putfh(&a[0], &c->dir_fh);
+    a[1].argop                = OP_REMOVE;
+    a[1].opremove.target.data = (void *) name;
+    a[1].opremove.target.len  = (uint32_t) strlen(name);
+
+    drc_v4_call(c, conn, cred, xid, a, 2, 0, &res);
+    return res.status;
+} /* v4_remove */
+
+static uint32_t
+v4_lookup(
+    struct drc_ctx              *c,
+    int                          conn,
+    const struct evpl_rpc2_cred *cred,
+    uint32_t                     xid,
+    const char                  *name)
+{
+    struct nfs_argop4 a[2];
+    struct drc_v4_res res;
+
+    memset(a, 0, sizeof(a));
+    drc_v4_putfh(&a[0], &c->dir_fh);
+    a[1].argop                 = OP_LOOKUP;
+    a[1].oplookup.objname.data = (void *) name;
+    a[1].oplookup.objname.len  = (uint32_t) strlen(name);
+
+    drc_v4_call(c, conn, cred, xid, a, 2, 0, &res);
+    return res.status;
+} /* v4_lookup */
+
+/* Resolve the working directory in the NFSv4 namespace: the pseudo-root, then
+ * the export, then the directory the trace works in.  Whether the bytes agree
+ * with the NFSv3 handle for the same object is one of the things this probe
+ * exists to answer, so they are obtained independently. */
+static void
+v4_resolve_dir(
+    struct drc_ctx              *c,
+    const struct evpl_rpc2_cred *cred,
+    struct mbt_fh               *out)
+{
+    struct nfs_argop4 a[4];
+    struct drc_v4_res res;
+
+    memset(a, 0, sizeof(a));
+    a[0].argop                 = OP_PUTROOTFH;
+    a[1].argop                 = OP_LOOKUP;
+    a[1].oplookup.objname.data = (void *) (c->mntpath + 1);
+    a[1].oplookup.objname.len  = (uint32_t) strlen(c->mntpath + 1);
+    a[2].argop                 = OP_LOOKUP;
+    a[2].oplookup.objname.data = (void *) DRC_DIR_NAME;
+    a[2].oplookup.objname.len  = (uint32_t) strlen(DRC_DIR_NAME);
+    a[3].argop                 = OP_GETFH;
+
+    drc_v4_call(c, 0, cred, 900001, a, 4, 0, &res);
+    if (res.status != NFS4_OK || !res.fh.has) {
+        fprintf(stderr, "drc probe: cannot resolve the working directory in "
+                "the NFSv4 namespace (status %u)\n", res.status);
+        exit(2);
+    }
+    *out = res.fh;
+} /* v4_resolve_dir */
+
+
+/* ---- NFSv4.1: the session reply cache ------------------------------------ */
+
+/*
+ * The 4.1 reply cache is a different mechanism from the two this suite models
+ * -- a slot table keyed by sequence id rather than a key over transport
+ * identity -- and it belongs with the sessions in the nfs4 model.  What is
+ * pinned here are the three answers a retry can get, because each is a
+ * normative requirement that is easy to get wrong and hard to reach from a
+ * random walk:
+ *
+ *   the reply was cached     replay it
+ *   it was not               SEQUENCE answers NFS4_OK and the operation AFTER
+ *                            it carries NFS4ERR_RETRY_UNCACHED_REP.  RFC 8881
+ *                            Section 2.10.6.1.3 forbids answering the Sequence
+ *                            operation itself with that error when Sequence is
+ *                            first, which it always is.
+ *   a different principal    NFS4ERR_SEQ_FALSE_RETRY, which Section
+ *                            2.10.6.1.3.1 makes a MUST
+ */
+
+struct drc_session {
+    uint64_t clientid;
+    uint32_t seqid;              /* csr_sequence from CREATE_SESSION */
+    uint8_t  id[NFS4_SESSIONID_SIZE];
+};
+
+static void
+v41_establish(
+    struct drc_ctx              *c,
+    const struct evpl_rpc2_cred *cred,
+    struct drc_session          *out)
+{
+    struct nfs_argop4                 a[1];
+    struct drc_v4_res                 res;
+    struct channel_attrs4             chan = {
+        .ca_headerpadsize          = 0,
+        .ca_maxrequestsize         = 1048576,
+        .ca_maxresponsesize        = 1048576,
+        .ca_maxresponsesize_cached = 65536,
+        .ca_maxoperations          = 16,
+        .ca_maxrequests            = 32,
+        .num_ca_rdma_ird           = 0,
+    };
+    static struct callback_sec_parms4 sec     = { .cb_secflavor = 0 };
+    static uint8_t                    verf[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    static const char                *owner   = "quintdrc-client";
+
+    memset(a, 0, sizeof(a));
+    a[0].argop = OP_EXCHANGE_ID;
+    memcpy(a[0].opexchange_id.eia_clientowner.co_verifier, verf, 8);
+    a[0].opexchange_id.eia_clientowner.co_ownerid.data = (void *) owner;
+    a[0].opexchange_id.eia_clientowner.co_ownerid.len  =
+        (uint32_t) strlen(owner);
+    a[0].opexchange_id.eia_flags                 = 0;
+    a[0].opexchange_id.eia_state_protect.spa_how = SP4_NONE;
+    a[0].opexchange_id.num_eia_client_impl_id    = 0;
+
+    drc_v4_call(c, 0, cred, 800001, a, 1, 1, &res);
+    if (res.status != NFS4_OK) {
+        fprintf(stderr, "drc probe: EXCHANGE_ID failed: %u\n", res.status);
+        exit(2);
+    }
+    out->clientid = res.clientid;
+    out->seqid    = res.seqid;
+
+    memset(a, 0, sizeof(a));
+    a[0].argop                                = OP_CREATE_SESSION;
+    a[0].opcreate_session.csa_clientid        = out->clientid;
+    a[0].opcreate_session.csa_sequence        = out->seqid;
+    a[0].opcreate_session.csa_flags           = 0;
+    a[0].opcreate_session.csa_fore_chan_attrs = chan;
+    a[0].opcreate_session.csa_back_chan_attrs = chan;
+    a[0].opcreate_session.csa_cb_program      = 0x40000000;
+    a[0].opcreate_session.num_csa_sec_parms   = 1;
+    a[0].opcreate_session.csa_sec_parms       = &sec;
+
+    drc_v4_call(c, 0, cred, 800002, a, 1, 1, &res);
+    if (res.status != NFS4_OK) {
+        fprintf(stderr, "drc probe: CREATE_SESSION failed: %u\n", res.status);
+        exit(2);
+    }
+    memcpy(out->id, res.sessionid, NFS4_SESSIONID_SIZE);
+} /* v41_establish */
+
+/* SEQUENCE(slot, seq, cachethis) followed by one GETATTR of the working
+ * directory, so the reply has a second operation for the uncached-retry error
+ * to land on.  Returns the compound status; the per-operation statuses are in
+ * *out. */
+static uint32_t
+v41_seq_getattr(
+    struct drc_ctx              *c,
+    const struct evpl_rpc2_cred *cred,
+    struct drc_session          *sess,
+    uint32_t                     slot,
+    uint32_t                     seq,
+    int                          cachethis,
+    struct drc_v4_res           *out)
+{
+    struct nfs_argop4 a[3];
+    uint32_t          bitmap[1] = { 1U << FATTR4_TYPE };
+
+    memset(a, 0, sizeof(a));
+    a[0].argop = OP_SEQUENCE;
+    memcpy(a[0].opsequence.sa_sessionid, sess->id, NFS4_SESSIONID_SIZE);
+    a[0].opsequence.sa_sequenceid     = seq;
+    a[0].opsequence.sa_slotid         = slot;
+    a[0].opsequence.sa_highest_slotid = 31;
+    a[0].opsequence.sa_cachethis      = cachethis;
+
+    drc_v4_putfh(&a[1], &c->dir_fh);
+
+    a[2].argop                      = OP_GETATTR;
+    a[2].opgetattr.attr_request     = bitmap;
+    a[2].opgetattr.num_attr_request = 1;
+
+    /* A fixed XID: the NFSv4.0 cache does not look at 4.1 COMPOUNDs, so
+     * nothing here depends on it. */
+    drc_v4_call(c, 0, cred, 810000 + seq, a, 3, 1, out);
+    return out->status;
+} /* v41_seq_getattr */
+
+/* ------------------------------------------------------------------------- */
+
+int
+main(
+    int   argc,
+    char *argv[])
+{
+    struct mbt_env        env;
+    struct mbt_env_opts   opts;
+    struct drc_ctx        c;
+    struct evpl_rpc2_cred u1, u2;
+    struct mbt_fh         fh_a1 = { 0 }, fh_a2 = { 0 };
+    struct mbt_fh         v3_dir = { 0 }, v4_dir = { 0 };
+    struct drc_dirsnap    snap;
+    uint32_t              st1, st2;
+    int                   i;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--dump") == 0) {
+            dump = 1;
+        } else if (strcmp(argv[i], "--no-caches") == 0) {
+            /* What the replay harness runs with: exact comparison of the
+             * directory after every step cannot tolerate a stale cache. */
+            no_caches = 1;
+        }
+    }
+
+    umask(0);
+
+    memset(&opts, 0, sizeof(opts));
+    opts.nfs3_drc       = 1;
+    opts.disable_caches = no_caches;
+
+    mbt_env_open_opts(&env, &opts);
+    mbt_env_fs_setup(&env, "fs0");
+
+    memset(&c, 0, sizeof(c));
+    c.env = &env;
+    snprintf(c.mntpath, sizeof(c.mntpath), "/fs0");
+
+    drc_cred_init(&u1, 1000);
+    drc_cred_init(&u2, 1001);
+
+    /* The shared wrappers used by trace setup run as root, which is what
+     * creates the 0777 working directory the two users then share. */
+    drc_trace_setup(&c);
+    v3_dir = c.dir_fh;
+
+    /* ------------------------------------------------------------------ *
+    *  1. Does a retransmit replay?  The whole premise.                   *
+    * ------------------------------------------------------------------ */
+    st1 = v3_mkdir(&c, 0, &u1, 100, "a", &fh_a1);
+    st2 = v3_mkdir(&c, 0, &u1, 100, "a", NULL);
+    report("v3/replay-same-conn", st1 == NFS3_OK && st2 == NFS3_OK,
+           "first=%u second=%u (a re-executed MKDIR would answer %u)",
+           st1, st2, NFS3ERR_EXIST);
+
+    /* ------------------------------------------------------------------ *
+    *  2. A different XID is a different request.                         *
+    * ------------------------------------------------------------------ */
+    st2 = v3_mkdir(&c, 0, &u1, 101, "a", NULL);
+    report("v3/other-xid-misses", st2 == NFS3ERR_EXIST, "status=%u", st2);
+
+    /* ------------------------------------------------------------------ *
+    *  3. The procedure is part of the key.  REMOVE and RMDIR carry       *
+    *     byte-identical arguments, so only the procedure number tells    *
+    *     them apart.                                                     *
+    * ------------------------------------------------------------------ */
+    st1 = v3_remove(&c, 0, &u1, 110, "a");           /* "a" is a directory */
+    st2 = v3_rmdir(&c, 0, &u1, 110, "a");
+    report("v3/proc-in-key", st2 == NFS3_OK,
+           "REMOVE(dir)=%u then RMDIR at the same xid=%u "
+           "(a key without the procedure would replay %u)", st1, st2, st1);
+
+    /* ------------------------------------------------------------------ *
+    *  4. Is a non-cacheable procedure ever answered from the cache?      *
+    *     A LOOKUP's arguments are byte-identical to the REMOVE above.    *
+    * ------------------------------------------------------------------ */
+    (void) v3_mkdir(&c, 0, &u1, 120, "b", NULL);
+    st2 = v3_remove(&c, 0, &u1, 121, "b");   /* a directory: ISDIR, no effect */
+    st1 = v3_lookup(&c, 0, &u1, 121, "b");
+    report("v3/idempotent-not-cached", st1 == NFS3_OK,
+           "REMOVE(dir)=%u then LOOKUP at the same xid=%u "
+           "(%u would mean the LOOKUP was answered from the REMOVE's entry)",
+           st2, st1, st2);
+
+    /* ------------------------------------------------------------------ *
+    *  5. Two connections, one address.  Under an in-process transport    *
+    *     every peer reports the same address, so an address-scoped entry *
+    *     is shared -- which is what the model's ADDR_OF records.         *
+    * ------------------------------------------------------------------ */
+    st1 = v3_mkdir(&c, 0, &u1, 130, "c", NULL);
+    st2 = v3_mkdir(&c, 1, &u1, 130, "c", NULL);
+    report("v3/scope-is-address", st2 == NFS3_OK,
+           "conn0=%u conn1=%u -- %s", st1, st2,
+           st2 == NFS3_OK ? "the two connections share one address"
+                          : "the two connections are separate clients");
+
+    /* ------------------------------------------------------------------ *
+    *  6. A reconnect must not lose an address-scoped entry: a reconnect  *
+    *     is the ordinary reason a retransmit exists.                     *
+    * ------------------------------------------------------------------ */
+    drc_reconnect(&c, 0);
+    st2 = v3_mkdir(&c, 0, &u1, 130, "c", NULL);
+    report("v3/survives-reconnect", st2 == NFS3_OK, "status=%u", st2);
+
+    /* ------------------------------------------------------------------ *
+    *  7. A different principal is a different requester.                 *
+    * ------------------------------------------------------------------ */
+    st2 = v3_mkdir(&c, 0, &u2, 130, "c", NULL);
+    report("v3/cred-in-key", st2 == NFS3ERR_EXIST,
+           "the same MKDIR under a second uid = %u "
+           "(%u would mean one user was answered from the other's entry)",
+           st2, NFS3_OK);
+
+    /* ------------------------------------------------------------------ *
+    *  8. A handle survives its object.  A retransmit carries the handle  *
+    *     it was built with, so the model must distinguish incarnations.  *
+    * ------------------------------------------------------------------ */
+    (void) v3_setsize(&c, 0, &u1, 140, &fh_a1, 4096);
+    (void) v3_rmdir(&c, 0, &u1, 141, "c");
+    (void) v3_mkdir(&c, 0, &u1, 142, "c", &fh_a2);
+    report("v3/fh-per-incarnation",
+           fh_a1.has && fh_a2.has && !mbt_fh_eq(&fh_a1, &fh_a2),
+           "a re-created name %s a new filehandle",
+           mbt_fh_eq(&fh_a1, &fh_a2) ? "keeps" : "gets");
+
+    /* ------------------------------------------------------------------ *
+    *  9. NFSv4.0: the same questions, connection-scoped.                 *
+    * ------------------------------------------------------------------ */
+    v4_resolve_dir(&c, &u1, &v4_dir);
+    report("v4/handle-matches-v3", mbt_fh_eq(&v3_dir, &v4_dir),
+           "the NFSv4 handle for the working directory %s the NFSv3 one",
+           mbt_fh_eq(&v3_dir, &v4_dir) ? "equals" : "differs from");
+
+    st1 = v4_create_dir(&c, 0, &u1, 200, "e");
+    st2 = v4_create_dir(&c, 0, &u1, 200, "e");
+    report("v4/replay-same-conn", st1 == NFS4_OK && st2 == NFS4_OK,
+           "first=%u second=%u (a re-executed CREATE would answer %u)",
+           st1, st2, NFS4ERR_EXIST);
+
+    st2 = v4_create_dir(&c, 1, &u1, 200, "e");
+    report("v4/scope-is-connection", st2 == NFS4ERR_EXIST,
+           "the same COMPOUND on a second connection = %u "
+           "(%u would mean the entry was not connection-scoped)",
+           st2, NFS4_OK);
+
+    /* ------------------------------------------------------------------ *
+    * 10. A reconnect drops a connection-scoped entry -- including when   *
+    *     the replacement is handed the memory the old one just freed.    *
+    * ------------------------------------------------------------------ */
+    drc_reconnect(&c, 0);
+    st2 = v4_create_dir(&c, 0, &u1, 200, "e");
+    report("v4/dropped-on-reconnect", st2 == NFS4ERR_EXIST,
+           "the same COMPOUND after a reconnect = %u "
+           "(%u would mean a recycled connection inherited a cache)",
+           st2, NFS4_OK);
+
+    /* ------------------------------------------------------------------ *
+    * 11. A read-only COMPOUND is never cached.  The v4 cache looks every *
+    *     COMPOUND up, so this is a real question rather than a           *
+    *     structural impossibility as it is for v3.                       *
+    * ------------------------------------------------------------------ */
+    (void) v4_remove(&c, 0, &u1, 210, "e");
+    st2 = v4_lookup(&c, 0, &u1, 210, "e");
+    report("v4/idempotent-not-cached", st2 == NFS4ERR_NOENT,
+           "LOOKUP after a REMOVE at the same xid = %u", st2);
+
+    (void) v4_lookup(&c, 0, &u1, 211, "e");
+    st2 = v4_create_dir(&c, 0, &u1, 211, "e");
+    report("v4/lookup-leaves-no-entry", st2 == NFS4_OK,
+           "CREATE at a LOOKUP's xid = %u", st2);
+
+    /* ------------------------------------------------------------------ *
+    * 12. The per-connection cache is bounded, and evicts oldest-first.   *
+    *     Sixteen entries plus one pushes the first out, so its           *
+    *     retransmit re-executes.                                         *
+    * ------------------------------------------------------------------ */
+    (void) v4_remove(&c, 0, &u1, 212, "e");
+    for (i = 0; i < 17; i++) {
+        char name[DRC_NAME_MAX];
+
+        snprintf(name, sizeof(name), "v%d", i);
+        st1 = v4_create_dir(&c, 0, &u1, (uint32_t) (300 + i), name);
+        if (st1 != NFS4_OK) {
+            fprintf(stderr, "drc probe: CREATE %s failed: %u\n", name, st1);
+            exit(2);
+        }
+    }
+    st2 = v4_create_dir(&c, 0, &u1, 300, "v0");
+    report("v4/oldest-evicted", st2 == NFS4ERR_EXIST,
+           "the oldest of 17 entries replayed as %u "
+           "(%u would mean it was still cached)", st2, NFS4_OK);
+
+    st2 = v4_create_dir(&c, 0, &u1, 316, "v16");
+    report("v4/newest-retained", st2 == NFS4_OK,
+           "the newest of 17 entries replayed as %u", st2);
+
+    /* ------------------------------------------------------------------ *
+    * 13. A different principal on an NFSv4.0 COMPOUND.                   *
+    * ------------------------------------------------------------------ */
+    st2 = v4_create_dir(&c, 0, &u2, 316, "v16");
+    report("v4/cred-in-key", st2 == NFS4ERR_EXIST,
+           "the same COMPOUND under a second uid = %u "
+           "(%u would mean one user was answered from the other's entry)",
+           st2, NFS4_OK);
+
+    /* ------------------------------------------------------------------ *
+    * 14. The operation semantics the model's filesystem slice encodes.   *
+    *     None of these are about the cache; they are what the cache is    *
+    *     replaying, and a wrong guess at any of them would fail every     *
+    *     trace for a reason that has nothing to do with a cache.  Each is *
+    *     run at a fresh XID so nothing here is answered from a cache.     *
+    * ------------------------------------------------------------------ */
+    {
+        struct mbt_fh f_fh, d_fh, gone_fh;
+        uint32_t      x = 400;
+
+        check_status("op/create-guarded-new",
+                     v3_create(&c, 0, &u1, x++, "f", &f_fh), NFS3_OK);
+        check_status("op/create-guarded-exists",
+                     v3_create(&c, 0, &u1, x++, "f", NULL), NFS3ERR_EXIST);
+        check_status("op/mkdir-exists",
+                     v3_mkdir(&c, 0, &u1, x++, "f", NULL), NFS3ERR_EXIST);
+        check_status("op/symlink-exists",
+                     v3_symlink(&c, 0, &u1, x++, "f"), NFS3ERR_EXIST);
+
+        check_status("op/remove-absent",
+                     v3_remove(&c, 0, &u1, x++, "zz"), NFS3ERR_NOENT);
+        check_status("op/rmdir-absent",
+                     v3_rmdir(&c, 0, &u1, x++, "zz"), NFS3ERR_NOENT);
+        check_status("op/rmdir-not-a-directory",
+                     v3_rmdir(&c, 0, &u1, x++, "f"), NFS3ERR_NOTDIR);
+
+        check_status("op/mkdir-new",
+                     v3_mkdir(&c, 0, &u1, x++, "g", &d_fh), NFS3_OK);
+        check_status("op/remove-a-directory",
+                     v3_remove(&c, 0, &u1, x++, "g"), NFS3ERR_ISDIR);
+
+        check_status("op/rename-absent-source",
+                     v3_rename(&c, 0, &u1, x++, "zz", "yy"), NFS3ERR_NOENT);
+        check_status("op/rename-free-target",
+                     v3_rename(&c, 0, &u1, x++, "f", "h"), NFS3_OK);
+
+        check_status("op/link-free-target",
+                     v3_link(&c, 0, &u1, x++, &f_fh, "i"), NFS3_OK);
+        check_status("op/link-taken-target",
+                     v3_link(&c, 0, &u1, x++, &f_fh, "i"), NFS3ERR_EXIST);
+
+        check_status("op/setsize-file",
+                     v3_setsize(&c, 0, &u1, x++, &f_fh, 4096), NFS3_OK);
+        check_status("op/setsize-directory",
+                     v3_setsize(&c, 0, &u1, x++, &d_fh, 0), NFS3ERR_ISDIR);
+
+        /*
+         * A handle whose object is gone is NFS3ERR_STALE (RFC 1813 section 3.3:
+         * "the file referred to by that file handle no longer exists").  It is
+         * also the state a retransmit can legitimately be in, which is what the
+         * replay check further down turns on.
+         */
+        (void) v3_create(&c, 0, &u1, x++, "j", &gone_fh);
+        (void) v3_remove(&c, 0, &u1, x++, "j");
+        check_status("op/setsize-stale-handle",
+                     v3_setsize(&c, 0, &u1, x++, &gone_fh, 0), NFS3ERR_STALE);
+        check_status("op/link-stale-handle",
+                     v3_link(&c, 0, &u1, x++, &gone_fh, "k"), NFS3ERR_STALE);
+
+        /* A removed directory's handle, the same way. */
+        {
+            struct mbt_fh dead_dir;
+
+            (void) v3_mkdir(&c, 0, &u1, x++, "n", &dead_dir);
+            (void) v3_rmdir(&c, 0, &u1, x++, "n");
+            check_status("op/getattr-removed-directory",
+                         v3_getattr_st(&c, 0, &u1, x++, &dead_dir),
+                         NFS3ERR_STALE);
+        }
+
+        /* The same directory removed through NFSv4 REMOVE rather than NFSv3
+         * RMDIR.  Same object, same removal, so the handle dies the same way --
+         * which protocol asked is not something a filehandle knows. */
+        {
+            struct mbt_fh v4_dead_dir;
+
+            (void) v3_mkdir(&c, 0, &u1, x++, "o", &v4_dead_dir);
+            check_status("op/v4-remove-directory",
+                         v4_remove(&c, 0, &u1, x++, "o"), NFS4_OK);
+            check_status("op/getattr-v4-removed-directory",
+                         v3_getattr_st(&c, 0, &u1, x++, &v4_dead_dir),
+                         NFS3ERR_STALE);
+        }
+
+        /*
+         * The same removal, but with the handle USED before it.
+         *
+         * Resolving a handle puts it in the VFS handle cache, which pins the
+         * object until the close sweep releases it -- so it still resolves,
+         * and GETATTR still succeeds, for a window afterwards.  That is not a
+         * defect and it is why the model never issues a FRESH request on a
+         * dead handle: Linux behaves the same way, because __ext4_iget's
+         * free-inode check sits after the "already cached" early return and an
+         * inode pinned by an open file or a dentry is returned without it.
+         * NFSv4 read-after-unlink depends on exactly this.
+         *
+         * It is asserted rather than merely tolerated because the alternative
+         * -- a handle going stale the instant its last name does, whatever
+         * still holds the object -- would break that.
+         */
+        {
+            struct mbt_fh touched;
+
+            (void) v3_mkdir(&c, 0, &u1, x++, "t1", &touched);
+            check_status("op/getattr-live-directory",
+                         v3_getattr_st(&c, 0, &u1, x++, &touched), NFS3_OK);
+            (void) v3_rmdir(&c, 0, &u1, x++, "t1");
+            check_status("op/getattr-pinned-removed-directory",
+                         v3_getattr_st(&c, 0, &u1, x++, &touched), NFS3_OK);
+        }
+
+        /* The same, for a regular file. */
+        {
+            struct mbt_fh tf;
+
+            (void) v3_create(&c, 0, &u1, x++, "t2", &tf);
+            check_status("op/getattr-live-file",
+                         v3_getattr_st(&c, 0, &u1, x++, &tf), NFS3_OK);
+            (void) v3_remove(&c, 0, &u1, x++, "t2");
+            check_status("op/getattr-pinned-removed-file",
+                         v3_getattr_st(&c, 0, &u1, x++, &tf), NFS3_OK);
+        }
+
+        /* And a directory both created and removed through NFSv4. */
+        {
+            struct mbt_fh v4_dir;
+
+            check_status("op/v4-create-directory",
+                         v4_create_dir(&c, 0, &u1, x++, "p4"), NFS4_OK);
+            drc_v3_begin(&c, 0, &u1, x++);
+            {
+                struct mbt_result *lr = mbt_lookup(&env, &c.dir_fh, "p4", 2);
+
+                v4_dir = lr->obj_fh;
+            }
+            drc_v3_end(&c);
+            check_status("op/v4-remove-v4-directory",
+                         v4_remove(&c, 0, &u1, x++, "p4"), NFS4_OK);
+            check_status("op/getattr-v4-created-removed-directory",
+                         v3_getattr_st(&c, 0, &u1, x++, &v4_dir),
+                         NFS3ERR_STALE);
+        }
+
+        /* RENAME over an occupied target: replaced when the types agree, and
+         * refused by type when they do not (RFC 1813 3.3.14 / POSIX
+         * rename(2)).  Renaming a name onto another name for the same object
+         * succeeds having done nothing. */
+        {
+            struct mbt_fh shared;
+
+            (void) v3_create(&c, 0, &u1, x++, "p", &shared);
+            (void) v3_create(&c, 0, &u1, x++, "q", NULL);
+            check_status("op/rename-replaces-same-type",
+                         v3_rename(&c, 0, &u1, x++, "p", "q"), NFS3_OK);
+            (void) v3_mkdir(&c, 0, &u1, x++, "r", NULL);
+            check_status("op/rename-file-onto-directory",
+                         v3_rename(&c, 0, &u1, x++, "q", "r"), NFS3ERR_ISDIR);
+            (void) v3_create(&c, 0, &u1, x++, "s", NULL);
+            check_status("op/rename-directory-onto-file",
+                         v3_rename(&c, 0, &u1, x++, "r", "s"), NFS3ERR_NOTDIR);
+            /* Two names for one object. */
+            (void) v3_link(&c, 0, &u1, x++, &shared, "u");
+            check_status("op/rename-onto-same-object",
+                         v3_rename(&c, 0, &u1, x++, "q", "u"), NFS3_OK);
+        }
+
+        /* A size on a symlink is not a size at all. */
+        {
+            struct mbt_fh lnk;
+
+            (void) v3_symlink(&c, 0, &u1, x++, "w");
+            drc_v3_begin(&c, 0, &u1, x++);
+            {
+                struct mbt_result *lr = mbt_lookup(&env, &c.dir_fh, "w", 1);
+
+                lnk = lr->obj_fh;
+            }
+            drc_v3_end(&c);
+            check_status("op/setsize-symlink",
+                         v3_setsize(&c, 0, &u1, x++, &lnk, 0), NFS3ERR_INVAL);
+        }
+
+        /* NFSv4 REMOVE covers both unlink and rmdir, so it has no type
+         * assertion of its own to make. */
+        check_status("op/v4-create-a-directory",
+                     v4_create_dir(&c, 0, &u1, x++, "m"), NFS4_OK);
+        check_status("op/v4-remove-a-directory",
+                     v4_remove(&c, 0, &u1, x++, "m"), NFS4_OK);
+        check_status("op/v4-lookup-absent",
+                     v4_lookup(&c, 0, &u1, x++, "zz"), NFS4ERR_NOENT);
+    }
+
+    /* ------------------------------------------------------------------ *
+    * 15. A retransmit carrying a handle whose object is gone.            *
+    *                                                                     *
+    *     The most demanding thing a cache does.  The client sent a        *
+    *     SETATTR, lost the reply, and removed the file before retrying;   *
+    *     the retry still carries the handle it was built with.  Answering *
+    *     it means not resolving that handle at all -- a server that       *
+    *     re-executed would answer for an object that no longer exists.    *
+    *     The random corpus does not generate this (what a FRESH request on *
+    *     a dead handle answers depends on chimera's own handle cache, and *
+    *     a trace that walked into it would be flaky); here it is exact.   *
+    * ------------------------------------------------------------------ */
+    {
+        struct mbt_fh doomed;
+
+        uint32_t      retry;
+
+        (void) v3_create(&c, 0, &u1, 500, "z", &doomed);
+        st1   = v3_setsize(&c, 0, &u1, 501, &doomed, 4096);
+        st2   = v3_remove(&c, 0, &u1, 502, "z");
+        retry = v3_setsize(&c, 0, &u1, 501, &doomed, 4096);
+        report("drc/replay-outlives-its-object",
+               st1 == NFS3_OK && st2 == NFS3_OK && retry == NFS3_OK,
+               "SETATTR=%u REMOVE=%u, and the retransmitted SETATTR answered "
+               "%u after its file was removed", st1, st2, retry);
+    }
+
+    /* ------------------------------------------------------------------ *
+    * 16. The NFSv4.1 session reply cache: the three answers a retry gets. *
+    * ------------------------------------------------------------------ */
+    {
+        struct drc_session sess;
+        struct drc_v4_res  r;
+
+        v41_establish(&c, &u1, &sess);
+
+        /* A cached request, then its retry: replayed. */
+        st1 = v41_seq_getattr(&c, &u1, &sess, 0, 1, 1, &r);
+        report("v41/first-sequence", st1 == NFS4_OK, "status=%u", st1);
+
+        st1 = v41_seq_getattr(&c, &u1, &sess, 0, 1, 1, &r);
+        report("v41/cached-retry-replays", st1 == NFS4_OK, "status=%u", st1);
+
+        /*
+         * A request whose reply was NOT cached, then its retry.
+         *
+         * RFC 8881 Section 2.10.6.1.1 makes the SEQUENCE reply itself always
+         * cached, and Section 2.10.6.1.3 says a replier "MUST NOT return
+         * NFS4ERR_RETRY_UNCACHED_REP in reply to a Sequence operation if the
+         * Sequence operation is the first operation" -- it goes on the
+         * operation after it instead.  Answering the SEQUENCE with the error
+         * tells the client its session is unusable rather than that this one
+         * reply is gone.
+         */
+        st1 = v41_seq_getattr(&c, &u1, &sess, 1, 1, 0, &r);
+        report("v41/first-uncached-sequence", st1 == NFS4_OK, "status=%u", st1);
+
+        st1 = v41_seq_getattr(&c, &u1, &sess, 1, 1, 0, &r);
+        report("v41/uncached-retry-spares-sequence",
+               r.nres >= 2 && r.resop[0] == OP_SEQUENCE &&
+               r.opstatus[0] == NFS4_OK &&
+               r.opstatus[1] == NFS4ERR_RETRY_UNCACHED_REP &&
+               st1 == NFS4ERR_RETRY_UNCACHED_REP,
+               "compound=%u, %d result(s), SEQUENCE=%u next=%u", st1, r.nres,
+               r.nres > 0 ? r.opstatus[0] : 0,
+               r.nres > 1 ? r.opstatus[1] : 0);
+
+        /*
+         * The same slot and sequence id under a different principal.
+         *
+         * RFC 8881 Section 2.10.6.1.3.1: "If the replier determines the users
+         * are different between the original request and a retry, then the
+         * replier MUST return NFS4ERR_SEQ_FALSE_RETRY."  Replaying instead
+         * hands the second user the first one's reply.
+         */
+        st1 = v41_seq_getattr(&c, &u1, &sess, 2, 1, 1, &r);
+        report("v41/first-sequence-slot2", st1 == NFS4_OK, "status=%u", st1);
+
+        st1 = v41_seq_getattr(&c, &u2, &sess, 2, 1, 1, &r);
+        report("v41/other-principal-is-a-false-retry",
+               st1 == NFS4ERR_SEQ_FALSE_RETRY,
+               "the same slot and sequence id under a second uid answered %u "
+               "(%u would mean one user was handed the other's reply)",
+               st1, NFS4_OK);
+
+        /* An error from SEQUENCE leaves the slot alone (RFC 8881
+         * Section 2.10.6.1.2), so the rightful owner still replays. */
+        st1 = v41_seq_getattr(&c, &u1, &sess, 2, 1, 1, &r);
+        report("v41/false-retry-leaves-the-slot", st1 == NFS4_OK,
+               "status=%u", st1);
+    }
+
+    /* ------------------------------------------------------------------ *
+    * 17. The directory the model predicts is the directory that is       *
+    *     there -- the check every trace step makes.                      *
+    * ------------------------------------------------------------------ */
+    drc_dir_snapshot(&c, &snap);
+    if (dump) {
+        printf("     working directory holds %d entr%s:", snap.n,
+               snap.n == 1 ? "y" : "ies");
+        for (i = 0; i < snap.n; i++) {
+            printf(" %s(type=%u,size=%llu)", snap.ents[i].name,
+                   snap.ents[i].ftype,
+                   (unsigned long long) snap.ents[i].size);
+        }
+        printf("\n");
+    }
+    report("dir/snapshot-readable", snap.n > 0, "%d entries", snap.n);
+
+    drc_conns_close(&c);
+    mbt_env_fs_teardown(&env, "fs0");
+    mbt_env_stop(&env);
+
+    if (failures) {
+        printf("\n%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("\nall checks passed\n");
+    return 0;
+} /* main */

--- a/src/server/nfs/tests/test_replay_slot.c
+++ b/src/server/nfs/tests/test_replay_slot.c
@@ -172,7 +172,15 @@ test_out_of_range_slot(void)
     destroy_session_table(&table, session);
 } /* test_out_of_range_slot */
 
-/* Case 4: in-progress retry (same seqid) -> RETRY_UNCACHED_REP. */
+/*
+ * Case 4: a retry that arrives while the original is still running.
+ *
+ * RFC 8881 Section 2.10.6.2: "The replier SHOULD deal with the issue by
+ * returning NFS4ERR_DELAY as the reply to SEQUENCE or CB_SEQUENCE operation,
+ * but implementations MAY return NFS4ERR_MISORDERED."  This used to answer
+ * NFS4ERR_RETRY_UNCACHED_REP, which is neither -- and which a client retries
+ * silently forever rather than backing off.
+ */
 static void
 test_in_progress_retry(void)
 {
@@ -194,7 +202,7 @@ test_in_progress_retry(void)
     /* Without calling finalize, a second SEQUENCE on the same slot with
      * the same seqid arrives -- libevpl has no DRC, so this hits us. */
     status = nfs4_replay_slot_acquire(session, 0, 1, true, &req2, &is_replay);
-    CHECK(status == NFS4ERR_RETRY_UNCACHED_REP);
+    CHECK(status == NFS4ERR_DELAY);
     CHECK(!is_replay);
 
     /* And a jump-ahead seqid -> MISORDERED. */
@@ -206,7 +214,14 @@ test_in_progress_retry(void)
     destroy_session_table(&table, session);
 } /* test_in_progress_retry */
 
-/* Case 5: COMPLETED retry (cachethis was false) -> RETRY_UNCACHED_REP. */
+/*
+ * Case 5: a retry of a request whose reply was not cached.
+ *
+ * The slot machinery reports NFS4ERR_RETRY_UNCACHED_REP; where that error ends
+ * up on the wire is the SEQUENCE handler's business, and RFC 8881 Section
+ * 2.10.6.1.3 puts it on the operation AFTER Sequence rather than on Sequence
+ * itself (chimera_nfs4_sequence).
+ */
 static void
 test_completed_retry_uncached(void)
 {
@@ -481,6 +496,103 @@ test_implicit_session_no_slots(void)
     destroy_session_table(&table, session);
 } /* test_implicit_session_no_slots */
 
+/*
+ * Case 11: a retry under a different principal is a false retry.
+ *
+ * RFC 8881 Section 2.10.6.1.3.1: a retry "that uses a different principal in
+ * the RPC request's credential field that translates to a different user" is a
+ * false retry, and "if the replier determines the users are different between
+ * the original request and a retry, then the replier MUST return
+ * NFS4ERR_SEQ_FALSE_RETRY".  Answering it from the cache hands one user
+ * another user's reply and silently drops the operation the second one asked
+ * for -- the same failure a reply cache exists to prevent, aimed at a
+ * different victim.
+ */
+static void
+test_false_retry_other_principal(void)
+{
+    struct nfs4_client_table table;
+    struct nfs4_session     *session = make_session(&table, TEST_SLOTS,
+                                                    TEST_MAXRESP);
+    struct nfs_request       req;
+    bool                     is_replay;
+    nfsstat4                 status;
+    char                     buf[8] = "cached";
+
+    reset_request(&req);
+    req.session                   = session;
+    req.principal_flavor          = 1;    /* AUTH_SYS */
+    req.principal_uid             = 1000;
+    req.principal_gid             = 1000;
+    req.principal_machinename     = "host";
+    req.principal_machinename_len = 4;
+
+    status = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    nfs4_replay_slot_finalize(&req);
+
+    /* Give the slot a cached reply, so that a same-user retry would replay and
+     * the difference is attributable to the principal alone. */
+    session->replay_slots[0].cached_buf = malloc(sizeof(buf));
+    memcpy(session->replay_slots[0].cached_buf, buf, sizeof(buf));
+    session->replay_slots[0].cached_len = sizeof(buf);
+    atomic_store(&session->replay_slots[0].state_word,
+                 nfs4_slot_word(1, NFS4_SLOT_CACHED));
+
+    /* The same user retries: replayed. */
+    reset_request(&req);
+    req.session                   = session;
+    req.principal_flavor          = 1;
+    req.principal_uid             = 1000;
+    req.principal_gid             = 1000;
+    req.principal_machinename     = "host";
+    req.principal_machinename_len = 4;
+    status                        = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    CHECK(is_replay);
+    nfs4_replay_slot_replay_done(&req);
+
+    /* A different uid on the same host: a false retry. */
+    reset_request(&req);
+    req.session                   = session;
+    req.principal_flavor          = 1;
+    req.principal_uid             = 1001;
+    req.principal_gid             = 1001;
+    req.principal_machinename     = "host";
+    req.principal_machinename_len = 4;
+    status                        = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4ERR_SEQ_FALSE_RETRY);
+    CHECK(!is_replay);
+
+    /* The same uid from a different machine is also a different user. */
+    reset_request(&req);
+    req.session                   = session;
+    req.principal_flavor          = 1;
+    req.principal_uid             = 1000;
+    req.principal_gid             = 1000;
+    req.principal_machinename     = "other";
+    req.principal_machinename_len = 5;
+    status                        = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4ERR_SEQ_FALSE_RETRY);
+    CHECK(!is_replay);
+
+    /* An error from SEQUENCE must leave the slot alone (RFC 8881
+     * Section 2.10.6.1.2), so the rightful owner can still replay. */
+    reset_request(&req);
+    req.session                   = session;
+    req.principal_flavor          = 1;
+    req.principal_uid             = 1000;
+    req.principal_gid             = 1000;
+    req.principal_machinename     = "host";
+    req.principal_machinename_len = 4;
+    status                        = nfs4_replay_slot_acquire(session, 0, 1, true, &req, &is_replay);
+    CHECK(status == NFS4_OK);
+    CHECK(is_replay);
+    nfs4_replay_slot_replay_done(&req);
+
+    destroy_session_table(&table, session);
+} /* test_false_retry_other_principal */
+
 int
 main(
     int   argc,
@@ -504,6 +616,7 @@ main(
     test_misordered_after_completed();
     test_slots_independent();
     test_implicit_session_no_slots();
+    test_false_retry_other_principal();
 
     printf("nfs4_replay_slot: all tests passed\n");
     return 0;

--- a/src/server/smb/smb_dump.c
+++ b/src/server/smb/smb_dump.c
@@ -58,1033 +58,541 @@ smb_command_name(uint32_t command)
     } /* switch */
 } /* smb_command_name */
 
+/* Every NTSTATUS the server can name, as data rather than a switch: the
+ * corpus only ever produces a few dozen of these, and a thousand case
+ * lines the tests can never reach say nothing useful about coverage.  The
+ * scan is linear, but this is the debug-level dump path -- it never runs
+ * at the default log level. */
+/* *INDENT-OFF* */
+static const struct {
+    uint32_t    status;
+    const char *name;
+} smb_status_names[] = {
+    { SMB2_STATUS_SUCCESS,                            "Success"     },
+    { SMB2_STATUS_SHUTDOWN,                           "Shutdown"     },
+    { SMB2_STATUS_PENDING,                            "Pending"     },
+    { SMB2_STATUS_SMB_BAD_FID,                        "SmbBadFid"     },
+    { SMB2_STATUS_NO_MORE_FILES,                      "NoMoreFiles"     },
+    { SMB2_STATUS_UNSUCCESSFUL,                       "Unsuccessful"     },
+    { SMB2_STATUS_NOT_IMPLEMENTED,                    "NotImplemented"     },
+    { SMB2_STATUS_INVALID_INFO_CLASS,                 "InvalidInfoClass"     },
+    { SMB2_STATUS_INFO_LENGTH_MISMATCH,               "InfoLengthMismatch"     },
+    { SMB2_STATUS_ACCESS_VIOLATION,                   "AccessViolation"     },
+    { SMB2_STATUS_IN_PAGE_ERROR,                      "InPageError"     },
+    { SMB2_STATUS_PAGEFILE_QUOTA,                     "PagefileQuota"     },
+    { SMB2_STATUS_INVALID_HANDLE,                     "InvalidHandle"     },
+    { SMB2_STATUS_BAD_INITIAL_STACK,                  "BadInitialStack"     },
+    { SMB2_STATUS_BAD_INITIAL_PC,                     "BadInitialPc"     },
+    { SMB2_STATUS_INVALID_CID,                        "InvalidCid"     },
+    { SMB2_STATUS_TIMER_NOT_CANCELED,                 "TimerNotCanceled"     },
+    { SMB2_STATUS_INVALID_PARAMETER,                  "InvalidParameter"     },
+    { SMB2_STATUS_NO_SUCH_DEVICE,                     "NoSuchDevice"     },
+    { SMB2_STATUS_NO_SUCH_FILE,                       "NoSuchFile"     },
+    { SMB2_STATUS_INVALID_DEVICE_REQUEST,             "InvalidDeviceRequest"     },
+    { SMB2_STATUS_END_OF_FILE,                        "EndOfFile"     },
+    { SMB2_STATUS_WRONG_VOLUME,                       "WrongVolume"     },
+    { SMB2_STATUS_NO_MEDIA_IN_DEVICE,                 "NoMediaInDevice"     },
+    { SMB2_STATUS_UNRECOGNIZED_MEDIA,                 "UnrecognizedMedia"     },
+    { SMB2_STATUS_NONEXISTENT_SECTOR,                 "NonexistentSector"     },
+    { SMB2_STATUS_MORE_PROCESSING_REQUIRED,           "MoreProcessingRequired"     },
+    { SMB2_STATUS_NO_MEMORY,                          "NoMemory"     },
+    { SMB2_STATUS_CONFLICTING_ADDRESSES,              "ConflictingAddresses"     },
+    { SMB2_STATUS_NOT_MAPPED_VIEW,                    "NotMappedView"     },
+    { SMB2_STATUS_UNABLE_TO_FREE_VM,                  "UnableToFreeVm"     },
+    { SMB2_STATUS_UNABLE_TO_DELETE_SECTION,           "UnableToDeleteSection"     },
+    { SMB2_STATUS_INVALID_SYSTEM_SERVICE,             "InvalidSystemService"     },
+    { SMB2_STATUS_ILLEGAL_INSTRUCTION,                "IllegalInstruction"     },
+    { SMB2_STATUS_INVALID_LOCK_SEQUENCE,              "InvalidLockSequence"     },
+    { SMB2_STATUS_INVALID_VIEW_SIZE,                  "InvalidViewSize"     },
+    { SMB2_STATUS_INVALID_FILE_FOR_SECTION,           "InvalidFileForSection"     },
+    { SMB2_STATUS_ALREADY_COMMITTED,                  "AlreadyCommitted"     },
+    { SMB2_STATUS_ACCESS_DENIED,                      "AccessDenied"     },
+    { SMB2_STATUS_BUFFER_TOO_SMALL,                   "BufferTooSmall"     },
+    { SMB2_STATUS_OBJECT_TYPE_MISMATCH,               "ObjectTypeMismatch"     },
+    { SMB2_STATUS_NONCONTINUABLE_EXCEPTION,           "NoncontinuableException"     },
+    { SMB2_STATUS_INVALID_DISPOSITION,                "InvalidDisposition"     },
+    { SMB2_STATUS_UNWIND,                             "Unwind"     },
+    { SMB2_STATUS_BAD_STACK,                          "BadStack"     },
+    { SMB2_STATUS_INVALID_UNWIND_TARGET,              "InvalidUnwindTarget"     },
+    { SMB2_STATUS_NOT_LOCKED,                         "NotLocked"     },
+    { SMB2_STATUS_PARITY_ERROR,                       "ParityError"     },
+    { SMB2_STATUS_UNABLE_TO_DECOMMIT_VM,              "UnableToDecommitVm"     },
+    { SMB2_STATUS_NOT_COMMITTED,                      "NotCommitted"     },
+    { SMB2_STATUS_INVALID_PORT_ATTRIBUTES,            "InvalidPortAttributes"     },
+    { SMB2_STATUS_PORT_MESSAGE_TOO_LONG,              "PortMessageTooLong"     },
+    { SMB2_STATUS_INVALID_PARAMETER_MIX,              "InvalidParameterMix"     },
+    { SMB2_STATUS_INVALID_QUOTA_LOWER,                "InvalidQuotaLower"     },
+    { SMB2_STATUS_DISK_CORRUPT_ERROR,                 "DiskCorruptError"     },
+    { SMB2_STATUS_OBJECT_NAME_INVALID,                "ObjectNameInvalid"     },
+    { SMB2_STATUS_OBJECT_NAME_NOT_FOUND,              "ObjectNameNotFound"     },
+    { SMB2_STATUS_OBJECT_NAME_COLLISION,              "ObjectNameCollision"     },
+    { SMB2_STATUS_HANDLE_NOT_WAITABLE,                "HandleNotWaitable"     },
+    { SMB2_STATUS_PORT_DISCONNECTED,                  "PortDisconnected"     },
+    { SMB2_STATUS_DEVICE_ALREADY_ATTACHED,            "DeviceAlreadyAttached"     },
+    { SMB2_STATUS_OBJECT_PATH_INVALID,                "ObjectPathInvalid"     },
+    { SMB2_STATUS_OBJECT_PATH_NOT_FOUND,              "ObjectPathNotFound"     },
+    { SMB2_STATUS_OBJECT_PATH_SYNTAX_BAD,             "ObjectPathSyntaxBad"     },
+    { SMB2_STATUS_DATA_OVERRUN,                       "DataOverrun"     },
+    { SMB2_STATUS_DATA_LATE_ERROR,                    "DataLateError"     },
+    { SMB2_STATUS_DATA_ERROR,                         "DataError"     },
+    { SMB2_STATUS_CRC_ERROR,                          "CrcError"     },
+    { SMB2_STATUS_SECTION_TOO_BIG,                    "SectionTooBig"     },
+    { SMB2_STATUS_PORT_CONNECTION_REFUSED,            "PortConnectionRefused"     },
+    { SMB2_STATUS_INVALID_PORT_HANDLE,                "InvalidPortHandle"     },
+    { SMB2_STATUS_SHARING_VIOLATION,                  "SharingViolation"     },
+    { SMB2_STATUS_QUOTA_EXCEEDED,                     "QuotaExceeded"     },
+    { SMB2_STATUS_INVALID_PAGE_PROTECTION,            "InvalidPageProtection"     },
+    { SMB2_STATUS_MUTANT_NOT_OWNED,                   "MutantNotOwned"     },
+    { SMB2_STATUS_SEMAPHORE_LIMIT_EXCEEDED,           "SemaphoreLimitExceeded"     },
+    { SMB2_STATUS_PORT_ALREADY_SET,                   "PortAlreadySet"     },
+    { SMB2_STATUS_SECTION_NOT_IMAGE,                  "SectionNotImage"     },
+    { SMB2_STATUS_SUSPEND_COUNT_EXCEEDED,             "SuspendCountExceeded"     },
+    { SMB2_STATUS_THREAD_IS_TERMINATING,              "ThreadIsTerminating"     },
+    { SMB2_STATUS_BAD_WORKING_SET_LIMIT,              "BadWorkingSetLimit"     },
+    { SMB2_STATUS_INCOMPATIBLE_FILE_MAP,              "IncompatibleFileMap"     },
+    { SMB2_STATUS_SECTION_PROTECTION,                 "SectionProtection"     },
+    { SMB2_STATUS_EAS_NOT_SUPPORTED,                  "EasNotSupported"     },
+    { SMB2_STATUS_EA_TOO_LARGE,                       "EaTooLarge"     },
+    { SMB2_STATUS_NONEXISTENT_EA_ENTRY,               "NonexistentEaEntry"     },
+    { SMB2_STATUS_NO_EAS_ON_FILE,                     "NoEasOnFile"     },
+    { SMB2_STATUS_EA_CORRUPT_ERROR,                   "EaCorruptError"     },
+    { SMB2_STATUS_FILE_LOCK_CONFLICT,                 "FileLockConflict"     },
+    { SMB2_STATUS_LOCK_NOT_GRANTED,                   "LockNotGranted"     },
+    { SMB2_STATUS_DELETE_PENDING,                     "DeletePending"     },
+    { SMB2_STATUS_CTL_FILE_NOT_SUPPORTED,             "CtlFileNotSupported"     },
+    { SMB2_STATUS_UNKNOWN_REVISION,                   "UnknownRevision"     },
+    { SMB2_STATUS_REVISION_MISMATCH,                  "RevisionMismatch"     },
+    { SMB2_STATUS_INVALID_OWNER,                      "InvalidOwner"     },
+    { SMB2_STATUS_INVALID_PRIMARY_GROUP,              "InvalidPrimaryGroup"     },
+    { SMB2_STATUS_NO_IMPERSONATION_TOKEN,             "NoImpersonationToken"     },
+    { SMB2_STATUS_CANT_DISABLE_MANDATORY,             "CantDisableMandatory"     },
+    { SMB2_STATUS_NO_LOGON_SERVERS,                   "NoLogonServers"     },
+    { SMB2_STATUS_NO_SUCH_LOGON_SESSION,              "NoSuchLogonSession"     },
+    { SMB2_STATUS_NO_SUCH_PRIVILEGE,                  "NoSuchPrivilege"     },
+    { SMB2_STATUS_PRIVILEGE_NOT_HELD,                 "PrivilegeNotHeld"     },
+    { SMB2_STATUS_INVALID_ACCOUNT_NAME,               "InvalidAccountName"     },
+    { SMB2_STATUS_USER_EXISTS,                        "UserExists"     },
+    { SMB2_STATUS_NO_SUCH_USER,                       "NoSuchUser"     },
+    { SMB2_STATUS_GROUP_EXISTS,                       "GroupExists"     },
+    { SMB2_STATUS_NO_SUCH_GROUP,                      "NoSuchGroup"     },
+    { SMB2_STATUS_MEMBER_IN_GROUP,                    "MemberInGroup"     },
+    { SMB2_STATUS_MEMBER_NOT_IN_GROUP,                "MemberNotInGroup"     },
+    { SMB2_STATUS_LAST_ADMIN,                         "LastAdmin"     },
+    { SMB2_STATUS_WRONG_PASSWORD,                     "WrongPassword"     },
+    { SMB2_STATUS_ILL_FORMED_PASSWORD,                "IllFormedPassword"     },
+    { SMB2_STATUS_PASSWORD_RESTRICTION,               "PasswordRestriction"     },
+    { SMB2_STATUS_LOGON_FAILURE,                      "LogonFailure"     },
+    { SMB2_STATUS_ACCOUNT_RESTRICTION,                "AccountRestriction"     },
+    { SMB2_STATUS_INVALID_LOGON_HOURS,                "InvalidLogonHours"     },
+    { SMB2_STATUS_INVALID_WORKSTATION,                "InvalidWorkstation"     },
+    { SMB2_STATUS_PASSWORD_EXPIRED,                   "PasswordExpired"     },
+    { SMB2_STATUS_ACCOUNT_DISABLED,                   "AccountDisabled"     },
+    { SMB2_STATUS_NONE_MAPPED,                        "NoneMapped"     },
+    { SMB2_STATUS_TOO_MANY_LUIDS_REQUESTED,           "TooManyLuidsRequested"     },
+    { SMB2_STATUS_LUIDS_EXHAUSTED,                    "LuidsExhausted"     },
+    { SMB2_STATUS_INVALID_SUB_AUTHORITY,              "InvalidSubAuthority"     },
+    { SMB2_STATUS_INVALID_ACL,                        "InvalidAcl"     },
+    { SMB2_STATUS_INVALID_SID,                        "InvalidSid"     },
+    { SMB2_STATUS_INVALID_SECURITY_DESCR,             "InvalidSecurityDescr"     },
+    { SMB2_STATUS_PROCEDURE_NOT_FOUND,                "ProcedureNotFound"     },
+    { SMB2_STATUS_INVALID_IMAGE_FORMAT,               "InvalidImageFormat"     },
+    { SMB2_STATUS_NO_TOKEN,                           "NoToken"     },
+    { SMB2_STATUS_BAD_INHERITANCE_ACL,                "BadInheritanceAcl"     },
+    { SMB2_STATUS_RANGE_NOT_LOCKED,                   "RangeNotLocked"     },
+    { SMB2_STATUS_DISK_FULL,                          "DiskFull"     },
+    { SMB2_STATUS_SERVER_DISABLED,                    "ServerDisabled"     },
+    { SMB2_STATUS_SERVER_NOT_DISABLED,                "ServerNotDisabled"     },
+    { SMB2_STATUS_TOO_MANY_GUIDS_REQUESTED,           "TooManyGuidsRequested"     },
+    { SMB2_STATUS_INVALID_ID_AUTHORITY,               "InvalidIdAuthority"     },
+    { SMB2_STATUS_AGENTS_EXHAUSTED,                   "AgentsExhausted"     },
+    { SMB2_STATUS_INVALID_VOLUME_LABEL,               "InvalidVolumeLabel"     },
+    { SMB2_STATUS_SECTION_NOT_EXTENDED,               "SectionNotExtended"     },
+    { SMB2_STATUS_NOT_MAPPED_DATA,                    "NotMappedData"     },
+    { SMB2_STATUS_RESOURCE_DATA_NOT_FOUND,            "ResourceDataNotFound"     },
+    { SMB2_STATUS_RESOURCE_TYPE_NOT_FOUND,            "ResourceTypeNotFound"     },
+    { SMB2_STATUS_RESOURCE_NAME_NOT_FOUND,            "ResourceNameNotFound"     },
+    { SMB2_STATUS_ARRAY_BOUNDS_EXCEEDED,              "ArrayBoundsExceeded"     },
+    { SMB2_STATUS_FLOAT_DENORMAL_OPERAND,             "FloatDenormalOperand"     },
+    { SMB2_STATUS_FLOAT_DIVIDE_BY_ZERO,               "FloatDivideByZero"     },
+    { SMB2_STATUS_FLOAT_INEXACT_RESULT,               "FloatInexactResult"     },
+    { SMB2_STATUS_FLOAT_INVALID_OPERATION,            "FloatInvalidOperation"     },
+    { SMB2_STATUS_FLOAT_OVERFLOW,                     "FloatOverflow"     },
+    { SMB2_STATUS_FLOAT_STACK_CHECK,                  "FloatStackCheck"     },
+    { SMB2_STATUS_FLOAT_UNDERFLOW,                    "FloatUnderflow"     },
+    { SMB2_STATUS_INTEGER_DIVIDE_BY_ZERO,             "IntegerDivideByZero"     },
+    { SMB2_STATUS_INTEGER_OVERFLOW,                   "IntegerOverflow"     },
+    { SMB2_STATUS_PRIVILEGED_INSTRUCTION,             "PrivilegedInstruction"     },
+    { SMB2_STATUS_TOO_MANY_PAGING_FILES,              "TooManyPagingFiles"     },
+    { SMB2_STATUS_FILE_INVALID,                       "FileInvalid"     },
+    { SMB2_STATUS_ALLOTTED_SPACE_EXCEEDED,            "AllottedSpaceExceeded"     },
+    { SMB2_STATUS_INSUFFICIENT_RESOURCES,             "InsufficientResources"     },
+    { SMB2_STATUS_DFS_EXIT_PATH_FOUND,                "DfsExitPathFound"     },
+    { SMB2_STATUS_DEVICE_DATA_ERROR,                  "DeviceDataError"     },
+    { SMB2_STATUS_DEVICE_NOT_CONNECTED,               "DeviceNotConnected"     },
+    { SMB2_STATUS_DEVICE_POWER_FAILURE,               "DevicePowerFailure"     },
+    { SMB2_STATUS_FREE_VM_NOT_AT_BASE,                "FreeVmNotAtBase"     },
+    { SMB2_STATUS_MEMORY_NOT_ALLOCATED,               "MemoryNotAllocated"     },
+    { SMB2_STATUS_WORKING_SET_QUOTA,                  "WorkingSetQuota"     },
+    { SMB2_STATUS_MEDIA_WRITE_PROTECTED,              "MediaWriteProtected"     },
+    { SMB2_STATUS_DEVICE_NOT_READY,                   "DeviceNotReady"     },
+    { SMB2_STATUS_INVALID_GROUP_ATTRIBUTES,           "InvalidGroupAttributes"     },
+    { SMB2_STATUS_BAD_IMPERSONATION_LEVEL,            "BadImpersonationLevel"     },
+    { SMB2_STATUS_CANT_OPEN_ANONYMOUS,                "CantOpenAnonymous"     },
+    { SMB2_STATUS_BAD_VALIDATION_CLASS,               "BadValidationClass"     },
+    { SMB2_STATUS_BAD_TOKEN_TYPE,                     "BadTokenType"     },
+    { SMB2_STATUS_BAD_MASTER_BOOT_RECORD,             "BadMasterBootRecord"     },
+    { SMB2_STATUS_INSTRUCTION_MISALIGNMENT,           "InstructionMisalignment"     },
+    { SMB2_STATUS_INSTANCE_NOT_AVAILABLE,             "InstanceNotAvailable"     },
+    { SMB2_STATUS_PIPE_NOT_AVAILABLE,                 "PipeNotAvailable"     },
+    { SMB2_STATUS_INVALID_PIPE_STATE,                 "InvalidPipeState"     },
+    { SMB2_STATUS_PIPE_BUSY,                          "PipeBusy"     },
+    { SMB2_STATUS_ILLEGAL_FUNCTION,                   "IllegalFunction"     },
+    { SMB2_STATUS_PIPE_DISCONNECTED,                  "PipeDisconnected"     },
+    { SMB2_STATUS_PIPE_CLOSING,                       "PipeClosing"     },
+    { SMB2_STATUS_PIPE_CONNECTED,                     "PipeConnected"     },
+    { SMB2_STATUS_PIPE_LISTENING,                     "PipeListening"     },
+    { SMB2_STATUS_INVALID_READ_MODE,                  "InvalidReadMode"     },
+    { SMB2_STATUS_IO_TIMEOUT,                         "IoTimeout"     },
+    { SMB2_STATUS_FILE_FORCED_CLOSED,                 "FileForcedClosed"     },
+    { SMB2_STATUS_PROFILING_NOT_STARTED,              "ProfilingNotStarted"     },
+    { SMB2_STATUS_PROFILING_NOT_STOPPED,              "ProfilingNotStopped"     },
+    { SMB2_STATUS_COULD_NOT_INTERPRET,                "CouldNotInterpret"     },
+    { SMB2_STATUS_FILE_IS_A_DIRECTORY,                "FileIsADirectory"     },
+    { SMB2_STATUS_NOT_SUPPORTED,                      "NotSupported"     },
+    { SMB2_STATUS_REMOTE_NOT_LISTENING,               "RemoteNotListening"     },
+    { SMB2_STATUS_DUPLICATE_NAME,                     "DuplicateName"     },
+    { SMB2_STATUS_BAD_NETWORK_PATH,                   "BadNetworkPath"     },
+    { SMB2_STATUS_NETWORK_BUSY,                       "NetworkBusy"     },
+    { SMB2_STATUS_DEVICE_DOES_NOT_EXIST,              "DeviceDoesNotExist"     },
+    { SMB2_STATUS_TOO_MANY_COMMANDS,                  "TooManyCommands"     },
+    { SMB2_STATUS_ADAPTER_HARDWARE_ERROR,             "AdapterHardwareError"     },
+    { SMB2_STATUS_INVALID_NETWORK_RESPONSE,           "InvalidNetworkResponse"     },
+    { SMB2_STATUS_UNEXPECTED_NETWORK_ERROR,           "UnexpectedNetworkError"     },
+    { SMB2_STATUS_BAD_REMOTE_ADAPTER,                 "BadRemoteAdapter"     },
+    { SMB2_STATUS_PRINT_QUEUE_FULL,                   "PrintQueueFull"     },
+    { SMB2_STATUS_NO_SPOOL_SPACE,                     "NoSpoolSpace"     },
+    { SMB2_STATUS_PRINT_CANCELLED,                    "PrintCancelled"     },
+    { SMB2_STATUS_NETWORK_NAME_DELETED,               "NetworkNameDeleted"     },
+    { SMB2_STATUS_NETWORK_ACCESS_DENIED,              "NetworkAccessDenied"     },
+    { SMB2_STATUS_BAD_DEVICE_TYPE,                    "BadDeviceType"     },
+    { SMB2_STATUS_BAD_NETWORK_NAME,                   "BadNetworkName"     },
+    { SMB2_STATUS_TOO_MANY_NAMES,                     "TooManyNames"     },
+    { SMB2_STATUS_TOO_MANY_SESSIONS,                  "TooManySessions"     },
+    { SMB2_STATUS_SHARING_PAUSED,                     "SharingPaused"     },
+    { SMB2_STATUS_REQUEST_NOT_ACCEPTED,               "RequestNotAccepted"     },
+    { SMB2_STATUS_REDIRECTOR_PAUSED,                  "RedirectorPaused"     },
+    { SMB2_STATUS_NET_WRITE_FAULT,                    "NetWriteFault"     },
+    { SMB2_STATUS_PROFILING_AT_LIMIT,                 "ProfilingAtLimit"     },
+    { SMB2_STATUS_NOT_SAME_DEVICE,                    "NotSameDevice"     },
+    { SMB2_STATUS_FILE_RENAMED,                       "FileRenamed"     },
+    { SMB2_STATUS_VIRTUAL_CIRCUIT_CLOSED,             "VirtualCircuitClosed"     },
+    { SMB2_STATUS_NO_SECURITY_ON_OBJECT,              "NoSecurityOnObject"     },
+    { SMB2_STATUS_CANT_WAIT,                          "CantWait"     },
+    { SMB2_STATUS_PIPE_EMPTY,                         "PipeEmpty"     },
+    { SMB2_STATUS_CANT_ACCESS_DOMAIN_INFO,            "CantAccessDomainInfo"     },
+    { SMB2_STATUS_CANT_TERMINATE_SELF,                "CantTerminateSelf"     },
+    { SMB2_STATUS_INVALID_SERVER_STATE,               "InvalidServerState"     },
+    { SMB2_STATUS_INVALID_DOMAIN_STATE,               "InvalidDomainState"     },
+    { SMB2_STATUS_INVALID_DOMAIN_ROLE,                "InvalidDomainRole"     },
+    { SMB2_STATUS_NO_SUCH_DOMAIN,                     "NoSuchDomain"     },
+    { SMB2_STATUS_DOMAIN_EXISTS,                      "DomainExists"     },
+    { SMB2_STATUS_DOMAIN_LIMIT_EXCEEDED,              "DomainLimitExceeded"     },
+    { SMB2_STATUS_OPLOCK_NOT_GRANTED,                 "OplockNotGranted"     },
+    { SMB2_STATUS_INVALID_OPLOCK_PROTOCOL,            "InvalidOplockProtocol"     },
+    { SMB2_STATUS_INTERNAL_DB_CORRUPTION,             "InternalDbCorruption"     },
+    { SMB2_STATUS_INTERNAL_ERROR,                     "InternalError"     },
+    { SMB2_STATUS_GENERIC_NOT_MAPPED,                 "GenericNotMapped"     },
+    { SMB2_STATUS_BAD_DESCRIPTOR_FORMAT,              "BadDescriptorFormat"     },
+    { SMB2_STATUS_INVALID_USER_BUFFER,                "InvalidUserBuffer"     },
+    { SMB2_STATUS_UNEXPECTED_IO_ERROR,                "UnexpectedIoError"     },
+    { SMB2_STATUS_UNEXPECTED_MM_CREATE_ERR,           "UnexpectedMmCreateErr"     },
+    { SMB2_STATUS_UNEXPECTED_MM_MAP_ERROR,            "UnexpectedMmMapError"     },
+    { SMB2_STATUS_UNEXPECTED_MM_EXTEND_ERR,           "UnexpectedMmExtendErr"     },
+    { SMB2_STATUS_NOT_LOGON_PROCESS,                  "NotLogonProcess"     },
+    { SMB2_STATUS_LOGON_SESSION_EXISTS,               "LogonSessionExists"     },
+    { SMB2_STATUS_INVALID_PARAMETER_1,                "InvalidParameter1"     },
+    { SMB2_STATUS_INVALID_PARAMETER_2,                "InvalidParameter2"     },
+    { SMB2_STATUS_INVALID_PARAMETER_3,                "InvalidParameter3"     },
+    { SMB2_STATUS_INVALID_PARAMETER_4,                "InvalidParameter4"     },
+    { SMB2_STATUS_INVALID_PARAMETER_5,                "InvalidParameter5"     },
+    { SMB2_STATUS_INVALID_PARAMETER_6,                "InvalidParameter6"     },
+    { SMB2_STATUS_INVALID_PARAMETER_7,                "InvalidParameter7"     },
+    { SMB2_STATUS_INVALID_PARAMETER_8,                "InvalidParameter8"     },
+    { SMB2_STATUS_INVALID_PARAMETER_9,                "InvalidParameter9"     },
+    { SMB2_STATUS_INVALID_PARAMETER_10,               "InvalidParameter10"     },
+    { SMB2_STATUS_INVALID_PARAMETER_11,               "InvalidParameter11"     },
+    { SMB2_STATUS_INVALID_PARAMETER_12,               "InvalidParameter12"     },
+    { SMB2_STATUS_REDIRECTOR_NOT_STARTED,             "RedirectorNotStarted"     },
+    { SMB2_STATUS_REDIRECTOR_STARTED,                 "RedirectorStarted"     },
+    { SMB2_STATUS_STACK_OVERFLOW,                     "StackOverflow"     },
+    { SMB2_STATUS_NO_SUCH_PACKAGE,                    "NoSuchPackage"     },
+    { SMB2_STATUS_BAD_FUNCTION_TABLE,                 "BadFunctionTable"     },
+    { SMB2_STATUS_DIRECTORY_NOT_EMPTY,                "DirectoryNotEmpty"     },
+    { SMB2_STATUS_FILE_CORRUPT_ERROR,                 "FileCorruptError"     },
+    { SMB2_STATUS_NOT_A_DIRECTORY,                    "NotADirectory"     },
+    { SMB2_STATUS_BAD_LOGON_SESSION_STATE,            "BadLogonSessionState"     },
+    { SMB2_STATUS_LOGON_SESSION_COLLISION,            "LogonSessionCollision"     },
+    { SMB2_STATUS_NAME_TOO_LONG,                      "NameTooLong"     },
+    { SMB2_STATUS_FILES_OPEN,                         "FilesOpen"     },
+    { SMB2_STATUS_CONNECTION_IN_USE,                  "ConnectionInUse"     },
+    { SMB2_STATUS_MESSAGE_NOT_FOUND,                  "MessageNotFound"     },
+    { SMB2_STATUS_PROCESS_IS_TERMINATING,             "ProcessIsTerminating"     },
+    { SMB2_STATUS_INVALID_LOGON_TYPE,                 "InvalidLogonType"     },
+    { SMB2_STATUS_NO_GUID_TRANSLATION,                "NoGuidTranslation"     },
+    { SMB2_STATUS_CANNOT_IMPERSONATE,                 "CannotImpersonate"     },
+    { SMB2_STATUS_IMAGE_ALREADY_LOADED,               "ImageAlreadyLoaded"     },
+    { SMB2_STATUS_ABIOS_NOT_PRESENT,                  "AbiosNotPresent"     },
+    { SMB2_STATUS_ABIOS_LID_NOT_EXIST,                "AbiosLidNotExist"     },
+    { SMB2_STATUS_ABIOS_LID_ALREADY_OWNED,            "AbiosLidAlreadyOwned"     },
+    { SMB2_STATUS_ABIOS_NOT_LID_OWNER,                "AbiosNotLidOwner"     },
+    { SMB2_STATUS_ABIOS_INVALID_COMMAND,              "AbiosInvalidCommand"     },
+    { SMB2_STATUS_ABIOS_INVALID_LID,                  "AbiosInvalidLid"     },
+    { SMB2_STATUS_ABIOS_SELECTOR_NOT_AVAILABLE,       "AbiosSelectorNotAvailable"     },
+    { SMB2_STATUS_ABIOS_INVALID_SELECTOR,             "AbiosInvalidSelector"     },
+    { SMB2_STATUS_NO_LDT,                             "NoLdt"     },
+    { SMB2_STATUS_INVALID_LDT_SIZE,                   "InvalidLdtSize"     },
+    { SMB2_STATUS_INVALID_LDT_OFFSET,                 "InvalidLdtOffset"     },
+    { SMB2_STATUS_INVALID_LDT_DESCRIPTOR,             "InvalidLdtDescriptor"     },
+    { SMB2_STATUS_INVALID_IMAGE_NE_FORMAT,            "InvalidImageNeFormat"     },
+    { SMB2_STATUS_RXACT_INVALID_STATE,                "RxactInvalidState"     },
+    { SMB2_STATUS_RXACT_COMMIT_FAILURE,               "RxactCommitFailure"     },
+    { SMB2_STATUS_MAPPED_FILE_SIZE_ZERO,              "MappedFileSizeZero"     },
+    { SMB2_STATUS_TOO_MANY_OPENED_FILES,              "TooManyOpenedFiles"     },
+    { SMB2_STATUS_CANCELLED,                          "Cancelled"     },
+    { SMB2_STATUS_CANNOT_DELETE,                      "CannotDelete"     },
+    { SMB2_STATUS_INVALID_COMPUTER_NAME,              "InvalidComputerName"     },
+    { SMB2_STATUS_FILE_DELETED,                       "FileDeleted"     },
+    { SMB2_STATUS_SPECIAL_ACCOUNT,                    "SpecialAccount"     },
+    { SMB2_STATUS_SPECIAL_GROUP,                      "SpecialGroup"     },
+    { SMB2_STATUS_SPECIAL_USER,                       "SpecialUser"     },
+    { SMB2_STATUS_MEMBERS_PRIMARY_GROUP,              "MembersPrimaryGroup"     },
+    { SMB2_STATUS_FILE_CLOSED,                        "FileClosed"     },
+    { SMB2_STATUS_TOO_MANY_THREADS,                   "TooManyThreads"     },
+    { SMB2_STATUS_THREAD_NOT_IN_PROCESS,              "ThreadNotInProcess"     },
+    { SMB2_STATUS_TOKEN_ALREADY_IN_USE,               "TokenAlreadyInUse"     },
+    { SMB2_STATUS_PAGEFILE_QUOTA_EXCEEDED,            "PagefileQuotaExceeded"     },
+    { SMB2_STATUS_COMMITMENT_LIMIT,                   "CommitmentLimit"     },
+    { SMB2_STATUS_INVALID_IMAGE_LE_FORMAT,            "InvalidImageLeFormat"     },
+    { SMB2_STATUS_INVALID_IMAGE_NOT_MZ,               "InvalidImageNotMz"     },
+    { SMB2_STATUS_INVALID_IMAGE_PROTECT,              "InvalidImageProtect"     },
+    { SMB2_STATUS_INVALID_IMAGE_WIN_16,               "InvalidImageWin16"     },
+    { SMB2_STATUS_LOGON_SERVER_CONFLICT,              "LogonServerConflict"     },
+    { SMB2_STATUS_TIME_DIFFERENCE_AT_DC,              "TimeDifferenceAtDc"     },
+    { SMB2_STATUS_SYNCHRONIZATION_REQUIRED,           "SynchronizationRequired"     },
+    { SMB2_STATUS_DLL_NOT_FOUND,                      "DllNotFound"     },
+    { SMB2_STATUS_OPEN_FAILED,                        "OpenFailed"     },
+    { SMB2_STATUS_IO_PRIVILEGE_FAILED,                "IoPrivilegeFailed"     },
+    { SMB2_STATUS_ORDINAL_NOT_FOUND,                  "OrdinalNotFound"     },
+    { SMB2_STATUS_ENTRYPOINT_NOT_FOUND,               "EntrypointNotFound"     },
+    { SMB2_STATUS_CONTROL_C_EXIT,                     "ControlCExit"     },
+    { SMB2_STATUS_LOCAL_DISCONNECT,                   "LocalDisconnect"     },
+    { SMB2_STATUS_REMOTE_DISCONNECT,                  "RemoteDisconnect"     },
+    { SMB2_STATUS_REMOTE_RESOURCES,                   "RemoteResources"     },
+    { SMB2_STATUS_LINK_FAILED,                        "LinkFailed"     },
+    { SMB2_STATUS_LINK_TIMEOUT,                       "LinkTimeout"     },
+    { SMB2_STATUS_INVALID_CONNECTION,                 "InvalidConnection"     },
+    { SMB2_STATUS_INVALID_ADDRESS,                    "InvalidAddress"     },
+    { SMB2_STATUS_DLL_INIT_FAILED,                    "DllInitFailed"     },
+    { SMB2_STATUS_MISSING_SYSTEMFILE,                 "MissingSystemfile"     },
+    { SMB2_STATUS_UNHANDLED_EXCEPTION,                "UnhandledException"     },
+    { SMB2_STATUS_APP_INIT_FAILURE,                   "AppInitFailure"     },
+    { SMB2_STATUS_PAGEFILE_CREATE_FAILED,             "PagefileCreateFailed"     },
+    { SMB2_STATUS_NO_PAGEFILE,                        "NoPagefile"     },
+    { SMB2_STATUS_INVALID_LEVEL,                      "InvalidLevel"     },
+    { SMB2_STATUS_WRONG_PASSWORD_CORE,                "WrongPasswordCore"     },
+    { SMB2_STATUS_ILLEGAL_FLOAT_CONTEXT,              "IllegalFloatContext"     },
+    { SMB2_STATUS_PIPE_BROKEN,                        "PipeBroken"     },
+    { SMB2_STATUS_REGISTRY_CORRUPT,                   "RegistryCorrupt"     },
+    { SMB2_STATUS_REGISTRY_IO_FAILED,                 "RegistryIoFailed"     },
+    { SMB2_STATUS_NO_EVENT_PAIR,                      "NoEventPair"     },
+    { SMB2_STATUS_UNRECOGNIZED_VOLUME,                "UnrecognizedVolume"     },
+    { SMB2_STATUS_SERIAL_NO_DEVICE_INITED,            "SerialNoDeviceInited"     },
+    { SMB2_STATUS_NO_SUCH_ALIAS,                      "NoSuchAlias"     },
+    { SMB2_STATUS_MEMBER_NOT_IN_ALIAS,                "MemberNotInAlias"     },
+    { SMB2_STATUS_MEMBER_IN_ALIAS,                    "MemberInAlias"     },
+    { SMB2_STATUS_ALIAS_EXISTS,                       "AliasExists"     },
+    { SMB2_STATUS_LOGON_NOT_GRANTED,                  "LogonNotGranted"     },
+    { SMB2_STATUS_TOO_MANY_SECRETS,                   "TooManySecrets"     },
+    { SMB2_STATUS_SECRET_TOO_LONG,                    "SecretTooLong"     },
+    { SMB2_STATUS_INTERNAL_DB_ERROR,                  "InternalDbError"     },
+    { SMB2_STATUS_FULLSCREEN_MODE,                    "FullscreenMode"     },
+    { SMB2_STATUS_TOO_MANY_CONTEXT_IDS,               "TooManyContextIds"     },
+    { SMB2_STATUS_LOGON_TYPE_NOT_GRANTED,             "LogonTypeNotGranted"     },
+    { SMB2_STATUS_NOT_REGISTRY_FILE,                  "NotRegistryFile"     },
+    { SMB2_STATUS_NT_CROSS_ENCRYPTION_REQUIRED,       "NtCrossEncryptionRequired"     },
+    { SMB2_STATUS_DOMAIN_CTRLR_CONFIG_ERROR,          "DomainCtrlrConfigError"     },
+    { SMB2_STATUS_FT_MISSING_MEMBER,                  "FtMissingMember"     },
+    { SMB2_STATUS_ILL_FORMED_SERVICE_ENTRY,           "IllFormedServiceEntry"     },
+    { SMB2_STATUS_ILLEGAL_CHARACTER,                  "IllegalCharacter"     },
+    { SMB2_STATUS_UNMAPPABLE_CHARACTER,               "UnmappableCharacter"     },
+    { SMB2_STATUS_UNDEFINED_CHARACTER,                "UndefinedCharacter"     },
+    { SMB2_STATUS_FLOPPY_VOLUME,                      "FloppyVolume"     },
+    { SMB2_STATUS_FLOPPY_ID_MARK_NOT_FOUND,           "FloppyIdMarkNotFound"     },
+    { SMB2_STATUS_FLOPPY_WRONG_CYLINDER,              "FloppyWrongCylinder"     },
+    { SMB2_STATUS_FLOPPY_UNKNOWN_ERROR,               "FloppyUnknownError"     },
+    { SMB2_STATUS_FLOPPY_BAD_REGISTERS,               "FloppyBadRegisters"     },
+    { SMB2_STATUS_DISK_RECALIBRATE_FAILED,            "DiskRecalibrateFailed"     },
+    { SMB2_STATUS_DISK_OPERATION_FAILED,              "DiskOperationFailed"     },
+    { SMB2_STATUS_DISK_RESET_FAILED,                  "DiskResetFailed"     },
+    { SMB2_STATUS_SHARED_IRQ_BUSY,                    "SharedIrqBusy"     },
+    { SMB2_STATUS_FT_ORPHANING,                       "FtOrphaning"     },
+    { SMB2_STATUS_PARTITION_FAILURE,                  "PartitionFailure"     },
+    { SMB2_STATUS_INVALID_BLOCK_LENGTH,               "InvalidBlockLength"     },
+    { SMB2_STATUS_DEVICE_NOT_PARTITIONED,             "DeviceNotPartitioned"     },
+    { SMB2_STATUS_UNABLE_TO_LOCK_MEDIA,               "UnableToLockMedia"     },
+    { SMB2_STATUS_UNABLE_TO_UNLOAD_MEDIA,             "UnableToUnloadMedia"     },
+    { SMB2_STATUS_EOM_OVERFLOW,                       "EomOverflow"     },
+    { SMB2_STATUS_NO_MEDIA,                           "NoMedia"     },
+    { SMB2_STATUS_NO_SUCH_MEMBER,                     "NoSuchMember"     },
+    { SMB2_STATUS_INVALID_MEMBER,                     "InvalidMember"     },
+    { SMB2_STATUS_KEY_DELETED,                        "KeyDeleted"     },
+    { SMB2_STATUS_NO_LOG_SPACE,                       "NoLogSpace"     },
+    { SMB2_STATUS_TOO_MANY_SIDS,                      "TooManySids"     },
+    { SMB2_STATUS_LM_CROSS_ENCRYPTION_REQUIRED,       "LmCrossEncryptionRequired"     },
+    { SMB2_STATUS_KEY_HAS_CHILDREN,                   "KeyHasChildren"     },
+    { SMB2_STATUS_CHILD_MUST_BE_VOLATILE,             "ChildMustBeVolatile"     },
+    { SMB2_STATUS_DEVICE_CONFIGURATION_ERROR,         "DeviceConfigurationError"     },
+    { SMB2_STATUS_DRIVER_INTERNAL_ERROR,              "DriverInternalError"     },
+    { SMB2_STATUS_INVALID_DEVICE_STATE,               "InvalidDeviceState"     },
+    { SMB2_STATUS_IO_DEVICE_ERROR,                    "IoDeviceError"     },
+    { SMB2_STATUS_DEVICE_PROTOCOL_ERROR,              "DeviceProtocolError"     },
+    { SMB2_STATUS_BACKUP_CONTROLLER,                  "BackupController"     },
+    { SMB2_STATUS_LOG_FILE_FULL,                      "LogFileFull"     },
+    { SMB2_STATUS_TOO_LATE,                           "TooLate"     },
+    { SMB2_STATUS_NO_TRUST_LSA_SECRET,                "NoTrustLsaSecret"     },
+    { SMB2_STATUS_NO_TRUST_SAM_ACCOUNT,               "NoTrustSamAccount"     },
+    { SMB2_STATUS_TRUSTED_DOMAIN_FAILURE,             "TrustedDomainFailure"     },
+    { SMB2_STATUS_TRUSTED_RELATIONSHIP_FAILURE,       "TrustedRelationshipFailure"     },
+    { SMB2_STATUS_EVENTLOG_FILE_CORRUPT,              "EventlogFileCorrupt"     },
+    { SMB2_STATUS_EVENTLOG_CANT_START,                "EventlogCantStart"     },
+    { SMB2_STATUS_TRUST_FAILURE,                      "TrustFailure"     },
+    { SMB2_STATUS_MUTANT_LIMIT_EXCEEDED,              "MutantLimitExceeded"     },
+    { SMB2_STATUS_NETLOGON_NOT_STARTED,               "NetlogonNotStarted"     },
+    { SMB2_STATUS_ACCOUNT_EXPIRED,                    "AccountExpired"     },
+    { SMB2_STATUS_POSSIBLE_DEADLOCK,                  "PossibleDeadlock"     },
+    { SMB2_STATUS_NETWORK_CREDENTIAL_CONFLICT,        "NetworkCredentialConflict"     },
+    { SMB2_STATUS_REMOTE_SESSION_LIMIT,               "RemoteSessionLimit"     },
+    { SMB2_STATUS_EVENTLOG_FILE_CHANGED,              "EventlogFileChanged"     },
+    { SMB2_STATUS_NOLOGON_INTERDOMAIN_TRUST_ACCOUNT,  "NologonInterdomainTrustAccount"     },
+    { SMB2_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT,  "NologonWorkstationTrustAccount"     },
+    { SMB2_STATUS_NOLOGON_SERVER_TRUST_ACCOUNT,       "NologonServerTrustAccount"     },
+    { SMB2_STATUS_DOMAIN_TRUST_INCONSISTENT,          "DomainTrustInconsistent"     },
+    { SMB2_STATUS_FS_DRIVER_REQUIRED,                 "FsDriverRequired"     },
+    { SMB2_STATUS_NO_USER_SESSION_KEY,                "NoUserSessionKey"     },
+    { SMB2_STATUS_USER_SESSION_DELETED,               "UserSessionDeleted"     },
+    { SMB2_STATUS_RESOURCE_LANG_NOT_FOUND,            "ResourceLangNotFound"     },
+    { SMB2_STATUS_INSUFF_SERVER_RESOURCES,            "InsuffServerResources"     },
+    { SMB2_STATUS_INVALID_BUFFER_SIZE,                "InvalidBufferSize"     },
+    { SMB2_STATUS_INVALID_ADDRESS_COMPONENT,          "InvalidAddressComponent"     },
+    { SMB2_STATUS_INVALID_ADDRESS_WILDCARD,           "InvalidAddressWildcard"     },
+    { SMB2_STATUS_TOO_MANY_ADDRESSES,                 "TooManyAddresses"     },
+    { SMB2_STATUS_ADDRESS_ALREADY_EXISTS,             "AddressAlreadyExists"     },
+    { SMB2_STATUS_ADDRESS_CLOSED,                     "AddressClosed"     },
+    { SMB2_STATUS_CONNECTION_DISCONNECTED,            "ConnectionDisconnected"     },
+    { SMB2_STATUS_CONNECTION_RESET,                   "ConnectionReset"     },
+    { SMB2_STATUS_TOO_MANY_NODES,                     "TooManyNodes"     },
+    { SMB2_STATUS_TRANSACTION_ABORTED,                "TransactionAborted"     },
+    { SMB2_STATUS_TRANSACTION_TIMED_OUT,              "TransactionTimedOut"     },
+    { SMB2_STATUS_TRANSACTION_NO_RELEASE,             "TransactionNoRelease"     },
+    { SMB2_STATUS_TRANSACTION_NO_MATCH,               "TransactionNoMatch"     },
+    { SMB2_STATUS_TRANSACTION_RESPONDED,              "TransactionResponded"     },
+    { SMB2_STATUS_TRANSACTION_INVALID_ID,             "TransactionInvalidId"     },
+    { SMB2_STATUS_TRANSACTION_INVALID_TYPE,           "TransactionInvalidType"     },
+    { SMB2_STATUS_NOT_SERVER_SESSION,                 "NotServerSession"     },
+    { SMB2_STATUS_NOT_CLIENT_SESSION,                 "NotClientSession"     },
+    { SMB2_STATUS_CANNOT_LOAD_REGISTRY_FILE,          "CannotLoadRegistryFile"     },
+    { SMB2_STATUS_DEBUG_ATTACH_FAILED,                "DebugAttachFailed"     },
+    { SMB2_STATUS_SYSTEM_PROCESS_TERMINATED,          "SystemProcessTerminated"     },
+    { SMB2_STATUS_DATA_NOT_ACCEPTED,                  "DataNotAccepted"     },
+    { SMB2_STATUS_NO_BROWSER_SERVERS_FOUND,           "NoBrowserServersFound"     },
+    { SMB2_STATUS_VDM_HARD_ERROR,                     "VdmHardError"     },
+    { SMB2_STATUS_DRIVER_CANCEL_TIMEOUT,              "DriverCancelTimeout"     },
+    { SMB2_STATUS_REPLY_MESSAGE_MISMATCH,             "ReplyMessageMismatch"     },
+    { SMB2_STATUS_MAPPED_ALIGNMENT,                   "MappedAlignment"     },
+    { SMB2_STATUS_IMAGE_CHECKSUM_MISMATCH,            "ImageChecksumMismatch"     },
+    { SMB2_STATUS_LOST_WRITEBEHIND_DATA,              "LostWritebehindData"     },
+    { SMB2_STATUS_CLIENT_SERVER_PARAMETERS_INVALID,   "ClientServerParametersInvalid"     },
+    { SMB2_STATUS_PASSWORD_MUST_CHANGE,               "PasswordMustChange"     },
+    { SMB2_STATUS_NOT_FOUND,                          "NotFound"     },
+    { SMB2_STATUS_NOT_TINY_STREAM,                    "NotTinyStream"     },
+    { SMB2_STATUS_RECOVERY_FAILURE,                   "RecoveryFailure"     },
+    { SMB2_STATUS_STACK_OVERFLOW_READ,                "StackOverflowRead"     },
+    { SMB2_STATUS_FAIL_CHECK,                         "FailCheck"     },
+    { SMB2_STATUS_DUPLICATE_OBJECTID,                 "DuplicateObjectid"     },
+    { SMB2_STATUS_OBJECTID_EXISTS,                    "ObjectidExists"     },
+    { SMB2_STATUS_CONVERT_TO_LARGE,                   "ConvertToLarge"     },
+    { SMB2_STATUS_RETRY,                              "Retry"     },
+    { SMB2_STATUS_FOUND_OUT_OF_SCOPE,                 "FoundOutOfScope"     },
+    { SMB2_STATUS_ALLOCATE_BUCKET,                    "AllocateBucket"     },
+    { SMB2_STATUS_PROPSET_NOT_FOUND,                  "PropsetNotFound"     },
+    { SMB2_STATUS_MARSHALL_OVERFLOW,                  "MarshallOverflow"     },
+    { SMB2_STATUS_INVALID_VARIANT,                    "InvalidVariant"     },
+    { SMB2_STATUS_DOMAIN_CONTROLLER_NOT_FOUND,        "DomainControllerNotFound"     },
+    { SMB2_STATUS_ACCOUNT_LOCKED_OUT,                 "AccountLockedOut"     },
+    { SMB2_STATUS_HANDLE_NOT_CLOSABLE,                "HandleNotClosable"     },
+    { SMB2_STATUS_CONNECTION_REFUSED,                 "ConnectionRefused"     },
+    { SMB2_STATUS_GRACEFUL_DISCONNECT,                "GracefulDisconnect"     },
+    { SMB2_STATUS_ADDRESS_ALREADY_ASSOCIATED,         "AddressAlreadyAssociated"     },
+    { SMB2_STATUS_ADDRESS_NOT_ASSOCIATED,             "AddressNotAssociated"     },
+    { SMB2_STATUS_CONNECTION_INVALID,                 "ConnectionInvalid"     },
+    { SMB2_STATUS_CONNECTION_ACTIVE,                  "ConnectionActive"     },
+    { SMB2_STATUS_NETWORK_UNREACHABLE,                "NetworkUnreachable"     },
+    { SMB2_STATUS_HOST_UNREACHABLE,                   "HostUnreachable"     },
+    { SMB2_STATUS_PROTOCOL_UNREACHABLE,               "ProtocolUnreachable"     },
+    { SMB2_STATUS_PORT_UNREACHABLE,                   "PortUnreachable"     },
+    { SMB2_STATUS_REQUEST_ABORTED,                    "RequestAborted"     },
+    { SMB2_STATUS_CONNECTION_ABORTED,                 "ConnectionAborted"     },
+    { SMB2_STATUS_BAD_COMPRESSION_BUFFER,             "BadCompressionBuffer"     },
+    { SMB2_STATUS_USER_MAPPED_FILE,                   "UserMappedFile"     },
+    { SMB2_STATUS_AUDIT_FAILED,                       "AuditFailed"     },
+    { SMB2_STATUS_TIMER_RESOLUTION_NOT_SET,           "TimerResolutionNotSet"     },
+    { SMB2_STATUS_CONNECTION_COUNT_LIMIT,             "ConnectionCountLimit"     },
+    { SMB2_STATUS_LOGIN_TIME_RESTRICTION,             "LoginTimeRestriction"     },
+    { SMB2_STATUS_LOGIN_WKSTA_RESTRICTION,            "LoginWkstaRestriction"     },
+    { SMB2_STATUS_IMAGE_MP_UP_MISMATCH,               "ImageMpUpMismatch"     },
+    { SMB2_STATUS_INSUFFICIENT_LOGON_INFO,            "InsufficientLogonInfo"     },
+    { SMB2_STATUS_BAD_DLL_ENTRYPOINT,                 "BadDllEntrypoint"     },
+    { SMB2_STATUS_BAD_SERVICE_ENTRYPOINT,             "BadServiceEntrypoint"     },
+    { SMB2_STATUS_LPC_REPLY_LOST,                     "LpcReplyLost"     },
+    { SMB2_STATUS_IP_ADDRESS_CONFLICT1,               "IpAddressConflict1"     },
+    { SMB2_STATUS_IP_ADDRESS_CONFLICT2,               "IpAddressConflict2"     },
+    { SMB2_STATUS_REGISTRY_QUOTA_LIMIT,               "RegistryQuotaLimit"     },
+    { SMB2_STATUS_PATH_NOT_COVERED,                   "PathNotCovered"     },
+    { SMB2_STATUS_NO_CALLBACK_ACTIVE,                 "NoCallbackActive"     },
+    { SMB2_STATUS_LICENSE_QUOTA_EXCEEDED,             "LicenseQuotaExceeded"     },
+    { SMB2_STATUS_PWD_TOO_SHORT,                      "PwdTooShort"     },
+    { SMB2_STATUS_PWD_TOO_RECENT,                     "PwdTooRecent"     },
+    { SMB2_STATUS_PWD_HISTORY_CONFLICT,               "PwdHistoryConflict"     },
+    { SMB2_STATUS_PLUGPLAY_NO_DEVICE,                 "PlugplayNoDevice"     },
+    { SMB2_STATUS_UNSUPPORTED_COMPRESSION,            "UnsupportedCompression"     },
+    { SMB2_STATUS_INVALID_HW_PROFILE,                 "InvalidHwProfile"     },
+    { SMB2_STATUS_INVALID_PLUGPLAY_DEVICE_PATH,       "InvalidPlugplayDevicePath"     },
+    { SMB2_STATUS_DRIVER_ORDINAL_NOT_FOUND,           "DriverOrdinalNotFound"     },
+    { SMB2_STATUS_DRIVER_ENTRYPOINT_NOT_FOUND,        "DriverEntrypointNotFound"     },
+    { SMB2_STATUS_RESOURCE_NOT_OWNED,                 "ResourceNotOwned"     },
+    { SMB2_STATUS_TOO_MANY_LINKS,                     "TooManyLinks"     },
+    { SMB2_STATUS_QUOTA_LIST_INCONSISTENT,            "QuotaListInconsistent"     },
+    { SMB2_STATUS_FILE_IS_OFFLINE,                    "FileIsOffline"     },
+    { SMB2_STATUS_VOLUME_DISMOUNTED,                  "VolumeDismounted"     },
+    { SMB2_STATUS_NOT_A_REPARSE_POINT,                "NotAReparsePoint"     },
+    { SMB2_STATUS_SERVER_UNAVAILABLE,                 "ServerUnavailable"     },
+    { SMB2_STATUS_BUFFER_OVERFLOW,                    "BufferOverflow"     },
+    { SMB2_STATUS_STOPPED_ON_SYMLINK,                 "StoppedOnSymlink"     },
+};
+/* *INDENT-ON* */
+
 static const char *
 smb_status_name(uint32_t status)
 {
-    switch (status) {
-        case SMB2_STATUS_SUCCESS:
-            return "Success";
-        case SMB2_STATUS_SHUTDOWN:
-            return "Shutdown";
-        case SMB2_STATUS_PENDING:
-            return "Pending";
-        case SMB2_STATUS_SMB_BAD_FID:
-            return "SmbBadFid";
-        case SMB2_STATUS_NO_MORE_FILES:
-            return "NoMoreFiles";
-        case SMB2_STATUS_UNSUCCESSFUL:
-            return "Unsuccessful";
-        case SMB2_STATUS_NOT_IMPLEMENTED:
-            return "NotImplemented";
-        case SMB2_STATUS_INVALID_INFO_CLASS:
-            return "InvalidInfoClass";
-        case SMB2_STATUS_INFO_LENGTH_MISMATCH:
-            return "InfoLengthMismatch";
-        case SMB2_STATUS_ACCESS_VIOLATION:
-            return "AccessViolation";
-        case SMB2_STATUS_IN_PAGE_ERROR:
-            return "InPageError";
-        case SMB2_STATUS_PAGEFILE_QUOTA:
-            return "PagefileQuota";
-        case SMB2_STATUS_INVALID_HANDLE:
-            return "InvalidHandle";
-        case SMB2_STATUS_BAD_INITIAL_STACK:
-            return "BadInitialStack";
-        case SMB2_STATUS_BAD_INITIAL_PC:
-            return "BadInitialPc";
-        case SMB2_STATUS_INVALID_CID:
-            return "InvalidCid";
-        case SMB2_STATUS_TIMER_NOT_CANCELED:
-            return "TimerNotCanceled";
-        case SMB2_STATUS_INVALID_PARAMETER:
-            return "InvalidParameter";
-        case SMB2_STATUS_NO_SUCH_DEVICE:
-            return "NoSuchDevice";
-        case SMB2_STATUS_NO_SUCH_FILE:
-            return "NoSuchFile";
-        case SMB2_STATUS_INVALID_DEVICE_REQUEST:
-            return "InvalidDeviceRequest";
-        case SMB2_STATUS_END_OF_FILE:
-            return "EndOfFile";
-        case SMB2_STATUS_WRONG_VOLUME:
-            return "WrongVolume";
-        case SMB2_STATUS_NO_MEDIA_IN_DEVICE:
-            return "NoMediaInDevice";
-        case SMB2_STATUS_UNRECOGNIZED_MEDIA:
-            return "UnrecognizedMedia";
-        case SMB2_STATUS_NONEXISTENT_SECTOR:
-            return "NonexistentSector";
-        case SMB2_STATUS_MORE_PROCESSING_REQUIRED:
-            return "MoreProcessingRequired";
-        case SMB2_STATUS_NO_MEMORY:
-            return "NoMemory";
-        case SMB2_STATUS_CONFLICTING_ADDRESSES:
-            return "ConflictingAddresses";
-        case SMB2_STATUS_NOT_MAPPED_VIEW:
-            return "NotMappedView";
-        case SMB2_STATUS_UNABLE_TO_FREE_VM:
-            return "UnableToFreeVm";
-        case SMB2_STATUS_UNABLE_TO_DELETE_SECTION:
-            return "UnableToDeleteSection";
-        case SMB2_STATUS_INVALID_SYSTEM_SERVICE:
-            return "InvalidSystemService";
-        case SMB2_STATUS_ILLEGAL_INSTRUCTION:
-            return "IllegalInstruction";
-        case SMB2_STATUS_INVALID_LOCK_SEQUENCE:
-            return "InvalidLockSequence";
-        case SMB2_STATUS_INVALID_VIEW_SIZE:
-            return "InvalidViewSize";
-        case SMB2_STATUS_INVALID_FILE_FOR_SECTION:
-            return "InvalidFileForSection";
-        case SMB2_STATUS_ALREADY_COMMITTED:
-            return "AlreadyCommitted";
-        case SMB2_STATUS_ACCESS_DENIED:
-            return "AccessDenied";
-        case SMB2_STATUS_BUFFER_TOO_SMALL:
-            return "BufferTooSmall";
-        case SMB2_STATUS_OBJECT_TYPE_MISMATCH:
-            return "ObjectTypeMismatch";
-        case SMB2_STATUS_NONCONTINUABLE_EXCEPTION:
-            return "NoncontinuableException";
-        case SMB2_STATUS_INVALID_DISPOSITION:
-            return "InvalidDisposition";
-        case SMB2_STATUS_UNWIND:
-            return "Unwind";
-        case SMB2_STATUS_BAD_STACK:
-            return "BadStack";
-        case SMB2_STATUS_INVALID_UNWIND_TARGET:
-            return "InvalidUnwindTarget";
-        case SMB2_STATUS_NOT_LOCKED:
-            return "NotLocked";
-        case SMB2_STATUS_PARITY_ERROR:
-            return "ParityError";
-        case SMB2_STATUS_UNABLE_TO_DECOMMIT_VM:
-            return "UnableToDecommitVm";
-        case SMB2_STATUS_NOT_COMMITTED:
-            return "NotCommitted";
-        case SMB2_STATUS_INVALID_PORT_ATTRIBUTES:
-            return "InvalidPortAttributes";
-        case SMB2_STATUS_PORT_MESSAGE_TOO_LONG:
-            return "PortMessageTooLong";
-        case SMB2_STATUS_INVALID_PARAMETER_MIX:
-            return "InvalidParameterMix";
-        case SMB2_STATUS_INVALID_QUOTA_LOWER:
-            return "InvalidQuotaLower";
-        case SMB2_STATUS_DISK_CORRUPT_ERROR:
-            return "DiskCorruptError";
-        case SMB2_STATUS_OBJECT_NAME_INVALID:
-            return "ObjectNameInvalid";
-        case SMB2_STATUS_OBJECT_NAME_NOT_FOUND:
-            return "ObjectNameNotFound";
-        case SMB2_STATUS_OBJECT_NAME_COLLISION:
-            return "ObjectNameCollision";
-        case SMB2_STATUS_HANDLE_NOT_WAITABLE:
-            return "HandleNotWaitable";
-        case SMB2_STATUS_PORT_DISCONNECTED:
-            return "PortDisconnected";
-        case SMB2_STATUS_DEVICE_ALREADY_ATTACHED:
-            return "DeviceAlreadyAttached";
-        case SMB2_STATUS_OBJECT_PATH_INVALID:
-            return "ObjectPathInvalid";
-        case SMB2_STATUS_OBJECT_PATH_NOT_FOUND:
-            return "ObjectPathNotFound";
-        case SMB2_STATUS_OBJECT_PATH_SYNTAX_BAD:
-            return "ObjectPathSyntaxBad";
-        case SMB2_STATUS_DATA_OVERRUN:
-            return "DataOverrun";
-        case SMB2_STATUS_DATA_LATE_ERROR:
-            return "DataLateError";
-        case SMB2_STATUS_DATA_ERROR:
-            return "DataError";
-        case SMB2_STATUS_CRC_ERROR:
-            return "CrcError";
-        case SMB2_STATUS_SECTION_TOO_BIG:
-            return "SectionTooBig";
-        case SMB2_STATUS_PORT_CONNECTION_REFUSED:
-            return "PortConnectionRefused";
-        case SMB2_STATUS_INVALID_PORT_HANDLE:
-            return "InvalidPortHandle";
-        case SMB2_STATUS_SHARING_VIOLATION:
-            return "SharingViolation";
-        case SMB2_STATUS_QUOTA_EXCEEDED:
-            return "QuotaExceeded";
-        case SMB2_STATUS_INVALID_PAGE_PROTECTION:
-            return "InvalidPageProtection";
-        case SMB2_STATUS_MUTANT_NOT_OWNED:
-            return "MutantNotOwned";
-        case SMB2_STATUS_SEMAPHORE_LIMIT_EXCEEDED:
-            return "SemaphoreLimitExceeded";
-        case SMB2_STATUS_PORT_ALREADY_SET:
-            return "PortAlreadySet";
-        case SMB2_STATUS_SECTION_NOT_IMAGE:
-            return "SectionNotImage";
-        case SMB2_STATUS_SUSPEND_COUNT_EXCEEDED:
-            return "SuspendCountExceeded";
-        case SMB2_STATUS_THREAD_IS_TERMINATING:
-            return "ThreadIsTerminating";
-        case SMB2_STATUS_BAD_WORKING_SET_LIMIT:
-            return "BadWorkingSetLimit";
-        case SMB2_STATUS_INCOMPATIBLE_FILE_MAP:
-            return "IncompatibleFileMap";
-        case SMB2_STATUS_SECTION_PROTECTION:
-            return "SectionProtection";
-        case SMB2_STATUS_EAS_NOT_SUPPORTED:
-            return "EasNotSupported";
-        case SMB2_STATUS_EA_TOO_LARGE:
-            return "EaTooLarge";
-        case SMB2_STATUS_NONEXISTENT_EA_ENTRY:
-            return "NonexistentEaEntry";
-        case SMB2_STATUS_NO_EAS_ON_FILE:
-            return "NoEasOnFile";
-        case SMB2_STATUS_EA_CORRUPT_ERROR:
-            return "EaCorruptError";
-        case SMB2_STATUS_FILE_LOCK_CONFLICT:
-            return "FileLockConflict";
-        case SMB2_STATUS_LOCK_NOT_GRANTED:
-            return "LockNotGranted";
-        case SMB2_STATUS_DELETE_PENDING:
-            return "DeletePending";
-        case SMB2_STATUS_CTL_FILE_NOT_SUPPORTED:
-            return "CtlFileNotSupported";
-        case SMB2_STATUS_UNKNOWN_REVISION:
-            return "UnknownRevision";
-        case SMB2_STATUS_REVISION_MISMATCH:
-            return "RevisionMismatch";
-        case SMB2_STATUS_INVALID_OWNER:
-            return "InvalidOwner";
-        case SMB2_STATUS_INVALID_PRIMARY_GROUP:
-            return "InvalidPrimaryGroup";
-        case SMB2_STATUS_NO_IMPERSONATION_TOKEN:
-            return "NoImpersonationToken";
-        case SMB2_STATUS_CANT_DISABLE_MANDATORY:
-            return "CantDisableMandatory";
-        case SMB2_STATUS_NO_LOGON_SERVERS:
-            return "NoLogonServers";
-        case SMB2_STATUS_NO_SUCH_LOGON_SESSION:
-            return "NoSuchLogonSession";
-        case SMB2_STATUS_NO_SUCH_PRIVILEGE:
-            return "NoSuchPrivilege";
-        case SMB2_STATUS_PRIVILEGE_NOT_HELD:
-            return "PrivilegeNotHeld";
-        case SMB2_STATUS_INVALID_ACCOUNT_NAME:
-            return "InvalidAccountName";
-        case SMB2_STATUS_USER_EXISTS:
-            return "UserExists";
-        case SMB2_STATUS_NO_SUCH_USER:
-            return "NoSuchUser";
-        case SMB2_STATUS_GROUP_EXISTS:
-            return "GroupExists";
-        case SMB2_STATUS_NO_SUCH_GROUP:
-            return "NoSuchGroup";
-        case SMB2_STATUS_MEMBER_IN_GROUP:
-            return "MemberInGroup";
-        case SMB2_STATUS_MEMBER_NOT_IN_GROUP:
-            return "MemberNotInGroup";
-        case SMB2_STATUS_LAST_ADMIN:
-            return "LastAdmin";
-        case SMB2_STATUS_WRONG_PASSWORD:
-            return "WrongPassword";
-        case SMB2_STATUS_ILL_FORMED_PASSWORD:
-            return "IllFormedPassword";
-        case SMB2_STATUS_PASSWORD_RESTRICTION:
-            return "PasswordRestriction";
-        case SMB2_STATUS_LOGON_FAILURE:
-            return "LogonFailure";
-        case SMB2_STATUS_ACCOUNT_RESTRICTION:
-            return "AccountRestriction";
-        case SMB2_STATUS_INVALID_LOGON_HOURS:
-            return "InvalidLogonHours";
-        case SMB2_STATUS_INVALID_WORKSTATION:
-            return "InvalidWorkstation";
-        case SMB2_STATUS_PASSWORD_EXPIRED:
-            return "PasswordExpired";
-        case SMB2_STATUS_ACCOUNT_DISABLED:
-            return "AccountDisabled";
-        case SMB2_STATUS_NONE_MAPPED:
-            return "NoneMapped";
-        case SMB2_STATUS_TOO_MANY_LUIDS_REQUESTED:
-            return "TooManyLuidsRequested";
-        case SMB2_STATUS_LUIDS_EXHAUSTED:
-            return "LuidsExhausted";
-        case SMB2_STATUS_INVALID_SUB_AUTHORITY:
-            return "InvalidSubAuthority";
-        case SMB2_STATUS_INVALID_ACL:
-            return "InvalidAcl";
-        case SMB2_STATUS_INVALID_SID:
-            return "InvalidSid";
-        case SMB2_STATUS_INVALID_SECURITY_DESCR:
-            return "InvalidSecurityDescr";
-        case SMB2_STATUS_PROCEDURE_NOT_FOUND:
-            return "ProcedureNotFound";
-        case SMB2_STATUS_INVALID_IMAGE_FORMAT:
-            return "InvalidImageFormat";
-        case SMB2_STATUS_NO_TOKEN:
-            return "NoToken";
-        case SMB2_STATUS_BAD_INHERITANCE_ACL:
-            return "BadInheritanceAcl";
-        case SMB2_STATUS_RANGE_NOT_LOCKED:
-            return "RangeNotLocked";
-        case SMB2_STATUS_DISK_FULL:
-            return "DiskFull";
-        case SMB2_STATUS_SERVER_DISABLED:
-            return "ServerDisabled";
-        case SMB2_STATUS_SERVER_NOT_DISABLED:
-            return "ServerNotDisabled";
-        case SMB2_STATUS_TOO_MANY_GUIDS_REQUESTED:
-            return "TooManyGuidsRequested";
-        case SMB2_STATUS_INVALID_ID_AUTHORITY:
-            return "InvalidIdAuthority";
-        case SMB2_STATUS_AGENTS_EXHAUSTED:
-            return "AgentsExhausted";
-        case SMB2_STATUS_INVALID_VOLUME_LABEL:
-            return "InvalidVolumeLabel";
-        case SMB2_STATUS_SECTION_NOT_EXTENDED:
-            return "SectionNotExtended";
-        case SMB2_STATUS_NOT_MAPPED_DATA:
-            return "NotMappedData";
-        case SMB2_STATUS_RESOURCE_DATA_NOT_FOUND:
-            return "ResourceDataNotFound";
-        case SMB2_STATUS_RESOURCE_TYPE_NOT_FOUND:
-            return "ResourceTypeNotFound";
-        case SMB2_STATUS_RESOURCE_NAME_NOT_FOUND:
-            return "ResourceNameNotFound";
-        case SMB2_STATUS_ARRAY_BOUNDS_EXCEEDED:
-            return "ArrayBoundsExceeded";
-        case SMB2_STATUS_FLOAT_DENORMAL_OPERAND:
-            return "FloatDenormalOperand";
-        case SMB2_STATUS_FLOAT_DIVIDE_BY_ZERO:
-            return "FloatDivideByZero";
-        case SMB2_STATUS_FLOAT_INEXACT_RESULT:
-            return "FloatInexactResult";
-        case SMB2_STATUS_FLOAT_INVALID_OPERATION:
-            return "FloatInvalidOperation";
-        case SMB2_STATUS_FLOAT_OVERFLOW:
-            return "FloatOverflow";
-        case SMB2_STATUS_FLOAT_STACK_CHECK:
-            return "FloatStackCheck";
-        case SMB2_STATUS_FLOAT_UNDERFLOW:
-            return "FloatUnderflow";
-        case SMB2_STATUS_INTEGER_DIVIDE_BY_ZERO:
-            return "IntegerDivideByZero";
-        case SMB2_STATUS_INTEGER_OVERFLOW:
-            return "IntegerOverflow";
-        case SMB2_STATUS_PRIVILEGED_INSTRUCTION:
-            return "PrivilegedInstruction";
-        case SMB2_STATUS_TOO_MANY_PAGING_FILES:
-            return "TooManyPagingFiles";
-        case SMB2_STATUS_FILE_INVALID:
-            return "FileInvalid";
-        case SMB2_STATUS_ALLOTTED_SPACE_EXCEEDED:
-            return "AllottedSpaceExceeded";
-        case SMB2_STATUS_INSUFFICIENT_RESOURCES:
-            return "InsufficientResources";
-        case SMB2_STATUS_DFS_EXIT_PATH_FOUND:
-            return "DfsExitPathFound";
-        case SMB2_STATUS_DEVICE_DATA_ERROR:
-            return "DeviceDataError";
-        case SMB2_STATUS_DEVICE_NOT_CONNECTED:
-            return "DeviceNotConnected";
-        case SMB2_STATUS_DEVICE_POWER_FAILURE:
-            return "DevicePowerFailure";
-        case SMB2_STATUS_FREE_VM_NOT_AT_BASE:
-            return "FreeVmNotAtBase";
-        case SMB2_STATUS_MEMORY_NOT_ALLOCATED:
-            return "MemoryNotAllocated";
-        case SMB2_STATUS_WORKING_SET_QUOTA:
-            return "WorkingSetQuota";
-        case SMB2_STATUS_MEDIA_WRITE_PROTECTED:
-            return "MediaWriteProtected";
-        case SMB2_STATUS_DEVICE_NOT_READY:
-            return "DeviceNotReady";
-        case SMB2_STATUS_INVALID_GROUP_ATTRIBUTES:
-            return "InvalidGroupAttributes";
-        case SMB2_STATUS_BAD_IMPERSONATION_LEVEL:
-            return "BadImpersonationLevel";
-        case SMB2_STATUS_CANT_OPEN_ANONYMOUS:
-            return "CantOpenAnonymous";
-        case SMB2_STATUS_BAD_VALIDATION_CLASS:
-            return "BadValidationClass";
-        case SMB2_STATUS_BAD_TOKEN_TYPE:
-            return "BadTokenType";
-        case SMB2_STATUS_BAD_MASTER_BOOT_RECORD:
-            return "BadMasterBootRecord";
-        case SMB2_STATUS_INSTRUCTION_MISALIGNMENT:
-            return "InstructionMisalignment";
-        case SMB2_STATUS_INSTANCE_NOT_AVAILABLE:
-            return "InstanceNotAvailable";
-        case SMB2_STATUS_PIPE_NOT_AVAILABLE:
-            return "PipeNotAvailable";
-        case SMB2_STATUS_INVALID_PIPE_STATE:
-            return "InvalidPipeState";
-        case SMB2_STATUS_PIPE_BUSY:
-            return "PipeBusy";
-        case SMB2_STATUS_ILLEGAL_FUNCTION:
-            return "IllegalFunction";
-        case SMB2_STATUS_PIPE_DISCONNECTED:
-            return "PipeDisconnected";
-        case SMB2_STATUS_PIPE_CLOSING:
-            return "PipeClosing";
-        case SMB2_STATUS_PIPE_CONNECTED:
-            return "PipeConnected";
-        case SMB2_STATUS_PIPE_LISTENING:
-            return "PipeListening";
-        case SMB2_STATUS_INVALID_READ_MODE:
-            return "InvalidReadMode";
-        case SMB2_STATUS_IO_TIMEOUT:
-            return "IoTimeout";
-        case SMB2_STATUS_FILE_FORCED_CLOSED:
-            return "FileForcedClosed";
-        case SMB2_STATUS_PROFILING_NOT_STARTED:
-            return "ProfilingNotStarted";
-        case SMB2_STATUS_PROFILING_NOT_STOPPED:
-            return "ProfilingNotStopped";
-        case SMB2_STATUS_COULD_NOT_INTERPRET:
-            return "CouldNotInterpret";
-        case SMB2_STATUS_FILE_IS_A_DIRECTORY:
-            return "FileIsADirectory";
-        case SMB2_STATUS_NOT_SUPPORTED:
-            return "NotSupported";
-        case SMB2_STATUS_REMOTE_NOT_LISTENING:
-            return "RemoteNotListening";
-        case SMB2_STATUS_DUPLICATE_NAME:
-            return "DuplicateName";
-        case SMB2_STATUS_BAD_NETWORK_PATH:
-            return "BadNetworkPath";
-        case SMB2_STATUS_NETWORK_BUSY:
-            return "NetworkBusy";
-        case SMB2_STATUS_DEVICE_DOES_NOT_EXIST:
-            return "DeviceDoesNotExist";
-        case SMB2_STATUS_TOO_MANY_COMMANDS:
-            return "TooManyCommands";
-        case SMB2_STATUS_ADAPTER_HARDWARE_ERROR:
-            return "AdapterHardwareError";
-        case SMB2_STATUS_INVALID_NETWORK_RESPONSE:
-            return "InvalidNetworkResponse";
-        case SMB2_STATUS_UNEXPECTED_NETWORK_ERROR:
-            return "UnexpectedNetworkError";
-        case SMB2_STATUS_BAD_REMOTE_ADAPTER:
-            return "BadRemoteAdapter";
-        case SMB2_STATUS_PRINT_QUEUE_FULL:
-            return "PrintQueueFull";
-        case SMB2_STATUS_NO_SPOOL_SPACE:
-            return "NoSpoolSpace";
-        case SMB2_STATUS_PRINT_CANCELLED:
-            return "PrintCancelled";
-        case SMB2_STATUS_NETWORK_NAME_DELETED:
-            return "NetworkNameDeleted";
-        case SMB2_STATUS_NETWORK_ACCESS_DENIED:
-            return "NetworkAccessDenied";
-        case SMB2_STATUS_BAD_DEVICE_TYPE:
-            return "BadDeviceType";
-        case SMB2_STATUS_BAD_NETWORK_NAME:
-            return "BadNetworkName";
-        case SMB2_STATUS_TOO_MANY_NAMES:
-            return "TooManyNames";
-        case SMB2_STATUS_TOO_MANY_SESSIONS:
-            return "TooManySessions";
-        case SMB2_STATUS_SHARING_PAUSED:
-            return "SharingPaused";
-        case SMB2_STATUS_REQUEST_NOT_ACCEPTED:
-            return "RequestNotAccepted";
-        case SMB2_STATUS_REDIRECTOR_PAUSED:
-            return "RedirectorPaused";
-        case SMB2_STATUS_NET_WRITE_FAULT:
-            return "NetWriteFault";
-        case SMB2_STATUS_PROFILING_AT_LIMIT:
-            return "ProfilingAtLimit";
-        case SMB2_STATUS_NOT_SAME_DEVICE:
-            return "NotSameDevice";
-        case SMB2_STATUS_FILE_RENAMED:
-            return "FileRenamed";
-        case SMB2_STATUS_VIRTUAL_CIRCUIT_CLOSED:
-            return "VirtualCircuitClosed";
-        case SMB2_STATUS_NO_SECURITY_ON_OBJECT:
-            return "NoSecurityOnObject";
-        case SMB2_STATUS_CANT_WAIT:
-            return "CantWait";
-        case SMB2_STATUS_PIPE_EMPTY:
-            return "PipeEmpty";
-        case SMB2_STATUS_CANT_ACCESS_DOMAIN_INFO:
-            return "CantAccessDomainInfo";
-        case SMB2_STATUS_CANT_TERMINATE_SELF:
-            return "CantTerminateSelf";
-        case SMB2_STATUS_INVALID_SERVER_STATE:
-            return "InvalidServerState";
-        case SMB2_STATUS_INVALID_DOMAIN_STATE:
-            return "InvalidDomainState";
-        case SMB2_STATUS_INVALID_DOMAIN_ROLE:
-            return "InvalidDomainRole";
-        case SMB2_STATUS_NO_SUCH_DOMAIN:
-            return "NoSuchDomain";
-        case SMB2_STATUS_DOMAIN_EXISTS:
-            return "DomainExists";
-        case SMB2_STATUS_DOMAIN_LIMIT_EXCEEDED:
-            return "DomainLimitExceeded";
-        case SMB2_STATUS_OPLOCK_NOT_GRANTED:
-            return "OplockNotGranted";
-        case SMB2_STATUS_INVALID_OPLOCK_PROTOCOL:
-            return "InvalidOplockProtocol";
-        case SMB2_STATUS_INTERNAL_DB_CORRUPTION:
-            return "InternalDbCorruption";
-        case SMB2_STATUS_INTERNAL_ERROR:
-            return "InternalError";
-        case SMB2_STATUS_GENERIC_NOT_MAPPED:
-            return "GenericNotMapped";
-        case SMB2_STATUS_BAD_DESCRIPTOR_FORMAT:
-            return "BadDescriptorFormat";
-        case SMB2_STATUS_INVALID_USER_BUFFER:
-            return "InvalidUserBuffer";
-        case SMB2_STATUS_UNEXPECTED_IO_ERROR:
-            return "UnexpectedIoError";
-        case SMB2_STATUS_UNEXPECTED_MM_CREATE_ERR:
-            return "UnexpectedMmCreateErr";
-        case SMB2_STATUS_UNEXPECTED_MM_MAP_ERROR:
-            return "UnexpectedMmMapError";
-        case SMB2_STATUS_UNEXPECTED_MM_EXTEND_ERR:
-            return "UnexpectedMmExtendErr";
-        case SMB2_STATUS_NOT_LOGON_PROCESS:
-            return "NotLogonProcess";
-        case SMB2_STATUS_LOGON_SESSION_EXISTS:
-            return "LogonSessionExists";
-        case SMB2_STATUS_INVALID_PARAMETER_1:
-            return "InvalidParameter1";
-        case SMB2_STATUS_INVALID_PARAMETER_2:
-            return "InvalidParameter2";
-        case SMB2_STATUS_INVALID_PARAMETER_3:
-            return "InvalidParameter3";
-        case SMB2_STATUS_INVALID_PARAMETER_4:
-            return "InvalidParameter4";
-        case SMB2_STATUS_INVALID_PARAMETER_5:
-            return "InvalidParameter5";
-        case SMB2_STATUS_INVALID_PARAMETER_6:
-            return "InvalidParameter6";
-        case SMB2_STATUS_INVALID_PARAMETER_7:
-            return "InvalidParameter7";
-        case SMB2_STATUS_INVALID_PARAMETER_8:
-            return "InvalidParameter8";
-        case SMB2_STATUS_INVALID_PARAMETER_9:
-            return "InvalidParameter9";
-        case SMB2_STATUS_INVALID_PARAMETER_10:
-            return "InvalidParameter10";
-        case SMB2_STATUS_INVALID_PARAMETER_11:
-            return "InvalidParameter11";
-        case SMB2_STATUS_INVALID_PARAMETER_12:
-            return "InvalidParameter12";
-        case SMB2_STATUS_REDIRECTOR_NOT_STARTED:
-            return "RedirectorNotStarted";
-        case SMB2_STATUS_REDIRECTOR_STARTED:
-            return "RedirectorStarted";
-        case SMB2_STATUS_STACK_OVERFLOW:
-            return "StackOverflow";
-        case SMB2_STATUS_NO_SUCH_PACKAGE:
-            return "NoSuchPackage";
-        case SMB2_STATUS_BAD_FUNCTION_TABLE:
-            return "BadFunctionTable";
-        case SMB2_STATUS_DIRECTORY_NOT_EMPTY:
-            return "DirectoryNotEmpty";
-        case SMB2_STATUS_FILE_CORRUPT_ERROR:
-            return "FileCorruptError";
-        case SMB2_STATUS_NOT_A_DIRECTORY:
-            return "NotADirectory";
-        case SMB2_STATUS_BAD_LOGON_SESSION_STATE:
-            return "BadLogonSessionState";
-        case SMB2_STATUS_LOGON_SESSION_COLLISION:
-            return "LogonSessionCollision";
-        case SMB2_STATUS_NAME_TOO_LONG:
-            return "NameTooLong";
-        case SMB2_STATUS_FILES_OPEN:
-            return "FilesOpen";
-        case SMB2_STATUS_CONNECTION_IN_USE:
-            return "ConnectionInUse";
-        case SMB2_STATUS_MESSAGE_NOT_FOUND:
-            return "MessageNotFound";
-        case SMB2_STATUS_PROCESS_IS_TERMINATING:
-            return "ProcessIsTerminating";
-        case SMB2_STATUS_INVALID_LOGON_TYPE:
-            return "InvalidLogonType";
-        case SMB2_STATUS_NO_GUID_TRANSLATION:
-            return "NoGuidTranslation";
-        case SMB2_STATUS_CANNOT_IMPERSONATE:
-            return "CannotImpersonate";
-        case SMB2_STATUS_IMAGE_ALREADY_LOADED:
-            return "ImageAlreadyLoaded";
-        case SMB2_STATUS_ABIOS_NOT_PRESENT:
-            return "AbiosNotPresent";
-        case SMB2_STATUS_ABIOS_LID_NOT_EXIST:
-            return "AbiosLidNotExist";
-        case SMB2_STATUS_ABIOS_LID_ALREADY_OWNED:
-            return "AbiosLidAlreadyOwned";
-        case SMB2_STATUS_ABIOS_NOT_LID_OWNER:
-            return "AbiosNotLidOwner";
-        case SMB2_STATUS_ABIOS_INVALID_COMMAND:
-            return "AbiosInvalidCommand";
-        case SMB2_STATUS_ABIOS_INVALID_LID:
-            return "AbiosInvalidLid";
-        case SMB2_STATUS_ABIOS_SELECTOR_NOT_AVAILABLE:
-            return "AbiosSelectorNotAvailable";
-        case SMB2_STATUS_ABIOS_INVALID_SELECTOR:
-            return "AbiosInvalidSelector";
-        case SMB2_STATUS_NO_LDT:
-            return "NoLdt";
-        case SMB2_STATUS_INVALID_LDT_SIZE:
-            return "InvalidLdtSize";
-        case SMB2_STATUS_INVALID_LDT_OFFSET:
-            return "InvalidLdtOffset";
-        case SMB2_STATUS_INVALID_LDT_DESCRIPTOR:
-            return "InvalidLdtDescriptor";
-        case SMB2_STATUS_INVALID_IMAGE_NE_FORMAT:
-            return "InvalidImageNeFormat";
-        case SMB2_STATUS_RXACT_INVALID_STATE:
-            return "RxactInvalidState";
-        case SMB2_STATUS_RXACT_COMMIT_FAILURE:
-            return "RxactCommitFailure";
-        case SMB2_STATUS_MAPPED_FILE_SIZE_ZERO:
-            return "MappedFileSizeZero";
-        case SMB2_STATUS_TOO_MANY_OPENED_FILES:
-            return "TooManyOpenedFiles";
-        case SMB2_STATUS_CANCELLED:
-            return "Cancelled";
-        case SMB2_STATUS_CANNOT_DELETE:
-            return "CannotDelete";
-        case SMB2_STATUS_INVALID_COMPUTER_NAME:
-            return "InvalidComputerName";
-        case SMB2_STATUS_FILE_DELETED:
-            return "FileDeleted";
-        case SMB2_STATUS_SPECIAL_ACCOUNT:
-            return "SpecialAccount";
-        case SMB2_STATUS_SPECIAL_GROUP:
-            return "SpecialGroup";
-        case SMB2_STATUS_SPECIAL_USER:
-            return "SpecialUser";
-        case SMB2_STATUS_MEMBERS_PRIMARY_GROUP:
-            return "MembersPrimaryGroup";
-        case SMB2_STATUS_FILE_CLOSED:
-            return "FileClosed";
-        case SMB2_STATUS_TOO_MANY_THREADS:
-            return "TooManyThreads";
-        case SMB2_STATUS_THREAD_NOT_IN_PROCESS:
-            return "ThreadNotInProcess";
-        case SMB2_STATUS_TOKEN_ALREADY_IN_USE:
-            return "TokenAlreadyInUse";
-        case SMB2_STATUS_PAGEFILE_QUOTA_EXCEEDED:
-            return "PagefileQuotaExceeded";
-        case SMB2_STATUS_COMMITMENT_LIMIT:
-            return "CommitmentLimit";
-        case SMB2_STATUS_INVALID_IMAGE_LE_FORMAT:
-            return "InvalidImageLeFormat";
-        case SMB2_STATUS_INVALID_IMAGE_NOT_MZ:
-            return "InvalidImageNotMz";
-        case SMB2_STATUS_INVALID_IMAGE_PROTECT:
-            return "InvalidImageProtect";
-        case SMB2_STATUS_INVALID_IMAGE_WIN_16:
-            return "InvalidImageWin16";
-        case SMB2_STATUS_LOGON_SERVER_CONFLICT:
-            return "LogonServerConflict";
-        case SMB2_STATUS_TIME_DIFFERENCE_AT_DC:
-            return "TimeDifferenceAtDc";
-        case SMB2_STATUS_SYNCHRONIZATION_REQUIRED:
-            return "SynchronizationRequired";
-        case SMB2_STATUS_DLL_NOT_FOUND:
-            return "DllNotFound";
-        case SMB2_STATUS_OPEN_FAILED:
-            return "OpenFailed";
-        case SMB2_STATUS_IO_PRIVILEGE_FAILED:
-            return "IoPrivilegeFailed";
-        case SMB2_STATUS_ORDINAL_NOT_FOUND:
-            return "OrdinalNotFound";
-        case SMB2_STATUS_ENTRYPOINT_NOT_FOUND:
-            return "EntrypointNotFound";
-        case SMB2_STATUS_CONTROL_C_EXIT:
-            return "ControlCExit";
-        case SMB2_STATUS_LOCAL_DISCONNECT:
-            return "LocalDisconnect";
-        case SMB2_STATUS_REMOTE_DISCONNECT:
-            return "RemoteDisconnect";
-        case SMB2_STATUS_REMOTE_RESOURCES:
-            return "RemoteResources";
-        case SMB2_STATUS_LINK_FAILED:
-            return "LinkFailed";
-        case SMB2_STATUS_LINK_TIMEOUT:
-            return "LinkTimeout";
-        case SMB2_STATUS_INVALID_CONNECTION:
-            return "InvalidConnection";
-        case SMB2_STATUS_INVALID_ADDRESS:
-            return "InvalidAddress";
-        case SMB2_STATUS_DLL_INIT_FAILED:
-            return "DllInitFailed";
-        case SMB2_STATUS_MISSING_SYSTEMFILE:
-            return "MissingSystemfile";
-        case SMB2_STATUS_UNHANDLED_EXCEPTION:
-            return "UnhandledException";
-        case SMB2_STATUS_APP_INIT_FAILURE:
-            return "AppInitFailure";
-        case SMB2_STATUS_PAGEFILE_CREATE_FAILED:
-            return "PagefileCreateFailed";
-        case SMB2_STATUS_NO_PAGEFILE:
-            return "NoPagefile";
-        case SMB2_STATUS_INVALID_LEVEL:
-            return "InvalidLevel";
-        case SMB2_STATUS_WRONG_PASSWORD_CORE:
-            return "WrongPasswordCore";
-        case SMB2_STATUS_ILLEGAL_FLOAT_CONTEXT:
-            return "IllegalFloatContext";
-        case SMB2_STATUS_PIPE_BROKEN:
-            return "PipeBroken";
-        case SMB2_STATUS_REGISTRY_CORRUPT:
-            return "RegistryCorrupt";
-        case SMB2_STATUS_REGISTRY_IO_FAILED:
-            return "RegistryIoFailed";
-        case SMB2_STATUS_NO_EVENT_PAIR:
-            return "NoEventPair";
-        case SMB2_STATUS_UNRECOGNIZED_VOLUME:
-            return "UnrecognizedVolume";
-        case SMB2_STATUS_SERIAL_NO_DEVICE_INITED:
-            return "SerialNoDeviceInited";
-        case SMB2_STATUS_NO_SUCH_ALIAS:
-            return "NoSuchAlias";
-        case SMB2_STATUS_MEMBER_NOT_IN_ALIAS:
-            return "MemberNotInAlias";
-        case SMB2_STATUS_MEMBER_IN_ALIAS:
-            return "MemberInAlias";
-        case SMB2_STATUS_ALIAS_EXISTS:
-            return "AliasExists";
-        case SMB2_STATUS_LOGON_NOT_GRANTED:
-            return "LogonNotGranted";
-        case SMB2_STATUS_TOO_MANY_SECRETS:
-            return "TooManySecrets";
-        case SMB2_STATUS_SECRET_TOO_LONG:
-            return "SecretTooLong";
-        case SMB2_STATUS_INTERNAL_DB_ERROR:
-            return "InternalDbError";
-        case SMB2_STATUS_FULLSCREEN_MODE:
-            return "FullscreenMode";
-        case SMB2_STATUS_TOO_MANY_CONTEXT_IDS:
-            return "TooManyContextIds";
-        case SMB2_STATUS_LOGON_TYPE_NOT_GRANTED:
-            return "LogonTypeNotGranted";
-        case SMB2_STATUS_NOT_REGISTRY_FILE:
-            return "NotRegistryFile";
-        case SMB2_STATUS_NT_CROSS_ENCRYPTION_REQUIRED:
-            return "NtCrossEncryptionRequired";
-        case SMB2_STATUS_DOMAIN_CTRLR_CONFIG_ERROR:
-            return "DomainCtrlrConfigError";
-        case SMB2_STATUS_FT_MISSING_MEMBER:
-            return "FtMissingMember";
-        case SMB2_STATUS_ILL_FORMED_SERVICE_ENTRY:
-            return "IllFormedServiceEntry";
-        case SMB2_STATUS_ILLEGAL_CHARACTER:
-            return "IllegalCharacter";
-        case SMB2_STATUS_UNMAPPABLE_CHARACTER:
-            return "UnmappableCharacter";
-        case SMB2_STATUS_UNDEFINED_CHARACTER:
-            return "UndefinedCharacter";
-        case SMB2_STATUS_FLOPPY_VOLUME:
-            return "FloppyVolume";
-        case SMB2_STATUS_FLOPPY_ID_MARK_NOT_FOUND:
-            return "FloppyIdMarkNotFound";
-        case SMB2_STATUS_FLOPPY_WRONG_CYLINDER:
-            return "FloppyWrongCylinder";
-        case SMB2_STATUS_FLOPPY_UNKNOWN_ERROR:
-            return "FloppyUnknownError";
-        case SMB2_STATUS_FLOPPY_BAD_REGISTERS:
-            return "FloppyBadRegisters";
-        case SMB2_STATUS_DISK_RECALIBRATE_FAILED:
-            return "DiskRecalibrateFailed";
-        case SMB2_STATUS_DISK_OPERATION_FAILED:
-            return "DiskOperationFailed";
-        case SMB2_STATUS_DISK_RESET_FAILED:
-            return "DiskResetFailed";
-        case SMB2_STATUS_SHARED_IRQ_BUSY:
-            return "SharedIrqBusy";
-        case SMB2_STATUS_FT_ORPHANING:
-            return "FtOrphaning";
-        case SMB2_STATUS_PARTITION_FAILURE:
-            return "PartitionFailure";
-        case SMB2_STATUS_INVALID_BLOCK_LENGTH:
-            return "InvalidBlockLength";
-        case SMB2_STATUS_DEVICE_NOT_PARTITIONED:
-            return "DeviceNotPartitioned";
-        case SMB2_STATUS_UNABLE_TO_LOCK_MEDIA:
-            return "UnableToLockMedia";
-        case SMB2_STATUS_UNABLE_TO_UNLOAD_MEDIA:
-            return "UnableToUnloadMedia";
-        case SMB2_STATUS_EOM_OVERFLOW:
-            return "EomOverflow";
-        case SMB2_STATUS_NO_MEDIA:
-            return "NoMedia";
-        case SMB2_STATUS_NO_SUCH_MEMBER:
-            return "NoSuchMember";
-        case SMB2_STATUS_INVALID_MEMBER:
-            return "InvalidMember";
-        case SMB2_STATUS_KEY_DELETED:
-            return "KeyDeleted";
-        case SMB2_STATUS_NO_LOG_SPACE:
-            return "NoLogSpace";
-        case SMB2_STATUS_TOO_MANY_SIDS:
-            return "TooManySids";
-        case SMB2_STATUS_LM_CROSS_ENCRYPTION_REQUIRED:
-            return "LmCrossEncryptionRequired";
-        case SMB2_STATUS_KEY_HAS_CHILDREN:
-            return "KeyHasChildren";
-        case SMB2_STATUS_CHILD_MUST_BE_VOLATILE:
-            return "ChildMustBeVolatile";
-        case SMB2_STATUS_DEVICE_CONFIGURATION_ERROR:
-            return "DeviceConfigurationError";
-        case SMB2_STATUS_DRIVER_INTERNAL_ERROR:
-            return "DriverInternalError";
-        case SMB2_STATUS_INVALID_DEVICE_STATE:
-            return "InvalidDeviceState";
-        case SMB2_STATUS_IO_DEVICE_ERROR:
-            return "IoDeviceError";
-        case SMB2_STATUS_DEVICE_PROTOCOL_ERROR:
-            return "DeviceProtocolError";
-        case SMB2_STATUS_BACKUP_CONTROLLER:
-            return "BackupController";
-        case SMB2_STATUS_LOG_FILE_FULL:
-            return "LogFileFull";
-        case SMB2_STATUS_TOO_LATE:
-            return "TooLate";
-        case SMB2_STATUS_NO_TRUST_LSA_SECRET:
-            return "NoTrustLsaSecret";
-        case SMB2_STATUS_NO_TRUST_SAM_ACCOUNT:
-            return "NoTrustSamAccount";
-        case SMB2_STATUS_TRUSTED_DOMAIN_FAILURE:
-            return "TrustedDomainFailure";
-        case SMB2_STATUS_TRUSTED_RELATIONSHIP_FAILURE:
-            return "TrustedRelationshipFailure";
-        case SMB2_STATUS_EVENTLOG_FILE_CORRUPT:
-            return "EventlogFileCorrupt";
-        case SMB2_STATUS_EVENTLOG_CANT_START:
-            return "EventlogCantStart";
-        case SMB2_STATUS_TRUST_FAILURE:
-            return "TrustFailure";
-        case SMB2_STATUS_MUTANT_LIMIT_EXCEEDED:
-            return "MutantLimitExceeded";
-        case SMB2_STATUS_NETLOGON_NOT_STARTED:
-            return "NetlogonNotStarted";
-        case SMB2_STATUS_ACCOUNT_EXPIRED:
-            return "AccountExpired";
-        case SMB2_STATUS_POSSIBLE_DEADLOCK:
-            return "PossibleDeadlock";
-        case SMB2_STATUS_NETWORK_CREDENTIAL_CONFLICT:
-            return "NetworkCredentialConflict";
-        case SMB2_STATUS_REMOTE_SESSION_LIMIT:
-            return "RemoteSessionLimit";
-        case SMB2_STATUS_EVENTLOG_FILE_CHANGED:
-            return "EventlogFileChanged";
-        case SMB2_STATUS_NOLOGON_INTERDOMAIN_TRUST_ACCOUNT:
-            return "NologonInterdomainTrustAccount";
-        case SMB2_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT:
-            return "NologonWorkstationTrustAccount";
-        case SMB2_STATUS_NOLOGON_SERVER_TRUST_ACCOUNT:
-            return "NologonServerTrustAccount";
-        case SMB2_STATUS_DOMAIN_TRUST_INCONSISTENT:
-            return "DomainTrustInconsistent";
-        case SMB2_STATUS_FS_DRIVER_REQUIRED:
-            return "FsDriverRequired";
-        case SMB2_STATUS_NO_USER_SESSION_KEY:
-            return "NoUserSessionKey";
-        case SMB2_STATUS_USER_SESSION_DELETED:
-            return "UserSessionDeleted";
-        case SMB2_STATUS_RESOURCE_LANG_NOT_FOUND:
-            return "ResourceLangNotFound";
-        case SMB2_STATUS_INSUFF_SERVER_RESOURCES:
-            return "InsuffServerResources";
-        case SMB2_STATUS_INVALID_BUFFER_SIZE:
-            return "InvalidBufferSize";
-        case SMB2_STATUS_INVALID_ADDRESS_COMPONENT:
-            return "InvalidAddressComponent";
-        case SMB2_STATUS_INVALID_ADDRESS_WILDCARD:
-            return "InvalidAddressWildcard";
-        case SMB2_STATUS_TOO_MANY_ADDRESSES:
-            return "TooManyAddresses";
-        case SMB2_STATUS_ADDRESS_ALREADY_EXISTS:
-            return "AddressAlreadyExists";
-        case SMB2_STATUS_ADDRESS_CLOSED:
-            return "AddressClosed";
-        case SMB2_STATUS_CONNECTION_DISCONNECTED:
-            return "ConnectionDisconnected";
-        case SMB2_STATUS_CONNECTION_RESET:
-            return "ConnectionReset";
-        case SMB2_STATUS_TOO_MANY_NODES:
-            return "TooManyNodes";
-        case SMB2_STATUS_TRANSACTION_ABORTED:
-            return "TransactionAborted";
-        case SMB2_STATUS_TRANSACTION_TIMED_OUT:
-            return "TransactionTimedOut";
-        case SMB2_STATUS_TRANSACTION_NO_RELEASE:
-            return "TransactionNoRelease";
-        case SMB2_STATUS_TRANSACTION_NO_MATCH:
-            return "TransactionNoMatch";
-        case SMB2_STATUS_TRANSACTION_RESPONDED:
-            return "TransactionResponded";
-        case SMB2_STATUS_TRANSACTION_INVALID_ID:
-            return "TransactionInvalidId";
-        case SMB2_STATUS_TRANSACTION_INVALID_TYPE:
-            return "TransactionInvalidType";
-        case SMB2_STATUS_NOT_SERVER_SESSION:
-            return "NotServerSession";
-        case SMB2_STATUS_NOT_CLIENT_SESSION:
-            return "NotClientSession";
-        case SMB2_STATUS_CANNOT_LOAD_REGISTRY_FILE:
-            return "CannotLoadRegistryFile";
-        case SMB2_STATUS_DEBUG_ATTACH_FAILED:
-            return "DebugAttachFailed";
-        case SMB2_STATUS_SYSTEM_PROCESS_TERMINATED:
-            return "SystemProcessTerminated";
-        case SMB2_STATUS_DATA_NOT_ACCEPTED:
-            return "DataNotAccepted";
-        case SMB2_STATUS_NO_BROWSER_SERVERS_FOUND:
-            return "NoBrowserServersFound";
-        case SMB2_STATUS_VDM_HARD_ERROR:
-            return "VdmHardError";
-        case SMB2_STATUS_DRIVER_CANCEL_TIMEOUT:
-            return "DriverCancelTimeout";
-        case SMB2_STATUS_REPLY_MESSAGE_MISMATCH:
-            return "ReplyMessageMismatch";
-        case SMB2_STATUS_MAPPED_ALIGNMENT:
-            return "MappedAlignment";
-        case SMB2_STATUS_IMAGE_CHECKSUM_MISMATCH:
-            return "ImageChecksumMismatch";
-        case SMB2_STATUS_LOST_WRITEBEHIND_DATA:
-            return "LostWritebehindData";
-        case SMB2_STATUS_CLIENT_SERVER_PARAMETERS_INVALID:
-            return "ClientServerParametersInvalid";
-        case SMB2_STATUS_PASSWORD_MUST_CHANGE:
-            return "PasswordMustChange";
-        case SMB2_STATUS_NOT_FOUND:
-            return "NotFound";
-        case SMB2_STATUS_NOT_TINY_STREAM:
-            return "NotTinyStream";
-        case SMB2_STATUS_RECOVERY_FAILURE:
-            return "RecoveryFailure";
-        case SMB2_STATUS_STACK_OVERFLOW_READ:
-            return "StackOverflowRead";
-        case SMB2_STATUS_FAIL_CHECK:
-            return "FailCheck";
-        case SMB2_STATUS_DUPLICATE_OBJECTID:
-            return "DuplicateObjectid";
-        case SMB2_STATUS_OBJECTID_EXISTS:
-            return "ObjectidExists";
-        case SMB2_STATUS_CONVERT_TO_LARGE:
-            return "ConvertToLarge";
-        case SMB2_STATUS_RETRY:
-            return "Retry";
-        case SMB2_STATUS_FOUND_OUT_OF_SCOPE:
-            return "FoundOutOfScope";
-        case SMB2_STATUS_ALLOCATE_BUCKET:
-            return "AllocateBucket";
-        case SMB2_STATUS_PROPSET_NOT_FOUND:
-            return "PropsetNotFound";
-        case SMB2_STATUS_MARSHALL_OVERFLOW:
-            return "MarshallOverflow";
-        case SMB2_STATUS_INVALID_VARIANT:
-            return "InvalidVariant";
-        case SMB2_STATUS_DOMAIN_CONTROLLER_NOT_FOUND:
-            return "DomainControllerNotFound";
-        case SMB2_STATUS_ACCOUNT_LOCKED_OUT:
-            return "AccountLockedOut";
-        case SMB2_STATUS_HANDLE_NOT_CLOSABLE:
-            return "HandleNotClosable";
-        case SMB2_STATUS_CONNECTION_REFUSED:
-            return "ConnectionRefused";
-        case SMB2_STATUS_GRACEFUL_DISCONNECT:
-            return "GracefulDisconnect";
-        case SMB2_STATUS_ADDRESS_ALREADY_ASSOCIATED:
-            return "AddressAlreadyAssociated";
-        case SMB2_STATUS_ADDRESS_NOT_ASSOCIATED:
-            return "AddressNotAssociated";
-        case SMB2_STATUS_CONNECTION_INVALID:
-            return "ConnectionInvalid";
-        case SMB2_STATUS_CONNECTION_ACTIVE:
-            return "ConnectionActive";
-        case SMB2_STATUS_NETWORK_UNREACHABLE:
-            return "NetworkUnreachable";
-        case SMB2_STATUS_HOST_UNREACHABLE:
-            return "HostUnreachable";
-        case SMB2_STATUS_PROTOCOL_UNREACHABLE:
-            return "ProtocolUnreachable";
-        case SMB2_STATUS_PORT_UNREACHABLE:
-            return "PortUnreachable";
-        case SMB2_STATUS_REQUEST_ABORTED:
-            return "RequestAborted";
-        case SMB2_STATUS_CONNECTION_ABORTED:
-            return "ConnectionAborted";
-        case SMB2_STATUS_BAD_COMPRESSION_BUFFER:
-            return "BadCompressionBuffer";
-        case SMB2_STATUS_USER_MAPPED_FILE:
-            return "UserMappedFile";
-        case SMB2_STATUS_AUDIT_FAILED:
-            return "AuditFailed";
-        case SMB2_STATUS_TIMER_RESOLUTION_NOT_SET:
-            return "TimerResolutionNotSet";
-        case SMB2_STATUS_CONNECTION_COUNT_LIMIT:
-            return "ConnectionCountLimit";
-        case SMB2_STATUS_LOGIN_TIME_RESTRICTION:
-            return "LoginTimeRestriction";
-        case SMB2_STATUS_LOGIN_WKSTA_RESTRICTION:
-            return "LoginWkstaRestriction";
-        case SMB2_STATUS_IMAGE_MP_UP_MISMATCH:
-            return "ImageMpUpMismatch";
-        case SMB2_STATUS_INSUFFICIENT_LOGON_INFO:
-            return "InsufficientLogonInfo";
-        case SMB2_STATUS_BAD_DLL_ENTRYPOINT:
-            return "BadDllEntrypoint";
-        case SMB2_STATUS_BAD_SERVICE_ENTRYPOINT:
-            return "BadServiceEntrypoint";
-        case SMB2_STATUS_LPC_REPLY_LOST:
-            return "LpcReplyLost";
-        case SMB2_STATUS_IP_ADDRESS_CONFLICT1:
-            return "IpAddressConflict1";
-        case SMB2_STATUS_IP_ADDRESS_CONFLICT2:
-            return "IpAddressConflict2";
-        case SMB2_STATUS_REGISTRY_QUOTA_LIMIT:
-            return "RegistryQuotaLimit";
-        case SMB2_STATUS_PATH_NOT_COVERED:
-            return "PathNotCovered";
-        case SMB2_STATUS_NO_CALLBACK_ACTIVE:
-            return "NoCallbackActive";
-        case SMB2_STATUS_LICENSE_QUOTA_EXCEEDED:
-            return "LicenseQuotaExceeded";
-        case SMB2_STATUS_PWD_TOO_SHORT:
-            return "PwdTooShort";
-        case SMB2_STATUS_PWD_TOO_RECENT:
-            return "PwdTooRecent";
-        case SMB2_STATUS_PWD_HISTORY_CONFLICT:
-            return "PwdHistoryConflict";
-        case SMB2_STATUS_PLUGPLAY_NO_DEVICE:
-            return "PlugplayNoDevice";
-        case SMB2_STATUS_UNSUPPORTED_COMPRESSION:
-            return "UnsupportedCompression";
-        case SMB2_STATUS_INVALID_HW_PROFILE:
-            return "InvalidHwProfile";
-        case SMB2_STATUS_INVALID_PLUGPLAY_DEVICE_PATH:
-            return "InvalidPlugplayDevicePath";
-        case SMB2_STATUS_DRIVER_ORDINAL_NOT_FOUND:
-            return "DriverOrdinalNotFound";
-        case SMB2_STATUS_DRIVER_ENTRYPOINT_NOT_FOUND:
-            return "DriverEntrypointNotFound";
-        case SMB2_STATUS_RESOURCE_NOT_OWNED:
-            return "ResourceNotOwned";
-        case SMB2_STATUS_TOO_MANY_LINKS:
-            return "TooManyLinks";
-        case SMB2_STATUS_QUOTA_LIST_INCONSISTENT:
-            return "QuotaListInconsistent";
-        case SMB2_STATUS_FILE_IS_OFFLINE:
-            return "FileIsOffline";
-        case SMB2_STATUS_VOLUME_DISMOUNTED:
-            return "VolumeDismounted";
-        case SMB2_STATUS_NOT_A_REPARSE_POINT:
-            return "NotAReparsePoint";
-        case SMB2_STATUS_SERVER_UNAVAILABLE:
-            return "ServerUnavailable";
-        case SMB2_STATUS_BUFFER_OVERFLOW:
-            return "BufferOverflow";
-        case SMB2_STATUS_STOPPED_ON_SYMLINK:
-            return "StoppedOnSymlink";
-        default:
-            return "Unknown";
-    } /* switch */
+    unsigned int i;
+
+    for (i = 0; i < sizeof(smb_status_names) / sizeof(smb_status_names[0]);
+         i++) {
+        if (smb_status_names[i].status == status) {
+            return smb_status_names[i].name;
+        }
+    }
+    return "Unknown";
 } /* smb_status_name */
 
 static const char *


### PR DESCRIPTION
Three additions to the quint quick tier, aimed at the cheapest of the coverage gaps (baseline 61% lines), plus the two server bugs the new corpora immediately found.

## The duplicate-request-cache suite (nfsdrc)

A server that executes a non-idempotent request twice has corrupted the client's view of the filesystem, and neither NFSv3 nor NFSv4.0 has in-protocol sequencing against that — both rely on the server remembering its recent replies, and nothing modelled that memory. `nfs_drc_mbt_replay` replays the new specs `nfsdrc` corpus (chimera-nas/specs#18) over both caches with `--paranoid` directory re-reads (a replayed SETATTR and a re-executed one answer the same status; the directory tells them apart), in two server configurations (NFSv3 cache on / off — "the switch does nothing" and "the switch works" are indistinguishable without a corpus for each). `nfs_drc_probe` pins the ground truth the model's constants encode. Rides on the rpc2 client XID accessor (chimera-nas/libevpl#147): replaying a retransmission means sending the same call with the same XID on the same connection.

Two server fixes land with the suite, both found when it was first built: a v3 cached reply could answer another principal's request (the credential is part of "the same request"; RFC 8881 2.10.6.1.3.1 states the hazard for 4.1 and it is identical here), and three RFC 8881 violations in the 4.1 session reply cache (`RETRY_UNCACHED_REP` answered on the SEQUENCE op itself, retries of in-flight requests answered the same way instead of `DELAY`, and false retries under a different principal replayed instead of `SEQ_FALSE_RETRY`).

The nfs4 model also gains `replayPrev` (specs side): the session reply cache was specified and never exercised, since every walk step takes the slot's next sequence id. Its very first corpus caught a live violation:

**nfs4: charge a cached reply to the session that owns the slot.** CREATE_SESSION is an ordinary operation once a SEQUENCE is present, and its handler points `req->session` at the session it creates — so the reply capture charged the *new* session's byte counter while the buffer landed on the *acquiring* session's slot. The acquiring session's unsigned counter eventually underflowed on reclaim, the per-session cap check then read it as enormous, every capture silently demoted from that point on, and every retransmit was answered `NFS4ERR_RETRY_UNCACHED_REP` instead of the cached reply.

## POSIX corpus against diskfs

The posix driver already spoke the named-filesystem backends; the batched replayer just never had scratch storage to hand it. It now self-provisions a mkdtemp session dir (as the NFS MBT harness does) and `batch_diskfs` replays the memfs profile — diskfs is chimera-native, so the model-conformant profile is the right one. 67 of 72 traces replay green; five are declined BY NAME in a new `posix_mbt_declines` registry (the posix analog of `smb2_mbt_trace_limits`), each entry naming the diskfs bug that retires it — all three found by this batch's first run:

* truncate of a file whose extents are shared with a clone walks the refcount btree off a freed node (ASAN SEGV: `diskfs_bt_run` ← `diskfs_refcount_dec` ← `diskfs_setattr_trunc_process`);
* `copy_file_range` copies and answers block-rounded byte counts past the source EOF (1024 requested at EOF−1024 → 4096 copied), growing the destination to match;
* `mkdirat` under a removed-but-open directory creates the entry instead of answering ENOENT.

cairn is deliberately not registered yet: ~12 traces fail across most flavors (seek-hole granularity, `clone_file_range` unsupported, dup'd-fd shared-offset drift, the same removed-directory gate) — a backend work list, not a decline list. The driver support is in place, so registering it later is one CMake block.

## smb_dump as data

The quint harnesses already run the stack at debug level, so the dump paths execute on every replay — yet `smb_dump.c` read as one of the largest uncovered files. The reason: `smb_status_name()` was ~1,000 lines of `case SMB2_STATUS_X: return "Name";`, of which a corpus can only ever reach the few dozen statuses the server produces. It is now the lookup table it always was; the coverage denominator stops carrying case lines no test could execute.

## Submodule pins

`ext/libevpl` pins libevpl main (`b27b5e8`, the #147 rebase-merge; tree-identical to the reviewed branch). `ext/specs` pins `4b17d2c` — the tip of specs#18's branch, now permanently reachable as a parent of the specs#18 merge commit. It deliberately does NOT pin the merge SHA: the merge tree also contains specs main's `posix-lock-flavor` and `nfs4-stepdata-live` models, which are ahead of what chimera implements (a pin past them regenerates stepLocks/stepData traces chimera cannot yet pass — their chimera counterparts are separate in-flight work). CI builds the corpus from source for a non-main pin (quint is installed on every runner, macOS included); the pin advances to a bundle-published main SHA once chimera absorbs those models.

## A note on the delegation traces

All 20 `stepDeleg` traces SKIP in the registered batch ("trace assumes a delegation grant, server granted none"). Initially read as a main regression, this turned out to be the designed state: the harness serves with delegations off by default and nothing ever registered a delegation-enabled batch, so the Deleg corpus never had a consumer at all. The stacked #1608 adds one (`--delegations` + `batch_deleg_*`), and the instances replay green there.
