### PR TITLE
posix/quint: bring the SMB client proxy under the POSIX harness (was 0% covered)

### DIFF
--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -126,6 +126,60 @@ set_tests_properties(chimera/posix/mbt/batch_nfs4_memfs PROPERTIES
     SKIP_RETURN_CODE 77
     TIMEOUT 600)
 
+# The same corpus through the SMB2 loopback: the posix client mounts the
+# in-process chimera SMB server through the smb proxy VFS module (src/vfs/smb).
+# The nfs3_ profile is the closest pinned match to what `posix_replay.py
+# --probe --backend smb_memfs` measures (they differ only in copy_file_range,
+# which the model exercises through an advertised-feature knob).
+#
+# OFF by default, and it is not a flake: the SMB2 loopback cannot satisfy the
+# POSIX model today, and the batch fails ~49 of 53 traces.  The blockers are
+# properties of src/vfs/smb, not of the harness:
+#
+#   SD1  a session is bound to the connection that authenticated it.  A second
+#        client thread opens its own connection and replays the mount's session
+#        id on it, and the server answers one of the session/connection-gone
+#        statuses, which the proxy maps to ESTALE -- so the first operation
+#        after the mount fails whenever it lands on another thread.  The driver
+#        pins core_threads=1 to work around it; SMB3 multichannel session
+#        binding is what would actually fix it.
+#   SD2  readdir returns exactly ONE entry per directory, whatever its size.
+#        The QUERY_DIRECTORY buffer is walked until the emit callback reports
+#        full, and the unconsumed remainder is freed; the resume query asks the
+#        server for the NEXT batch, which is empty, so entries 2..N are lost.
+#   SD3  symlink_at directly under the mount root reports SUCCESS without
+#        creating anything: lstat of the new name then answers ENOENT, readlink
+#        answers ELOOP, and it is absent from readdir.
+#   SD4  no POSIX owner or mode.  chmod/chown are accepted and dropped, getattr
+#        reports the CALLING credential as the owner and a synthesized mode
+#        (0755/0644), and directory nlink is always 1.  Every EACCES/EPERM the
+#        model expects therefore does not happen.
+#   SD5  only the mount-root handle is re-openable by fh (chimera_smb_open_fh),
+#        so every op the client routes through a resolved PARENT handle rather
+#        than through its path-op strategy answers ESTALE: link and utimens at
+#        any depth, and symlink/mknod below the first level.  ESTALE is also
+#        the wrong answer for an operation the backend simply does not
+#        implement -- mknod at the first level, which does reach the module,
+#        correctly answers ENOTSUP.
+#
+# Turn it on with -DCHIMERA_POSIX_MBT_SMB=ON to measure progress against that
+# list; it joins the quick tier only once it can pass.
+option(CHIMERA_POSIX_MBT_SMB
+       "Register the POSIX MBT batch over the SMB2 loopback (known failing)" OFF)
+if(CHIMERA_POSIX_MBT_SMB)
+    add_test(NAME chimera/posix/mbt/batch_smb_memfs
+        COMMAND $<TARGET_FILE:posix_mbt_replay>
+                --backend smb_memfs
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix
+                --exclude-prefix step --exclude-prefix disk_
+                --exclude-prefix fuse_ --exclude-prefix nfs4_)
+    set_tests_properties(chimera/posix/mbt/batch_smb_memfs PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_smb_memfs"
+        LABELS "quint;posix_mbt;memfs;smb_mbt"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endif()
+
 # The disk_ profile replayed against the host-passthrough backends.  The
 # backing store is a fresh directory per trace under $CHIMERA_MBT_SCRATCH
 # (default: the build tree), whose filesystem must support name_to_handle_at

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -32,6 +32,23 @@ target_include_directories(posix_mbt_replay PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(posix_mbt_replay
     chimera_posix chimera_client chimera_server chimera_metrics jansson)
 
+# Ground-truth probe for the SMB2 loopback.  Corpus-free (a fixed script, not a
+# model replay), so it runs whether or not a trace bundle is available -- and it
+# is what actually executes src/vfs/smb in the quick tier while the MBT batch
+# below stays parked.  See the SD1-SD5 block further down, and the file header
+# for what its pinned-defect assertions mean.
+add_executable(smb_loopback_probe smb_loopback_probe.c)
+target_include_directories(smb_loopback_probe PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(smb_loopback_probe
+    chimera_posix chimera_client chimera_server chimera_metrics jansson)
+
+add_test(NAME chimera/posix/smb/loopback_probe
+    COMMAND $<TARGET_FILE:smb_loopback_probe>)
+set_tests_properties(chimera/posix/smb/loopback_probe PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb_loopback_probe"
+    LABELS "quint;posix_mbt;memfs;smb_mbt"
+    TIMEOUT 300)
+
 if(NOT SPECS_BUNDLE_AVAILABLE)
     message(STATUS "posix MBT replay ctest skipped (no specs trace corpus)")
     return()

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -45,6 +45,7 @@
 #include "posix/posix_internal.h"
 #include "client/client.h"
 #include "server/server.h"
+#include "common/test_users.h"
 #include "common/logging.h"
 #include "common/platform.h"
 #include "common/tcp_flavor.h"
@@ -54,6 +55,18 @@
 #define DRIVER_BLOCK_SIZE 4096
 #define MAX_PIDS          4
 #define MAX_DIRS          64
+
+/* SMB2 loopback (smb_<module>): the client mounts the in-process chimera SMB
+ * server through the smb VFS proxy module.  Unlike NFS's per-request AUTH_SYS
+ * credential, an SMB session authenticates ONE account for the life of the
+ * mount, so the driver binds it to root -- the only identity under which the
+ * model's fsInit normalization (chmod/chown of the export root) can run at
+ * all.  Every model process therefore reaches the server as uid 0 -- one of
+ * the reasons this backend cannot satisfy the POSIX model yet; the SD* list in
+ * CMakeLists.txt has the rest. */
+#define SMB_LOOPBACK_PATH "127.0.0.1:share"
+#define SMB_LOOPBACK_OPTS \
+        "user=root,password=" CHIMERA_TEST_USER_SMBPASSWD ",domain=WORKGROUP"
 
 static struct chimera_vfs_cred    driver_creds[MAX_PIDS];
 static mode_t                     driver_umasks[MAX_PIDS];
@@ -70,6 +83,7 @@ static FILE                      *proto_out;
  * MBT batches get from a per-trace fsname.  Set once in main(). */
 static const char                *g_module;     /* VFS module (memfs/...)     */
 static int                        g_nfs_version; /* 0 = direct; 3/4 = loopback */
+static int                        g_smb;         /* 1 = SMB2 loopback          */
 static int                        g_strict_dac; /* chimera enforces DAC beyond
                                                  * the model: NFS loopback or a
                                                  * passthrough backend (engine
@@ -287,8 +301,12 @@ normalize_root(void)
     }
     chimera_posix_set_cred(&g_root_cred);
     (void) chimera_posix_umask(0);
-    if (chimera_posix_chmod("/test", 0777) != 0 ||
-        chimera_posix_chown("/test", 0, 0) != 0) {
+    if (chimera_posix_chmod("/test", 0777) != 0) {
+        fprintf(stderr, "posix_driver: normalize chmod: %s\n", strerror(errno));
+        return -1;
+    }
+    if (chimera_posix_chown("/test", 0, 0) != 0) {
+        fprintf(stderr, "posix_driver: normalize chown: %s\n", strerror(errno));
         return -1;
     }
     return 0;
@@ -976,16 +994,17 @@ handle(json_t *req)
                 driver_dirs[i] = NULL;
             }
         }
-        if (g_nfs_version) {
+        if (g_nfs_version || g_smb) {
             /* Loopback recycle: the filesystem lives server-side, so cycle it
              * there while the server, client, and RPC connection stay up.
              * Unmount the client (the proxy's UMNT/session teardown), re-point
              * the server-side share at a fresh uniquely-named fs, and remount:
-             * the fresh MOUNT/PUTROOTFH hands back a new root FH, so neither
-             * content nor a cached handle can cross traces.  The client umount
-             * races the async close sweep exactly like the direct path below,
-             * and the server-side rmfs races the NFS server's own cached open
-             * handles, so both get the same bounded retry (5s ceiling). */
+             * the fresh MOUNT/PUTROOTFH (SMB: TREE_CONNECT) hands back a new
+             * root FH, so neither content nor a cached handle can cross
+             * traces.  The client umount races the async close sweep exactly
+             * like the direct path below, and the server-side rmfs races the
+             * protocol server's own cached open handles, so both get the same
+             * bounded retry (5s ceiling). */
             char mount_options[64];
             int  rc;
             int  tries = 0;
@@ -1005,6 +1024,11 @@ handle(json_t *req)
                 usleep(1000);
             }
             tries = 0;
+            if (g_smb) {
+                /* An SMB share holds a reference on its mount; drop it before
+                 * unmounting (mirrors smb2_env_fs_teardown). */
+                chimera_server_remove_share(g_server, "share");
+            }
             while ((rc = chimera_server_unmount(g_server, "share")) != 0) {
                 if (rc != CHIMERA_VFS_EBUSY || ++tries >= 15) {
                     fprintf(stderr,
@@ -1072,14 +1096,33 @@ handle(json_t *req)
                     return res_int(-1, chimera_posix_errno_from_status(rc));
                 }
             }
-            snprintf(mount_options, sizeof(mount_options), "vers=%d",
-                     g_nfs_version);
-            if (chimera_posix_mount_with_options("/test", "nfs",
-                                                 "127.0.0.1:/share",
-                                                 mount_options) != 0) {
-                fprintf(stderr, "posix_driver: newfs nfs%d remount failed: %s\n",
-                        g_nfs_version, strerror(errno));
-                return res_int(-1, errno);
+            if (g_smb) {
+                rc = chimera_server_create_share(g_server, "share", "share", 0);
+                if (rc != 0) {
+                    fprintf(stderr,
+                            "posix_driver: newfs share creation failed: %d\n",
+                            rc);
+                    return res_int(-1, chimera_posix_errno_from_status(rc));
+                }
+                if (chimera_posix_mount_with_options("/test", "smb",
+                                                     SMB_LOOPBACK_PATH,
+                                                     SMB_LOOPBACK_OPTS) != 0) {
+                    fprintf(stderr,
+                            "posix_driver: newfs smb remount failed: %s\n",
+                            strerror(errno));
+                    return res_int(-1, errno);
+                }
+            } else {
+                snprintf(mount_options, sizeof(mount_options), "vers=%d",
+                         g_nfs_version);
+                if (chimera_posix_mount_with_options("/test", "nfs",
+                                                     "127.0.0.1:/share",
+                                                     mount_options) != 0) {
+                    fprintf(stderr,
+                            "posix_driver: newfs nfs%d remount failed: %s\n",
+                            g_nfs_version, strerror(errno));
+                    return res_int(-1, errno);
+                }
             }
             if (normalize_root() != 0) {
                 fprintf(stderr, "posix_driver: newfs normalize failed: %s\n",
@@ -1192,6 +1235,7 @@ posix_env_setup(
     struct chimera_vfs_cred       root_cred;
     const char                   *module      = backend;
     int                           nfs_version = 0;
+    int                           smb         = 0;
     char                          module_cfg[4096];
     char                          session_dir[256];
 
@@ -1208,16 +1252,20 @@ posix_env_setup(
 
     chimera_vfs_cred_init_unix(&root_cred, 0, 0, 0, NULL);
 
-    /* Backend selection: `backend` names the VFS module (default memfs), or an
-     * NFS loopback path nfs3_<module>/nfs4_<module> (an in-process chimera
-     * server exports the module and the client mounts it over localhost NFS).
-     * `storage` is a scratch directory for backends with real storage. */
+    /* Backend selection: `backend` names the VFS module (default memfs), or a
+     * loopback path -- nfs3_<module>/nfs4_<module>/smb_<module> -- in which an
+     * in-process chimera server exports the module and the client mounts it
+     * back over that protocol's proxy VFS module.  `storage` is a scratch
+     * directory for backends with real storage. */
     if (strncmp(backend, "nfs3_", 5) == 0) {
         nfs_version = 3;
         module      = backend + 5;
     } else if (strncmp(backend, "nfs4_", 5) == 0) {
         nfs_version = 4;
         module      = backend + 5;
+    } else if (strncmp(backend, "smb_", 4) == 0) {
+        smb    = 1;
+        module = backend + 4;
     }
 
     /* diskfs/cairn need real scratch storage.  The interactive driver takes
@@ -1315,25 +1363,45 @@ posix_env_setup(
 
     config = chimera_client_config_init();
 
-    if (nfs_version) {
-        /* Loopback NFS: an in-process server exports the module as /share and
-         * the client mounts it over the nfs proxy module.  Both sides use the
-         * libevpl INPROC transport (named endpoints, no real ports), so the
-         * server's services never collide with concurrent drivers and no
-         * network namespace, root, or Linux-specific isolation is needed --
-         * every driver process gets its own inproc endpoint namespace, exactly
-         * like the NFS/SMB MBT harnesses. */
+    if (nfs_version || smb) {
+        /* Protocol loopback: an in-process server exports the module as the
+         * "share" and the client mounts it back over that protocol's proxy VFS
+         * module.  Both sides use the libevpl INPROC transport (named
+         * endpoints, no real ports), so the server's services never collide
+         * with concurrent drivers and no network namespace, root, or
+         * Linux-specific isolation is needed -- every driver process gets its
+         * own inproc endpoint namespace, exactly like the NFS/SMB MBT
+         * harnesses. */
         struct chimera_server_config *server_config;
         char                          mount_options[64];
 
         chimera_client_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
+        if (smb) {
+            /* The smb proxy is not in the client's default module set. */
+            chimera_client_config_add_module(config, "smb", "", "");
+            /* One worker thread.  The smb proxy authenticates ONE session, on
+             * the connection belonging to the thread that ran the MOUNT, and a
+             * second thread's connection replays that session id on a fresh
+             * connection -- which the server rejects
+             * (STATUS_USER_SESSION_DELETED -> ESTALE) because binding a
+             * session to another connection is SMB3 multichannel, which
+             * neither side implements.  The POSIX client round-robins requests
+             * across core_threads workers, so anything above 1 makes the very
+             * first post-mount operation fail.  See SD1. */
+            config->core_threads = 1;
+        }
 
         server_config = chimera_server_config_init();
         chimera_server_config_set_tcp_flavor(server_config,
                                              CHIMERA_TCP_FLAVOR_INPROC);
-        /* Protocols are opt-in (default off): the loopback path needs the NFS
-         * server, or chimera_server_create_export has no nfs_shared to add to. */
-        chimera_server_config_set_nfs_enabled(server_config, 1);
+        /* Protocols are opt-in (default off): the loopback path needs its own
+         * server, or chimera_server_create_export/_share has nothing to add
+         * the export to. */
+        if (smb) {
+            chimera_server_config_set_smb_enabled(server_config, 1);
+        } else {
+            chimera_server_config_set_nfs_enabled(server_config, 1);
+        }
         if (!posix_module_is_passthrough(module)) {
             /* linux/io_uring are already in the server's default module set
              * (Linux builds); adding them again would double-register. */
@@ -1385,13 +1453,25 @@ posix_env_setup(
             chimera_server_mount(server, "share", module, "fs0", NULL);
         }
 
-        if (chimera_server_create_export(server, "/share", "/share",
-                                         4242, NULL) != 0) {
+        if (smb) {
+            if (chimera_server_create_share(server, "share", "share", 0) != 0) {
+                fprintf(stderr, "posix_driver: share creation failed\n");
+                return 1;
+            }
+        } else if (chimera_server_create_export(server, "/share", "/share",
+                                                4242, NULL) != 0) {
             fprintf(stderr, "posix_driver: export creation failed\n");
             return 1;
         }
 
         chimera_server_start(server);
+
+        if (smb) {
+            /* SESSION_SETUP authenticates against the server's user table, so
+             * the account the mount binds to has to exist before the client
+             * connects. */
+            chimera_test_add_server_users(server);
+        }
 
         posix = chimera_posix_init(config, &root_cred, metrics);
         if (!posix) {
@@ -1399,14 +1479,24 @@ posix_env_setup(
             return 1;
         }
 
-        snprintf(mount_options, sizeof(mount_options), "vers=%d",
-                 nfs_version);
-        if (chimera_posix_mount_with_options("/test", "nfs",
-                                             "127.0.0.1:/share",
-                                             mount_options) != 0) {
-            fprintf(stderr, "posix_driver: nfs%d mount failed\n",
-                    nfs_version);
-            return 1;
+        if (smb) {
+            if (chimera_posix_mount_with_options("/test", "smb",
+                                                 SMB_LOOPBACK_PATH,
+                                                 SMB_LOOPBACK_OPTS) != 0) {
+                fprintf(stderr, "posix_driver: smb mount failed: %s\n",
+                        strerror(errno));
+                return 1;
+            }
+        } else {
+            snprintf(mount_options, sizeof(mount_options), "vers=%d",
+                     nfs_version);
+            if (chimera_posix_mount_with_options("/test", "nfs",
+                                                 "127.0.0.1:/share",
+                                                 mount_options) != 0) {
+                fprintf(stderr, "posix_driver: nfs%d mount failed\n",
+                        nfs_version);
+                return 1;
+            }
         }
     } else {
         if (strcmp(module, "memfs") == 0) {
@@ -1477,6 +1567,7 @@ posix_env_setup(
      * the server/metrics handles so posix_env_teardown can release them. */
     g_module      = module;
     g_nfs_version = nfs_version;
+    g_smb         = smb;
     g_strict_dac  = nfs_version != 0 || posix_module_is_passthrough(module);
     g_root_cred   = root_cred;
     g_server      = server;
@@ -1484,7 +1575,8 @@ posix_env_setup(
 
     /* Normalize the root to the model's fsInit(0777, 0, 0). */
     if (normalize_root() != 0) {
-        fprintf(stderr, "posix_driver: root normalization failed\n");
+        fprintf(stderr, "posix_driver: root normalization failed: %s\n",
+                strerror(errno));
         return 1;
     }
     return 0;
@@ -1506,6 +1598,9 @@ posix_env_teardown(void)
     }
     if (g_server) {
         int tries = 0;
+        if (g_smb) {
+            chimera_server_remove_share(g_server, "share");
+        }
         while (chimera_server_unmount(g_server, "share") != 0 &&
                ++tries < 15) {
             usleep(1000);

--- a/src/posix/tests/quint/posix_replay.py
+++ b/src/posix/tests/quint/posix_replay.py
@@ -150,8 +150,23 @@ NFS4_PROFILE = dict(PROFILE, copyRange=False, cloneRange=False,
 FUSE_PROFILE = dict(PROFILE, cloneRange=False, strictAtime=True,
                     chownSuppGroup=False)
 
+# The SMB2 loopback (posix client -> vfs/smb proxy -> in-process chimera SMB
+# server -> memfs), probed 2026-09-01.  It reads like the NFS3 loopback except
+# that copy_file_range works, but the numbers below are less meaningful than
+# the other profiles' are: SMB2 carries no POSIX owner or mode, so every
+# permission-derived key is measuring an absence rather than a policy.
+# stickyWriteArm "true" and chownSuppGroup "true" are exactly that -- the
+# operations the probe expects to be refused simply are not checked, and
+# errStickyAcces comes back None because the denial never happens.  The
+# profile is pinned for --check-profile drift detection only; it is NOT a
+# statement that the backend implements this policy.  See the SD* list in
+# CMakeLists.txt for why no smb_ trace corpus is generated from it yet.
+SMB_PROFILE = dict(PROFILE, cloneRange=False, seekHole=False, strictAtime=True,
+                   stickyWriteArm=True, errStickyAcces=None)
+
 PROFILES = {
     "memfs": PROFILE,
+    "smb_memfs": SMB_PROFILE,
     "fuse_memfs": FUSE_PROFILE,
     "diskfs": DISK_PROFILE,
     "cairn": DISK_PROFILE,

--- a/src/posix/tests/quint/smb_loopback_probe.c
+++ b/src/posix/tests/quint/smb_loopback_probe.c
@@ -1,0 +1,572 @@
+/* SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Ground-truth probe for the POSIX-over-SMB2 loopback (posix client -> the smb
+ * proxy VFS module -> an in-process chimera SMB server -> memfs).
+ *
+ * The full POSIX model corpus cannot run over this backend yet -- see the
+ * SD1-SD5 list in CMakeLists.txt -- so this probe is what actually executes
+ * src/vfs/smb in the quick tier.  It is a fixed script rather than a model
+ * replay, and it asserts two different kinds of thing:
+ *
+ *   * the operations the proxy DOES implement, asserted as correctness.  These
+ *     are ordinary regressions if they break.
+ *
+ *   * the SD2-SD5 defects, asserted as the DEFECT.  Pinning them is what keeps
+ *     them visible: an unexercised bug is indistinguishable from a fixed one,
+ *     and the whole module read 0% before this file existed.  A pin that starts
+ *     failing means somebody fixed the underlying defect -- delete the pin,
+ *     replace it with the correctness assertion named in its comment, and drop
+ *     the corresponding SD entry from CMakeLists.txt.
+ *
+ * The pins deliberately assert behavioural SIGNATURES (an operation fails; a
+ * created object cannot be seen afterwards; fewer entries come back than were
+ * created) rather than exact errno numbers, because the numbers the proxy
+ * produces are neither stable across platforms nor, in several cases, the ones
+ * POSIX defines for the situation.  That imprecision is itself part of SD5.
+ *
+ * The op-execution engine is reused verbatim from posix_driver.c, as in
+ * posix_mbt_replay.c.
+ */
+
+#define POSIX_DRIVER_ENGINE_ONLY
+#include "posix_driver.c"
+
+static int probe_failures;
+
+/* ---- request/response helpers ------------------------------------------ */
+
+/* Run one driver op.  Returns the response object; the caller owns it. */
+static json_t *
+probe_call(json_t *req)
+{
+    json_t *res;
+
+    errno = 0;
+    res   = handle(req);
+    json_decref(req);
+    if (!res) {
+        fprintf(stderr, "smb_loopback_probe: driver returned no response\n");
+        exit(1);
+    }
+    return res;
+} /* probe_call */
+
+static json_t *
+probe_req(const char *op)
+{
+    json_t *req = json_object();
+
+    json_object_set_new(req, "op", json_string(op));
+    json_object_set_new(req, "pid", json_integer(0));
+    return req;
+} /* probe_req */
+
+static void
+probe_set_str(
+    json_t     *req,
+    const char *key,
+    const char *val)
+{
+    json_object_set_new(req, key, json_string(val));
+} /* probe_set_str */
+
+static void
+probe_set_int(
+    json_t     *req,
+    const char *key,
+    long long   val)
+{
+    json_object_set_new(req, key, json_integer(val));
+} /* probe_set_int */
+
+static long long
+probe_ret(json_t *res)
+{
+    return json_integer_value(json_object_get(res, "ret"));
+} /* probe_ret */
+
+static long long
+probe_field(
+    json_t     *res,
+    const char *key)
+{
+    return json_integer_value(json_object_get(res, key));
+} /* probe_field */
+
+static void
+probe_fail(
+    const char *what,
+    const char *detail)
+{
+    fprintf(stderr, "smb_loopback_probe: FAIL %s: %s\n", what, detail);
+    probe_failures++;
+} /* probe_fail */
+
+/* Assert an operation succeeded (the working surface). */
+static void
+probe_ok(
+    const char *what,
+    json_t     *res)
+{
+    if (probe_ret(res) < 0) {
+        char detail[128];
+
+        snprintf(detail, sizeof(detail), "expected success, got errno %lld",
+                 probe_field(res, "err"));
+        probe_fail(what, detail);
+    }
+    json_decref(res);
+} /* probe_ok */
+
+/* Assert an operation failed, without pinning which errno.  Used both for
+ * genuine POSIX errors whose value is not the point, and for the SD5 pins. */
+static void
+probe_err(
+    const char *what,
+    json_t     *res)
+{
+    if (probe_ret(res) >= 0) {
+        probe_fail(what, "expected failure, got success");
+    }
+    json_decref(res);
+} /* probe_err */
+
+static void
+probe_eq(
+    const char *what,
+    long long   got,
+    long long   want)
+{
+    if (got != want) {
+        char detail[128];
+
+        snprintf(detail, sizeof(detail), "expected %lld, got %lld", want, got);
+        probe_fail(what, detail);
+    }
+} /* probe_eq */
+
+/* ---- op shorthands ------------------------------------------------------ */
+
+static json_t *
+op_stat(
+    const char *path,
+    int         follow)
+{
+    json_t *r = probe_req("stat");
+
+    probe_set_str(r, "path", path);
+    json_object_set_new(r, "follow", json_boolean(follow));
+    return probe_call(r);
+} /* op_stat */
+
+static json_t *
+op_path(
+    const char *op,
+    const char *path)
+{
+    json_t *r = probe_req(op);
+
+    probe_set_str(r, "path", path);
+    return probe_call(r);
+} /* op_path */
+
+static json_t *
+op_mkdir(
+    const char *path,
+    int         mode)
+{
+    json_t *r = probe_req("mkdir");
+
+    probe_set_str(r, "path", path);
+    probe_set_int(r, "mode", mode);
+    return probe_call(r);
+} /* op_mkdir */
+
+static json_t *
+op_open(
+    const char *path,
+    int         flags,
+    int         mode)
+{
+    json_t *r = probe_req("open");
+
+    probe_set_str(r, "path", path);
+    probe_set_int(r, "flags", flags);
+    probe_set_int(r, "mode", mode);
+    return probe_call(r);
+} /* op_open */
+
+static json_t *
+op_fd(
+    const char *op,
+    int         fd)
+{
+    json_t *r = probe_req(op);
+
+    probe_set_int(r, "fd", fd);
+    return probe_call(r);
+} /* op_fd */
+
+static json_t *
+op_two_path(
+    const char *op,
+    const char *old_path,
+    const char *new_path)
+{
+    json_t *r = probe_req(op);
+
+    probe_set_str(r, "old", old_path);
+    probe_set_str(r, "new", new_path);
+    return probe_call(r);
+} /* op_two_path */
+
+/* Create an empty file, asserting both legs. */
+static void
+probe_touch(const char *path)
+{
+    json_t   *res = op_open(path, O_CREAT | O_WRONLY, 0644);
+    long long fd  = probe_ret(res);
+
+    if (fd < 0) {
+        probe_fail("touch", path);
+        json_decref(res);
+        return;
+    }
+    json_decref(res);
+    probe_ok("touch close", op_fd("close", (int) fd));
+} /* probe_touch */
+
+/* ---- the working surface ------------------------------------------------ */
+
+/* Everything the proxy implements correctly today.  A regression here is an
+ * ordinary bug, not a pinned defect. */
+static void
+probe_working_surface(void)
+{
+    json_t   *res;
+    long long fd;
+
+    /* The mount root, as the driver normalized it. */
+    res = op_stat("/test", 1);
+    probe_ok("stat mount root", json_incref(res));
+    {
+        const char *ftype = json_string_value(json_object_get(res, "ftype"));
+
+        if (!ftype || strcmp(ftype, "dir") != 0) {
+            probe_fail("stat mount root", "not reported as a directory");
+        }
+    }
+    json_decref(res);
+
+    probe_ok("mkdir", op_mkdir("/test/w", 0755));
+    probe_ok("mkdir nested", op_mkdir("/test/w/sub", 0755));
+
+    /* Create, write, read back, at depth: the path-op strategy resolves the
+     * whole path against the mount root, so depth is not a limit here (unlike
+     * SD5's parent-handle route). */
+    res = op_open("/test/w/sub/f", O_CREAT | O_RDWR, 0644);
+    probe_ok("open O_CREAT", json_incref(res));
+    fd = probe_ret(res);
+    json_decref(res);
+
+    if (fd >= 0) {
+        json_t *w = probe_req("write");
+
+        probe_set_int(w, "fd", (int) fd);
+        probe_set_str(w, "data", "aGVsbG8=");     /* "hello" */
+        res = probe_call(w);
+        probe_eq("write returns the byte count", probe_ret(res), 5);
+        json_decref(res);
+
+        res = probe_req("pread");
+        probe_set_int(res, "fd", (int) fd);
+        probe_set_int(res, "off", 1);
+        probe_set_int(res, "len", 3);
+        res = probe_call(res);
+        probe_eq("pread returns the byte count", probe_ret(res), 3);
+        if (json_object_get(res, "data")) {
+            probe_eq("pread returns the written bytes",
+                     strcmp(json_string_value(json_object_get(res, "data")),
+                            "ZWxs") == 0, 1);              /* "ell" */
+        } else {
+            probe_fail("pread", "no data in the response");
+        }
+        json_decref(res);
+
+        probe_ok("fsync", op_fd("fsync", (int) fd));
+        probe_ok("close", op_fd("close", (int) fd));
+    }
+
+    res = op_stat("/test/w/sub/f", 1);
+    probe_ok("stat the written file", json_incref(res));
+    probe_eq("size reflects the write", probe_field(res, "size"), 5);
+    json_decref(res);
+
+    /* Exclusive create over an existing name is refused. */
+    probe_err("O_CREAT|O_EXCL over an existing file",
+              op_open("/test/w/sub/f", O_CREAT | O_EXCL | O_WRONLY, 0644));
+
+    /* Truncate by path, then observe the new size. */
+    res = probe_req("truncate");
+    probe_set_str(res, "path", "/test/w/sub/f");
+    probe_set_int(res, "len", 2);
+    probe_ok("truncate", probe_call(res));
+    res = op_stat("/test/w/sub/f", 1);
+    probe_eq("size reflects the truncate", probe_field(res, "size"), 2);
+    json_decref(res);
+
+    /* Rename and remove, both at depth. */
+    probe_ok("rename", op_two_path("rename", "/test/w/sub/f", "/test/w/sub/g"));
+    probe_ok("stat the renamed file", op_stat("/test/w/sub/g", 1));
+    probe_err("stat the old name", op_stat("/test/w/sub/f", 1));
+    probe_ok("unlink", op_path("unlink", "/test/w/sub/g"));
+
+    /* Type assertions on removal. */
+    probe_err("unlink of a directory", op_path("unlink", "/test/w/sub"));
+    probe_ok("rmdir", op_path("rmdir", "/test/w/sub"));
+    probe_err("rmdir of a missing name", op_path("rmdir", "/test/w/sub"));
+    probe_err("stat of a missing name", op_stat("/test/w/missing", 1));
+
+    probe_ok("statvfs", op_path("statvfs", "/test"));
+} /* probe_working_surface */
+
+/* ---- the pinned defects ------------------------------------------------- */
+
+/* SD2: readdir returns fewer entries than the directory holds, and omits the
+ * "." and ".." the other backends emit.  The QUERY_DIRECTORY buffer is walked
+ * until the emit callback reports full and the unconsumed remainder is freed;
+ * the resume query asks the server for the next batch, which is empty.
+ *
+ * When SD2 is fixed this must become: all five names come back. */
+static void
+probe_pin_readdir(void)
+{
+    static const char *const names[] = { "e0", "e1", "e2" };
+    json_t                  *res;
+    long long                sid;
+    size_t                   i, n;
+
+    probe_ok("readdir setup mkdir", op_mkdir("/test/rd", 0755));
+    for (i = 0; i < 3; i++) {
+        char path[64];
+
+        snprintf(path, sizeof(path), "/test/rd/%s", names[i]);
+        probe_touch(path);
+    }
+
+    res = op_path("opendir", "/test/rd");
+    probe_ok("opendir", json_incref(res));
+    sid = probe_ret(res);
+    json_decref(res);
+    if (sid < 0) {
+        return;
+    }
+
+    res = probe_req("readdir");
+    probe_set_int(res, "sid", sid);
+    res = probe_call(res);
+    n   = json_array_size(json_object_get(res, "names"));
+    json_decref(res);
+
+    /* PINNED DEFECT (SD2).  A correct backend returns 5 here: ".", "..", and
+     * the three files.  Assert only that entries are LOST, so the pin does not
+     * depend on how many happen to fit one emit buffer. */
+    if (n >= 5) {
+        probe_fail("SD2 pin",
+                   "readdir returned every entry -- SD2 looks FIXED; replace "
+                   "this pin with an equality assertion and drop SD2");
+    } else if (n == 0) {
+        probe_fail("SD2 pin", "readdir returned nothing at all (worse than SD2)");
+    }
+
+    res = probe_req("closedir");
+    probe_set_int(res, "sid", sid);
+    probe_ok("closedir", probe_call(res));
+} /* probe_pin_readdir */
+
+/* SD3: symlink directly under the mount root reports SUCCESS and creates
+ * nothing.  SD5: below the first level the same call fails instead.  Either
+ * way no symlink exists afterwards, which is the signature worth pinning.
+ *
+ * When SD3/SD5 are fixed this must become: symlink succeeds at both depths and
+ * the link is visible to lstat with the target readlink returns. */
+static void
+probe_pin_symlink(void)
+{
+    json_t *res;
+
+    res = probe_req("symlink");
+    probe_set_str(res, "path", "/test/sym");
+    probe_set_str(res, "target", "w");
+    json_decref(probe_call(res));
+
+    /* PINNED DEFECT (SD3/SD5): whatever the call reported, nothing was made. */
+    res = op_stat("/test/sym", 0);
+    if (probe_ret(res) >= 0) {
+        probe_fail("SD3 pin",
+                   "the symlink exists -- SD3 looks FIXED; assert readlink "
+                   "returns the target instead and drop SD3");
+    }
+    json_decref(res);
+} /* probe_pin_symlink */
+
+/* SD4: SMB2 carries no POSIX owner or mode.  chmod and chown are accepted and
+ * dropped, getattr reports the CALLING credential as the owner and a
+ * synthesized mode, and directory nlink is always 1.
+ *
+ * When SD4 is fixed these must become: mode 0700 after the chmod, uid/gid
+ * 4242/4243 after the chown, and nlink >= 2 on a directory. */
+static void
+probe_pin_no_posix_metadata(void)
+{
+    json_t   *res;
+    long long mode_before, mode_after;
+
+    probe_touch("/test/meta");
+
+    res         = op_stat("/test/meta", 1);
+    mode_before = probe_field(res, "mode");
+    json_decref(res);
+
+    res = probe_req("chmod");
+    probe_set_str(res, "path", "/test/meta");
+    probe_set_int(res, "mode", 0700);
+    json_decref(probe_call(res));
+
+    res        = op_stat("/test/meta", 1);
+    mode_after = probe_field(res, "mode");
+    json_decref(res);
+
+    /* PINNED DEFECT (SD4). */
+    if (mode_after != mode_before) {
+        probe_fail("SD4 mode pin",
+                   "chmod changed the reported mode -- SD4 looks FIXED for "
+                   "mode; assert it equals 0700 and narrow SD4");
+    }
+
+    res = probe_req("chown");
+    probe_set_str(res, "path", "/test/meta");
+    probe_set_int(res, "uid", 4242);
+    probe_set_int(res, "gid", 4243);
+    json_object_set_new(res, "follow", json_boolean(1));
+    json_decref(probe_call(res));
+
+    res = op_stat("/test/meta", 1);
+    /* PINNED DEFECT (SD4): the owner reported is the CALLER (root, uid 0 --
+     * the identity the loopback's single SMB session authenticated as), not
+     * the one just set. */
+    if (probe_field(res, "uid") == 4242) {
+        probe_fail("SD4 owner pin",
+                   "chown took effect -- SD4 looks FIXED for ownership; "
+                   "assert uid/gid equal 4242/4243 and narrow SD4");
+    } else {
+        probe_eq("SD4: getattr reports the calling credential",
+                 probe_field(res, "uid"), 0);
+    }
+    json_decref(res);
+
+    res = op_stat("/test/w", 1);
+    /* PINNED DEFECT (SD4): a directory's link count is synthesized as 1; POSIX
+     * requires at least 2 (itself and "."). */
+    if (probe_field(res, "nlink") >= 2) {
+        probe_fail("SD4 nlink pin",
+                   "directory nlink is >= 2 -- SD4 looks FIXED for nlink; "
+                   "assert it and narrow SD4");
+    }
+    json_decref(res);
+} /* probe_pin_no_posix_metadata */
+
+/* SD5: only the mount-root handle is re-openable by fh, so every operation the
+ * client routes through a resolved PARENT handle fails.  link and utimens fail
+ * at any depth; mknod reaches the module at the first level (and correctly
+ * reports "unsupported" there) but fails the same way below it.
+ *
+ * When SD5 is fixed, link and mknod should report "unsupported" rather than a
+ * handle error, and utimens should succeed. */
+static void
+probe_pin_parent_handle_ops(void)
+{
+    json_t *res;
+
+    probe_touch("/test/src");
+
+    probe_err("SD5: link", op_two_path("link", "/test/src", "/test/dst"));
+
+    res = probe_req("utimens");
+    probe_set_str(res, "path", "/test/src");
+    probe_set_str(res, "atype", "val");
+    probe_set_int(res, "asec", 1000);
+    probe_set_int(res, "ansec", 0);
+    probe_set_str(res, "mtype", "val");
+    probe_set_int(res, "msec", 2000);
+    probe_set_int(res, "mnsec", 0);
+    json_object_set_new(res, "follow", json_boolean(1));
+    probe_err("SD5: utimens by path", probe_call(res));
+
+    res = probe_req("mknod");
+    probe_set_str(res, "path", "/test/w/fifo");
+    probe_set_int(res, "mode", 0644);
+    probe_set_str(res, "ftype", "fifo");
+    probe_err("SD5: mknod below the mount root", probe_call(res));
+} /* probe_pin_parent_handle_ops */
+
+/* ---- driver ------------------------------------------------------------- */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    json_t *res;
+
+    (void) argc;
+    (void) argv;
+
+    /* Clean result stream: chimera logs go to stderr (fd 1 -> stderr), our
+     * output to the saved stdout -- the same three steps posix_mbt_replay.c
+     * uses, including reusing posix_driver.c's proto_out.  Reusing it is not
+     * incidental: proto_out is a file-scope static in posix_driver.c, and a TU
+     * that includes the driver without touching it fails the Linux build with
+     * -Werror=unused-variable (gcc warns where clang does not). */
+    {
+        int out_fd = dup(STDOUT_FILENO);
+
+        proto_out = out_fd >= 0 ? fdopen(out_fd, "w") : NULL;
+        if (!proto_out || dup2(STDERR_FILENO, STDOUT_FILENO) < 0 ||
+            dup2(fileno(proto_out), STDOUT_FILENO) < 0) {
+            fprintf(stderr, "smb_loopback_probe: stream setup failed\n");
+            return 1;
+        }
+    }
+
+    if (posix_env_setup("smb_memfs", NULL) != 0) {
+        fprintf(stderr, "smb_loopback_probe: SMB loopback setup failed\n");
+        return 1;
+    }
+
+    probe_working_surface();
+    probe_pin_readdir();
+    probe_pin_symlink();
+    probe_pin_no_posix_metadata();
+    probe_pin_parent_handle_ops();
+
+    /* The per-trace recycle: client umount, share/filesystem cycle, remount.
+     * The MBT batch leans on this between every trace, so prove it works even
+     * while the batch itself is parked -- and prove the fresh filesystem really
+     * is empty. */
+    res = probe_req("newfs");
+    probe_ok("newfs recycle", probe_call(res));
+    probe_err("the recycled filesystem is empty", op_stat("/test/w", 1));
+    probe_ok("the recycled filesystem is usable", op_mkdir("/test/after", 0755));
+
+    posix_env_teardown();
+
+    if (probe_failures) {
+        fprintf(stderr, "smb_loopback_probe: %d failure(s)\n", probe_failures);
+        return 1;
+    }
+    printf("smb_loopback_probe: OK\n");
+    return 0;
+} /* main */

--- a/src/vfs/smb/smb_ops.c
+++ b/src/vfs/smb/smb_ops.c
@@ -515,7 +515,12 @@ chimera_smb_lookup_create_reply(
 
     smb_parse_create_reply(body, &r);
 
-    /* Path-only: return attrs but NO child fh (va_fh stays unset). */
+    /* Path-only: return attrs but NO child fh.  The length has to be zeroed
+     * explicitly -- vfs requests come off a free list, so va_fh_len still
+     * holds whatever the previous request left there, and the engine reads it
+     * (vfs_proc_lookup_at.c) to decide whether a child fh came back. */
+    request->lookup_at.r_attr.va_fh_len = 0;
+
     smb_apply_attrs(request, &request->lookup_at.r_attr, &r.info,
                     XXH3_64bits(request->lookup_at.component,
                                 request->lookup_at.component_len));

--- a/src/vfs/vfs_proc_lookup_at.c
+++ b/src/vfs/vfs_proc_lookup_at.c
@@ -24,10 +24,17 @@ chimera_vfs_lookup_at_complete(struct chimera_vfs_request *request)
 
     if (request->status == CHIMERA_VFS_OK) {
         /* A path-only backend resolves the whole path in one shot and returns no
-         * stable child fh (va_fh_len == 0).  Skip the child name/attr cache: a
-         * zero-length fh is the name cache's NEGATIVE (ENOENT) marker, so caching
-         * a success-without-fh here would poison subsequent lookups. */
-        if (request->lookup_at.r_attr.va_fh_len > 0) {
+         * stable child fh.  Skip the child name/attr cache: a zero-length fh is
+         * the name cache's NEGATIVE (ENOENT) marker, so caching a
+         * success-without-fh here would poison subsequent lookups.
+         *
+         * The authority for "a handle came back" is the ATTR_FH set bit, not
+         * va_fh_len: requests are recycled through a free list, so a backend
+         * that simply does not fill the handle in leaves the previous request's
+         * length behind -- and that stale length would otherwise reach a
+         * memcpy as a size. */
+        if ((request->lookup_at.r_attr.va_set_mask & CHIMERA_VFS_ATTR_FH) &&
+            request->lookup_at.r_attr.va_fh_len > 0) {
             chimera_vfs_name_cache_insert(thread, name_cache,
                                           request->lookup_at.handle->fh_hash,
                                           request->lookup_at.handle->fh,


### PR DESCRIPTION
`src/vfs/smb` — the SMB2 **client** proxy VFS module — was at **0% coverage**:
0 of 129 functions, 0 of 2,800 lines. Nothing labelled `quint` executed it. Its
only test, `smb_mount_test`, is gated behind `CHIMERA_LIMITS_TESTING`. (This
predates the PR: #1609 reports the same 0% on the same day.)

This brings it under the POSIX model harness, the SMB2 sibling of the existing
`nfs3_`/`nfs4_` loopbacks: the posix client mounts an in-process chimera SMB
server through the smb proxy, over the inproc transport, backed by memfs.

## What lands in CI

`chimera/posix/smb/loopback_probe` — a corpus-free, green, quick-tier test over
that loopback. Measured over the probe alone:

| File | Lines |
|---|---|
| `smb_ntlm.c` | 0% → **86%** |
| `smb_ops.c` | 0% → **83%** |
| `smb_mount.c` | 0% → **81%** |
| `smb_umount.c` | 0% → **81%** |
| `smb_io.c` | 0% → **80%** |
| `smb.c` | 0% → **64%** |
| `smb_namespace.c` | 0% → **54%** |

It asserts two distinct kinds of thing, and says which is which:

- the operations the proxy **does** implement — create/write/read at depth,
  exclusive create, truncate, rename, unlink, the rmdir/unlink type assertions,
  statvfs, and the per-trace `newfs` recycle — as ordinary correctness.
- **SD2–SD5 as the defect.** An unexercised bug is indistinguishable from a
  fixed one, so each pin names what to assert instead once the defect is fixed,
  and fails loudly if the behaviour improves. The pins assert behavioural
  signatures (the op fails; the created object cannot be seen afterwards; fewer
  entries return than were created) rather than errno values, because the
  numbers this proxy produces are neither stable across platforms nor the ones
  POSIX defines here — itself part of SD5.

## The memory-safety fix

`chimera_smb_lookup_create_reply` documented that it returns "attrs but NO child
fh", but only left `va_fh` unwritten — and vfs requests come off a free list, so
`va_fh_len` still held the previous request's value. `chimera_vfs_lookup_at_complete`
reads that length to decide whether a handle came back, so garbage sailed past
the `> 0` test and became the size argument of the name cache's memcpy:

```
ERROR: AddressSanitizer: negative-size-param: (size=-1718575551)
  #2 chimera_vfs_name_cache_insert vfs_name_cache.h:272
  #3 chimera_vfs_lookup_at_complete vfs_proc_lookup_at.c:31
  #4 chimera_smb_lookup_close_reply smb_ops.c:491
```

Fixed on both sides: the smb reply zeroes the length, and the engine now gates
on the `ATTR_FH` set bit rather than on `va_fh_len` alone, so the next path-only
backend cannot reintroduce the overflow by simply not writing a field. The probe
executes that line 14 times per run.

## The MBT batch, parked

The harness also gains `smb_<module>` as a POSIX MBT backend, registered as
`chimera/posix/mbt/batch_smb_memfs` behind `-DCHIMERA_POSIX_MBT_SMB=ON` and
**off by default**: it fails 49 of 53 traces (2,916 divergences). That is not
instability — the SMB2 loopback cannot satisfy the POSIX model yet, and the five
blockers are recorded next to the test so turning the flag on measures progress
against a named list rather than against noise.

| | Defect |
|---|---|
| **SD1** | An SMB session is bound to the connection that authenticated it. A second client thread opens its own connection and replays the mount's session id; the server rejects it, mapped to ESTALE — so the first operation after the mount fails whenever it lands on another thread. The driver pins `core_threads=1`; SMB3 multichannel session binding is the real fix. |
| **SD2** | `readdir` returns exactly **one** entry per directory, whatever its size (verified at 1/2/3/5/10). The QUERY_DIRECTORY buffer is walked until the emit callback reports full, then the unconsumed remainder is freed; the resume query asks the server for the *next* batch, which is empty. Entries 2..N are lost. |
| **SD3** | `symlink` directly under the mount root reports **success and creates nothing**: `lstat` answers ENOENT, `readlink` answers ELOOP, and it is absent from readdir. |
| **SD4** | No POSIX owner or mode. `chmod`/`chown` are accepted and dropped, `getattr` reports the *calling* credential as owner and a synthesized mode, directory `nlink` is always 1 — so every EACCES/EPERM the model expects does not happen. |
| **SD5** | Only the mount-root handle is re-openable by fh, so every op routed through a resolved *parent* handle answers ESTALE: `link` and `utimens` at any depth, `symlink`/`mknod` below the first level. |

SD2 is the natural next PR: self-contained, clearly root-caused, and the largest
single obstacle to the batch running for real.

## Note on the corpus

No `smb_` trace corpus is generated. The model has no knob for "no owner, no
mode", so a pinned specs profile would assert a policy this backend does not
implement; the batch reuses the `nfs3_` corpus, whose measured profile differs
only in `copy_file_range`. `posix_replay.py` pins the probed profile for
`--check-profile` drift detection. Once SD2–SD5 are fixed, a dedicated
`posixSmb` profile in `ext/specs` is the right next step.
