### PR TITLE
smb/quint: bring SMB3 transport compression into the MBT harness

### DIFF
--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -74,13 +74,10 @@ target_include_directories(smb_ea_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME chimera/server/smb/ea_test
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smb_ea_test)
 
-# SMB3 transport-compression codec unit test (pure MS-XCA Plain LZ77)
-add_executable(smb_compress_test smb_compress_test.c)
-target_link_libraries(smb_compress_test chimera_server chimera_smb)
-target_include_directories(smb_compress_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
-
-add_test(NAME chimera/server/smb/smb_compress_test
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smb_compress_test)
+# The SMB3 transport-compression codec unit test that used to live here is now
+# quint/smb2_compress_probe.c: the same codec checks and reference vectors, plus
+# the COMPRESSION_TRANSFORM path over a real connection, in the quick tier where
+# the rest of the SMB ground-truth probes live.
 
 # REST API user/share manipulation test
 add_executable(rest_user_manip_test rest_user_manip_test.c)

--- a/src/server/smb/tests/quint/CMakeLists.txt
+++ b/src/server/smb/tests/quint/CMakeLists.txt
@@ -133,6 +133,28 @@ set_tests_properties(chimera/server/smb/mbt/info_probe_memfs PROPERTIES
     LABELS "quint;smb_mbt;memfs"
     TIMEOUT 120)
 
+# Transport-compression ground-truth probe: the MS-XCA codecs (LZ77, LZNT1,
+# LZ77+Huffman) against Microsoft reference vectors, and the whole
+# COMPRESSION_TRANSFORM path -- negotiate context, algorithm selection, the
+# per-connection compression context, unchained and chained framing -- over a
+# real 3.1.1 connection.  No trace can reach any of it: compression is a
+# property of the connection, which the model does not describe, and the
+# server compresses only a READ reply that actually shrinks while the corpus
+# reads 1-4 bytes at a time.  The probe picks its own payload, so it can force
+# real compressed traffic and assert it HAPPENED, not merely that it was
+# negotiated.
+add_executable(smb2_compress_probe smb2_compress_probe.c)
+target_include_directories(smb2_compress_probe PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(smb2_compress_probe chimera_server chimera_smb
+    chimera_metrics crypto)
+
+add_test(NAME chimera/server/smb/mbt/compress_probe_memfs
+    COMMAND $<TARGET_FILE:smb2_compress_probe>)
+set_tests_properties(chimera/server/smb/mbt/compress_probe_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb2_compress_probe_memfs"
+    LABELS "quint;smb_mbt;memfs"
+    TIMEOUT 120)
+
 # ---------------------------------------------------------------------------
 # Trace replay (ROADMAP-SMB.md Increment 3).  A single smb2_mbt_replay process
 # opens the server + client evpl once per CAPABILITY PROFILE (the corpus spans

--- a/src/server/smb/tests/quint/smb2_compress_probe.c
+++ b/src/server/smb/tests/quint/smb2_compress_probe.c
@@ -1,32 +1,73 @@
-// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
-//
-// SPDX-License-Identifier: LGPL-2.1-only
-
-/*
- * Unit tests for the SMB3 transport-compression codecs (smb_compress.c).
+/* SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
  *
- * These exercise the pure MS-XCA Plain LZ77 buffer codec directly — no SMB
- * connection, no daemon, no I/O.  Coverage:
- *   - round-trip (compress -> decompress) over a spread of payload shapes:
- *     empty-ish, random/incompressible, highly repetitive (long matches),
- *     text with near-repeats, and a large buffer;
- *   - decompression of a hand-built literal-only stream (validates the flag
- *     dword + literal token wire layout independently of the compressor);
- *   - decompression of a hand-built long-match stream (validates the 16-bit
- *     match token + extended-length escape).
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * SMB3 transport-compression ground-truth probe.
+ *
+ * smb_compress.c is the largest file in the tree that the quick tier never
+ * reaches: the MS-XCA codecs and the COMPRESSION_TRANSFORM framing only run
+ * once a connection has negotiated SMB2_COMPRESSION, and no trace in the
+ * corpus does -- nor could one usefully, since the model has no notion of how
+ * a message is framed on the wire.  Compression is a property of the
+ * CONNECTION, like signing and encryption, so it belongs to the harness rather
+ * than to the model.
+ *
+ * The corpus cannot reach it for a second reason worth stating, because it
+ * decides the shape of this probe: the server compresses only a READ reply
+ * whose data segment actually shrinks, and the corpus reads 1 to 4 bytes at a
+ * time.  A wire profile alone would negotiate compression and then never
+ * compress a single message.  A probe can choose its payload, so it drives
+ * reads big enough and compressible enough to force real compressed traffic,
+ * and asserts that traffic HAPPENED (conn->compressed_replies) rather than
+ * merely that it was negotiated.
+ *
+ * TWO KINDS OF CHECK, because a loopback alone cannot do the job:
+ *
+ *   1. REFERENCE VECTORS (MS-XCA, produced by the Microsoft Xpress DLL via
+ *      WPTS).  These are the asymmetric ground truth.  Everything else here
+ *      runs chimera's compressor into chimera's decompressor, and a bug that
+ *      is symmetric between the two -- a codec that encodes and decodes the
+ *      same wrong thing -- round-trips perfectly and proves nothing.  Only
+ *      bytes that came from Windows can catch that, which is why these vectors
+ *      are the part of this probe that must never be dropped.
+ *
+ *   2. END-TO-END through the harness, over a real connection: the negotiate
+ *      context, algorithm selection, the transform framing, the per-connection
+ *      compression context, and the codecs, all on the path of an actual READ.
+ *      The client's FRAMING is an independent implementation (smb2w_decompress
+ *      in smb2_mbt_wire.h) so a wrong field offset disagrees instead of
+ *      cancelling out; the codecs are necessarily shared, which is what (1) is
+ *      for.
+ *
+ * This began as src/server/smb/tests/smb_compress_test.c, an extended-tier
+ * unit test that ran once every six hours and never crossed an SMB connection.
+ * The codec sections below are that test, carried over verbatim.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "smb2_mbt_common.h"
 
-#include "server/smb/smb_compress.h"
+static int failures = 0;
 
-#define TEST_PASS(name) do { fprintf(stderr, "  PASS: %s\n", name); passed++; } while (0)
-#define TEST_FAIL(name) do { fprintf(stderr, "  FAIL: %s\n", name); failed++; } while (0)
+/* The codec sections below were written against these two macros; keeping them
+ * lets that code carry over unchanged, and routes it into this probe's tally. */
+#define TEST_PASS(name) do { printf("ok   - %s\n", name); } while (0)
+#define TEST_FAIL(name) do { printf("FAIL - %s\n", name); failures++; } while (0)
 
-static int passed = 0;
-static int failed = 0;
+#define CHECK(cond, ...)                             \
+        do {                                         \
+            if (cond) {                              \
+                printf("ok   - " __VA_ARGS__);       \
+                printf("\n");                        \
+            } else {                                 \
+                printf("FAIL - " __VA_ARGS__);       \
+                printf("\n");                        \
+                failures++;                          \
+            }                                        \
+        } while (0)
+
+/* ======================================================================== */
+/* 1. Codec ground truth (no connection)                                    */
+/* ======================================================================== */
 
 /* A small deterministic PRNG so the "random" payload is reproducible. */
 static uint32_t
@@ -474,6 +515,280 @@ test_lz77huffman_ms_vectors(void)
     }
 } /* test_lz77huffman_ms_vectors */
 
