### PR TITLE
call-claude/call-codex: fall back to in-tree worktrees/ outside the devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ private
 *.orig
 Testing
 compile_commands.json
+/worktrees/
 settings.local.json
 .serena
 

--- a/call-claude
+++ b/call-claude
@@ -7,7 +7,6 @@
 
 set -e
 
-WORKTREE_BASE="/worktrees"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
@@ -16,8 +15,9 @@ Usage: $(basename "$0") [OPTIONS]
 
 Create a git worktree and launch Claude Code in it.
 
-The worktree is created in /worktrees/<name>. Claude Code will show a one-time
-trust dialog for new worktrees. File permissions for the worktree's build
+The worktree is created in /worktrees/<name> if /worktrees exists (devcontainer
+volume), otherwise in worktrees/<name> under the main source tree. Claude Code
+will show a one-time trust dialog for new worktrees. File permissions for the worktree's build
 directory are pre-configured in .claude/settings.local.json.
 
 Options:
@@ -86,6 +86,14 @@ GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 MAIN_REPO="$(dirname "$GIT_COMMON_DIR")"
 if [[ "$GIT_COMMON_DIR" == ".git" ]]; then
     MAIN_REPO="$GIT_ROOT"
+fi
+
+# Worktrees live in /worktrees when it exists (devcontainer volume mount),
+# otherwise in an ignored worktrees/ directory under the main source tree.
+if [[ -d /worktrees ]]; then
+    WORKTREE_BASE="/worktrees"
+else
+    WORKTREE_BASE="$MAIN_REPO/worktrees"
 fi
 
 init_submodules() {

--- a/call-codex
+++ b/call-codex
@@ -7,7 +7,6 @@
 
 set -e
 
-WORKTREE_BASE="/worktrees"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
@@ -16,7 +15,8 @@ Usage: $(basename "$0") [OPTIONS]
 
 Create a git worktree and launch Codex CLI in it.
 
-The worktree is created in /worktrees/<name>.
+The worktree is created in /worktrees/<name> if /worktrees exists (devcontainer
+volume), otherwise in worktrees/<name> under the main source tree.
 
 Options:
   -b <branch>           Setup worktree from an existing branch
@@ -84,6 +84,14 @@ GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 MAIN_REPO="$(dirname "$GIT_COMMON_DIR")"
 if [[ "$GIT_COMMON_DIR" == ".git" ]]; then
     MAIN_REPO="$GIT_ROOT"
+fi
+
+# Worktrees live in /worktrees when it exists (devcontainer volume mount),
+# otherwise in an ignored worktrees/ directory under the main source tree.
+if [[ -d /worktrees ]]; then
+    WORKTREE_BASE="/worktrees"
+else
+    WORKTREE_BASE="$MAIN_REPO/worktrees"
 fi
 
 init_submodules() {


### PR DESCRIPTION
The `call-claude` and `call-codex` launcher scripts hardcoded `/worktrees` as the worktree base, which only exists as a volume mount inside the devcontainer — running them natively (e.g. on macOS) failed.

Now the scripts use `/worktrees` when it exists and otherwise fall back to a `worktrees/` directory under the main source tree, which is added to `.gitignore`. Per-worktree build outputs already land inside each worktree (`./build/{Debug,Release}`), so the in-tree location builds independently without conflicts.
