### PR TITLE
tests/posix: report errno when fstest's read or write fails

### DIFF
--- a/src/posix/tests/test_fstest.c
+++ b/src/posix/tests/test_fstest.c
@@ -143,10 +143,22 @@ create_file(
         ssize_t written;
 
         gen_buffer(buf, loop, child, fnum, size);
+        errno   = 0;
         written = chimera_posix_pwrite(fd, buf, block_size, size);
         if (written != block_size) {
-            fprintf(stderr, "Write failed at offset %d: wrote %zd, expected %d\n",
-                    size, written, block_size);
+            /* Separate the two faults and name the errno.  A short write and a
+             * failed one have different causes, and "wrote -1" on its own says
+             * nothing about which -- ENOSPC, EIO and a timeout all look alike
+             * in a CI log, which is exactly where this fires. */
+            if (written < 0) {
+                fprintf(stderr,
+                        "Write failed at offset %d in %s: %s (errno %d)\n",
+                        size, fname, strerror(errno), errno);
+            } else {
+                fprintf(stderr,
+                        "Short write at offset %d in %s: wrote %zd of %d\n",
+                        size, fname, written, block_size);
+            }
             free(buf);
             chimera_posix_close(fd);
             return 1;
@@ -186,10 +198,18 @@ check_file(
     for (size = 0; size < file_size; size += block_size * do_frags) {
         ssize_t nread;
 
+        errno = 0;
         nread = chimera_posix_pread(fd, buf, block_size, size);
         if (nread != block_size) {
-            fprintf(stderr, "Read failed at offset %d: read %zd, expected %d\n",
-                    size, nread, block_size);
+            if (nread < 0) {
+                fprintf(stderr,
+                        "Read failed at offset %d in %s: %s (errno %d)\n",
+                        size, fname, strerror(errno), errno);
+            } else {
+                fprintf(stderr,
+                        "Short read at offset %d in %s: read %zd of %d\n",
+                        size, fname, nread, block_size);
+            }
             ret = 1;
             break;
         }


### PR DESCRIPTION
The nightly Extended run fails `chimera/posix/fstest_nfs4_linux` and
`fstest_nfs4_io_uring` — 4 of its 8 failing jobs, across both architectures and
both build types — with a message that cannot be acted on:

```
Write failed at offset 0: wrote -1, expected 1024
```

A write returned −1. ENOSPC, EIO, a backend timeout and a truncated transfer all
print exactly that line, so there is no way to tell an environment problem from a
server bug. These fire on CI runners, where the log is the only evidence anyone
gets.

This names the errno and the file, and separates the two faults — a short write
and a failed write have different causes and deserve different messages. The read
side gets the same treatment.

Forcing ENOSPC against a full backing store now produces:

```
Write failed at offset 827392 in /test/child0/file1: No space left on device (errno 28)
```

That also establishes something useful about the nightly failure: ENOSPC does
produce the exact `wrote -1` signature seen there. It is a candidate explanation,
not a proven one — which is the point. The next occurrence will say which it is in
one run, instead of costing another investigation.

No behavior change. Verified on the `nfs4_linux`, `nfs4_memfs`, `memfs` and
`linux` backends; the failure path was exercised deliberately by filling the
backing filesystem.

Note on what this does *not* do: it does not fix the underlying failure. I could
not reproduce it — 20 sequential and 40 parallel runs against a real ext4 backing
store, all green. This makes the next report diagnosable rather than guessing at a
fix for a fault whose cause is still unknown.
