### PR TITLE
nfs4/quint: the corpus against diskfs and cairn, and the three clone bugs it found

### DIFF
--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -171,10 +171,10 @@ static const struct {
     const char *trace;      /* trace file basename */
     const char *why;
 } posix_mbt_declines[] = {
-    /* diskfs mkdirat under a directory that has been removed (still open via
-     * dirfd) creates the entry instead of answering ENOENT. */
-    { "diskfs", "stepFds_128_0x1_3.itf.json",
-      "create under a removed directory succeeds" },
+    /* Currently empty -- every entry the first diskfs rounds added has been
+     * retired by a fix.  The sentinel keeps the array non-empty; add new
+     * declines above it. */
+    { NULL, NULL, NULL },
 };
 
 static const char *
@@ -187,7 +187,8 @@ posix_mbt_declined(const char *path)
     for (i = 0;
          i < sizeof(posix_mbt_declines) / sizeof(posix_mbt_declines[0]);
          i++) {
-        if (strcmp(posix_mbt_declines[i].backend, g_module) == 0 &&
+        if (posix_mbt_declines[i].backend &&
+            strcmp(posix_mbt_declines[i].backend, g_module) == 0 &&
             strcmp(posix_mbt_declines[i].trace, base) == 0) {
             return posix_mbt_declines[i].why;
         }

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -171,13 +171,6 @@ static const struct {
     const char *trace;      /* trace file basename */
     const char *why;
 } posix_mbt_declines[] = {
-    /* diskfs copy_file_range copies and answers block-rounded byte counts
-     * past the source EOF (1024 requested at EOF-1024 -> 4096 copied), and
-     * the destination grows to match. */
-    { "diskfs", "stepData_128_0x1_2.itf.json",
-      "copy_file_range over-copies past source EOF" },
-    { "diskfs", "step_256_0x100_1.itf.json",
-      "copy_file_range over-copies past source EOF" },
     /* diskfs mkdirat under a directory that has been removed (still open via
      * dirfd) creates the entry instead of answering ENOENT. */
     { "diskfs", "stepFds_128_0x1_3.itf.json",

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -171,11 +171,6 @@ static const struct {
     const char *trace;      /* trace file basename */
     const char *why;
 } posix_mbt_declines[] = {
-    /* diskfs truncate of a file whose extents are shared with a clone walks
-     * the refcount btree off a freed node (ASAN SEGV: diskfs_bt_run <-
-     * diskfs_refcount_dec <- diskfs_setattr_trunc_process). */
-    { "diskfs", "stepData_128_0x1_3.itf.json",
-      "truncate over cloned extents crashes the refcount walk" },
     /* diskfs copy_file_range copies and answers block-rounded byte counts
      * past the source EOF (1024 requested at EOF-1024 -> 4096 copied), and
      * the destination grows to match. */

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -183,8 +183,6 @@ static const struct {
       "copy_file_range over-copies past source EOF" },
     { "diskfs", "step_256_0x100_1.itf.json",
       "copy_file_range over-copies past source EOF" },
-    { "diskfs", "step_256_0x100_2.itf.json",
-      "copy_file_range over-copies past source EOF" },
     /* diskfs mkdirat under a directory that has been removed (still open via
      * dirfd) creates the entry instead of answering ENOENT. */
     { "diskfs", "stepFds_128_0x1_3.itf.json",

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -313,6 +313,42 @@ set_tests_properties(chimera/server/nfs/mbt4/batch_memfs PROPERTIES
     SKIP_RETURN_CODE 77
     TIMEOUT 300)
 
+# The same corpus -- every minor version instance it carries (4.0, 4.1 and
+# 4.2) -- against the other named-filesystem backends, as the NFS3 suite runs
+# above: diskfs/cairn self-provision scratch under their mkdtemp session dirs,
+# and a trace whose capability profile the live backend cannot honor skips
+# individually.  Its first runs surfaced three diskfs clone bugs (beyond-EOF
+# ranges accepted, source holes leaving stale destination data, the walk
+# reprocessing its own split piece) and the D4-17 real-holes seek refinement
+# the hole-tracking backends need.
+#
+# The linux/io_uring passthroughs are NOT registered: the replayer drives them
+# (--backend linux|io_uring, container-only), but ~115 of 120 traces diverge
+# on host-kernel semantics -- attribute omission on the passthrough fast path
+# (the nfs3 replayer's --max-attr-skip-rate machinery has no v4 counterpart
+# yet), host change-info freshness, host mode/link answers.  That is the same
+# class of engagement the nfs3 passthrough batches needed (their own
+# reconciliation registry and model profile) and is its own piece of work.
+add_test(NAME chimera/server/nfs/mbt4/batch_diskfs
+    COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4
+            --backend diskfs)
+set_tests_properties(chimera/server/nfs/mbt4/batch_diskfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_diskfs"
+    LABELS "quint;nfs4_mbt;diskfs"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 600)
+
+if(CAIRN_ENABLED)
+    add_test(NAME chimera/server/nfs/mbt4/batch_cairn
+        COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4
+                --backend cairn)
+    set_tests_properties(chimera/server/nfs/mbt4/batch_cairn PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_cairn"
+        LABELS "quint;nfs4_mbt;cairn"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endif()
+
 # pNFS.  --pnfs N makes the replayer stand up a whole metadata-server cluster
 # inside the test process: the server it already ran becomes the MDS, plus N
 # more chimera servers as flex-files data servers, each on its own inproc

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -349,6 +349,28 @@ if(CAIRN_ENABLED)
         TIMEOUT 600)
 endif()
 
+# The same corpus with delegations SERVED.  The corpus's Deleg instances
+# assume grants and skip against the default (delegations-off) server above;
+# the delegation-free instances assume none and skip here when the server
+# grants on their opens -- the capability reconciliation self-selects each
+# trace into whichever batch matches, and between the two every instance
+# replays.  Until this batch existed the Deleg instances had no consumer at
+# all: they were generated, skipped silently in the default batch, and the
+# delegation wire paths were covered only by the deterministic deleg_probe.
+foreach(dback memfs diskfs cairn)
+    if(dback STREQUAL "cairn" AND NOT CAIRN_ENABLED)
+        continue()
+    endif()
+    add_test(NAME chimera/server/nfs/mbt4/batch_deleg_${dback}
+        COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4
+                --backend ${dback} --delegations)
+    set_tests_properties(chimera/server/nfs/mbt4/batch_deleg_${dback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_deleg_${dback}"
+        LABELS "quint;nfs4_mbt;${dback}"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endforeach()
+
 # pNFS.  --pnfs N makes the replayer stand up a whole metadata-server cluster
 # inside the test process: the server it already ran becomes the MDS, plus N
 # more chimera servers as flex-files data servers, each on its own inproc

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -270,6 +270,7 @@ enum v4_dev {
     DEV_LOOKUPP_SYMLINK,          /* D4-7 */
     DEV_COARSE_TYPE_ERR,          /* D4-15 */
     DEV_READLINK_DIR_INVAL,       /* D4-16 */
+    DEV_REAL_HOLES,               /* D4-17 */
     DEV_COUNT,
 };
 
@@ -280,7 +281,18 @@ static const char *v4_dev_ids[DEV_COUNT] = {
     "D4-7-lookupp-symlink",
     "D4-15-coarse-type-error",
     "D4-16-readlink-dir-inval",
+    "D4-17-real-holes",
 };
+
+/* Set when the backend tracks holes for real (every backend but memfs, whose
+* block_size is pinned to the model's granularity): the model, like memfs,
+* reads every byte below EOF as data and puts the sole hole at EOF, while a
+* hole-tracking backend legitimately refines that -- SEEK_HOLE may find a
+* genuine hole earlier, SEEK_DATA may skip never-written ranges to a later
+* offset or answer NFS4ERR_NXIO when nothing but holes remain below EOF.
+* All of those are conformant (RFC 7862 15.11); D4-17 records the acceptance,
+* exactly as the posix suite's PT2 rule does for its passthrough backends. */
+static int g_backend_real_holes;
 
 #define E_WRONG_TYPE 10083
 
@@ -2916,6 +2928,15 @@ classify_status_mismatch(
         o->status_dev = ast;
         return;
     }
+    /* D4-17: SEEK_DATA over ranges the model believes are data but the
+     * backend never materialized -- nothing but real holes remain below EOF,
+     * and NFS4ERR_NXIO is the conformant answer (RFC 7862 15.11.3). */
+    if (g_backend_real_holes && strcmp(tag, "SSeek") == 0 &&
+        est == NFS4_OK && ast == NFS4ERR_NXIO) {
+        o->dev_hits[DEV_REAL_HOLES]++;
+        o->status_dev = ast;
+        return;
+    }
     if (strcmp(tag, "SClose") == 0 &&
         ((est == NFS4_OK && ast == E_LOCKS_HELD) ||
          (est == E_LOCKS_HELD && ast == NFS4_OK))) {
@@ -3382,11 +3403,30 @@ check_result(
                      r->newsize);
         }
     } else if (strcmp(tag, "SSeek") == 0) {
+        uint64_t moff = (uint64_t) jf_i64(v, "offset") * V4_BLOCK_SIZE;
+
+        if (g_backend_real_holes &&
+            (r->offset != moff || r->eof != jf_bool(v, "eof"))) {
+            uint64_t qoff = req ? (uint64_t) jf_i64(jf_val(req), "off") *
+                V4_BLOCK_SIZE : 0;
+            int      wdata = req ? jf_bool(jf_val(req), "whatData") : 0;
+
+            /* D4-17: accept the hole-tracking refinement -- a HOLE at or
+             * after the queried offset but no later than the model's EOF
+             * answer, or DATA at or past the model's offset (real holes
+             * skipped).  The eof flag follows the refined offset, so it is
+             * excused with it. */
+            if ((!wdata && r->offset >= qoff && r->offset <= moff) ||
+                (wdata && r->offset >= moff)) {
+                o->dev_hits[DEV_REAL_HOLES]++;
+                return;
+            }
+        }
         if (r->eof != jf_bool(v, "eof")) {
             mism_add(m, "seek.eof: expected %d, got %d",
                      jf_bool(v, "eof"), r->eof);
         }
-        if (r->offset != (uint64_t) jf_i64(v, "offset") * V4_BLOCK_SIZE) {
+        if (r->offset != moff) {
             mism_add(m, "seek.offset: expected %" PRId64 ", got %" PRIu64,
                      jf_i64(v, "offset") * V4_BLOCK_SIZE, r->offset);
         }
@@ -4391,7 +4431,8 @@ main(
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
-                        "[--backend memfs|diskfs|cairn] [--pnfs N] "
+                        "[--backend memfs|diskfs|cairn|linux|io_uring] "
+                        "[--pnfs N] "
                         "[--mandatory CAP] [--dry-run] [--verbose]\n",
                         argv[0]);
                 mbt_free_traces(traces, ntraces);
@@ -4412,7 +4453,8 @@ main(
      * once here (it dispatches to the trace-local oracle via g_recall_oracle). */
     /* memfs_config only reaches the memfs module; diskfs and cairn
      * self-provision their scratch under the env's session dir. */
-    opts.module = backend;
+    opts.module          = backend;
+    g_backend_real_holes = strcmp(backend, "memfs") != 0;
 
     if (!dry_run) {
         mbt_env_open_opts(&env, &opts);

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -2944,7 +2944,8 @@ classify_status_mismatch(
                       est, ast);
         return;
     }
-    if (strcmp(tag, "SOpen") == 0 && est == E_DELAY && ast == NFS4_OK) {
+    if ((strcmp(tag, "SOpen") == 0 || strcmp(tag, "SRemove") == 0) &&
+        est == E_DELAY && ast == NFS4_OK) {
         caps_mismatch(o, m, "conflictDelays",
                       "model expected NFS4ERR_DELAY during recall, server "
                       "completed the op");
@@ -4364,6 +4365,7 @@ main(
         { "mandatory",      required_argument, 0, 'M' },
         { "backend",        required_argument, 0, 'b' },
         { "pnfs",           required_argument, 0, 'p' },
+        { "delegations",    no_argument,       0, 'g' },
         { "dry-run",        no_argument,       0, 'n' },
         { "verbose",        no_argument,       0, 'v' },
         { 0,                0,                 0, 0   },
@@ -4395,7 +4397,7 @@ main(
      * shared helper; getopt only recognizes them so it does not error. */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:M:b:p:nv", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:M:b:p:gnv", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -4409,6 +4411,13 @@ main(
                 break;
             case 'b':
                 backend = optarg;
+                break;
+            case 'g':
+                /* Serve with delegations on.  The corpus's Deleg instances
+                 * assume grants and skip against the default server; the
+                 * delegation-free instances assume none and skip against
+                 * this one -- two complementary batches cover the corpus. */
+                opts.nfs4_delegations = 1;
                 break;
             case 'n':
                 dry_run = 1;
@@ -4432,7 +4441,7 @@ main(
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
                         "[--backend memfs|diskfs|cairn|linux|io_uring] "
-                        "[--pnfs N] "
+                        "[--pnfs N] [--delegations] "
                         "[--mandatory CAP] [--dry-run] [--verbose]\n",
                         argv[0]);
                 mbt_free_traces(traces, ntraces);

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -894,6 +894,10 @@ diskfs_setattr_inode_cb(
         request->setattr.set_attr->va_size < inode->size) {
 
         p->inode_stash[0] = inode;
+        /* Not carried over from the pooled request's previous life: the trunc
+         * walk's ext_release acquires the refcount inode lazily on the first
+         * reflink-shared extent it frees, keyed on this being NULL. */
+        p->inode_stash[2] = NULL;
         p->loop_off       = request->setattr.set_attr->va_size;
 
         op = diskfs_bt_op_alloc(thread);

--- a/src/vfs/diskfs/diskfs_clone.c
+++ b/src/vfs/diskfs/diskfs_clone.c
@@ -1090,6 +1090,16 @@ diskfs_clone_rc_acquired_cb(
 
     diskfs_map_attrs(p->thread, &request->clone_range.r_pre_attr, dst);
 
+    /* The source range must lie within the source file (the FICLONERANGE
+     * contract, and RFC 7862 15.13.3's MUST for the CLONE op that rides on
+     * this).  Checked here, with the inodes locked, so the size cannot move
+     * underneath the decision -- memfs enforces the same rule. */
+    if (request->clone_range.src_offset + request->clone_range.length >
+        src->size) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EINVAL);
+        return;
+    }
+
     p->clone_src_base = request->clone_range.src_offset;
     p->clone_dst_base = request->clone_range.dst_offset;
     p->loop_off       = request->clone_range.src_offset;

--- a/src/vfs/diskfs/diskfs_clone.c
+++ b/src/vfs/diskfs/diskfs_clone.c
@@ -597,8 +597,8 @@ diskfs_clone_advance(struct chimera_vfs_request *request)
     struct diskfs_thread          *thread = p->thread;
     struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
 
-    uint64_t eend = p->ext_iter.file_offset + p->ext_iter.length;
-    uint64_t oend = eend < p->loop_pos ? eend : p->loop_pos;
+    uint64_t                       eend = p->ext_iter.file_offset + p->ext_iter.length;
+    uint64_t                       oend = eend < p->loop_pos ? eend : p->loop_pos;
 
     /* Step past everything the step just processed.  Advancing from the
      * ORIGINAL extent's start is not enough: when the source split rewrote it
@@ -872,7 +872,7 @@ diskfs_clone_dst_clear_cb(
 
     if (!have || p->clone_dst_ext.file_offset >= dend) {
         /* Nothing (left) overlapping: the range is clear. */
-        diskfs_clone_insert_dst_record(request);
+        p->clone_clear_cont(request);
         return;
     }
 
@@ -925,17 +925,20 @@ diskfs_clone_dst_clear(struct chimera_vfs_request *request)
 static void
 diskfs_clone_insert_dst(struct chimera_vfs_request *request)
 {
-    struct diskfs_request_private *p      = request->plugin_data;
-    struct diskfs_extent          *e      = &p->ext_iter;
-    uint64_t                       ostart = e->file_offset > p->clone_src_base ?
-        e->file_offset : p->clone_src_base;
+    struct diskfs_request_private *p    = request->plugin_data;
+    struct diskfs_extent          *e    = &p->ext_iter;
     uint64_t                       oend = (e->file_offset + e->length) < p->loop_pos ?
         (e->file_offset + e->length) : p->loop_pos;
 
-    /* Clear whatever the destination already holds across this step's range
-     * before recording the shared extent there. */
-    p->clone_dst_clear_start = p->clone_dst_base + (ostart - p->clone_src_base);
-    p->clone_dst_clear_end   = p->clone_dst_clear_start + (oend - ostart);
+    /* Clear whatever the destination already holds from where the last step
+     * left off through this step's range.  Starting at clone_cleared_to (not
+     * this step's own start) is what clears the ranges opposite source holes
+     * the walk skipped: a clone replicates the source's holes, so stale
+     * destination data there must go too. */
+    p->clone_dst_clear_start = p->clone_cleared_to;
+    p->clone_dst_clear_end   = p->clone_dst_base + (oend - p->clone_src_base);
+    p->clone_cleared_to      = p->clone_dst_clear_end;
+    p->clone_clear_cont      = diskfs_clone_insert_dst_record;
 
     diskfs_clone_dst_clear(request);
 } /* diskfs_clone_insert_dst */
@@ -1042,6 +1045,19 @@ diskfs_clone_walk_cb(
     diskfs_bt_op_free(p->thread, op);
 
     if (!have || p->ext_iter.file_offset >= p->loop_pos) {
+        /* Source exhausted.  If a trailing source hole remains, the matching
+        * destination range still holds whatever it held before the clone --
+        * clear it (to zeros, as the source reads there) before finishing. */
+        uint64_t dst_end = p->clone_dst_base + (p->loop_pos - p->clone_src_base);
+
+        if (p->clone_cleared_to < dst_end) {
+            p->clone_dst_clear_start = p->clone_cleared_to;
+            p->clone_dst_clear_end   = dst_end;
+            p->clone_cleared_to      = dst_end;
+            p->clone_clear_cont      = diskfs_clone_finalize;
+            diskfs_clone_dst_clear(request);
+            return;
+        }
         diskfs_clone_finalize(request);
         return;
     }
@@ -1108,10 +1124,11 @@ diskfs_clone_rc_acquired_cb(
         return;
     }
 
-    p->clone_src_base = request->clone_range.src_offset;
-    p->clone_dst_base = request->clone_range.dst_offset;
-    p->loop_off       = request->clone_range.src_offset;
-    p->loop_pos       = request->clone_range.src_offset + request->clone_range.length;
+    p->clone_src_base   = request->clone_range.src_offset;
+    p->clone_dst_base   = request->clone_range.dst_offset;
+    p->clone_cleared_to = request->clone_range.dst_offset;
+    p->loop_off         = request->clone_range.src_offset;
+    p->loop_pos         = request->clone_range.src_offset + request->clone_range.length;
 
     diskfs_clone_walk(request);
 } /* diskfs_clone_rc_acquired_cb */

--- a/src/vfs/diskfs/diskfs_clone.c
+++ b/src/vfs/diskfs/diskfs_clone.c
@@ -597,10 +597,18 @@ diskfs_clone_advance(struct chimera_vfs_request *request)
     struct diskfs_thread          *thread = p->thread;
     struct diskfs_bt_op           *op     = diskfs_bt_op_alloc(thread);
 
-    /* Step to the extent following the one just processed.  (A plain re-floor of
-     * an advanced offset would return the same extent again, since floor is the
-     * largest key <= offset.) */
-    if (diskfs_ext_next_async(op, thread, p->inode_stash[1], p->ext_iter.file_offset,
+    uint64_t eend = p->ext_iter.file_offset + p->ext_iter.length;
+    uint64_t oend = eend < p->loop_pos ? eend : p->loop_pos;
+
+    /* Step past everything the step just processed.  Advancing from the
+     * ORIGINAL extent's start is not enough: when the source split rewrote it
+     * as [head][overlap=SHARED][tail], the overlap and tail carry keys larger
+     * than the original's, so next(estart) would return the overlap piece the
+     * step itself just inserted -- reprocessing it double-bumps the refcount
+     * and re-inserts the destination record onto a live key.  next(oend - 1)
+     * lands on the tail (or the following extent) in the split and unsplit
+     * cases alike. */
+    if (diskfs_ext_next_async(op, thread, p->inode_stash[1], oend - 1,
                               p->rec_scratch, sizeof(p->rec_scratch),
                               diskfs_clone_walk_cb, request)) {
         diskfs_clone_walk_cb(op, op->result, request);

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -371,6 +371,17 @@ struct diskfs_request_private {
      * refcount bump and the advance all still need. */
     uint64_t                    clone_dst_clear_start;
     uint64_t                    clone_dst_clear_end;
+    /* How far (in destination offsets) the clone has cleared so far.  Each
+     * step clears from here through its own overlap end, which is what makes
+     * the ranges opposite SOURCE HOLES get cleared too: a clone replicates
+     * the source's holes, so stale destination extents there must go the
+     * same as anywhere else in the range. */
+    uint64_t                    clone_cleared_to;
+    /* Where the destination clear pass hands control when its range is clear:
+     * the per-step shared-extent insert, or the finalize after the trailing
+     * hole's clear. */
+    void                        (*clone_clear_cont)(
+        struct chimera_vfs_request *);
     struct diskfs_extent        clone_dst_ext;
     /* Whole-extent CoW privatize: the shared extent being copied to private
      * blocks, the freshly-allocated destination, and the bytes copied so far. */

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -642,6 +642,16 @@ diskfs_lookup_at_parent_cb(
         return;
     }
 
+    /* A directory that has been removed stays resolvable while a descriptor
+     * pins it, but POSIX lets nothing be created in or resolved through it
+     * any more (Linux answers ENOENT for every *at() call against such a
+     * dirfd).  A removed directory's nlink is zeroed, so that is the test --
+     * after the type check, matching the order *at() resolution uses. */
+    if (parent->nlink == 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
     diskfs_map_attrs(thread, &request->lookup_at.r_dir_attr, parent);
 
     if (namelen == 1 && name[0] == '.') {
@@ -887,6 +897,16 @@ diskfs_mkdir_at_parent_cb(
         return;
     }
 
+    /* A directory that has been removed stays resolvable while a descriptor
+     * pins it, but POSIX lets nothing be created in or resolved through it
+     * any more (Linux answers ENOENT for every *at() call against such a
+     * dirfd).  A removed directory's nlink is zeroed, so that is the test --
+     * after the type check, matching the order *at() resolution uses. */
+    if (parent->nlink == 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
     diskfs_map_attrs(thread, &request->mkdir_at.r_dir_pre_attr, parent);
 
     p->inode_stash[0] = parent;
@@ -1070,6 +1090,16 @@ diskfs_mknod_at_parent_cb(
 
     if (!S_ISDIR(parent->mode)) {
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    /* A directory that has been removed stays resolvable while a descriptor
+     * pins it, but POSIX lets nothing be created in or resolved through it
+     * any more (Linux answers ENOENT for every *at() call against such a
+     * dirfd).  A removed directory's nlink is zeroed, so that is the test --
+     * after the type check, matching the order *at() resolution uses. */
+    if (parent->nlink == 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
@@ -1327,6 +1357,16 @@ diskfs_remove_at_parent_cb(
 
     if (!S_ISDIR(parent->mode)) {
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    /* A directory that has been removed stays resolvable while a descriptor
+     * pins it, but POSIX lets nothing be created in or resolved through it
+     * any more (Linux answers ENOENT for every *at() call against such a
+     * dirfd).  A removed directory's nlink is zeroed, so that is the test --
+     * after the type check, matching the order *at() resolution uses. */
+    if (parent->nlink == 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
@@ -2028,6 +2068,16 @@ diskfs_open_at_parent_cb(
         return;
     }
 
+    /* A directory that has been removed stays resolvable while a descriptor
+     * pins it, but POSIX lets nothing be created in or resolved through it
+     * any more (Linux answers ENOENT for every *at() call against such a
+     * dirfd).  A removed directory's nlink is zeroed, so that is the test --
+     * after the type check, matching the order *at() resolution uses. */
+    if (parent->nlink == 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
+        return;
+    }
+
     diskfs_map_attrs(thread, &request->open_at.r_dir_pre_attr, parent);
 
     p->inode_stash[0] = parent;
@@ -2375,6 +2425,16 @@ diskfs_symlink_at_parent_cb(
 
     if (!S_ISDIR(parent->mode)) {
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    /* A directory that has been removed stays resolvable while a descriptor
+     * pins it, but POSIX lets nothing be created in or resolved through it
+     * any more (Linux answers ENOENT for every *at() call against such a
+     * dirfd).  A removed directory's nlink is zeroed, so that is the test --
+     * after the type check, matching the order *at() resolution uses. */
+    if (parent->nlink == 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 
@@ -3331,6 +3391,16 @@ diskfs_link_at_parent_cb(
 
     if (!S_ISDIR(parent->mode)) {
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOTDIR);
+        return;
+    }
+
+    /* A directory that has been removed stays resolvable while a descriptor
+     * pins it, but POSIX lets nothing be created in or resolved through it
+     * any more (Linux answers ENOENT for every *at() call against such a
+     * dirfd).  A removed directory's nlink is zeroed, so that is the test --
+     * after the type check, matching the order *at() resolution uses. */
+    if (parent->nlink == 0) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_ENOENT);
         return;
     }
 

--- a/src/vfs/vfs_proc_copy_range.c
+++ b/src/vfs/vfs_proc_copy_range.c
@@ -34,6 +34,14 @@ struct chimera_vfs_copy_fallback {
     uint64_t                          dst_offset;
     uint64_t                          remaining;
     uint64_t                          copied;
+    /* The last read came up short or reported EOF: the source has no more
+     * bytes to give as of this copy, so the in-flight write is the final hop.
+     * Without this the loop keeps reading -- and a same-file copy whose
+     * destination writes extend the source then feeds on its own output,
+     * copying the zeros it just materialized until the requested length is
+     * exhausted. */
+    int                               src_exhausted;
+    uint32_t                          read_len;     /* current hop's ask */
     uint64_t                          post_attr_mask;
     struct chimera_vfs_attrs          r_pre_attr;
     struct chimera_vfs_attrs          r_post_attr;
@@ -106,6 +114,11 @@ chimera_vfs_copy_fallback_write_cb(
     ctx->dst_offset += length;
     ctx->remaining  -= length;
 
+    if (ctx->src_exhausted) {
+        chimera_vfs_copy_fallback_finish(ctx, CHIMERA_VFS_OK);
+        return;
+    }
+
     chimera_vfs_copy_fallback_step(ctx);
 } /* chimera_vfs_copy_fallback_write_cb */
 
@@ -134,6 +147,14 @@ chimera_vfs_copy_fallback_read_cb(
         }
         chimera_vfs_copy_fallback_finish(ctx, CHIMERA_VFS_OK);
         return;
+    }
+
+    /* A short or EOF-flagged read is the source's EOF as of this copy: write
+     * what it gave and stop there (copy_file_range(2) semantics).  Reading on
+     * regardless is how a same-file copy came to copy its own freshly written
+     * zeros. */
+    if (eof || (uint64_t) count < ctx->read_len) {
+        ctx->src_exhausted = 1;
     }
 
     /* Copy the read result into a single freshly allocated buffer we fully own.
@@ -204,6 +225,7 @@ chimera_vfs_copy_fallback_step(struct chimera_vfs_copy_fallback *ctx)
             : (uint32_t) ctx->remaining;
 
     ctx->hold_niov = 0;
+    ctx->read_len  = chunk;
 
     chimera_vfs_read(
         ctx->thread,


### PR DESCRIPTION
Now rebased onto main with #1603 merged. Extends the NFS4 model suite across the named-filesystem backends, and fixes everything its runs found — including three deeper diskfs/vfs bugs whose fixes retire the entire POSIX decline registry #1603 introduced: `posix/mbt/batch_diskfs` now replays 72 of 72 traces.

## What this enables

The nfs4 corpus carries instances at every minor version — 4.0, 4.1, and 4.2 — and only ever replayed against memfs. `mbt4/batch_diskfs` and `mbt4/batch_cairn` now run the whole corpus (all three minors) against those backends, self-provisioning scratch exactly as the NFS3 suite's batches do. With the fixes below, both are green across the full corpus on macOS and the CI containers.

## What the first runs found

Every fault sat in the 4.2 data operations (SEEK / CLONE / WRITE_SAME / READ_PLUS) — the op families no other suite drives through these backends. Three real diskfs clone bugs, each its own commit:

1. **A clone whose source range passes EOF answered OK** where FICLONERANGE and RFC 7862 15.13.3 mandate EINVAL (memfs already enforced it).
2. **A clone left stale destination data opposite source holes** — the destination-range clearing ran per source *extent*, and the walk skips holes, so cloned-over ranges kept their pre-clone bytes. Silent data corruption: a READ of a cloned-over block returned old data where every conforming backend reads zeros. The clearing now tracks its own progress across the whole range, holes included.
3. **The clone walk reprocessed its own source split**: advancing from the original extent's start returns the just-inserted SHARED overlap piece, double-bumping the refcount (permanently unfreeable device blocks) and re-inserting the destination record onto a live key. Latent under the old per-step clearing; an abort under the new one; wrong either way.

One deviation, not a fault: the hole-tracking backends legitimately refine the model's everything-below-EOF-is-data view of SEEK (a genuine hole earlier than the model's EOF answer; SEEK_DATA skipping never-written ranges or answering NXIO — all RFC 7862 15.11-conformant). Registered as **D4-17-real-holes**, the v4-wire analog of the posix suite's PT2 rule, gated on every backend but memfs.

## What is deliberately left out

The linux/io_uring passthroughs: the replayer drives them (`--backend linux|io_uring`, container-only), but ~115 of 120 traces diverge on host-kernel semantics — attribute omission on the passthrough fast path (the nfs3 replayer's `--max-attr-skip-rate` machinery has no v4 counterpart), host change-info freshness, host mode/link answers. That is the same class of engagement the nfs3 passthrough batches needed (their own reconciliation registry and model profile) and is scoped as its own follow-up.

## The delegation instances get a consumer

The "delegation regression" noted on #1603 turned out to be no regression at all: the corpus's twenty Deleg instances were generated and never replayed anywhere — the only registered batch serves with delegations off (the harness default), so they all skipped on the capability reconciliation, silently and by design. `--delegations` serves with them on, and `batch_deleg_{memfs,diskfs,cairn}` replays the corpus against that server: the Deleg instances run for real (14 of 20; the rest skip on per-trace grant-pattern mismatches), the no-grant instances self-select out, and between the two server configurations every instance has a home. One registry extension rode along: the `conflictDelays` capability arm now covers REMOVE as well as OPEN (the model may assume a conflicting REMOVE is delayed behind a recall; chimera completes it — a server choice RFC 8881 10.4.3 permits).

## Three more, from chasing the declines

The clone fixes re-opened the POSIX-side declines for re-testing, and pulling those threads retired every remaining entry:

5. **diskfs: the truncate walk starts with a stale refcount-inode stash.** The shrink branch of setattr never cleared `inode_stash[2]`, the slot `ext_release` keys its lazy refcount-inode acquisition on; request privates are pooled, so a stale non-NULL pointer skipped the acquire and the refcount decrement walked a b+tree through a dangling inode — the declined ASAN SEGV.
6. **vfs: a short read ends the server-side copy fallback.** The generic copy fallback only stopped on a zero-byte read; a short (EOF) read looped for more, and a same-file copy then fed on its own output — the destination write extends the file, the next read returns the zeros the copy just materialized — answering the full requested count where copy_file_range(2) stops at the source's EOF. Both fallback backends (diskfs, cairn) were affected; the two copy declines retire.
7. **diskfs: nothing resolves through a removed directory.** Every `*at` parent callback now answers ENOENT for an nlink-0 parent (the POSIX rule Linux enforces and memfs already implemented); mkdirat through a removed-but-open dirfd used to create entries in the dead directory. The last decline retires.
