### PR TITLE
posix/quint: the corpus against cairn, completing the engine-backend matrix

### DIFF
--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -45,9 +45,10 @@ endif()
 # if every trace skips.
 #
 # The specs `posix` corpus carries per-backend profiles distinguished by
-# filename prefix: memfs (no prefix), the NFS loopbacks (nfs3_/nfs4_), the
-# on-disk/passthrough backends (disk_) and FUSE (fuse_).  Each registered
-# batch selects its profile with --exclude-prefix.
+# filename prefix: memfs (no prefix, and also what diskfs replays), the NFS
+# loopbacks (nfs3_/nfs4_), the no-clone profile (disk_, shared by cairn and
+# the linux/io_uring passthroughs) and FUSE (fuse_).  Each registered batch
+# selects its profile with --exclude-prefix.
 add_test(NAME chimera/posix/mbt/batch_memfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend memfs
@@ -70,12 +71,6 @@ set_tests_properties(chimera/posix/mbt/batch_memfs PROPERTIES
 # posix_mbt_declines (posix_mbt_replay.c), each naming the diskfs bug that
 # retires the entry.
 #
-# cairn is deliberately NOT registered yet: the same corpus fails ~12 traces
-# across most flavors there (SEEK_DATA/SEEK_HOLE at rocksdb block granularity,
-# clone_file_range unsupported, dup'd-fd shared-offset drift, and the same
-# removed-directory create gate diskfs misses), which is a backend work list,
-# not a decline list.  The driver already speaks cairn (--backend cairn), so
-# registering it later is this same block again.
 add_test(NAME chimera/posix/mbt/batch_diskfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend diskfs
@@ -85,6 +80,32 @@ add_test(NAME chimera/posix/mbt/batch_diskfs
 set_tests_properties(chimera/posix/mbt/batch_diskfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_diskfs"
     LABELS "quint;posix_mbt;diskfs"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 600)
+
+# cairn, the other on-disk backend, completing the engine-backend matrix.  It
+# is the one engine backend the memfs profile does not fit: cairn advertises
+# neither CHIMERA_VFS_CAP_COPY_RANGE nor CHIMERA_VFS_CAP_CLONE_RANGE, and
+# while the VFS supplies a generic copy fallback for the former there is no
+# clone fallback -- clone answers ENOTSUP.  So cairn replays the `disk_`
+# profile (posix_run.qnt's posixDisk instance, F_CLONE_RANGE = FeatOff), the
+# same profile the linux/io_uring passthrough batches below replay, and
+# selects it the same way: exclude the unprefixed memfs traces (they all
+# begin "step") and the three prefixed profiles, leaving disk_ alone.
+#
+# diskfs stays on the memfs profile above rather than joining cairn here: it
+# does implement clone, so holding it to the model-conformant profile is what
+# exercises that path (and is what found the clone defects behind its two
+# remaining declines).
+add_test(NAME chimera/posix/mbt/batch_cairn
+    COMMAND $<TARGET_FILE:posix_mbt_replay>
+            --backend cairn
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix
+            --exclude-prefix step --exclude-prefix nfs3_
+            --exclude-prefix nfs4_ --exclude-prefix fuse_)
+set_tests_properties(chimera/posix/mbt/batch_cairn PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_cairn"
+    LABELS "quint;posix_mbt;cairn"
     SKIP_RETURN_CODE 77
     TIMEOUT 600)
 

--- a/src/posix/tests/quint/posix_deviations.py
+++ b/src/posix/tests/quint/posix_deviations.py
@@ -432,9 +432,17 @@ KNOWN_DEVIATIONS = [
         posix="clone_file_range: source range must lie within the source "
               "file (EINVAL)",
         summary="clone_file_range with a source range beyond EOF returns "
-                "success instead of EINVAL",
-        root_cause="memfs clone path does not validate the source range",
-        candidate_fix="validate offSrc+len <= source size",
+                "success instead of EINVAL, and the destination grows to "
+                "cover the range",
+        root_cause="the diskfs clone path does not validate the source "
+                   "range.  Recorded against memfs originally; memfs has "
+                   "since gained the check and no longer reaches this entry "
+                   "(0 hits across the memfs corpus, 3 across diskfs), so "
+                   "the entry now describes diskfs alone -- and, being "
+                   "reconcilable, is what hides the errno divergence until a "
+                   "later read inside the grown region fails instead",
+        candidate_fix="validate offSrc+len <= source size in diskfs "
+                      "clone_range, as memfs does; then retire this entry",
         ops=("RCloneRange",),
         expected_status=EINVAL,
         actual_status=OK,

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -90,6 +90,18 @@ posix_module_is_passthrough(const char *module)
     return strcmp(module, "linux") == 0 || strcmp(module, "io_uring") == 0;
 } /* posix_module_is_passthrough */
 
+/* Backends that record where a file's data actually lives, and so answer
+ * SEEK_DATA/SEEK_HOLE from a real extent map: the passthroughs (whose host
+ * filesystem tracks holes) and cairn (whose extents are its own RocksDB
+ * records).  memfs and diskfs instead report every byte below EOF as data
+ * with the sole hole at EOF, which is what the model abstracts.  Both are
+ * POSIX-valid; see the PT2 reconciliation for the resulting refinement. */
+static int
+posix_module_tracks_holes(const char *module)
+{
+    return posix_module_is_passthrough(module) || strcmp(module, "cairn") == 0;
+} /* posix_module_tracks_holes */
+
 static int
 pt_rm_cb(
     const char        *path,

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1931,15 +1931,17 @@ op_lseek(
             record_dev("ND7");
             return;
         }
-        /* PT2: a passthrough backend sits on a real filesystem that tracks
-         * holes, while the model (like the engine backends) reports every
-         * byte below EOF as data and the sole hole as starting at EOF.
-         * Both are POSIX-valid, so accept the real filesystem's refinement:
+        /* PT2: a hole-tracking backend knows where a file's data actually
+         * lives -- a passthrough because its host filesystem records that,
+         * cairn because its extents are its own records -- while the model
+         * (like memfs and diskfs) reports every byte below EOF as data and
+         * the sole hole as starting at EOF.
+         * Both are POSIX-valid, so accept the real backend's refinement:
          * SEEK_HOLE may find a hole at or after the queried offset but no
          * later than the model's EOF answer; SEEK_DATA may skip real holes
          * to a later offset than the model's, or answer ENXIO when nothing
          * but holes remain below EOF. */
-        if (posix_module_is_passthrough(g_module) && exp_e == 0 &&
+        if (posix_module_tracks_holes(g_module) && exp_e == 0 &&
             (whence == SEEK_DATA || whence == SEEK_HOLE)) {
             int64_t qoff = tf_field(rv, "off");
             int64_t moff = tf_field(res_v, "off");
@@ -1951,6 +1953,17 @@ op_lseek(
                 ok = (e == 6) || (e == 0 && (int64_t) rc >= moff);
             }
             if (ok) {
+                /* Accepting the refinement leaves the descriptor sitting on
+                 * the backend's answer while the model's sits on its own, and
+                 * an lseek moves the shared file offset: every later SEEK_CUR
+                 * and every implicit-offset read on this fd would inherit the
+                 * difference and diverge for reasons that have nothing to do
+                 * with holes.  Put the descriptor back on the model's rails --
+                 * the offset the model recorded is reachable by construction
+                 * (the model always succeeded here, exp_e == 0). */
+                apply_cred(pid);
+                chimera_posix_lseek(rfd(pid, tf_field(rv, "fd")),
+                                    (off_t) moff, SEEK_SET);
                 record_dev("PT2");
                 return;
             }

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3785,6 +3785,24 @@ cairn_read(
 
     inode = ih.inode;
 
+    /* read() of a directory is EISDIR; other non-regular types are EINVAL.
+     * Without this a directory read walks the extent map instead: a cairn
+     * directory carries a nominal size of 4096 and owns no extents, so the
+     * read fell through to the ordinary path and answered 4096 zero bytes
+     * where POSIX requires a failure.  memfs and diskfs both gate this. */
+    if (unlikely(!S_ISREG(inode->mode))) {
+        /* Decide before releasing: the handle owns the RocksDB slice `inode`
+         * points into, so it is freed memory once released. */
+        enum chimera_vfs_error err = S_ISDIR(inode->mode) ?
+            CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL;
+
+        cairn_inode_handle_release(&ih);
+        cairn_read_end(thread);
+        request->status = err;
+        request->complete(request);
+        return;
+    }
+
     /* relatime: only stamp atime when the file changed since last access or the
      * recorded atime is a day stale, so steady-state reads neither rewrite the
      * inode to RocksDB nor churn the VFS attr cache. */

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2830,6 +2830,20 @@ cairn_mkdir_at(
         return;
     }
 
+    /* A removed directory outlives its removal only as long as a descriptor
+     * pins it, and POSIX lets nothing be created in or resolved through it any
+     * more (Linux answers ENOENT for every *at() call made against such a
+     * dirfd).  cairn zeroes a directory's link count when it is removed, so
+     * that is the test.  It follows the type check, matching the order *at()
+     * resolution uses: what the descriptor names first, whether it still
+     * exists second. */
+    if (parent_inode->nlink == 0) {
+        cairn_inode_handle_release(&parent_ih);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
     dirent_key.keytype = CAIRN_KEY_DIRENT;
     dirent_key.inum    = parent_inode->inum;
     dirent_key.hash    = request->mkdir_at.name_hash;
@@ -2948,6 +2962,20 @@ cairn_mknod_at(
         return;
     }
 
+    /* A removed directory outlives its removal only as long as a descriptor
+     * pins it, and POSIX lets nothing be created in or resolved through it any
+     * more (Linux answers ENOENT for every *at() call made against such a
+     * dirfd).  cairn zeroes a directory's link count when it is removed, so
+     * that is the test.  It follows the type check, matching the order *at()
+     * resolution uses: what the descriptor names first, whether it still
+     * exists second. */
+    if (parent_inode->nlink == 0) {
+        cairn_inode_handle_release(&parent_ih);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
     dirent_key.keytype = CAIRN_KEY_DIRENT;
     dirent_key.inum    = parent_inode->inum;
     dirent_key.hash    = request->mknod_at.name_hash;
@@ -3058,6 +3086,20 @@ cairn_remove_at(
     if (!S_ISDIR(parent_inode->mode)) {
         cairn_inode_handle_release(&parent_ih);
         request->status = CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
+    }
+
+    /* A removed directory outlives its removal only as long as a descriptor
+     * pins it, and POSIX lets nothing be created in or resolved through it any
+     * more (Linux answers ENOENT for every *at() call made against such a
+     * dirfd).  cairn zeroes a directory's link count when it is removed, so
+     * that is the test.  It follows the type check, matching the order *at()
+     * resolution uses: what the descriptor names first, whether it still
+     * exists second. */
+    if (parent_inode->nlink == 0) {
+        cairn_inode_handle_release(&parent_ih);
+        request->status = CHIMERA_VFS_ENOENT;
         request->complete(request);
         return;
     }
@@ -3474,6 +3516,20 @@ cairn_open_at(
     if (!S_ISDIR(parent_inode->mode)) {
         cairn_inode_handle_release(&parent_ih);
         request->status = CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
+    }
+
+    /* A removed directory outlives its removal only as long as a descriptor
+     * pins it, and POSIX lets nothing be created in or resolved through it any
+     * more (Linux answers ENOENT for every *at() call made against such a
+     * dirfd).  cairn zeroes a directory's link count when it is removed, so
+     * that is the test.  It follows the type check, matching the order *at()
+     * resolution uses: what the descriptor names first, whether it still
+     * exists second. */
+    if (parent_inode->nlink == 0) {
+        cairn_inode_handle_release(&parent_ih);
+        request->status = CHIMERA_VFS_ENOENT;
         request->complete(request);
         return;
     }
@@ -4444,6 +4500,20 @@ cairn_symlink_at(
         return;
     }
 
+    /* A removed directory outlives its removal only as long as a descriptor
+     * pins it, and POSIX lets nothing be created in or resolved through it any
+     * more (Linux answers ENOENT for every *at() call made against such a
+     * dirfd).  cairn zeroes a directory's link count when it is removed, so
+     * that is the test.  It follows the type check, matching the order *at()
+     * resolution uses: what the descriptor names first, whether it still
+     * exists second. */
+    if (parent_inode->nlink == 0) {
+        cairn_inode_handle_release(&parent_ih);
+        request->status = CHIMERA_VFS_ENOENT;
+        request->complete(request);
+        return;
+    }
+
     cairn_map_attrs(fs, &request->symlink_at.r_dir_pre_attr, parent_inode);
 
     dirent_key.keytype = CAIRN_KEY_DIRENT;
@@ -4960,6 +5030,20 @@ cairn_link_at(
     if (!S_ISDIR(parent_inode->mode)) {
         cairn_inode_handle_release(&parent_ih);
         request->status = CHIMERA_VFS_ENOTDIR;
+        request->complete(request);
+        return;
+    }
+
+    /* A removed directory outlives its removal only as long as a descriptor
+     * pins it, and POSIX lets nothing be created in or resolved through it any
+     * more (Linux answers ENOENT for every *at() call made against such a
+     * dirfd).  cairn zeroes a directory's link count when it is removed, so
+     * that is the test.  It follows the type check, matching the order *at()
+     * resolution uses: what the descriptor names first, whether it still
+     * exists second. */
+    if (parent_inode->nlink == 0) {
+        cairn_inode_handle_release(&parent_ih);
+        request->status = CHIMERA_VFS_ENOENT;
         request->complete(request);
         return;
     }

--- a/src/vfs/vfs_proc_umount.c
+++ b/src/vfs/vfs_proc_umount.c
@@ -31,11 +31,54 @@ chimera_vfs_umount_wake(struct chimera_vfs_thread *thread)
     evpl_ring_doorbell(&thread->doorbell);
 } /* chimera_vfs_umount_wake */
 
+/*
+ * Reclaim a torn-down mount after an RCU grace period.
+ *
+ * Mount-table readers run chimera_vfs_mount_table_lookup() under
+ * urcu_qsbr_read_lock() and dereference entry->mount->root_fh to match the
+ * mount id.  chimera_vfs_mount_table_remove() unlinks the entry and gives the
+ * ENTRY a grace period (call_rcu) before freeing it -- but the mount it points
+ * at used to be freed the instant the backend's UMOUNT completed, with no
+ * grace period at all.  A reader that entered the lookup before the unlink
+ * still walks that entry and follows the now-dangling entry->mount.
+ *
+ * Seen as an intermittent ASAN heap-use-after-free (read of 16 bytes in the
+ * lookup's memcmp) when the deferred-close sweep resolved a mount on one
+ * thread while a per-trace filesystem recycle unmounted it on another.  Give
+ * the mount the same grace period its entry gets.
+ *
+ * struct chimera_vfs_mount cannot carry the rcu_head itself: vfs.h is
+ * deliberately urcu-free, so the head lives in this wrapper instead.
+ */
+struct chimera_vfs_mount_reclaim {
+    struct rcu_head           rcu;
+    struct chimera_vfs_mount *mount;
+};
+
+static void
+chimera_vfs_mount_reclaim_rcu(struct rcu_head *head)
+{
+    struct chimera_vfs_mount_reclaim *reclaim =
+        container_of(head, struct chimera_vfs_mount_reclaim, rcu);
+    struct chimera_vfs_mount         *mount = reclaim->mount;
+
+    free(mount->path);
+    free(mount->module_path);
+    free(mount->options);
+    free(mount);
+    free(reclaim);
+} /* chimera_vfs_mount_reclaim_rcu */
+
 static void
 chimera_vfs_umount_complete(struct chimera_vfs_request *request)
 {
-    struct chimera_vfs_thread    *thread   = request->thread;
-    chimera_vfs_umount_callback_t callback = request->proto_callback;
+    struct chimera_vfs_thread        *thread   = request->thread;
+    chimera_vfs_umount_callback_t     callback = request->proto_callback;
+    /* Read the mount out before the request is freed -- the frees below used
+     * to reach through request->umount.mount after chimera_vfs_request_free()
+     * had already returned the request to its magazine. */
+    struct chimera_vfs_mount         *mount = request->umount.mount;
+    struct chimera_vfs_mount_reclaim *reclaim;
 
     chimera_vfs_complete(request);
 
@@ -45,12 +88,17 @@ chimera_vfs_umount_complete(struct chimera_vfs_request *request)
 
     chimera_vfs_umount_wake(thread);
 
-    free(request->umount.mount->path);
-    free(request->umount.mount->module_path);
-    free(request->umount.mount->options);
-    free(request->umount.mount);
+    reclaim = malloc(sizeof(*reclaim));
 
-} /* chimera_vfs_umount */
+    if (likely(reclaim)) {
+        reclaim->mount = mount;
+        call_rcu(&reclaim->rcu, chimera_vfs_mount_reclaim_rcu);
+    }
+    /* Out of memory: leak the mount rather than free it early.  It is one
+     * small allocation on a path that only runs at umount, and the alternative
+     * is the use-after-free this exists to prevent. */
+
+} /* chimera_vfs_umount_complete */
 
 
 /*


### PR DESCRIPTION
Completes the POSIX MBT engine-backend matrix — memfs, diskfs, and now cairn — and fixes what registering cairn found. Rebased onto main now that #1603 has merged.

`chimera/posix/mbt/batch_cairn` is green with no declines: 63 traces, 0 failures. It starts from 12 failing traces.

## Why cairn needs a different profile

cairn is the one engine backend the memfs profile does not fit. It advertises neither `CHIMERA_VFS_CAP_COPY_RANGE` nor `CHIMERA_VFS_CAP_CLONE_RANGE`; the VFS supplies a generic copy fallback for the former, but there is no clone fallback, so clone answers `ENOTSUP` and a corpus that draws clone ops cannot replay against it.

It therefore takes the `disk_` profile (`posix_run.qnt`'s `posixDisk` instance, `F_CLONE_RANGE = FeatOff`) — the same profile the linux and io_uring passthrough batches already replay — and selects it the same way. diskfs stays on the memfs profile: it *does* implement clone, and holding it to the model-conformant profile is what exercises that path.

Worth recording: the specs `posixDisk` comment claims diskfs and cairn "probe identically except clone_range is unsupported" (pinned 2026-08-11). That is stale for diskfs, which gained `CAP_CLONE_RANGE` on 2026-06-18. Correcting it needs a specs PR plus a pin bump, so it is not in this branch.

## The server bugs it found

**A server-side copy ran past the source's end.** The generic fallback — what any backend without `CAP_COPY_RANGE` gets, so diskfs and cairn both — streamed the requested length through read/write hops and consulted only `remaining`. Nothing looked at the source's EOF, and every hop re-read it. That breaks the moment source and destination are the same file, which the protocol layer permits between non-overlapping ranges: writing past the old EOF extends the file, and the next hop reads back the bytes this very copy just wrote. Requesting 8192 bytes from offset 0 of a 1024-byte file answered 8192 and grew the destination to match. memfs implements COPY_RANGE natively and never took this path.

**cairn read a directory as data.** `cairn_read` never asked what kind of object it had. A cairn directory carries a nominal size of 4096 and owns no extents, so a read of a directory descriptor fell through to the ordinary path and answered 4096 fabricated zero bytes where POSIX requires `EISDIR`.

**Nothing gated creates on a removed parent.** A removed directory stays resolvable while a descriptor pins it, but POSIX lets nothing be created in or resolved through it. memfs enforces that; diskfs and cairn zero the link count identically and then never looked at it — every create path checked the parent's *type* and none its *existence*.

**An unmounted mount was freed with no grace period.** `chimera_vfs_mount_table_lookup` walks the bucket chain under `urcu_qsbr_read_lock()` and dereferences `entry->mount->root_fh`. The table gives the *entry* a grace period via `call_rcu`, but the mount it points at was freed the instant the backend's UMOUNT completed. A reader that entered the lookup before the unlink follows a dangling `entry->mount`. Pre-existing, and it surfaced here as an intermittent ASAN heap-use-after-free once the new batch added mount/unmount churn. The frees also reached through `request->umount.mount` after `chimera_vfs_request_free()` had returned the request to its magazine.

## A reconciliation that had become a blindfold

PD19 records "clone_file_range with a source range beyond EOF returns success instead of `EINVAL`", root cause noted as memfs. memfs has since gained the check; diskfs has not. Measured: **0 hits across the memfs corpus, 3 across diskfs.**

A `reconcilable` entry that outlives its bug stops documenting anything and starts hiding the same defect elsewhere. It swallowed diskfs's clone errno divergence outright, and the damage surfaced seven steps later as `read count: expected 0, got 1024` — a read inside the region the bad clone had grown, which reads as unrelated corruption. This branch points the entry at its real owner and notes that it retires with the diskfs fix; it does not add the diskfs check, because #1608 already has it.

## The seek reconciliation needed two fixes

PT2 accepts a hole-tracking backend's more precise `SEEK_DATA`/`SEEK_HOLE` answers, since the model abstracts every byte below EOF as data. It was gated on `posix_module_is_passthrough()`, which names how a backend stores data rather than the property that matters — cairn tracks real holes too. Gated on the property instead.

More subtly, accepting the refinement left the descriptor on the backend's offset while the model's sat elsewhere, and an lseek moves the shared file offset. Every later `SEEK_CUR` and implicit-offset read inherited the drift and diverged for reasons unrelated to holes — one accepted seek became a relative-seek mismatch and two wrong-offset reads several steps later. The descriptor now goes back on the model's rails after acceptance. This removes the same latent drift from the linux and io_uring batches.

## Rebased onto main with #1608 merged — overlap resolved

The overlap this section used to warn about is settled in the rebase, exactly as it recommended:

* The copy-fallback commit is **dropped** — main's `vfs: a short read ends the server-side copy fallback` (#1608) covers it and also terminates on a short read without the `eof` flag.
* The removed-directory gate keeps **only its cairn half** (retitled `cairn: nothing may be created in a directory that has been removed`); main's diskfs gates (#1608) cover that side across all seven paths.
* The two diskfs declines this branch carried are gone entirely: both bugs (the truncate-over-clone SEGV, clone past source EOF) are fixed on main, and the decline registry is empty there.

What lands here, on top of merged main: the mount-table use-after-free fix, cairn's directory-read EISDIR, cairn's removed-directory gates, the PT2 hole-tracking re-gate plus the seek re-rail (which also removes latent offset drift from the linux/io_uring batches), and `posix/mbt/batch_cairn` on the `disk_` profile — completing the POSIX engine-backend matrix with no declines.
