### PR TITLE
smb: pin the client's dialect with vers=, and cover the whole matrix

### DIFF
--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -49,6 +49,36 @@ set_tests_properties(chimera/posix/smb/loopback_probe PROPERTIES
     LABELS "quint;posix_mbt;memfs;smb_mbt"
     TIMEOUT 300)
 
+# The same probe once per SMB dialect the client can carry.  Without a pinned
+# vers= the server selects the highest dialect in common, which against our own
+# server is always 3.1.1 -- so 2.1, 3.0 and 3.0.2 were dead code in practice no
+# matter how many tests ran.  Pinning is the only way to reach them.
+#
+# A pinned mount offers exactly ONE dialect, so a mount that comes up is proof
+# the connection is speaking that dialect: the server can only select the one
+# offered or fail to find one in common.  There is no readback to trust.
+foreach(vers 2.1 3.0 3.0.2 3.1.1)
+    add_test(NAME chimera/posix/smb/loopback_probe_${vers}
+        COMMAND $<TARGET_FILE:smb_loopback_probe> ${vers})
+    set_tests_properties(chimera/posix/smb/loopback_probe_${vers} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb_loopback_probe_${vers}"
+        LABELS "quint;posix_mbt;memfs;smb_mbt"
+        TIMEOUT 300)
+endforeach()
+
+# 2.0.2 is the dialect the client does NOT carry: it is absent from
+# CHIMERA_SMB_CLIENT_DIALECTS, and chimera_smb_client_negotiate_reply refuses it
+# outright.  The server does speak it, so this is a real negotiation that the
+# CLIENT declines -- and it is what proves vers= is honoured at all.  A vers=
+# that was silently ignored would negotiate 3.1.1, mount happily, and fail this
+# test.  If 2.0.2 support is ever added, this test starts failing and says so.
+add_test(NAME chimera/posix/smb/loopback_dialect_refused_2.0.2
+    COMMAND $<TARGET_FILE:smb_loopback_probe> 2.0.2 expect-mount-failure)
+set_tests_properties(chimera/posix/smb/loopback_dialect_refused_2.0.2 PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=smb_loopback_refused_2.0.2"
+    LABELS "quint;posix_mbt;memfs;smb_mbt"
+    TIMEOUT 300)
+
 if(NOT SPECS_BUNDLE_AVAILABLE)
     message(STATUS "posix MBT replay ctest skipped (no specs trace corpus)")
     return()

--- a/src/posix/tests/quint/posix_driver.c
+++ b/src/posix/tests/quint/posix_driver.c
@@ -68,6 +68,13 @@
 #define SMB_LOOPBACK_OPTS \
         "user=root,password=" CHIMERA_TEST_USER_SMBPASSWD ",domain=WORKGROUP"
 
+/* Dialect to pin the SMB loopback mount to (a vers= value: "2.1", "3.0",
+ * "3.0.2", "3.1.1", ...), or NULL to offer the client's full set and let the
+ * server select -- which always lands on the highest it speaks.  A caller sets
+ * this BEFORE posix_env_setup; smb_loopback_probe drives it from argv so one
+ * binary covers the whole dialect matrix. */
+static const char                *g_smb_vers;
+
 static struct chimera_vfs_cred    driver_creds[MAX_PIDS];
 static mode_t                     driver_umasks[MAX_PIDS];
 static CHIMERA_DIR               *driver_dirs[MAX_DIRS];
@@ -127,6 +134,22 @@ pt_rm_cb(
     (void) ftw;
     return (type == FTW_DP ? rmdir(path) : unlink(path));
 } /* pt_rm_cb */