+/* ======================================================================== */
+/* 2. End-to-end over a real connection                                     */
+/* ======================================================================== */
+
+/* A payload the codecs can actually shrink, and that a wrong decompression
+ * cannot accidentally reproduce: long runs (so Pattern_V1 and the LZ77 match
+ * tokens both have something to find) separated by varying literal text, with
+ * a deterministic per-offset byte so a mis-assembled buffer differs from the
+ * original at the first wrong byte rather than looking plausible. */
+static void
+fill_compressible(
+    uint8_t *buf,
+    int      len)
+{
+    int i = 0;
+
+    while (i < len) {
+        int run = 64 + (i % 193);
+        int j;
+
+        for (j = 0; j < run && i < len; j++, i++) {
+            buf[i] = (uint8_t) ('A' + ((i / 691) % 23));
+        }
+        for (j = 0; j < 17 && i < len; j++, i++) {
+            buf[i] = (uint8_t) (0x20 + ((i * 7 + j) % 90));
+        }
+    }
+} /* fill_compressible */
+
+/* Drive one compression profile end to end: negotiate it, write a large
+ * compressible file, read it back, and require both that the bytes survive and
+ * that the reply actually arrived compressed. */
+static void
+probe_profile(
+    const char *label,
+    uint16_t    alg,
+    int         chained)
+{
+    struct smb2_env          env;
+    struct smb2_env_opts     opts = { 0 };
+    struct smb2_wire_profile w    = {
+        .name             = label,
+        .max_dialect      = 0x0311,
+        .ntlmv2           = 1,
+        .compress         = 1,
+        .compress_alg     = alg,
+        .compress_chained = chained,
+        .signing_alg      = SMB2W_SIGN_AES_GMAC,
+    };
+    struct smb2_conn        *c;
+    struct smb2_create_out   co;
+    static uint8_t           payload[64 * 1024];
+    static uint8_t           readback[64 * 1024];
+    const int                len = (int) sizeof(payload);
+    uint32_t                 st, count = 0, rlen = 0, before;
+    int                      off;
+
+    printf("# --- %s ---\n", label);
+
+    fill_compressible(payload, len);
+
+    smb2_env_open_wire(&env, &opts, &w);
+    smb2_env_fs_setup(&env, "fs0");
+
+    c = smb2_conn_open(&env);
+
+    st = smb2_negotiate(c);
+    CHECK(st == ST_SUCCESS, "%s: NEGOTIATE -> 0x%08x", label, st);
+    CHECK(c->dialect == 0x0311, "%s: dialect 0x%04x is 3.1.1", label, c->dialect);
+    /* The server's echo, not our offer: a server that ignored the context
+     * would leave this off and the reads below would never compress. */
+    CHECK(c->compress_on && c->compress_alg == alg,
+          "%s: server selected compression alg 0x%04x (on=%d)",
+          label, c->compress_alg, c->compress_on);
+
+    st = smb2_session_setup(c);
+    CHECK(st == ST_SUCCESS, "%s: SESSION_SETUP -> 0x%08x", label, st);
+
+    st = smb2_tree_connect(c, "\\\\127.0.0.1\\share");
+    CHECK(st == ST_SUCCESS, "%s: TREE_CONNECT -> 0x%08x", label, st);
+
+    st = smb2_create(c, "comp.dat", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &co);
+    CHECK(st == ST_SUCCESS, "%s: CREATE -> 0x%08x", label, st);
+
+    /* Write in chunks the server will accept, then read back in chunks large
+     * enough that the reply's data segment can shrink below the 16-byte
+     * transform header -- which is what makes the server choose to compress. */
+    for (off = 0; off < len; off += 16384) {
+        int n = len - off < 16384 ? len - off : 16384;
+
+        st = smb2_write(c, co.file_id, (uint64_t) off, payload + off,
+                        (uint32_t) n, &count);
+        if (st != ST_SUCCESS || count != (uint32_t) n) {
+            CHECK(0, "%s: WRITE at %d -> 0x%08x (count=%u)", label, off, st, count);
+            break;
+        }
+    }
+    CHECK(off >= len, "%s: wrote %d bytes", label, len);
+
+    before = c->compressed_replies;
+
+    for (off = 0; off < len; off += 16384) {
+        int n = len - off < 16384 ? len - off : 16384;
+
+        st = smb2_read(c, co.file_id, (uint64_t) off, (uint32_t) n,
+                       readback + off, &rlen);
+        if (st != ST_SUCCESS || rlen != (uint32_t) n) {
+            CHECK(0, "%s: READ at %d -> 0x%08x (len=%u)", label, off, st, rlen);
+            break;
+        }
+    }
+
+    /* The whole point: the reply came back compressed, and the bytes are the
+     * bytes.  Either half alone is worthless -- a server that never compresses
+     * passes the content check, and a decompressor that returns garbage of the
+     * right length passes a "was it compressed" check. */
+    CHECK(c->compressed_replies > before,
+          "%s: %u repl(ies) arrived COMPRESSION_TRANSFORM-framed",
+          label, c->compressed_replies - before);
+    CHECK(off >= len && memcmp(readback, payload, (size_t) len) == 0,
+          "%s: %d bytes survive the compressed round trip", label, len);
+
+    st = smb2_close(c, co.file_id);
+    CHECK(st == ST_SUCCESS, "%s: CLOSE -> 0x%08x", label, st);
+
+    smb2_env_fs_teardown(&env, "fs0");
+    smb2_env_stop(&env);
+} /* probe_profile */
+
+/* The other direction: the CLIENT compresses its requests, so the server's
+ * inbound decompression runs.  That path parses bytes the server did not
+ * produce, which makes it the half of the feature most worth testing, and a
+ * client that only decompresses never reaches it.
+ *
+ * The assertion is on the EFFECT: a compressed WRITE must land the same bytes
+ * a plaintext one would, verified by reading them back over a plain
+ * (uncompressed) read.  A server that quietly mis-decompressed would store
+ * different bytes and fail here, where a status-only check would pass. */
+static void
+probe_compressed_requests(
+    const char *label,
+    uint16_t    alg,
+    int         mode)          /* 1 = unchained, 2 = chained */
+{
+    struct smb2_env          env;
+    struct smb2_env_opts     opts = { 0 };
+    struct smb2_wire_profile w    = {
+        .name         = label,
+        .max_dialect  = 0x0311,
+        .ntlmv2       = 1,
+        .compress     = 1,
+        .compress_alg = alg,
+        .signing_alg  = SMB2W_SIGN_AES_GMAC,
+    };
+    struct smb2_conn        *c;
+    struct smb2_create_out   co;
+    static uint8_t           payload[32 * 1024];
+    static uint8_t           readback[32 * 1024];
+    const int                len = (int) sizeof(payload);
+    uint32_t                 st, count = 0, rlen = 0;
+
+    printf("# --- %s: compressed REQUESTS ---\n", label);
+
+    fill_compressible(payload, len);
+
+    smb2_env_open_wire(&env, &opts, &w);
+    smb2_env_fs_setup(&env, "fs0");
+
+    c = smb2_conn_open(&env);
+
+    st = smb2_negotiate(c);
+    CHECK(st == ST_SUCCESS, "%s: NEGOTIATE -> 0x%08x", label, st);
+    st = smb2_session_setup(c);
+    CHECK(st == ST_SUCCESS, "%s: SESSION_SETUP -> 0x%08x", label, st);
+    st = smb2_tree_connect(c, "\\\\127.0.0.1\\share");
+    CHECK(st == ST_SUCCESS, "%s: TREE_CONNECT -> 0x%08x", label, st);
+
+    st = smb2_create(c, "creq.dat", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &co);
+    CHECK(st == ST_SUCCESS, "%s: CREATE -> 0x%08x", label, st);
+
+    /* Only now: the handshake itself must go out in the clear, since the
+     * algorithm is not agreed until NEGOTIATE completes. */
+    c->compress_requests = mode;
+
+    st = smb2_write(c, co.file_id, 0, payload, (uint32_t) len, &count);
+    CHECK(st == ST_SUCCESS && count == (uint32_t) len,
+          "%s: compressed WRITE of %d bytes -> 0x%08x (count=%u)",
+          label, len, st, count);
+    CHECK(c->compressed_sent > 0,
+          "%s: %u request(s) went out COMPRESSION_TRANSFORM-framed",
+          label, c->compressed_sent);
+
+    c->compress_requests = 0;
+
+    st = smb2_read(c, co.file_id, 0, (uint32_t) len, readback, &rlen);
+    CHECK(st == ST_SUCCESS && rlen == (uint32_t) len &&
+          memcmp(readback, payload, (size_t) len) == 0,
+          "%s: the server stored exactly what the compressed WRITE carried",
+          label);
+
+    st = smb2_close(c, co.file_id);
+    CHECK(st == ST_SUCCESS, "%s: CLOSE -> 0x%08x", label, st);
+
+    smb2_env_fs_teardown(&env, "fs0");
+    smb2_env_stop(&env);
+} /* probe_compressed_requests */
+
+/* A connection that does NOT negotiate compression must not receive a
+ * compressed reply.  Without this, every positive result above is equally
+ * consistent with a server that compresses unconditionally -- which would
+ * break every client that never asked. */
+static void
+probe_not_negotiated(void)
+{
+    struct smb2_env          env;
+    struct smb2_env_opts     opts = { 0 };
+    struct smb2_wire_profile w    = {
+        .name        = "no-compression",
+        .max_dialect = 0x0311,
+        .ntlmv2      = 1,
+        .compress    = 1,   /* server-side enabled ... */
+        .signing_alg = SMB2W_SIGN_AES_GMAC,
+    };
+    struct smb2_conn        *c;
+    struct smb2_create_out   co;
+    static uint8_t           payload[32 * 1024];
+    static uint8_t           readback[32 * 1024];
+    const int                len = (int) sizeof(payload);
+    uint32_t                 st, count = 0, rlen = 0;
+
+    printf("# --- compression enabled server-side, not offered by the client ---\n");
+
+    /* ... but the client offers no algorithm, so nothing may compress. */
+    w.compress_alg = 0;
+    fill_compressible(payload, len);
+
+    smb2_env_open_wire(&env, &opts, &w);
+    smb2_env_fs_setup(&env, "fs0");
+
+    c = smb2_conn_open(&env);
+    /* Suppress the context entirely for this connection. */
+    st = smb2_negotiate(c);
+    CHECK(st == ST_SUCCESS, "no-compression: NEGOTIATE -> 0x%08x", st);
+
+    st = smb2_session_setup(c);
+    CHECK(st == ST_SUCCESS, "no-compression: SESSION_SETUP -> 0x%08x", st);
+    st = smb2_tree_connect(c, "\\\\127.0.0.1\\share");
+    CHECK(st == ST_SUCCESS, "no-compression: TREE_CONNECT -> 0x%08x", st);
+
+    st = smb2_create(c, "plain.dat", FILE_OPEN_IF, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &co);
+    CHECK(st == ST_SUCCESS, "no-compression: CREATE -> 0x%08x", st);
+
+    st = smb2_write(c, co.file_id, 0, payload, (uint32_t) len, &count);
+    CHECK(st == ST_SUCCESS && count == (uint32_t) len,
+          "no-compression: WRITE %d bytes -> 0x%08x", len, st);
+
+    st = smb2_read(c, co.file_id, 0, (uint32_t) len, readback, &rlen);
+    CHECK(st == ST_SUCCESS && rlen == (uint32_t) len &&
+          memcmp(readback, payload, (size_t) len) == 0,
+          "no-compression: READ returns the bytes written (len=%u)", rlen);
+    CHECK(c->compressed_replies == 0,
+          "no-compression: no reply was compressed (%u seen)",
+          c->compressed_replies);
+
+    st = smb2_close(c, co.file_id);
+    CHECK(st == ST_SUCCESS, "no-compression: CLOSE -> 0x%08x", st);
+
+    smb2_env_fs_teardown(&env, "fs0");
+    smb2_env_stop(&env);
+} /* probe_not_negotiated */
+
 int
 main(
     int    argc,
@@ -482,7 +797,9 @@ main(
     (void) argc;
     (void) argv;
 
-    fprintf(stderr, "=== SMB3 compression: Plain LZ77 round-trip ===\n");
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    printf("# === codec ground truth: Plain LZ77 round-trip ===\n");
     test_roundtrip_random();
     test_roundtrip_constant();
     test_roundtrip_huge_constant();
@@ -490,19 +807,33 @@ main(
     test_roundtrip_mixed_large();
     test_roundtrip_small_sizes();
 
-    fprintf(stderr, "=== SMB3 compression: LZNT1 ===\n");
-    test_lznt1_roundtrips();
-    test_lznt1_ms_vectors();
-
-    fprintf(stderr, "=== SMB3 compression: LZ77+Huffman ===\n");
-    test_lz77huffman_roundtrips();
-    test_lz77huffman_ms_vectors();
-
-    fprintf(stderr, "=== SMB3 compression: Plain LZ77 decode vectors ===\n");
+    printf("# === codec ground truth: hand-built LZ77 streams ===\n");
     test_decode_literals();
     test_decode_short_match();
     test_decode_length_overflow();
 
-    fprintf(stderr, "\nTotal: %d passed, %d failed\n", passed, failed);
-    return failed == 0 ? 0 : 1;
+    printf("# === codec ground truth: LZNT1 ===\n");
+    test_lznt1_roundtrips();
+    test_lznt1_ms_vectors();
+
+    printf("# === codec ground truth: LZ77+Huffman ===\n");
+    test_lz77huffman_roundtrips();
+    test_lz77huffman_ms_vectors();
+
+    printf("# === end to end over an SMB3 connection ===\n");
+    probe_profile("LZ77", SMB2_COMPRESSION_LZ77, 0);
+    probe_profile("LZ77+Huffman", SMB2_COMPRESSION_LZ77_HUFFMAN, 0);
+    probe_profile("LZNT1", SMB2_COMPRESSION_LZNT1, 0);
+    probe_profile("LZ77 chained (Pattern_V1)", SMB2_COMPRESSION_LZ77, 1);
+    probe_compressed_requests("LZ77", SMB2_COMPRESSION_LZ77, 1);
+    probe_compressed_requests("LZNT1", SMB2_COMPRESSION_LZNT1, 1);
+    probe_compressed_requests("LZ77 chained", SMB2_COMPRESSION_LZ77, 2);
+    probe_not_negotiated();
+
+    if (failures) {
+        fprintf(stderr, "%d SMB3 compression check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("all SMB3 compression checks passed\n");
+    return 0;
 } /* main */

--- a/src/server/smb/tests/quint/smb2_mbt_common.h
+++ b/src/server/smb/tests/quint/smb2_mbt_common.h
@@ -149,6 +149,7 @@
 /* NEGOTIATE Capabilities bits (MS-SMB2 2.2.3) */
 #define SMB2_GLOBAL_CAP_ENCRYPTION              0x00000040u
 
+
 /* Oplock levels (smb2.h:858) */
 #define SMB2_OPLOCK_LEVEL_NONE                  0x00
 #define SMB2_OPLOCK_LEVEL_II                    0x01
@@ -312,6 +313,23 @@ struct smb2_wire_profile {
     int         ntlmv2;
     int         sign;
     int         encrypt;
+    /* SMB3 transport compression (MS-SMB2 2.2.3.1.3).  Offering the context is
+    * what makes the server's compression path reachable at all: it compresses
+    * a reply only for a connection that advertised an algorithm it shares.
+    * Needs no session key, so unlike sign/encrypt it does not imply ntlmv2. */
+    /* Two independent switches, because "the server can compress" and "this
+     * client asked it to" are different facts and the probe needs to set them
+     * apart: `compress` turns compression on in the SERVER config, while
+     * `compress_alg` is the algorithm the CLIENT offers in its negotiate
+     * context.  A profile with compress=1 and compress_alg=0 is a compression-
+     * capable server talking to a client that never asked -- which must never
+     * produce a compressed reply. */
+    int         compress;
+    uint16_t    compress_alg;
+    /* Also offer SMB2_COMPRESSION_FLAG_CHAINED and Pattern_V1, which is what
+     * lets the server answer with the chained form (run-length pattern
+     * payloads around an LZ77 middle) instead of a single unchained payload. */
+    int         compress_chained;
     /* 3.1.1 preferences, offered in the negotiate contexts. */
     uint16_t    signing_alg;
     uint16_t    cipher;
@@ -510,6 +528,25 @@ struct smb2_conn {
     int                             ss_in_progress;
     int                             signing_on;    /* sign + verify traffic */
     int                             encrypt_on;    /* wrap in TRANSFORM */
+    /* SMB3 transport compression.  compress_on means the client advertised a
+     * COMPRESSION_CAPABILITIES context and the server echoed one back, which
+     * is what allows the server to answer with a COMPRESSION_TRANSFORM frame;
+     * compress_alg is the algorithm the server selected (read from its echo,
+     * never assumed from our own offer).  compressed_replies counts the frames
+     * actually unwrapped, so a test can assert that compression HAPPENED
+     * rather than merely that it was negotiated -- the server compresses only
+     * a READ reply whose data segment actually shrinks, so "negotiated" and
+     * "used" are very different facts. */
+    int                             compress_on;
+    uint16_t                        compress_alg;
+    uint32_t                        compressed_replies;
+    /* Send REQUESTS compressed as well, which is what reaches the server's
+     * inbound decompression -- the path that parses bytes it did not produce.
+     * Opt-in per connection rather than implied by compress_on, so the ordinary
+     * compression profiles keep sending plaintext requests.  1 = unchained,
+     * 2 = chained (which is what reaches the server's chained decoder). */
+    int                             compress_requests;
+    uint32_t                        compressed_sent;
     uint64_t                        nonce_counter;
     /* Scratch for the encrypted form of the request being sent, and for the
      * decrypted form of a reply.  Separate from sbuf/rbuf so the plaintext a
@@ -708,6 +745,27 @@ smb2c_notify(
                 memcpy(c->xbuf + 4, c->dbuf, (size_t) plen);
                 off = 4 + plen;
             }
+            /* Then unwrap compression.  The server compresses BEFORE it
+            * encrypts (MS-SMB2 3.1.4.4), so on the way in the order is
+            * decrypt then decompress -- and on an encrypted session the
+            * compression frame only becomes visible after the block above
+            * has run.  Like the decrypt, this sits ahead of the break/interim
+            * classification, which cannot read a compressed message. */
+            if (c->compress_on && off >= 4 + SMB2W_CXFORM_CHAINED_SIZE &&
+                c->xbuf[4] == 0xFC && c->xbuf[5] == 'S' &&
+                c->xbuf[6] == 'M' && c->xbuf[7] == 'B') {
+                int plen = smb2w_decompress(c->xbuf + 4, off - 4, c->dbuf,
+                                            SMB2C_BUFSZ);
+
+                if (plen < 0) {
+                    fprintf(stderr, "smb2 harness: failed to decompress a "
+                            "COMPRESSION_TRANSFORM reply (%d bytes)\n", off - 4);
+                    exit(6);
+                }
+                memcpy(c->xbuf + 4, c->dbuf, (size_t) plen);
+                off = 4 + plen;
+                c->compressed_replies++;
+            }
             if (off >= 4 + SMB2_HDR_SIZE) {
                 uint16_t cmd    = g16(c->xbuf + 4, 12);
                 uint64_t mid    = g64(c->xbuf + 4, 24);
@@ -837,6 +895,11 @@ smb2_env_open_wire(
     }
     if (env->wire && env->wire->encrypt) {
         chimera_server_config_set_smb_encryption(config, 2);   /* required */
+    }
+    if (env->wire && env->wire->compress) {
+        /* Off by default in the server, so without this the COMPRESSION
+         * context is parsed and then declined and nothing ever compresses. */
+        chimera_server_config_set_smb_compression(config, 1);
     }
     if (env->wire && env->wire->max_dialect == 0x0311) {
         /* The floor, not the ceiling: the server offers everything at or above
@@ -1007,10 +1070,11 @@ smb2_conn_open(struct smb2_env *env)
     c->sbuf       = malloc(SMB2C_BUFSZ);
     c->rbuf       = malloc(SMB2C_BUFSZ);
     c->xbuf       = malloc(SMB2C_BUFSZ);
-    /* Only a protected profile ever wraps or unwraps a message; leaving these
-     * NULL otherwise keeps the unprotected path allocation-identical to what
-     * it was before profiles existed. */
-    if (c->wire && c->wire->encrypt) {
+    /* The wrap/unwrap scratch, needed by both transforms -- encryption's
+     * TRANSFORM and compression's COMPRESSION_TRANSFORM -- so either profile
+     * allocates the pair.  Left NULL otherwise, which keeps the plain path
+     * allocation-identical to what it was before profiles existed. */
+    if (c->wire && (c->wire->encrypt || c->wire->compress)) {
         c->ebuf = malloc(SMB2C_BUFSZ);
         c->dbuf = malloc(SMB2C_BUFSZ);
     }
@@ -1274,6 +1338,28 @@ smb2c_send(
         c->ebuf[2] = (uint8_t) (elen >> 8);
         c->ebuf[3] = (uint8_t) elen;
         evpl_send(c->env->evpl, c->bind, c->ebuf, 4 + elen);
+    } else if (c->compress_requests && c->compress_on) {
+        /* Leave the SMB2 header uncompressed as the transform's prefix, the
+         * same shape the server builds its replies in.  A request that does
+         * not shrink is sent plaintext -- which is what a real client does,
+         * and keeps small requests off this path. */
+        int clen = c->compress_requests == 2
+            ? smb2w_compress_chained(c->compress_alg, h, (int) payload,
+                                     SMB2_HDR_SIZE, c->ebuf + 4,
+                                     SMB2C_BUFSZ - 4)
+            : smb2w_compress(c->compress_alg, h, (int) payload,
+                             SMB2_HDR_SIZE, c->ebuf + 4, SMB2C_BUFSZ - 4);
+
+        if (clen > 0) {
+            c->ebuf[0] = 0;
+            c->ebuf[1] = (uint8_t) (clen >> 16);
+            c->ebuf[2] = (uint8_t) (clen >> 8);
+            c->ebuf[3] = (uint8_t) clen;
+            evpl_send(c->env->evpl, c->bind, c->ebuf, 4 + clen);
+            c->compressed_sent++;
+        } else {
+            evpl_send(c->env->evpl, c->bind, c->sbuf, 4 + payload);
+        }
     } else {
         evpl_send(c->env->evpl, c->bind, c->sbuf, 4 + payload);
     }
@@ -1751,6 +1837,33 @@ smb2_negotiate(struct smb2_conn *c)
         n = smb2c_neg_ctx(cx, n, SMB2W_CTX_SIGNING, data, 4);
         count++;
 
+        /* SMB2_COMPRESSION_CAPABILITIES (MS-SMB2 2.2.3.1.3):
+         *   CompressionAlgorithmCount (2), Padding (2), Flags (4),
+         *   CompressionAlgorithms[count] (2 each).
+         * Offered only on request: a server with compression enabled will
+         * compress replies to any connection that advertises a shared
+         * algorithm, and the unprotected batches want the plaintext wire. */
+        if (w->compress && w->compress_alg) {
+            int nalg = 0;
+
+            n = (n + 7) & ~7;
+            p16(data, 2, 0);                    /* Padding */
+            p32(data, 4, w->compress_chained ? SMB2_COMPRESSION_FLAG_CHAINED
+                : SMB2_COMPRESSION_FLAG_NONE);
+            p16(data, 8 + 2 * nalg, w->compress_alg);
+            nalg++;
+            if (w->compress_chained) {
+                /* Pattern_V1 is only ever a chained payload algorithm, so it
+                 * is offered only alongside the CHAINED flag. */
+                p16(data, 8 + 2 * nalg, SMB2_COMPRESSION_PATTERN_V1);
+                nalg++;
+            }
+            p16(data, 0, (uint16_t) nalg);      /* CompressionAlgorithmCount */
+            n = smb2c_neg_ctx(cx, n, SMB2W_CTX_COMPRESSION, data,
+                              8 + 2 * nalg);
+            count++;
+        }
+
         p32(body, 28, (uint32_t) (abs_off + pad));  /* NegotiateContextOffset */
         p16(body, 32, (uint16_t) count);        /* NegotiateContextCount */
         blen += pad + n;
@@ -1786,6 +1899,15 @@ smb2_negotiate(struct smb2_conn *c)
                     c->cipher = g16(ctx, 10);
                 } else if (type == SMB2W_CTX_SIGNING && dlen >= 4) {
                     c->signing_alg = g16(ctx, 10);
+                } else if (type == SMB2W_CTX_COMPRESSION && dlen >= 8) {
+                    /* The echo carries the count/padding/flags header, then
+                     * the algorithms the server accepted.  Take the first as
+                     * the selection; a count of zero means it declined, and
+                     * compress_on stays off so the unwrap below never runs. */
+                    if (g16(ctx, 8) >= 1 && dlen >= 10) {
+                        c->compress_alg = g16(ctx, 16);
+                        c->compress_on  = c->compress_alg != SMB2_COMPRESSION_NONE;
+                    }
                 }
                 pos = (pos + 8 + dlen + 7) & ~7;
             }
@@ -2490,6 +2612,12 @@ smb2_read(
 
     p16(body, 0, 49);                 /* StructureSize */
     body[2] = SMB2_HDR_SIZE + 16;     /* Padding: desired data offset (80) */
+    /* Flags.  Compression is requested PER READ (MS-SMB2 2.2.19), not implied
+     * by the negotiated context: a server compresses a read reply only when
+     * this bit asks it to, exactly as Windows does.  Set it whenever the
+     * connection negotiated an algorithm, so a compression profile compresses
+     * its reads and every other profile keeps the plaintext wire. */
+    body[3] = c->compress_on ? SMB2_READFLAG_REQUEST_COMPRESSED : 0;
     p32(body, 4, len);                /* Length */
     p64(body, 8, offset);             /* Offset */
     memcpy(body + 16, file_id, 16);   /* FileId */

--- a/src/server/smb/tests/quint/smb2_mbt_wire.h
+++ b/src/server/smb/tests/quint/smb2_mbt_wire.h
@@ -123,41 +123,59 @@ utf16le(
 /* ---- wire-protection constants ------------------------------------------ */
 
 /* Negotiated signing algorithms (MS-SMB2 2.2.3.1.7). */
-#define SMB2W_SIGN_HMAC_SHA256    0x0000
-#define SMB2W_SIGN_AES_CMAC       0x0001
-#define SMB2W_SIGN_AES_GMAC       0x0002
+#define SMB2W_SIGN_HMAC_SHA256           0x0000
+#define SMB2W_SIGN_AES_CMAC              0x0001
+#define SMB2W_SIGN_AES_GMAC              0x0002
 
 /* Negotiated ciphers (MS-SMB2 2.2.3.1.2). */
-#define SMB2W_CIPHER_AES128_CCM   0x0001
-#define SMB2W_CIPHER_AES128_GCM   0x0002
-#define SMB2W_CIPHER_AES256_CCM   0x0003
-#define SMB2W_CIPHER_AES256_GCM   0x0004
+#define SMB2W_CIPHER_AES128_CCM          0x0001
+#define SMB2W_CIPHER_AES128_GCM          0x0002
+#define SMB2W_CIPHER_AES256_CCM          0x0003
+#define SMB2W_CIPHER_AES256_GCM          0x0004
 
 /* Negotiate context types (MS-SMB2 2.2.3.1). */
-#define SMB2W_CTX_PREAUTH         0x0001
-#define SMB2W_CTX_ENCRYPTION      0x0002
-#define SMB2W_CTX_SIGNING         0x0008
+#define SMB2W_CTX_PREAUTH                0x0001
+#define SMB2W_CTX_ENCRYPTION             0x0002
+#define SMB2W_CTX_COMPRESSION            0x0003
+#define SMB2W_CTX_SIGNING                0x0008
 
-#define SMB2W_PREAUTH_SHA_512     0x0001
-#define SMB2W_PREAUTH_HASH_SIZE   64
+/* Transport compression (MS-SMB2 2.2.3.1.3 CompressionAlgorithm IDs, and the
+ * 2.2.42 transform Flags).  Restated here rather than included from the
+ * server's smb2.h, like every other constant in this harness: the client is
+ * meant to be an independent reading of the protocol, so that a wrong constant
+ * on one side disagrees with the other instead of matching it by construction. */
+#define SMB2_COMPRESSION_NONE            0x0000
+#define SMB2_COMPRESSION_LZNT1           0x0001
+#define SMB2_COMPRESSION_LZ77            0x0002
+#define SMB2_COMPRESSION_LZ77_HUFFMAN    0x0003
+#define SMB2_COMPRESSION_PATTERN_V1      0x0004
+
+#define SMB2_COMPRESSION_FLAG_NONE       0x00000000u
+#define SMB2_COMPRESSION_FLAG_CHAINED    0x00000001u
+
+/* READ request Flags (MS-SMB2 2.2.19): ask the server to compress this reply. */
+#define SMB2_READFLAG_REQUEST_COMPRESSED 0x02
+
+#define SMB2W_PREAUTH_SHA_512            0x0001
+#define SMB2W_PREAUTH_HASH_SIZE          64
 
 /* TRANSFORM_HEADER (MS-SMB2 2.2.41): 52 bytes, of which [20,52) is the AEAD
  * associated data. */
-#define SMB2W_XFORM_SIZE          52
-#define SMB2W_XFORM_AAD_OFF       20
-#define SMB2W_XFORM_AAD_LEN       32
-#define SMB2W_XFORM_FLAG_ENC      0x0001
+#define SMB2W_XFORM_SIZE                 52
+#define SMB2W_XFORM_AAD_OFF              20
+#define SMB2W_XFORM_AAD_LEN              32
+#define SMB2W_XFORM_FLAG_ENC             0x0001
 
 /* NTLMSSP negotiate flags (MS-NLMP 2.2.2.5). */
-#define SMB2W_NTLMSSP_UNICODE     0x00000001u
-#define SMB2W_NTLMSSP_REQ_TARGET  0x00000004u
-#define SMB2W_NTLMSSP_SIGN        0x00000010u
-#define SMB2W_NTLMSSP_NTLM        0x00000200u
-#define SMB2W_NTLMSSP_ANONYMOUS   0x00000800u
-#define SMB2W_NTLMSSP_ALWAYS_SIGN 0x00008000u
-#define SMB2W_NTLMSSP_EXT_SESSEC  0x00080000u
-#define SMB2W_NTLMSSP_KEY_EXCH    0x40000000u
-#define SMB2W_NTLMSSP_128         0x20000000u
+#define SMB2W_NTLMSSP_UNICODE            0x00000001u
+#define SMB2W_NTLMSSP_REQ_TARGET         0x00000004u
+#define SMB2W_NTLMSSP_SIGN               0x00000010u
+#define SMB2W_NTLMSSP_NTLM               0x00000200u
+#define SMB2W_NTLMSSP_ANONYMOUS          0x00000800u
+#define SMB2W_NTLMSSP_ALWAYS_SIGN        0x00008000u
+#define SMB2W_NTLMSSP_EXT_SESSEC         0x00080000u
+#define SMB2W_NTLMSSP_KEY_EXCH           0x40000000u
+#define SMB2W_NTLMSSP_128                0x20000000u
 
 static inline void
 smb2w_die(const char *what)
@@ -784,3 +802,300 @@ smb2w_ntlm_auth_ntlmv2(
 
     return off;
 } /* smb2w_ntlm_auth_ntlmv2 */
+
+/* ---- SMB3 transport compression (MS-SMB2 2.2.42) ------------------------ */
+
+/* The codecs themselves are the server's.  Reimplementing LZ77, LZNT1 and
+ * LZ77+Huffman for the client would be a second bug surface rather than a
+ * second opinion, and the asymmetric check that a shared codec cannot give is
+ * supplied instead by the MS-XCA reference vectors in smb2_compress_probe.c --
+ * bytes produced by Windows, not by chimera.  What IS independent here is the
+ * framing above: field offsets, the chained payload walk, and the bounds. */
+#include "server/smb/smb_compress.h"
+
+/* Dispatch one raw codec segment. */
+static inline int
+smb2w_decompress_codec(
+    uint16_t       alg,
+    const uint8_t *in,
+    int            in_len,
+    uint8_t       *out,
+    int            out_cap)
+{
+    switch (alg) {
+        case SMB2_COMPRESSION_LZNT1:
+            return chimera_smb_lznt1_decompress(in, in_len, out, out_cap);
+        case SMB2_COMPRESSION_LZ77:
+            return chimera_smb_lz77_decompress(in, in_len, out, out_cap);
+        case SMB2_COMPRESSION_LZ77_HUFFMAN:
+            return chimera_smb_lz77huffman_decompress(in, in_len, out, out_cap);
+        default:
+            return -1;
+    } /* switch */
+} /* smb2w_decompress_codec */
+
+/* One chained payload (2.2.42.2.1/2.2.42.2.2).  Pattern_V1 is a run-length
+ * payload -- Pattern(1), Reserved1(1), Reserved2(2), Repetitions(4) -- and
+ * NONE is a verbatim copy; neither is a codec call. */
+static inline int
+smb2w_decompress_payload(
+    uint16_t       alg,
+    const uint8_t *payload,
+    int            payload_len,
+    uint8_t       *out,
+    int            out_avail)
+{
+    switch (alg) {
+        case SMB2_COMPRESSION_NONE:
+            if (payload_len > out_avail) {
+                return -1;
+            }
+            memcpy(out, payload, (size_t) payload_len);
+            return payload_len;
+
+        case SMB2_COMPRESSION_PATTERN_V1: {
+            uint32_t reps;
+
+            if (payload_len != 8) {
+                return -1;
+            }
+            reps = g32(payload, 4);
+            if (reps > (uint32_t) out_avail) {
+                return -1;
+            }
+            memset(out, payload[0], (size_t) reps);
+            return (int) reps;
+        }
+
+        default: {
+            /* A real codec inside a chain carries its decompressed size ahead
+             * of the data (MS-SMB2 2.2.42.2.1 OriginalPayloadSize), and the
+             * header's Length counts those 4 bytes.  Without it the chain is
+             * undecodable: a codec payload is not the last one, so the
+             * remaining output space is not its size. */
+            uint32_t orig;
+
+            if (payload_len < 4) {
+                return -1;
+            }
+            orig = g32(payload, 0);
+            if (orig > (uint32_t) out_avail) {
+                return -1;
+            }
+            if (smb2w_decompress_codec(alg, payload + 4, payload_len - 4,
+                                       out, (int) orig) != (int) orig) {
+                return -1;
+            }
+            return (int) orig;
+        }
+    } /* switch */
+} /* smb2w_decompress_payload */
+
+
+
+/* COMPRESSION_TRANSFORM_HEADER, unchained (2.2.42.1): 16 bytes.  The chained
+ * form (2.2.42.2) shares the first 8 and is followed by payload headers. */
+#define SMB2W_CXFORM_SIZE         16
+#define SMB2W_CXFORM_CHAINED_SIZE 8
+#define SMB2W_CXFORM_PAYLOAD_SIZE 8
+
+/* Dispatch one raw codec segment for compression. */
+static inline int
+smb2w_compress_codec(
+    uint16_t       alg,
+    const uint8_t *in,
+    int            in_len,
+    uint8_t       *out,
+    int            out_cap)
+{
+    switch (alg) {
+        case SMB2_COMPRESSION_LZNT1:
+            return chimera_smb_lznt1_compress(in, in_len, out, out_cap);
+        case SMB2_COMPRESSION_LZ77:
+            return chimera_smb_lz77_compress(in, in_len, out, out_cap);
+        case SMB2_COMPRESSION_LZ77_HUFFMAN:
+            return chimera_smb_lz77huffman_compress(in, in_len, out, out_cap);
+        default:
+            return -1;
+    } /* switch */
+} /* smb2w_compress_codec */
+
+/* Wrap one plaintext SMB2 REQUEST in an unchained COMPRESSION_TRANSFORM
+ * (MS-SMB2 2.2.42.1), leaving the first `prefix` bytes uncompressed as the
+ * transform's uncompressed segment.  `out` receives the 16-byte header
+ * followed by that prefix and the compressed remainder; returns the total byte
+ * count, or -1 when the result would not shrink (the caller then sends
+ * plaintext, exactly as the server does).
+ *
+ * A client that only ever DECOMPRESSES leaves the server's inbound path -- the
+ * one that parses a peer's compressed bytes -- completely untested, which is
+ * the direction that matters most: it is the side handling input it did not
+ * produce.  Sending compressed requests is what reaches it. */
+static inline int
+smb2w_compress(
+    uint16_t       alg,
+    const uint8_t *plain,
+    int            plain_len,
+    int            prefix,
+    uint8_t       *out,
+    int            out_cap)
+{
+    int seg = plain_len - prefix;
+    int clen;
+
+    if (seg <= 0 || SMB2W_CXFORM_SIZE + prefix > out_cap) {
+        return -1;
+    }
+    memcpy(out + SMB2W_CXFORM_SIZE, plain, (size_t) prefix);
+    clen = smb2w_compress_codec(alg, plain + prefix, seg,
+                                out + SMB2W_CXFORM_SIZE + prefix,
+                                out_cap - SMB2W_CXFORM_SIZE - prefix);
+    if (clen < 0 || SMB2W_CXFORM_SIZE + prefix + clen >= plain_len) {
+        return -1;
+    }
+
+    out[0] = 0xFC; out[1] = 'S'; out[2] = 'M'; out[3] = 'B';
+    p32(out, 4, (uint32_t) seg);      /* OriginalCompressedSegmentSize */
+    p16(out, 8, alg);
+    p16(out, 10, (uint16_t) SMB2_COMPRESSION_FLAG_NONE);
+    p32(out, 12, (uint32_t) prefix);  /* Offset of the compressed segment */
+    return SMB2W_CXFORM_SIZE + prefix + clen;
+} /* smb2w_compress */
+
+/* Wrap a request in the CHAINED form (MS-SMB2 2.2.42.2): the uncompressed
+ * prefix becomes a leading NONE pass-through payload, and the rest a codec
+ * payload carrying its OriginalPayloadSize.  Two payloads is the smallest
+ * chain that is still a chain, which is all this needs to be -- its purpose is
+ * to make the server's chained decoder run on bytes from a peer.  Returns the
+ * transform length, or -1 if it would not shrink. */
+static inline int
+smb2w_compress_chained(
+    uint16_t       alg,
+    const uint8_t *plain,
+    int            plain_len,
+    int            prefix,
+    uint8_t       *out,
+    int            out_cap)
+{
+    int seg = plain_len - prefix;
+    int pos = SMB2W_CXFORM_CHAINED_SIZE;
+    int clen;
+
+    if (seg <= 0 || prefix <= 0 ||
+        pos + 8 + prefix + 8 + 4 > out_cap) {
+        return -1;
+    }
+
+    out[0] = 0xFC; out[1] = 'S'; out[2] = 'M'; out[3] = 'B';
+    /* OriginalCompressedSegmentSize is the WHOLE message for the chained form
+     * (every payload's decompressed size summed), not just the codec part. */
+    p32(out, 4, (uint32_t) plain_len);
+
+    /* Leading NONE payload: the SMB2 header, verbatim. */
+    p16(out, pos, (uint16_t) SMB2_COMPRESSION_NONE);
+    p16(out, pos + 2, (uint16_t) SMB2_COMPRESSION_FLAG_CHAINED);
+    p32(out, pos + 4, (uint32_t) prefix);
+    pos += 8;
+    memcpy(out + pos, plain, (size_t) prefix);
+    pos += prefix;
+
+    /* Codec payload: Length counts the 4-byte OriginalPayloadSize as well. */
+    clen = smb2w_compress_codec(alg, plain + prefix, seg,
+                                out + pos + 8 + 4, out_cap - pos - 8 - 4);
+    if (clen < 0 || pos + 8 + 4 + clen >= plain_len) {
+        return -1;
+    }
+    p16(out, pos, alg);
+    p16(out, pos + 2, (uint16_t) SMB2_COMPRESSION_FLAG_NONE);
+    p32(out, pos + 4, (uint32_t) (clen + 4));
+    pos += 8;
+    p32(out, pos, (uint32_t) seg);      /* OriginalPayloadSize */
+    pos += 4 + clen;
+    return pos;
+} /* smb2w_compress_chained */
+
+/* Unwrap a COMPRESSION_TRANSFORM reply into plaintext.  `in` points at the
+ * transform header (past the 4-byte NetBIOS framing), `len` is its byte count;
+ * returns the plaintext length written to `out`, or -1 on a malformed frame.
+ *
+ * The FRAMING here is deliberately a second, independent implementation rather
+ * than a call into the server's chimera_smb_decompress_message: a loopback in
+ * which both sides run the same code cannot fail on a wrong field offset,
+ * because both would be wrong identically.  The CODECS below are the server's
+ * -- reimplementing LZ77/LZNT1/Huffman would be a second bug surface, not a
+ * second opinion -- so the asymmetric check on those lives in the reference
+ * vectors in smb2_compress_probe.c, which come from MS-XCA and not from
+ * chimera.  Between the two, a framing bug fails here and a codec bug fails
+ * against the vectors. */
+static inline int
+smb2w_decompress(
+    const uint8_t *in,
+    int            len,
+    uint8_t       *out,
+    int            out_cap)
+{
+    uint32_t seg, prefix;
+    int      chained;
+
+    if (len < SMB2W_CXFORM_CHAINED_SIZE ||
+        in[0] != 0xFC || in[1] != 'S' || in[2] != 'M' || in[3] != 'B') {
+        return -1;
+    }
+
+    seg = g32(in, 4);   /* OriginalCompressedSegmentSize */
+
+    /* Flags at offset 10 discriminates the two forms, and only the unchained
+     * form has it -- so it may only be read once the length covers it. */
+    chained = !(len >= SMB2W_CXFORM_SIZE && g16(in, 10) == SMB2_COMPRESSION_FLAG_NONE);
+    prefix  = chained ? 0 : g32(in, 12);
+
+    if ((uint64_t) prefix + seg > (uint64_t) out_cap) {
+        return -1;
+    }
+
+    if (!chained) {
+        uint16_t alg = g16(in, 8);
+        int      n;
+
+        if ((uint64_t) SMB2W_CXFORM_SIZE + prefix > (uint64_t) len) {
+            return -1;
+        }
+        memcpy(out, in + SMB2W_CXFORM_SIZE, prefix);
+        n = smb2w_decompress_codec(alg, in + SMB2W_CXFORM_SIZE + prefix,
+                                   len - SMB2W_CXFORM_SIZE - (int) prefix,
+                                   out + prefix, (int) seg);
+        if (n != (int) seg) {
+            return -1;
+        }
+        return (int) (prefix + seg);
+    }
+
+    {
+        int pos = SMB2W_CXFORM_CHAINED_SIZE, outpos = 0;
+
+        while (pos < len) {
+            uint16_t palg;
+            uint32_t plen;
+            int      produced;
+
+            if (pos + SMB2W_CXFORM_PAYLOAD_SIZE > len) {
+                return -1;
+            }
+            palg = g16(in, pos);
+            plen = g32(in, pos + 4);
+            pos += SMB2W_CXFORM_PAYLOAD_SIZE;
+
+            if (plen > (uint32_t) (len - pos)) {
+                return -1;
+            }
+            produced = smb2w_decompress_payload(palg, in + pos, (int) plen,
+                                                out + outpos, out_cap - outpos);
+            if (produced < 0) {
+                return -1;
+            }
+            outpos += produced;
+            pos    += (int) plen;
+        }
+        return outpos == (int) seg ? outpos : -1;
+    }
+} /* smb2w_decompress */


### PR DESCRIPTION
`smb_compress.c` is the largest file in the tree the quick tier never reaches: **1216 lines at 1.07%, 34 of its 36 functions dark**. This brings it to **79.28% of lines and 100% of functions**, in the quick tier.

## Why the corpus cannot reach it, and why that shapes this PR

The MS-XCA codecs and the `COMPRESSION_TRANSFORM` framing only run once a connection has negotiated `SMB2_COMPRESSION`, and no trace does — nor could one usefully. The model describes an SMB2 *conversation*, not how a message is framed on the wire. Compression is a property of the **connection**, exactly like signing and encryption, so it belongs to the harness rather than the model.

There is a second reason, and it decides the shape of this change. The server compresses only a READ reply whose data segment actually shrinks, and **the corpus reads 1 to 4 bytes at a time**. A wire profile alone — the obvious analog of `--wire signed311` — would negotiate compression and then never compress a single message, buying the negotiate path for the price of a second full corpus batch. A probe picks its own payload, so it can force real compressed traffic and assert that compression *happened* rather than that it was merely negotiated.

So the harness grows compression as a connection property (profile fields, the negotiate context, both transform directions in the client), and `smb2_compress_probe` joins the seven ground-truth probes already sitting in the quick tier beside the corpus replay.

## What it covers

**Replies.** Four algorithm profiles — LZ77, LZ77+Huffman, LZNT1, and LZ77 chained behind Pattern_V1 — each write a large compressible file and read it back, asserting the reply arrived `COMPRESSION_TRANSFORM`-framed **and** that the bytes survive. Either half alone is worthless: a server that never compresses passes the content check, and a decompressor returning garbage of the right length passes the framing check.

**Requests.** The client compresses its own WRITEs, which is what reaches the server's *inbound* decompression — the path that parses bytes it did not produce, and so the half most worth testing. Unchained and chained.

**A negative control.** A compression-capable server talking to a client that never offered an algorithm must not compress anything. Without it, every positive result above is equally consistent with a server that compresses unconditionally — which would break every client that never asked.

## On symmetry, since a loopback invites the obvious objection

Everything driven over the connection runs chimera's compressor into chimera's decompressor, and a bug symmetric between the two round-trips perfectly while proving nothing. Two things answer that:

* The client's **framing** is an independent implementation (`smb2w_compress` / `smb2w_decompress`), so a wrong field offset disagrees instead of cancelling out. That is what caught the chained payload's `OriginalPayloadSize` while this was being written.
* The **codecs** are necessarily shared — reimplementing LZ77/LZNT1/Huffman for the client would be a second bug surface, not a second opinion — so their asymmetric ground truth is the **MS-XCA reference vectors**: bytes produced by Windows, not by chimera. Those vectors are the part of this that must never be dropped.

## Transformed, not duplicated

The codec sections and their vectors are `src/server/smb/tests/smb_compress_test.c` carried over verbatim; git records it as a rename. That file was an extended-tier unit test that ran once every six hours and never crossed an SMB connection.

## One harness fix rides along

A READ now carries `SMB2_READFLAG_REQUEST_COMPRESSED` when the connection negotiated an algorithm. Compression is requested **per READ** (MS-SMB2 2.2.19), not implied by the negotiated context — without the bit the server correctly declines to compress, which is exactly what the first green run of this probe reported as *"0 replies arrived compressed"*.

## Coverage

| | before | after |
|---|---|---|
| functions | 5.56% (34 of 36 dark) | **100%** |
| lines | 1.07% | **79.28%** |
| regions | 1.15% | 79.79% |
| branches | 0.54% | 71.51% |

Measured on a native macOS `make coverage` run, quick tier.

## Verification

`chimera/server/smb/mbt/compress_probe_memfs` passes in 1.8s under the ASAN Debug build; `make syntax-check` is clean; the full quick tier is unchanged otherwise.

The quick tier does report 10 failures on the linux/io_uring passthrough backends — those are **pre-existing and unrelated to this branch**, verified by running them at the branch base where they fail identically. They need a backing filesystem supporting `name_to_handle_at`, which the local container's virtiofs build tree does not provide.
