### PR TITLE
io_uring: decide a read's EOF once both of its completions have landed

### DIFF
--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -867,11 +867,10 @@ chimera_io_uring_reap(
                             chimera_linux_statx_to_attr(&request->read.r_attr, stx);
                         }
 
-                        if (request->status == CHIMERA_VFS_OK) {
-                            request->read.r_eof =
-                                (request->read.length > 0 &&
-                                 request->read.offset + request->read.r_length >= stx->stx_size);
-                        }
+                        /* r_eof is NOT computed here.  It needs r_length,
+                         * which the readv slot supplies, and the two CQEs
+                         * complete in either order -- so it is computed once
+                         * both have landed, below the switch. */
                     }
                 }
                 break;
@@ -921,6 +920,33 @@ chimera_io_uring_reap(
         } /* switch */
 
         --request->token_count;
+
+        /* A READ answers from two SQEs -- the readv and a statx companion --
+         * and they complete in either order.  Only the readv knows how many
+         * bytes came back, and only the statx knows where the file ends, so
+         * whether this read reached EOF is not decidable until BOTH have
+         * landed: computing it in either handler makes the answer depend on
+         * which CQE won the race.  It did -- a read ending exactly at EOF fell
+         * back to the readv's "a short read means EOF", which is false for a
+         * full read, whenever the statx completed first.
+         *
+         * Decide it here, where the last CQE of the pair has been accounted
+         * for.  stx_mask is the validity flag: it is cleared before the statx
+         * is submitted and the kernel sets the bits it filled in, so an unset
+         * STATX_SIZE means the companion failed and the readv's fallback
+         * stands. */
+        if (request->token_count == 0 &&
+            request->opcode == CHIMERA_VFS_OP_READ &&
+            request->status == CHIMERA_VFS_OK &&
+            request->read.length > 0) {
+            struct statx *read_stx = (struct statx *) request->plugin_data;
+
+            if (read_stx->stx_mask & STATX_SIZE) {
+                request->read.r_eof =
+                    request->read.offset + request->read.r_length >=
+                    read_stx->stx_size;
+            }
+        }
 
         if (request->token_count == 0) {
             if (request->opcode == CHIMERA_VFS_OP_OPEN_AT ||
@@ -2081,6 +2107,13 @@ chimera_io_uring_read(
     fd = (int) request->read.handle->vfs_private;
 
     io_uring_prep_readv(sqe, fd, iov, i, request->read.offset);
+
+    /* Cleared so the completion side can tell a filled-in statx from an
+     * untouched one: the kernel sets stx_mask to the fields it returned, and
+     * the r_eof decision keys off STATX_SIZE being present.  The buffer is
+     * pooled scratch, so without this it would carry a previous request's mask
+     * (and size) into that test. */
+    stx->stx_mask = 0;
 
     sqe = chimera_io_uring_get_sqe(thread, request, 1, 0);
     io_uring_prep_statx(sqe, fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,


### PR DESCRIPTION
Fixes the merge-queue flake that failed #1611's first queue attempt: `chimera/server/nfs/mbt/batch_io_uring`, `nfs3/step_128_9`, `MISMATCH: eof: expected 1, got 0`.

## The race

An io_uring READ is two SQEs — the readv and a statx companion — and their CQEs complete in either order. Only the readv knows how many bytes came back; only the statx knows where the file ends. Whether the read reached EOF needs **both**, but it was being answered twice, once in each handler:

* the readv slot set `r_eof = (cqe->res < request->read.length)` — the "a short read means EOF" fallback;
* the statx slot overwrote it with the real test, `offset + r_length >= stx_size`, guarded on the request already being `OK`.

So which answer survived depended on which CQE won. When the statx completed **first**, `r_length` was still 0 and the status guard did not hold, so the refinement was skipped and the readv's fallback stood — and that fallback is wrong for a read ending exactly at EOF, because such a read is not short. A READ of 2 bytes at offset 3 of a 5-byte file answered `eof=0` where NFS3 requires `eof=1`.

The comment on the neighbouring EINVAL branch already knew the ordering was unspecified — *"the two CQEs complete in either order, so the statx slot may already have run"* — the eof computation had simply not been held to it.

## The fix

Compute it once, where the second of the two CQEs is accounted for (`token_count == 0`), from both inputs.

`stx_mask` is the validity flag: it is cleared before the statx is submitted — the scratch buffer is pooled, so it would otherwise carry a previous request's mask and size — and the kernel sets the bits it filled in, so an absent `STATX_SIZE` means the companion failed and the readv's fallback stands exactly as before.

## Reproduction and verification

The race needs contention, which is why a single trace replayed alone never shows it (0/40) and why CI only hits it occasionally at `ctest -j 32`:

| | eof mismatch |
|---|---|
| unfixed, 8-way parallel batch runs | **1 / 32** |
| fixed, 8-way parallel batch runs | **0 / 64** |

Run in a privileged container against a real ext4 loopback (the passthrough backends need `name_to_handle_at`, which neither overlayfs nor the bind-mounted worktree provides).

With that scratch in place the whole passthrough set passes, this fix included — `nfs/mbt/{batch,deviation_probe}_{linux,io_uring}` and `posix/mbt/batch_{linux,io_uring,nfs3_linux,nfs4_linux,nfs3_io_uring,nfs4_io_uring}`, 10/10. `make syntax-check` is clean.

## Scope

This is one of **two** distinct pre-existing flakes seen in #1611's queue attempts; neither is caused by that PR, whose diff is confined to `src/server/smb/tests/`. The other is a libevpl fatal — `failed to ring doorbell (fd -1): errno=9 (Bad file descriptor)` at `doorbell.c:79`, aborting `chimera/posix/mbt/batch_nfs3_linux` — a teardown race that is being investigated separately.