+
+/* Build the SMB loopback's mount option string, appending the pinned dialect
+ * when one was requested.  Shared by the initial mount and the newfs remount so
+ * a recycled mount cannot silently drop back to the negotiated default. */
+static const char *
+smb_mount_options(
+    char  *buf,
+    size_t cap)
+{
+    if (g_smb_vers) {
+        snprintf(buf, cap, "%s,vers=%s", SMB_LOOPBACK_OPTS, g_smb_vers);
+    } else {
+        snprintf(buf, cap, "%s", SMB_LOOPBACK_OPTS);
+    }
+    return buf;
+} /* smb_mount_options */
 
 /* Recursively remove a passthrough backing tree.  Space on the scratch
  * filesystem is a real budget (CI roots it on a shared volume), so the old
@@ -1018,6 +1041,7 @@ handle(json_t *req)
              * protocol server's own cached open handles, so both get the same
              * bounded retry (5s ceiling). */
             char mount_options[64];
+            char smb_options[192];
             int  rc;
             int  tries = 0;
 
@@ -1116,9 +1140,10 @@ handle(json_t *req)
                             rc);
                     return res_int(-1, chimera_posix_errno_from_status(rc));
                 }
-                if (chimera_posix_mount_with_options("/test", "smb",
-                                                     SMB_LOOPBACK_PATH,
-                                                     SMB_LOOPBACK_OPTS) != 0) {
+                if (chimera_posix_mount_with_options(
+                        "/test", "smb", SMB_LOOPBACK_PATH,
+                        smb_mount_options(smb_options,
+                                          sizeof(smb_options))) != 0) {
                     fprintf(stderr,
                             "posix_driver: newfs smb remount failed: %s\n",
                             strerror(errno));
@@ -1229,6 +1254,27 @@ handle(json_t *req)
 
     return res_int(-1, ENOSYS);
 } /* handle */
+
+/* Unwind a loopback bring-up that got as far as a running server and client but
+ * failed to mount.  Both sides own evpl thread pools, and returning with those
+ * threads live races process teardown: they keep entering evpl_run while the
+ * global evpl state under them is destroyed, which SIGSEGVs in evpl_now_ticks
+ * about one run in five.  A caller whose RESULT is "the mount was refused" --
+ * the vers= dialect matrix does exactly that -- would flake on it.
+ *
+ * The server is destroyed first: its threads are the ones that crash, and the
+ * client shutdown is what pulls the shared evpl state out from under them. */
+static void
+posix_env_setup_unwind(
+    struct chimera_server     *server,
+    struct prometheus_metrics *metrics)
+{
+    if (server) {
+        chimera_server_destroy(server);
+    }
+    chimera_posix_shutdown();
+    prometheus_metrics_destroy(metrics);
+} /* posix_env_setup_unwind */
 
 /* Bring up the chimera POSIX client (plus an in-process loopback NFS server
  * for the nfs3_/nfs4_ backends), create and mount fs0, and normalize the root
@@ -1386,6 +1432,7 @@ posix_env_setup(
          * harnesses. */
         struct chimera_server_config *server_config;
         char                          mount_options[64];
+        char                          smb_options[192];
 
         chimera_client_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
         if (smb) {
@@ -1492,11 +1539,13 @@ posix_env_setup(
         }
 
         if (smb) {
-            if (chimera_posix_mount_with_options("/test", "smb",
-                                                 SMB_LOOPBACK_PATH,
-                                                 SMB_LOOPBACK_OPTS) != 0) {
+            if (chimera_posix_mount_with_options(
+                    "/test", "smb", SMB_LOOPBACK_PATH,
+                    smb_mount_options(smb_options,
+                                      sizeof(smb_options))) != 0) {
                 fprintf(stderr, "posix_driver: smb mount failed: %s\n",
                         strerror(errno));
+                posix_env_setup_unwind(server, metrics);
                 return 1;
             }
         } else {
@@ -1507,6 +1556,7 @@ posix_env_setup(
                                                  mount_options) != 0) {
                 fprintf(stderr, "posix_driver: nfs%d mount failed\n",
                         nfs_version);
+                posix_env_setup_unwind(server, metrics);
                 return 1;
             }
         }

--- a/src/posix/tests/quint/smb_loopback_probe.c
+++ b/src/posix/tests/quint/smb_loopback_probe.c
@@ -519,10 +519,23 @@ main(
     int    argc,
     char **argv)
 {
-    json_t *res;
+    const char *vers        = (argc > 1 && argv[1][0]) ? argv[1] : NULL;
+    int         expect_fail = (argc > 2 &&
+                               strcmp(argv[2], "expect-mount-failure") == 0);
+    json_t     *res;
 
-    (void) argc;
-    (void) argv;
+    /* Optional argv[1] pins the mount's dialect (a vers= value).  With no
+     * argument the client offers its whole set and the server selects, which
+     * against a current server is always the highest -- so the older dialects
+     * are only ever reached by naming them.
+     *
+     * A pinned mount offers exactly one dialect, so the server can only select
+     * that one or fail to find a dialect in common.  A mount that comes up is
+     * therefore PROOF the connection is speaking the requested dialect -- there
+     * is no readback to trust, and a vers= that was quietly ignored would have
+     * negotiated 3.1.1 and shown up as the expect-mount-failure case passing
+     * when it should not. */
+    g_smb_vers = vers;
 
     /* Clean result stream: chimera logs go to stderr (fd 1 -> stderr), our
      * output to the saved stdout -- the same three steps posix_mbt_replay.c
@@ -542,9 +555,26 @@ main(
     }
 
     if (posix_env_setup("smb_memfs", NULL) != 0) {
-        fprintf(stderr, "smb_loopback_probe: SMB loopback setup failed\n");
+        if (expect_fail) {
+            printf("smb_loopback_probe: vers=%s refused the mount, as expected\n",
+                   vers);
+            return 0;
+        }
+        fprintf(stderr, "smb_loopback_probe: SMB loopback setup failed (vers=%s)\n",
+                vers ? vers : "<negotiated>");
         return 1;
     }
+
+    if (expect_fail) {
+        fprintf(stderr,
+                "smb_loopback_probe: vers=%s mounted, but this dialect is not "
+                "one the client can carry -- either it gained support (update "
+                "the test) or vers= was ignored\n", vers);
+        return 1;
+    }
+
+    fprintf(stderr, "smb_loopback_probe: mounted with vers=%s\n",
+            vers ? vers : "<negotiated>");
 
     probe_working_surface();
     probe_pin_readdir();

--- a/src/vfs/smb/smb_internal.h
+++ b/src/vfs/smb/smb_internal.h
@@ -142,6 +142,13 @@ struct chimera_smb_client_server {
     char                  password[256];
     uint16_t              port;
 
+    /* Dialect pinned by the mount's vers= option, or 0 to offer the full
+     * CHIMERA_SMB_CLIENT_DIALECTS set and take whatever the server selects.
+     * Pinning is what makes the sub-3.1.1 paths reachable at all: the server
+     * always picks the highest dialect in common, so an unpinned mount against
+     * a modern server never negotiates anything but 3.1.1. */
+    uint16_t              forced_dialect;
+
     struct evpl_endpoint *endpoint;
 
     /* Shared session state, written once by the mount handshake. */

--- a/src/vfs/smb/smb_mount.c
+++ b/src/vfs/smb/smb_mount.c
@@ -542,8 +542,11 @@ chimera_smb_client_append_neg_context(
 void
 chimera_smb_client_conn_on_connected(struct chimera_smb_client_conn *conn)
 {
-    static const uint16_t    dialects[CHIMERA_SMB_CLIENT_NUM_DIALECTS] =
+    static const uint16_t    all_dialects[CHIMERA_SMB_CLIENT_NUM_DIALECTS] =
         CHIMERA_SMB_CLIENT_DIALECTS;
+    const uint16_t          *dialects = all_dialects;
+    uint16_t                 pinned;
+    int                      num_dialects = CHIMERA_SMB_CLIENT_NUM_DIALECTS;
     struct evpl_iovec        iov;
     struct evpl_iovec_cursor cursor;
     struct smb2_header      *hdr;
@@ -552,7 +555,26 @@ chimera_smb_client_conn_on_connected(struct chimera_smb_client_conn *conn)
     uint8_t                  signing_ctx[2 + 2 * 2];
     int                      ctx_offset_pos, ctx_count_pos;
     int                      ctx_offset, msg_len;
+    int                      send_contexts;
     int                      i;
+
+    /* A pinned mount (vers=) offers that dialect alone, so the server's
+     * "highest in common" selection can only land there. */
+    if (conn->server->forced_dialect) {
+        pinned       = conn->server->forced_dialect;
+        dialects     = &pinned;
+        num_dialects = 1;
+    }
+
+    /* Negotiate contexts exist only from 3.1.1; sending them while offering an
+     * older dialect is a protocol error, and the reply parser only consumes
+     * them for 3.1.1 anyway. */
+    send_contexts = 0;
+    for (i = 0; i < num_dialects; i++) {
+        if (dialects[i] == SMB2_DIALECT_3_1_1) {
+            send_contexts = 1;
+        }
+    }
 
     memset(client_guid, 0, sizeof(client_guid));
 
@@ -564,7 +586,7 @@ chimera_smb_client_conn_on_connected(struct chimera_smb_client_conn *conn)
     conn->negotiated_signing_alg = SMB2_SIGNING_AES_CMAC; /* 3.1.1 default */
 
     evpl_iovec_cursor_append_uint16(&cursor, SMB2_NEGOTIATE_REQUEST_SIZE);
-    evpl_iovec_cursor_append_uint16(&cursor, CHIMERA_SMB_CLIENT_NUM_DIALECTS);
+    evpl_iovec_cursor_append_uint16(&cursor, (uint16_t) num_dialects);
     evpl_iovec_cursor_append_uint16(&cursor, SMB2_SIGNING_ENABLED);
     evpl_iovec_cursor_append_uint16(&cursor, 0); /* Reserved */
     evpl_iovec_cursor_append_uint32(&cursor, 0); /* Capabilities */
@@ -577,8 +599,18 @@ chimera_smb_client_conn_on_connected(struct chimera_smb_client_conn *conn)
     evpl_iovec_cursor_append_uint16(&cursor, 0);
     evpl_iovec_cursor_append_uint16(&cursor, 0); /* Reserved2 */
 
-    for (i = 0; i < CHIMERA_SMB_CLIENT_NUM_DIALECTS; i++) {
+    for (i = 0; i < num_dialects; i++) {
         evpl_iovec_cursor_append_uint16(&cursor, dialects[i]);
+    }
+
+    if (!send_contexts) {
+        /* Pre-3.1.1: no contexts, and the offset/count stay the zeros written
+         * above (Reserved on those dialects). */
+        (void) chimera_smb_client_msg_from_iov(&iov, &cursor, &msg_len);
+        chimera_smb_client_preauth_fold(conn, hdr, msg_len);
+        chimera_smb_client_pdu_finish(conn, &iov, &cursor, conn->mount_request,
+                                      chimera_smb_client_negotiate_reply, NULL);
+        return;
     }
 
     /* 3.1.1 negotiate contexts.  Offset is 8-byte aligned from the SMB2 header;
@@ -619,6 +651,51 @@ chimera_smb_client_conn_on_connected(struct chimera_smb_client_conn *conn)
                                   chimera_smb_client_negotiate_reply, NULL);
 } /* chimera_smb_client_conn_on_connected */
 
+/* Map a vers= mount option to an SMB2 dialect.  Accepts the dotted names an
+ * administrator would write (and mount.cifs accepts) plus a raw 0xNNNN, so a
+ * test matrix can name dialects the same way the specs do.  Returns 0 for an
+ * unrecognized value, which the caller reports as EINVAL rather than quietly
+ * falling back -- a mount that silently ignored vers= would look like it had
+ * tested a dialect it never negotiated. */
+static uint16_t
+chimera_smb_client_parse_vers(const char *vers)
+{
+    static const struct {
+        const char *name;
+        uint16_t    dialect;
+    } table[] = {
+        /* *INDENT-OFF* */
+        /* uncrustify 0.78.1 pushes the closing brace one column further right
+         * on every pass over an aligned initializer table like this, so a
+         * second `make syntax` never matches the first.  Fenced, as the other
+         * aligned tables in the tree are. */
+        { "2.0.2", SMB2_DIALECT_2_0_2 },
+        { "2.1",   SMB2_DIALECT_2_1   },
+        { "3",     SMB2_DIALECT_3_0   },
+        { "3.0",   SMB2_DIALECT_3_0   },
+        { "3.0.2", SMB2_DIALECT_3_0_2 },
+        { "3.02",  SMB2_DIALECT_3_0_2 },
+        { "3.1.1", SMB2_DIALECT_3_1_1 },
+        { "3.11",  SMB2_DIALECT_3_1_1 },
+        /* *INDENT-ON* */
+    };
+    unsigned long raw;
+    char         *end;
+    size_t        i;
+
+    for (i = 0; i < sizeof(table) / sizeof(table[0]); i++) {
+        if (strcmp(vers, table[i].name) == 0) {
+            return table[i].dialect;
+        }
+    }
+
+    raw = strtoul(vers, &end, 0);
+    if (end != vers && *end == '\0' && raw <= UINT16_MAX) {
+        return (uint16_t) raw;
+    }
+    return 0;
+} /* chimera_smb_client_parse_vers */
+
 /* ---- MOUNT entry point ------------------------------------------------- */
 
 void
@@ -630,11 +707,13 @@ chimera_smb_client_mount(
     struct chimera_smb_client_server *server;
     struct chimera_smb_client_conn   *conn;
     const char                       *user, *password, *domain, *port_opt;
+    const char                       *vers_opt;
     char                              host[256];
     char                              share[256];
     const char                       *colon;
     int                               host_len;
     uint16_t                          port;
+    uint16_t                          forced_dialect = 0;
 
     shared->tcp_flavor   = chimera_vfs_request_tcp_flavor(request);
     shared->tcp_protocol = chimera_tcp_flavor_to_protocol(shared->tcp_flavor);
@@ -661,12 +740,24 @@ chimera_smb_client_mount(
     password = chimera_smb_client_get_option(&request->mount.options, "password");
     domain   = chimera_smb_client_get_option(&request->mount.options, "domain");
     port_opt = chimera_smb_client_get_option(&request->mount.options, "port");
+    vers_opt = chimera_smb_client_get_option(&request->mount.options, "vers");
 
     if (!user || !password) {
         chimera_smbclient_error("SMB mount requires user= and password= options");
         request->status = CHIMERA_VFS_EINVAL;
         request->complete(request);
         return;
+    }
+
+    if (vers_opt) {
+        forced_dialect = chimera_smb_client_parse_vers(vers_opt);
+        if (!forced_dialect) {
+            chimera_smbclient_error("SMB mount vers=%s is not a dialect this "
+                                    "client understands", vers_opt);
+            request->status = CHIMERA_VFS_EINVAL;
+            request->complete(request);
+            return;
+        }
     }
 
     port = port_opt ? (uint16_t) atoi(port_opt) : CHIMERA_SMB_CLIENT_PORT;
@@ -685,8 +776,9 @@ chimera_smb_client_mount(
     snprintf(server->domain, sizeof(server->domain), "%s",
              domain ? domain : CHIMERA_SMB_CLIENT_DEFAULT_DOMAIN);
     snprintf(server->password, sizeof(server->password), "%s", password);
-    server->port     = port;
-    server->endpoint = chimera_tcp_flavor_endpoint_create(
+    server->port           = port;
+    server->forced_dialect = forced_dialect;
+    server->endpoint       = chimera_tcp_flavor_endpoint_create(
         shared->tcp_flavor, server->hostname, server->port);
 
     conn = chimera_smb_client_get_conn(thread, server);


### PR DESCRIPTION
## The gap

The SMB client offers every dialect it can carry on every NEGOTIATE, and the
server picks the highest in common. Against our own server that is always
**3.1.1**, verified on the wire:

```
SMB mount established: //127.0.0.1/share (dialect 0x0311, session ..., tree 1)
```

So 2.1, 3.0 and 3.0.2 were unreachable in practice — different signing-key
derivation, different signing algorithms, and a NEGOTIATE with no contexts at
all, none of it ever executed no matter how many tests ran.

To answer the question directly: the client advertises **4 of the 5** dialects
(`CHIMERA_SMB_CLIENT_DIALECTS` = 2.1, 3.0, 3.0.2, 3.1.1). It does **not** carry
2.0.2 — `chimera_smb_client_negotiate_reply` refuses it — though the server
speaks all five. Until this PR, only one of those four had ever been exercised.

## What this adds

`vers=` as a client mount option. A pinned mount offers exactly **one** dialect,
so the server can only select that one or fail to find one in common — a mount
that comes up is *proof* the connection is speaking the dialect asked for, with
no readback to trust.

Two details the pinned path needs:

- negotiate contexts (preauth integrity, signing capabilities) exist only from
  3.1.1; sending them while offering an older dialect is a protocol error, so
  they are emitted only when 3.1.1 is on offer.
- an unrecognized `vers=` is EINVAL, not a silent fallback. A quietly-ignored
  option would come up on 3.1.1 and look like it had tested a dialect it never
  negotiated.

`vers=` accepts the dotted names an administrator would write (`2.1`, `3.0`,
`3.0.2`, `3.1.1`, plus the `3.02`/`3.11` spellings mount.cifs takes) or a raw
`0xNNNN`.

## Results

The loopback probe now runs once per dialect. **All four pass the full probe**,
each verifiably negotiating the dialect named:

| vers= | negotiated | probe |
|---|---|---|
| `2.1` | 0x0210 | pass |
| `3.0` | 0x0300 | pass |
| `3.0.2` | 0x0302 | pass |
| `3.1.1` | 0x0311 | pass |
| `2.0.2` | — | mount refused (expected; client does not carry it) |

`loopback_dialect_refused_2.0.2` is the companion negative and is what proves
`vers=` is honoured at all: an ignored option would negotiate 3.1.1, mount
happily, and fail that test.

Coverage of `src/vfs/smb` from the probe alone, over #1610's single-dialect
baseline: `smb.c` 64% → **71%**, `smb_mount.c` 81% → **82%** — the signing and
no-context negotiate paths.

## A crash the negative test walked into

Building a test whose *result* is "the mount was refused" exposed a shutdown
race in the harness. A failed mount left both the in-process server and the
client holding live evpl thread pools; returning from `posix_env_setup` without
stopping them races process teardown, and those threads keep entering
`evpl_run` while the global evpl state is destroyed underneath:

```
SEGV on unknown address 0x0000000000c8
  #0 evpl_now_ticks evpl_shared.h:70
  #1 evpl_run evpl.c:797
  #2 evpl_thread_function thread.c:109
```

Measured at **2 crashes in 10 runs**. `posix_env_setup_unwind` stops the server
first (its threads are the ones that crash) and then the client: **0 in 20**
after. Worth noting the obvious wrong fix — shutting the *client* down alone
made it deterministic at 20/20, because that is what pulls the shared evpl
state out from under the still-running server threads.

Quick tier: 55/55 green.
