### PR TITLE
fix/smb: advertise 64 KiB max read / write size for SMB 2.0.2 (no multi credit)

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -341,6 +341,14 @@ struct chimera_smb_conn;
  * evpl buffer cannot be satisfied with one iovec. */
 #define CHIMERA_SMB_MAX_TRANSACT_SIZE         (1 * 1024 * 1024)
 
+/* MaxReadSize/MaxWriteSize advertised in NEGOTIATE.  Per MS-SMB2 3.2.4.1.5, a
+ * connection without SMB2_GLOBAL_CAP_LARGE_MTU (dialect < 2.1, or multi-credit
+ * disabled) charges exactly one credit per request regardless of size, which
+ * fixes the largest single payload at 64 KiB; only a connection granted
+ * LARGE_MTU may advertise the larger multi-credit size. */
+#define CHIMERA_SMB_MAX_RW_SIZE_LARGE_MTU     (8 * 1024 * 1024)
+#define CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT 65536
+
 /* Maximum supported file size, matching the Windows/Samba value
  * (0xFFFFFFF0000 == 2^44 - 2^16).  A write, SetEndOfFile or SetAllocation whose
  * size would exceed this is rejected with STATUS_INVALID_PARAMETER. */

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -165,9 +165,14 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     }
     request->negotiate.r_capabilities      = conn->capabilities;
     request->negotiate.r_max_transact_size = CHIMERA_SMB_MAX_TRANSACT_SIZE;
-    request->negotiate.r_max_read_size     = 8 * 1024 * 1024;
-    request->negotiate.r_max_write_size    = 8 * 1024 * 1024;
-    request->negotiate.r_system_time       = chimera_nt_time(&now);
+    if (conn->capabilities & SMB2_GLOBAL_CAP_LARGE_MTU) {
+        request->negotiate.r_max_read_size  = CHIMERA_SMB_MAX_RW_SIZE_LARGE_MTU;
+        request->negotiate.r_max_write_size = CHIMERA_SMB_MAX_RW_SIZE_LARGE_MTU;
+    } else {
+        request->negotiate.r_max_read_size  = CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT;
+        request->negotiate.r_max_write_size = CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT;
+    }
+    request->negotiate.r_system_time = chimera_nt_time(&now);
     /* ServerStartTime is the SMB server instance start time (captured once at
      * init), not the OS boot time -- so an in-place chimera restart is visible
      * to clients keying off this field (issue #1225, MS-SMB2 3.3.1.5). */


### PR DESCRIPTION
Chimera advertised an 8 MB `MaxReadSize`/`MaxWriteSize` during `NEGOTIATE` for all SMB2 dialects.

That is only valid when `SMB2_GLOBAL_CAP_LARGE_MTU` is granted. For SMB 2.0.2, multi-credit is not available, so the maximum single request payload should stay at 64 KiB. Windows advertises `65536` for SMB 2.0.2, while Chimera was advertising `8388608`.

Fixes #1469.

## Fix

Gate `r_max_read_size` and `r_max_write_size` on `conn->capabilities & SMB2_GLOBAL_CAP_LARGE_MTU`, matching the existing capability check.

When `LARGE_MTU` is not granted, fall back to `CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT` (`65536`).

## Verification

* Built Chimera and started a memfs-backed SMB share.
* Captured `NEGOTIATE` with `tcpdump`/`tshark` using `smbclient` forced to `client max protocol=SMB2_02`.
* Before: `Capabilities=0x0`, but `MaxReadSize`/`MaxWriteSize=8388608`.
* After: `MaxReadSize`/`MaxWriteSize=65536`, consistent with the advertised capabilities.
* Re-tested with an SMB 2.1-3.1.1 capable client: `MaxReadSize`/`MaxWriteSize` remain `8388608` when `LARGE_MTU` is granted.