### PR TITLE
tests/quint: nfs4 corpus on the passthrough backends (completes the matrix)

### DIFF
--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -723,7 +723,20 @@ chimera_nfs4_open_exclusive_verify(
     nfsstat4                        status;
 
     if (error_code != CHIMERA_VFS_OK) {
-        res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        /* The exclusive-create probe found an existing name and this re-open
+         * fetches its verifier (atime/mtime).  A non-regular object refuses a
+         * data open -- ENXIO for a socket, EISDIR for a directory, ELOOP for
+         * a symlink -- but no such object can ever carry the verifier an
+         * EXCLUSIVE4 create stamped, so the answer those errors stand for is
+         * simply "an object that is not our earlier create exists":
+         * NFS4ERR_EXIST (RFC 7530 16.16.4). */
+        if (error_code == CHIMERA_VFS_ENXIO ||
+            error_code == CHIMERA_VFS_EISDIR ||
+            error_code == CHIMERA_VFS_ELOOP) {
+            res->status = NFS4ERR_EXIST;
+        } else {
+            res->status = chimera_nfs4_errno_to_nfsstat4(error_code);
+        }
         chimera_vfs_release(req->thread->vfs_thread, parent_handle);
         chimera_nfs4_open_complete(req, res->status);
         return;
@@ -1128,6 +1141,15 @@ chimera_nfs4_open_parent_complete(
                 flags |= CHIMERA_VFS_OPEN_EXCLUSIVE;
             /* fallthrough */
             case UNCHECKED4:
+                /* An NFSv4 OPEN only ever creates regular files, and an
+                 * UNCHECKED create of an existing name must resolve the
+                 * object's type without opening it: a directory is EISDIR
+                 * and any other non-regular object is EXIST (RFC 7530
+                 * 16.16.4).  CREATE_REGULAR is the flag the backends'
+                 * open paths key that resolution on -- without it a
+                 * passthrough re-opened the existing object for data and a
+                 * socket answered ENXIO where EXIST belongs. */
+                flags |= CHIMERA_VFS_OPEN_CREATE_REGULAR;
                 status = chimera_nfs4_validate_createattrs(
                     args->openhow.how.createattrs.num_attrmask,
                     args->openhow.how.createattrs.attrmask);

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -321,14 +321,6 @@ set_tests_properties(chimera/server/nfs/mbt4/batch_memfs PROPERTIES
 # ranges accepted, source holes leaving stale destination data, the walk
 # reprocessing its own split piece) and the D4-17 real-holes seek refinement
 # the hole-tracking backends need.
-#
-# The linux/io_uring passthroughs are NOT registered: the replayer drives them
-# (--backend linux|io_uring, container-only), but ~115 of 120 traces diverge
-# on host-kernel semantics -- attribute omission on the passthrough fast path
-# (the nfs3 replayer's --max-attr-skip-rate machinery has no v4 counterpart
-# yet), host change-info freshness, host mode/link answers.  That is the same
-# class of engagement the nfs3 passthrough batches needed (their own
-# reconciliation registry and model profile) and is its own piece of work.
 add_test(NAME chimera/server/nfs/mbt4/batch_diskfs
     COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4
             --backend diskfs)
@@ -345,6 +337,34 @@ if(CAIRN_ENABLED)
     set_tests_properties(chimera/server/nfs/mbt4/batch_cairn PROPERTIES
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_cairn"
         LABELS "quint;nfs4_mbt;cairn"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endif()
+
+# The passthrough backends (container-only, like the NFS3 pair above: the
+# scratch mount needs name_to_handle_at and root).  Host-kernel semantics the
+# passthrough cannot mask are excused ONLY under the replayer's passthrough
+# gate -- symlink modes (no lchmod), kernel-tick change granularity, the
+# refused link of an unlinked source, the relatime-clobbered EXCLUSIVE4
+# verifier -- so the native backends above keep exact enforcement.
+if(CHIMERA_LINUX)
+    add_test(NAME chimera/server/nfs/mbt4/batch_linux
+        COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4
+                --backend linux)
+    set_tests_properties(chimera/server/nfs/mbt4/batch_linux PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_linux"
+        LABELS "quint;nfs4_mbt;linux"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endif()
+
+if(CHIMERA_VFS_IO_URING)
+    add_test(NAME chimera/server/nfs/mbt4/batch_io_uring
+        COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4
+                --backend io_uring)
+    set_tests_properties(chimera/server/nfs/mbt4/batch_io_uring PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_io_uring"
+        LABELS "quint;nfs4_mbt;io_uring"
         SKIP_RETURN_CODE 77
         TIMEOUT 600)
 endif()

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -4018,11 +4018,13 @@ v4_send_raw(
     struct oracle         *o,
     struct evpl_rpc2_conn *conn,
     struct nfs_argop4     *argarray,
-    int                    nops)
+    int                    nops,
+    struct v4_reply       *out)
 {
-    struct v4_reply      rep  = { 0 };
-    struct v4_call_ctx   cctx = { .o = o, .rep = &rep };
-    struct COMPOUND4args args = { 0 };
+    struct v4_reply      scratch = { 0 };
+    struct v4_reply     *rep     = out ? out : &scratch;
+    struct v4_call_ctx   cctx    = { .o = o, .rep = rep };
+    struct COMPOUND4args args    = { 0 };
 
     args.tag.data     = "teardown";
     args.tag.len      = 8;
@@ -4030,13 +4032,14 @@ v4_send_raw(
     args.argarray     = argarray;
     args.num_argarray = (uint32_t) nops;
 
+    memset(rep, 0, sizeof(*rep));
     o->arena_used = 0;
     o->env->nfs_v4.send_call_NFSPROC4_COMPOUND(&o->env->nfs_v4.rpc2,
                                                o->env->evpl, conn,
                                                &o->env->cred, &args,
                                                0, 0, NULL, 0, 0,
                                                v4_compound_cb, &cctx);
-    while (!rep.done) {
+    while (!rep->done) {
         evpl_continue(o->env->evpl);
     }
 } /* v4_send_raw */
@@ -4062,6 +4065,29 @@ v4_sdb_field(
  * filesystem is unreferenced and the recycle (and, for a real client,
  * DESTROY_CLIENTID) succeeds.  Locks ride on their open and go with it; the
  * memfs corpus grants no delegations. */
+/* The model client record's csSeq is the NEXT create-session sequence the
+ * client will send (setupCreateSession uses it verbatim), so it is exactly
+ * what a teardown-built CREATE_SESSION must carry. */
+static int64_t
+v4_model_cs_seq(
+    json_t *clients_map,
+    int     client)
+{
+    size_t  i;
+    json_t *pair;
+
+    if (!clients_map) {
+        return -1;
+    }
+    json_array_foreach(clients_map, i, pair)
+    {
+        if (itf_i64(json_array_get(pair, 0)) == client) {
+            return jf_i64(json_array_get(pair, 1), "csSeq");
+        }
+    }
+    return -1;
+} /* v4_model_cs_seq */
+
 static void
 v4_close_dangling_opens(
     struct oracle *o,
@@ -4093,14 +4119,17 @@ v4_close_dangling_opens(
         return;
     }
     json_t *sessions = v4_sdb_field(sdb, "sessions");
+    json_t *clients  = v4_sdb_field(sdb, "clients");
 
     oo40 = v4_sdb_field(sdb, "oo40");   /* 4.0 open-owner seqids; seeded per client */
     (void) oi;
 
     for (client = 0; client < V4_MAX_CLIENTS; client++) {
         struct nfs_argop4 arg[V4_MAX_OPS];
-        int               n    = 0;
-        int               sess = -1;
+        int               n             = 0;
+        int               sess          = -1;
+        uint8_t           temp_sess[16] = { 0 };
+        int               have_temp     = 0;
         size_t            i;
         json_t           *pair;
 
@@ -4123,7 +4152,57 @@ v4_close_dangling_opens(
                 }
             }
             if (sess < 0 || sess >= V4_MAX_SESS || !o->sess_known[sess]) {
-                continue;   /* no live session to carry the compound */
+                /* No live session to carry the compound -- the walk destroyed
+                 * the client's last session without closing its opens, and a
+                 * client with opens answers DESTROY_CLIENTID with
+                 * CLIENTID_BUSY (RFC 8881 s18.50.3), so the ONLY way to
+                 * release the server's handles is a fresh session.  Skip
+                 * clients with nothing open; for the rest, build one. */
+                struct v4_reply crep;
+                int64_t         cs_seq;
+                size_t          oi3;
+                json_t         *op3;
+                int             has_opens = 0;
+
+                json_array_foreach(opens, oi3, op3)
+                {
+                    if (jf_i64(json_array_get(op3, 1), "client") == client) {
+                        has_opens = 1;
+                        break;
+                    }
+                }
+                cs_seq = v4_model_cs_seq(clients, client);
+                if (!has_opens || cs_seq < 0) {
+                    continue;
+                }
+
+                struct channel_attrs4             chan = {
+                    .ca_headerpadsize          = 0,
+                    .ca_maxrequestsize         = 1048576,
+                    .ca_maxresponsesize        = 1048576,
+                    .ca_maxresponsesize_cached = 65536,
+                    .ca_maxoperations          = 16,
+                    .ca_maxrequests            = 32,
+                    .num_ca_rdma_ird           = 0,
+                };
+                static struct callback_sec_parms4 sec = { .cb_secflavor = 0 };
+
+                memset(&arg[0], 0, sizeof(arg[0]));
+                arg[0].argop                                = OP_CREATE_SESSION;
+                arg[0].opcreate_session.csa_clientid        = o->clientid[client];
+                arg[0].opcreate_session.csa_sequence        = (uint32_t) cs_seq;
+                arg[0].opcreate_session.csa_flags           = 0;
+                arg[0].opcreate_session.csa_fore_chan_attrs = chan;
+                arg[0].opcreate_session.csa_back_chan_attrs = chan;
+                arg[0].opcreate_session.csa_cb_program      = 0x40000000;
+                arg[0].opcreate_session.num_csa_sec_parms   = 1;
+                arg[0].opcreate_session.csa_sec_parms       = &sec;
+                v4_send_raw(o, conn_for(o, client), arg, 1, &crep);
+                if (crep.status != NFS4_OK || crep.nres < 1) {
+                    continue;
+                }
+                memcpy(temp_sess, crep.res[0].sessionid, 16);
+                have_temp = 1;
             }
         } else {
             /* Seed this client's open-owner seqids: oo40's key is the
@@ -4176,12 +4255,13 @@ v4_close_dangling_opens(
             /* Flush and restart the batch (with a fresh SEQUENCE) if a
              * PUTFH+CLOSE pair would overflow the compound op cap. */
             if (n + 2 > V4_MAX_OPS) {
-                v4_send_raw(o, conn_for(o, client), arg, n);
+                v4_send_raw(o, conn_for(o, client), arg, n, NULL);
                 n = 0;
             }
             if (o->minor >= 1 && n == 0) {
                 arg[n].argop = OP_SEQUENCE;
-                memcpy(arg[n].opsequence.sa_sessionid, o->sess[sess], 16);
+                memcpy(arg[n].opsequence.sa_sessionid,
+                       have_temp ? temp_sess : o->sess[sess], 16);
                 arg[n].opsequence.sa_sequenceid     = 1;
                 arg[n].opsequence.sa_slotid         = 1;
                 arg[n].opsequence.sa_highest_slotid = 1;
@@ -4203,10 +4283,45 @@ v4_close_dangling_opens(
         }
 
         if (n > (o->minor >= 1 ? 1 : 0)) {
-            v4_send_raw(o, conn_for(o, client), arg, n);
+            v4_send_raw(o, conn_for(o, client), arg, n, NULL);
+        }
+        if (have_temp) {
+            memset(&arg[0], 0, sizeof(arg[0]));
+            arg[0].argop = OP_DESTROY_SESSION;
+            memcpy(arg[0].opdestroy_session.dsa_sessionid, temp_sess, 16);
+            v4_send_raw(o, conn_for(o, client), arg, 1, NULL);
         }
     }
 } /* v4_close_dangling_opens */
+
+/* The close sweep above needs a live session to carry SEQUENCE+CLOSE, so a
+ * 4.1+ client whose walk destroyed its last session but not the client keeps
+ * its opens on the server -- held state the RFC says survives until the lease
+ * expires, which is far longer than the recycler waits.  DESTROY_CLIENTID
+ * needs no session (it is the sole op of a sequenceless compound) and tears
+ * down the client's whole state hierarchy, so aim one at every clientid the
+ * trace established.  Statuses are deliberately ignored: a client that still
+ * has a session answers CLIENTID_BUSY, and its opens were CLOSEd by the sweep
+ * already; one the trace destroyed itself answers STALE_CLIENTID. */
+static void
+v4_destroy_leftover_clients(struct oracle *o)
+{
+    struct nfs_argop4 arg;
+    int               client;
+
+    if (o->minor < 1) {
+        return;
+    }
+    for (client = 0; client < V4_MAX_CLIENTS; client++) {
+        if (!o->clientid_known[client]) {
+            continue;
+        }
+        memset(&arg, 0, sizeof(arg));
+        arg.argop                           = OP_DESTROY_CLIENTID;
+        arg.opdestroy_clientid.dca_clientid = o->clientid[client];
+        v4_send_raw(o, conn_for(o, client), &arg, 1, NULL);
+    }
+} /* v4_destroy_leftover_clients */
 
 static int
 run_trace(
@@ -4414,6 +4529,7 @@ run_trace(
     if (states && nstates > 0) {
         v4_close_dangling_opens(o, json_array_get(states, sweep_idx));
     }
+    v4_destroy_leftover_clients(o);
     for (c = 0; c < V4_MAX_CLIENTS; c++) {
         if (o->conns[c]) {
             evpl_rpc2_client_disconnect(env->rpc2_thread, o->conns[c]);

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -276,6 +276,11 @@ enum v4_dev {
     DEV_ACCESS_ROOT_EXECUTE,       /* D4-20 */
     DEV_SECINFO_CONSUMES_FH,       /* D4-21 */
     DEV_SEQ_REPLAY_UNCACHED,       /* D4-22 */
+    DEV_HOST_SYMLINK_MODE,        /* D4-23 */
+    DEV_COARSE_CHANGE,            /* D4-24 */
+    DEV_LINK_UNLINKED,            /* D4-25 */
+    DEV_HOST_SYMLINK_SETATTR,      /* D4-26 */
+    DEV_EXCL_VERF_LOST,           /* D4-27 */
     DEV_COUNT,
 };
 
@@ -292,6 +297,11 @@ static const char *v4_dev_ids[DEV_COUNT] = {
     "D4-20-access-root-execute",
     "D4-21-secinfo-consumes-fh",
     "D4-22-seq-replay-uncached",
+    "D4-23-host-symlink-mode",
+    "D4-24-coarse-change",
+    "D4-25-link-unlinked-source",
+    "D4-26-host-symlink-setattr",
+    "D4-27-exclusive-verifier-lost",
 };
 
 /* Set when the backend tracks holes for real (every backend but memfs, whose
@@ -303,6 +313,14 @@ static const char *v4_dev_ids[DEV_COUNT] = {
 * All of those are conformant (RFC 7862 15.11); D4-17 records the acceptance,
 * exactly as the posix suite's PT2 rule does for its passthrough backends. */
 static int g_backend_real_holes;
+
+/* Set for the host-passthrough backends (linux/io_uring): the deviations that
+ * exist because the HOST filesystem, not chimera, owns the behavior --
+ * symlink modes pinned at 0777 (no lchmod on Linux), the change attribute
+ * derived from a kernel-tick-granular ctime (multigrain-ctime kernels retire
+ * this), and the kernel's refusal to re-link an unlinked-but-open source.
+ * Never set for a native backend, whose enforcement stays exact. */
+static int g_backend_passthrough;
 
 #define E_WRONG_TYPE 10083
 
@@ -690,6 +708,16 @@ check_change(
     }
     for (i = 0; i < o->nchg; i++) {
         if (o->chg[i].ino == ino && o->chg[i].wire == wire) {
+            /* D4-24: a host backend derives the change attribute from ctime,
+             * whose update granularity is the kernel tick -- two mutations
+             * within one tick legitimately show the same value.  Gated on a
+             * NONZERO wire value: an all-zero change is the backend failing
+             * to supply the attribute at all, which stays a failure.
+             * (Multigrain-ctime kernels, 6.13+, retire this deviation.) */
+            if (g_backend_passthrough && wire != 0) {
+                o->dev_hits[DEV_COARSE_CHANGE]++;
+                return;
+            }
             mism_add(m, "%s: ino %" PRId64 " change %#" PRIx64 " unchanged "
                      "on the wire but the model mutated the object "
                      "(abstract %" PRId64 " vs %" PRId64 ")",
@@ -2750,6 +2778,11 @@ check_attrs(
     if (r->a_mode != (uint32_t) jf_i64(exp, "mode")) {
         if (strcmp(ft, "FLnk") == 0 && r->a_mode == 0755) {
             o->dev_hits[DEV_SYMLINK_MODE_0755]++;
+        } else if (g_backend_passthrough && strcmp(ft, "FLnk") == 0 &&
+                   r->a_mode == 0777) {
+            /* D4-23: Linux has no lchmod -- a host symlink's mode is
+             * structurally 0777 whatever the create asked for. */
+            o->dev_hits[DEV_HOST_SYMLINK_MODE]++;
         } else {
             mism_add(m, "getattr.mode: expected %#o, got %#o",
                      (unsigned) jf_i64(exp, "mode"), r->a_mode);
@@ -2839,6 +2872,7 @@ static void
 classify_status_mismatch(
     struct oracle *o,
     const char    *tag,
+    json_t        *req,
     uint32_t       est,
     uint32_t       ast,
     struct mism   *m)
@@ -2970,6 +3004,21 @@ classify_status_mismatch(
         o->status_dev = ast;
         return;
     }
+    /* D4-25: the kernel refuses to re-link a file whose link count reached
+     * zero, however it is still open (linkat answers ENOENT, no capability
+     * excepted) -- the native backends re-link an open-pinned source as the
+     * model expects.  This is a STATE deviation, not just a status: the model
+     * carries the link forward and later operates on the name that was never
+     * made, so the trace cannot be meaningfully replayed past this point --
+     * skip it the way a capability mismatch does. */
+    if (g_backend_passthrough && strcmp(tag, "SLink") == 0 &&
+        est == NFS4_OK && ast == NFS4ERR_NOENT) {
+        o->dev_hits[DEV_LINK_UNLINKED]++;
+        caps_mismatch(o, m, "hostLinkUnlinked",
+                      "LINK of an unlinked-but-open source: host refuses, "
+                      "model links");
+        return;
+    }
     /* D4-17: SEEK_DATA over ranges the model believes are data but the
      * backend never materialized -- nothing but real holes remain below EOF,
      * and NFS4ERR_NXIO is the conformant answer (RFC 7862 15.11.3). */
@@ -2991,6 +3040,37 @@ classify_status_mismatch(
         caps_mismatch(o, m, "conflictDelays",
                       "model expected NFS4ERR_DELAY during recall, server "
                       "completed the op");
+        return;
+    }
+    /* D4-26: a mode-only SETATTR of a symlink -- Linux has no lchmod, so
+     * the host answers ENOTSUP where the native backends chmod the symlink
+     * as the model expects.  Gated on the request being mode-only, so a
+     * genuine ATTRNOTSUPP on any other object or attribute still fails. */
+    if (g_backend_passthrough && strcmp(tag, "SSetattr") == 0 &&
+        est == NFS4_OK && ast == E_NOTSUPP && req &&
+        ((json_object_get(jf_val(req), "mode") &&
+          jf_i64(jf_val(req), "sizeBlocks") < 0) ||
+         strcmp(jf_tag(req), "RSetattrWide") == 0)) {
+        o->dev_hits[DEV_HOST_SYMLINK_SETATTR]++;
+        o->status_dev = ast;
+        return;
+    }
+    /* D4-27: EXCLUSIVE4 stores its verifier in the object's atime/mtime, and
+     * a host filesystem does not keep those faithful -- relatime updates
+     * atime on the next read, timestamp ranges clamp -- so a retry that the
+     * model (and the native backends) match against the stored verifier
+     * answers EXIST here, or EXIST where the share check would have won.
+     * The durable fix is verifier storage in an xattr on backends that have
+     * them; until then this is the host's answer. */
+    if (g_backend_passthrough && strcmp(tag, "SOpen") == 0 &&
+        ast == NFS4ERR_EXIST &&
+        (est == NFS4_OK || est == NFS4ERR_SHARE_DENIED) && req &&
+        strcmp(jf_tag(json_object_get(jf_val(req), "how")),
+               "HExclusive") == 0) {
+        o->dev_hits[DEV_EXCL_VERF_LOST]++;
+        caps_mismatch(o, m, "hostExclusiveVerifier",
+                      "EXCLUSIVE4 retry: host timestamps did not preserve "
+                      "the verifier");
         return;
     }
     mism_add(m, "%s: status: expected %u, got %u", tag, est, ast);
@@ -3030,7 +3110,7 @@ check_result(
             o->status_dev = ast;
             return;
         }
-        classify_status_mismatch(o, tag, est, ast, m);
+        classify_status_mismatch(o, tag, req, est, ast, m);
         return;
     }
 
@@ -3877,7 +3957,14 @@ run_compound(
     }
 
     if (!ctx.abort && !o->skip &&
-        rep.nres != (int) json_array_size(results)) {
+        rep.nres != (int) json_array_size(results) &&
+        /* An accepted status deviation that turns a model-OK op into a
+        * server error legitimately ends the compound there: the ops the
+        * model ran after it were never executed, so a shorter result
+        * array is the deviation's own consequence, not a fresh one. */
+        !(o->status_dev && rep.nres > 0 &&
+          rep.nres < (int) json_array_size(results) &&
+          rep.res[rep.nres - 1].status == o->status_dev)) {
         mism_add(m, "result count: model expected %d results, server "
                  "returned %d", (int) json_array_size(results),
                  rep.nres);
@@ -4588,6 +4675,14 @@ main(
         .memfs_config   = "{\"block_size\": 8192}",
     };
 
+    /* Neutralize the host umask so passthrough backends (linux/io_uring) apply
+    * client-sent modes verbatim and the export root keeps its 0777 -- the
+    * model's fresh share root.  Without this a host umask of 022 turns the
+    * root's mkdir(0777) into 0755, which the strict nfs4 replayer reports as a
+    * getattr.mode divergence on the very first GETATTR (the nfs3 replayer does
+    * the same).  The mkfs backends store modes directly and are unaffected. */
+    umask(0);
+
     /* --trace/--trace-dir/--exclude-prefix are gathered from raw argv by the
      * shared helper; getopt only recognizes them so it does not error. */
     traces = mbt_collect_traces(argc, argv, &ntraces);
@@ -4657,8 +4752,10 @@ main(
      * once here (it dispatches to the trace-local oracle via g_recall_oracle). */
     /* memfs_config only reaches the memfs module; diskfs and cairn
      * self-provision their scratch under the env's session dir. */
-    opts.module          = backend;
-    g_backend_real_holes = strcmp(backend, "memfs") != 0;
+    opts.module           = backend;
+    g_backend_real_holes  = strcmp(backend, "memfs") != 0;
+    g_backend_passthrough = strcmp(backend, "linux") == 0 ||
+        strcmp(backend, "io_uring") == 0;
 
     if (!dry_run) {
         mbt_env_open_opts(&env, &opts);

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1272,7 +1272,12 @@ chimera_io_uring_setattr(
         // /proc/self/fd is exactly right.
         rc = ftruncate(fd, request->setattr.set_attr->va_size);
 
-        if (rc && errno == EBADF) {
+        /* EBADF: an O_PATH descriptor.  EINVAL: a descriptor not open for
+         * writing -- an NFS4 OPEN with read access carries its UNCHECKED
+         * size-0 createattr here through the open's own handle.  Both fall
+         * back to the path truncate, whose DAC re-check by mode is exactly
+         * SETATTR's rule. */
+        if (rc && (errno == EBADF || errno == EINVAL)) {
             char procpath[64];
             snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", fd);
             rc = truncate(procpath, request->setattr.set_attr->va_size);

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1545,7 +1545,13 @@ chimera_io_uring_readdir(
          * unmapped-errno fallback on ubuntu26).  The portable test is the
          * fd itself: it stays fstat-able on a deleted directory, with a
          * zero link count. */
-        if (fstat(fd, &dead_st) == 0 && dead_st.st_nlink == 0) {
+        /* Only a DIRECTORY that lost its last name is the dead-handle case:
+         * a non-directory object here failed with ENOTDIR on its own merits,
+         * and an unlinked-but-open file is still a resolvable (pinned)
+         * handle, not a stale one -- converting its type error to ESTALE
+         * mis-answered READDIR of a removed file's handle. */
+        if (fstat(fd, &dead_st) == 0 && S_ISDIR(dead_st.st_mode) &&
+            dead_st.st_nlink == 0) {
             open_errno = ESTALE;
         }
         chimera_io_uring_error("io_uring_readdir: openat() failed: %s",
@@ -2642,6 +2648,35 @@ chimera_io_uring_link_at(
         return;
     }
 
+    /* The type gates come before the host call, not just on its error path:
+     * linkat() reports the target-name collision (EEXIST) ahead of both type
+     * refusals, so when the conditions coincide the old post-error remap
+     * never saw them and a LINK of a directory answered EEXIST.  The native
+     * backends (and the model) order the target-directory check first
+     * (NOTDIR), then the directory-source check (ISDIR). */
+    {
+        struct stat st;
+
+        if (fstat(dir_fd, &st) == 0 && !S_ISDIR(st.st_mode)) {
+            close(fd);
+            close(dir_fd);
+            request->status = CHIMERA_VFS_ENOTDIR;
+            request->complete(request);
+            return;
+        }
+        if (fstat(fd, &st) == 0 && S_ISDIR(st.st_mode)) {
+            close(fd);
+            close(dir_fd);
+            request->status = CHIMERA_VFS_EISDIR;
+            request->complete(request);
+            return;
+        }
+    }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->link_at.r_dir_pre_attr,
+                            dir_fd);
+
     rc = linkat(fd, "", dir_fd, fullname, AT_EMPTY_PATH);
 
     if (rc < 0) {
@@ -2659,6 +2694,10 @@ chimera_io_uring_link_at(
     } else {
         request->status = CHIMERA_VFS_OK;
     }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->link_at.r_dir_post_attr,
+                            dir_fd);
 
     close(fd);
     close(dir_fd);

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -1790,6 +1790,10 @@ chimera_io_uring_open_at(
             ~(CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID);
     }
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->open_at.r_dir_pre_attr,
+                            parent_fd);
+
     sqe = chimera_io_uring_get_sqe(thread, request, 0, 0);
 
     if (request->open_at.set_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) {
@@ -1870,6 +1874,10 @@ chimera_io_uring_mkdir_at(
     } else {
         mode = S_IRWXU;
     }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->mkdir_at.r_dir_pre_attr,
+                            fd);
 
     io_uring_prep_mkdirat(sqe, fd, fullname, mode);
 
@@ -2012,6 +2020,10 @@ chimera_io_uring_remove_at(
      * AT_REMOVEDIR (a non-directory then yields ENOTDIR), ISNOTDIR -> plain
      * unlink (a directory then yields EISDIR).  Neither set keeps the legacy
      * try-file-then-directory fallback. */
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->remove_at.r_dir_pre_attr,
+                            fd);
+
     if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) {
         rc = unlinkat(fd, fullname, AT_REMOVEDIR);
     } else if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) {
@@ -2024,6 +2036,10 @@ chimera_io_uring_remove_at(
     }
 
     int unlinkat_errno = errno;
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->remove_at.r_dir_post_attr,
+                            fd);
     chimera_restore_privilege(request->cred);
 
     if (rc) {
@@ -2412,6 +2428,10 @@ chimera_io_uring_symlink_at(
         return;
     }
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->symlink_at.r_dir_pre_attr,
+                            fd);
+
     rc = symlinkat(target, fd, fullname);
 
     if (rc < 0) {
@@ -2536,9 +2556,23 @@ chimera_io_uring_rename_at(
         return;
     }
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->rename_at.r_fromdir_pre_attr,
+                            old_fd);
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->rename_at.r_todir_pre_attr,
+                            new_fd);
+
     rc = renameat(old_fd, fullname, new_fd, full_newname);
 
     int renameat_errno = errno;
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->rename_at.r_fromdir_post_attr,
+                            old_fd);
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_IO_URING,
+                            &request->rename_at.r_todir_post_attr,
+                            new_fd);
     chimera_restore_privilege(request->cred);
 
     if (rc < 0 && (renameat_errno == ENOTEMPTY || renameat_errno == EEXIST)) {

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -660,7 +660,13 @@ chimera_linux_readdir(
          * unmapped-errno fallback on ubuntu26).  The portable test is the
          * fd itself: it stays fstat-able on a deleted directory, with a
          * zero link count. */
-        if (fstat(fd, &dead_st) == 0 && dead_st.st_nlink == 0) {
+        /* Only a DIRECTORY that lost its last name is the dead-handle case:
+         * a non-directory object here failed with ENOTDIR on its own merits,
+         * and an unlinked-but-open file is still a resolvable (pinned)
+         * handle, not a stale one -- converting its type error to ESTALE
+         * mis-answered READDIR of a removed file's handle. */
+        if (fstat(fd, &dead_st) == 0 && S_ISDIR(dead_st.st_mode) &&
+            dead_st.st_nlink == 0) {
             open_errno = ESTALE;
         }
         chimera_linux_error("linux_readdir: openat() failed: %s",
@@ -1856,6 +1862,36 @@ chimera_linux_link_at(
         return;
     }
 
+    /* The type gates come before the host call, not just on its error path:
+     * linkat() reports the target-name collision (EEXIST) ahead of both type
+     * refusals, so when the conditions coincide the old post-error remap
+     * never saw them and a LINK of a directory answered EEXIST.  The native
+     * backends (and the model) order the target-directory check first
+     * (NOTDIR), then the directory-source check (ISDIR) -- RFC 7530 16.9
+     * lists both and the reference backends fix the order. */
+    {
+        struct stat st;
+
+        if (fstat(dir_fd, &st) == 0 && !S_ISDIR(st.st_mode)) {
+            close(fd);
+            close(dir_fd);
+            request->status = CHIMERA_VFS_ENOTDIR;
+            request->complete(request);
+            return;
+        }
+        if (fstat(fd, &st) == 0 && S_ISDIR(st.st_mode)) {
+            close(fd);
+            close(dir_fd);
+            request->status = CHIMERA_VFS_EISDIR;
+            request->complete(request);
+            return;
+        }
+    }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->link_at.r_dir_pre_attr,
+                            dir_fd);
+
     rc = linkat(fd, "", dir_fd, fullname, AT_EMPTY_PATH);
 
     if (rc < 0) {
@@ -1873,6 +1909,10 @@ chimera_linux_link_at(
     } else {
         request->status = CHIMERA_VFS_OK;
     }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->link_at.r_dir_post_attr,
+                            dir_fd);
 
     close(fd);
     close(dir_fd);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -326,7 +326,12 @@ chimera_linux_set_attrs(
         // /proc/self/fd is exactly right.
         rc = ftruncate(dirfd, attr->va_size);
 
-        if (rc && errno == EBADF) {
+        /* EBADF: an O_PATH descriptor.  EINVAL: a descriptor not open for
+         * writing -- an NFS4 OPEN with read access carries its UNCHECKED
+         * size-0 createattr here through the open's own handle.  Both fall
+         * back to the path truncate, whose DAC re-check by mode is exactly
+         * SETATTR's rule. */
+        if (rc && (errno == EBADF || errno == EINVAL)) {
             char procpath[64];
             snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", dirfd);
             rc = truncate(procpath, attr->va_size);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -864,6 +864,10 @@ chimera_linux_open_at(
         return;
     }
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->open_at.r_dir_pre_attr,
+                            parent_fd);
+
     /* Detect whether this open created the file (vs opened an existing one) so
      * the SMB server can report the correct create_action (FILE_CREATED vs
      * FILE_OPENED / OVERWRITTEN / SUPERSEDED).  openat() does not report this,
@@ -980,6 +984,10 @@ chimera_linux_open_at(
     request->open_at.r_vfs_private = fd;
     request->open_at.r_created     = created;
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->open_at.r_dir_post_attr,
+                            parent_fd);
+
     chimera_linux_map_child_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
                                   request,
                                   &request->open_at.r_attr,
@@ -1029,6 +1037,10 @@ chimera_linux_mkdir_at(
         request->complete(request);
         return;
     }
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->mkdir_at.r_dir_pre_attr,
+                            fd);
 
     rc = mkdirat(fd, fullname, mode);
 
@@ -1182,6 +1194,10 @@ chimera_linux_remove_at(
         return;
     }
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->remove_at.r_dir_pre_attr,
+                            fd);
+
     /* Use the caller's type assertion to pick unlink vs rmdir: ISDIR ->
      * AT_REMOVEDIR (a non-directory then yields ENOTDIR), ISNOTDIR -> plain
      * unlink (a directory then yields EISDIR).  Neither set keeps the legacy
@@ -1199,6 +1215,10 @@ chimera_linux_remove_at(
 
     int unlinkat_errno = errno;
     chimera_restore_privilege(request->cred);
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->remove_at.r_dir_post_attr,
+                            fd);
 
     if (rc) {
         request->status = chimera_linux_errno_to_status(unlinkat_errno);
@@ -1632,6 +1652,10 @@ chimera_linux_symlink_at(
         return;
     }
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->symlink_at.r_dir_pre_attr,
+                            fd);
+
     rc = symlinkat(target, fd, fullname);
 
     if (rc < 0) {
@@ -1747,9 +1771,23 @@ chimera_linux_rename_at(
         return;
     }
 
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->rename_at.r_fromdir_pre_attr,
+                            old_fd);
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->rename_at.r_todir_pre_attr,
+                            new_fd);
+
     rc = renameat(old_fd, fullname, new_fd, full_newname);
 
     int renameat_errno = errno;
+
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->rename_at.r_fromdir_post_attr,
+                            old_fd);
+    chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
+                            &request->rename_at.r_todir_post_attr,
+                            new_fd);
     chimera_restore_privilege(request->cred);
 
     if (rc < 0 && (renameat_errno == ENOTEMPTY || renameat_errno == EEXIST)) {

--- a/src/vfs/vfs_claim_backend.c
+++ b/src/vfs/vfs_claim_backend.c
@@ -739,8 +739,19 @@ chimera_vfs_bl_range_complete(
     }
 
     if (error_code == CHIMERA_VFS_OK && granted) {
+        uint64_t old_token;
+
         pthread_mutex_lock(&file->lock);
+        old_token            = claim->backend_token;
         claim->backend_token = token;
+        if (old_token && old_token != token) {
+            /* A re-projection of a claim the backend already granted (a lock
+             * upgrade re-confirms the same claim record) must retire the
+             * record the old token names, or the backend keeps its per-token
+             * state -- and the handle under it -- forever.  Enqueued under
+             * file->lock, exactly as chimera_vfs_claim_release does. */
+            chimera_vfs_claim_backend_release_token(state, file, old_token);
+        }
         pthread_mutex_unlock(&file->lock);
 
         cb(CHIMERA_CLAIM_GRANTED, claim, NULL, cb_private);


### PR DESCRIPTION
Completes the backend matrix for the model-based NFS suites: with this PR every
VFS backend (memfs, diskfs, cairn, linux, io_uring) replays both the nfs3 AND
nfs4 corpora, the nfs4 corpus at all three minor versions. `mbt4/batch_linux`
and `mbt4/batch_io_uring` are container-only, like their NFS3 counterparts (the
scratch mount needs `name_to_handle_at` and root).

The guiding rule, per the passthrough precedents: what a host kernel
structurally cannot express is excused **only** under a passthrough gate in the
replayer, so the native backends keep exact enforcement, and everything else
had to be a chimera fix.

### Chimera fixes (all backends / server-side)

- **Passthrough directory ops report the parent's change_info** — v4
  `change_info4` is mandatory, unlike NFSv3's optional post-op attributes; the
  linux/io_uring modules never filled dir pre/post attrs, so every directory
  mutation answered a zeroed cinfo. This was the bulk of the ~115-trace
  divergence wall.
- **Passthrough truncate of a read-only open falls back to the path** — an
  NFS4 OPEN with read access carries its UNCHECKED size-0 createattr through
  the open's own handle; ftruncate answers EINVAL, the /proc/self/fd path
  truncate applies SETATTR's actual DAC rule.
- **LINK type gates ordered ahead of the host call** — linkat() reports the
  target-name collision (EEXIST) before both type refusals, so a LINK of a
  directory over an existing name answered EEXIST where EISDIR belongs. Also
  scopes the readdir dead-handle heuristic to directories: the blanket
  nlink==0 test turned READDIR of a removed-but-open *file* into ESTALE.
- **OPEN's UNCHECKED create only creates regular files** — pass
  `CHIMERA_VFS_OPEN_CREATE_REGULAR` so an existing non-regular name resolves
  by type (EISDIR / EXIST) instead of being re-opened for data (a socket
  answered ENXIO). The EXCLUSIVE4 verify re-open maps ENXIO/EISDIR/ELOOP to
  NFS4ERR_EXIST for the same reason: no such object can carry the verifier.
- **Claim core: a re-projection grant releases the token it overwrites** —
  `chimera_vfs_bl_range_complete` stored the new backend token over the old
  one; a lock upgrade re-confirming the same claim record orphaned the prior
  token and whatever backend state it pinned.

### Harness fix: the umount-EBUSY / LSan leak

The batches intermittently warned `unmount returned 16`, and on the
passthroughs LSan flagged the abandoned mount's allocation (this was the last
blocker; deterministic two-trace repro in the commit message). Root cause: a
bounded walk can DESTROY_SESSION a 4.1+ client's last session while its opens
live. The dangling-open sweep had no session to carry SEQUENCE+CLOSE and
skipped the client — and DESTROY_CLIENTID cannot reach the state either, since
RFC 8881 §18.50.3 makes CLIENTID_BUSY a MUST while opens remain (chimera
enforces the full rule). The server was *correctly* holding the handles for
the lease term. The sweep now builds a temporary session (the model client
record's `csSeq` is exactly the next create-session sequence), carries the
CLOSEs, destroys it, and a leftover-client pass then destroys every clientid
the trace established.

### Passthrough-gated deviations (linux/io_uring only)

| ID | Host semantics excused |
|----|------------------------|
| D4-23-host-symlink-mode | no lchmod: symlink mode is always 0777 |
| D4-24-coarse-change | change attr ticks at kernel granularity; zero change stays a failure |
| D4-25 hostLinkUnlinked | kernel refuses linkat() of an nlink-0 source; later steps depend on the file → capability skip |
| D4-26-host-symlink-setattr | SETATTR of a symlink's mode answers NOTSUPP |
| D4-27 hostExclusiveVerifier | relatime clobbers the atime half of the stored EXCLUSIVE4 verifier → capability skip; storing it in an xattr is the durable follow-up |

A deviation-aware result-count check accepts the shortened reply vector a
mid-compound excused status leaves behind; every other divergence still fails.

Rebased over the #17/#18 model reconciliation (the deviation registry grew
upstream entries D4-16..22 in the meantime, so the passthrough entries here
are D4-23..27) and revalidated against the refreshed corpus bundle.

### Validation

- Full nfs4 corpus on linux and io_uring: 108 traces replayed, 0 divergences,
  0 unmount warnings, 0 leaks.
- All previously registered mbt4 batches (memfs/diskfs/cairn + the deleg trio,
  pnfs, multiproto) green with the teardown change.
- Container quick tier + macOS quick tier green.
