### PR TITLE
smb2: drive CHANGE_NOTIFY from the model, and five fixes it found

### DIFF
--- a/docs/design/smb_change_notify.md
+++ b/docs/design/smb_change_notify.md
@@ -106,6 +106,14 @@ The work spans three layers:
 - **Invalidate** by `(parent_fh, name)` is O(num_shards): forward lookups are common (resolver hot path), invalidations are rare (rename/remove). The fwd-shard is computed from each candidate entry's `fwd_key`, so a single shard's eviction kills both indexes; the invalidator scans all reverse-key shards because it only knows `rev_key = parent_hash ^ name_hash`.
 - Entries are freed via `call_rcu`. Readers use `urcu_memb_read_lock()`.
 
+### Outstanding requests per handle
+
+A handle carries a **FIFO of outstanding requests**, not one. MS-FSA 2.1.5.9 keeps them on `Open.PendingNotifyChanges` and appends; an overlapped client keeps two or three `ReadDirectoryChangesW` calls posted on a directory precisely so there is never a window with none. A change wakes the **oldest**, which drains the ring and completes; the rest stay for the next one. A close, tree disconnect or logoff finishes **all** of them; a `CANCEL` ends exactly the one it names.
+
+Everything else about the handle — the VFS watch, the ring, the overflow and deleted flags — is shared by all of them, so this decides *which request is answered*, not what is observed.
+
+(This was a single slot until the model-based suite was replayed against Samba: a second request was refused `STATUS_INVALID_PARAMETER` citing "MS-SMB2 §3.3.5.10", which is *Receiving an SMB2 CLOSE Request*. CHANGE_NOTIFY is §3.3.5.19 and imposes no such limit.)
+
 ### SMB CHANGE_NOTIFY handler
 
 `chimera_smb_change_notify(request)` in `smb_proc_change_notify.c`:
@@ -154,8 +162,8 @@ The work spans three layers:
 
 - `vfs_proc_mkdir_at`: `DIR_ADDED` on parent.
 - `vfs_proc_remove_at`: `DIR_REMOVED` or `FILE_REMOVED` on parent based on `S_ISDIR(r_removed_attr.va_mode)`. The completion handler strips `MASK_STAT` from `r_removed_attr.va_set_mask` after consuming `va_mode` so the downstream attr-cache insert (keyed by the removed object's FH, which on Linux is identical for all hardlinks to the same inode) does not pollute the cache with the pre-unlink `nlink` value.
-- `vfs_proc_rename_at`:
-  - Intra-dir: single `RENAMED` on the dir, carrying `(new_name, old_name)`. The SMB serializer expands this to a `FILE_ACTION_RENAMED_OLD_NAME` + `FILE_ACTION_RENAMED_NEW_NAME` pair.
+- `vfs_proc_rename_at`: raises `RENAMED` or `RENAMED_DIR` according to the renamed object's type, which the caller supplies via `CHIMERA_VFS_RENAME_SRC_IS_DIR` — only the SMB layer knows it, since the open carries the type and the rename request does not. MS-FSCC 2.7.1 scopes `FILE_NOTIFY_CHANGE_FILE_NAME` to file names "including renaming" and `_DIR_NAME` to directory ones, so a `DIR_NAME` watcher must not be woken because a *file* was renamed. A caller that does not set the flag (every NFS and S3 path) raises `RENAMED`, which both name filters see — the conservative answer for a protocol that cannot tell us.
+  - Intra-dir: a single event on the dir, carrying `(new_name, old_name)`. The SMB serializer expands this to a `FILE_ACTION_RENAMED_OLD_NAME` + `FILE_ACTION_RENAMED_NEW_NAME` pair.
   - Cross-dir: source dir gets `RENAMED(name=NULL, old_name=src)` (serializes as `RENAMED_OLD_NAME` only); dest dir gets `RENAMED(name=dst, old_name=NULL)` (serializes as `RENAMED_NEW_NAME` only). Matches Windows convention. The source-side `name_len==0` triggers a subtree overflow rather than running the resolver (which would otherwise build a leafless relpath).
 - `smb_proc_create`: keyed on what the open actually DID, not on the disposition it asked for (MS-FSA 2.1.5.1) —
   - **created** (`r_created`): `DIR_ADDED` for a directory, `FILE_ADDED | STREAM_NAME` for a regular file (its default `$DATA` stream appears with it).
@@ -215,6 +223,7 @@ Documented in code; load-bearing for safety.
 
 ## Known limitations (documented in code)
 
+- Re-arming a watch with `WATCH_TREE` flipped keeps the buffered events. It used to purge them and raise overflow, on the grounds that a subtree event names its object by a relative path and an exact event by a bare filename, with no per-event tag to tell them apart. That is an argument about our event representation, not the protocol's: nothing mandates a purge, and Samba delivers across the flip. If the names ever do become ambiguous in practice the fix is to tag the events, not to drop a client's changes.
 - Subtree (`WATCH_TREE`) *delivery* is not covered by the model-based suite: the generated namespace is flat, so the flag reaches the server and the subtree registry but no mutation happens below a watched directory. The exact-watch half is covered; the RPL resolver is not, which is most of what remains dark in `vfs_notify.c`.
 - Subtree resolver funnels through `sync_delegation_threads[0]` — perf bottleneck under heavy subtree-watch + mutation load.
 - `chimera_vfs_notify_destroy` blocks indefinitely if a delegation thread wedges (with progress logs); contract documented as "callers must quiesce frontends first."

--- a/docs/design/smb_change_notify.md
+++ b/docs/design/smb_change_notify.md
@@ -157,9 +157,15 @@ The work spans three layers:
 - `vfs_proc_rename_at`:
   - Intra-dir: single `RENAMED` on the dir, carrying `(new_name, old_name)`. The SMB serializer expands this to a `FILE_ACTION_RENAMED_OLD_NAME` + `FILE_ACTION_RENAMED_NEW_NAME` pair.
   - Cross-dir: source dir gets `RENAMED(name=NULL, old_name=src)` (serializes as `RENAMED_OLD_NAME` only); dest dir gets `RENAMED(name=dst, old_name=NULL)` (serializes as `RENAMED_NEW_NAME` only). Matches Windows convention. The source-side `name_len==0` triggers a subtree overflow rather than running the resolver (which would otherwise build a leafless relpath).
-- `smb_proc_create`: `DIR_ADDED` or `FILE_ADDED` based on `S_ISDIR(attr->va_mode)` of the post-create handle, on parent. Fires for `CREATE`, `OPEN_IF`, `OVERWRITE_IF`, `SUPERSEDE` (the create-capable dispositions; can yield spurious ADDED on OPEN_IF + existing file — documented limitation pending `create_action` plumbing through the VFS).
-- `smb_proc_write`: `FILE_MODIFIED` on parent.
-- `smb_proc_set_info` (non-rename path): `ATTRS_CHANGED` on parent.
+- `smb_proc_create`: keyed on what the open actually DID, not on the disposition it asked for (MS-FSA 2.1.5.1) —
+  - **created** (`r_created`): `DIR_ADDED` for a directory, `FILE_ADDED | STREAM_NAME` for a regular file (its default `$DATA` stream appears with it).
+  - **overwritten/superseded** of a name that already existed: `FILE_MODIFIED | SIZE_CHANGED | ATTRS_CHANGED | STREAM_SIZE` — a MODIFIED, not an ADDED.
+  - **opened** an existing file: nothing. Opening a file is not a change to the directory that holds it.
+
+  Reporting `ADDED` for every create-capable disposition (what this did before) is wrong in both directions once a filter is involved: a client watching `FILE_NOTIFY_CHANGE_SIZE` or `_ATTRIBUTES` was told nothing about an overwrite that changed both, and a client watching `FILE_NOTIFY_CHANGE_FILE_NAME` was woken for opens that created nothing. Found by the quint MBT suite.
+- `smb_proc_write`: `FILE_MODIFIED | STREAM_WRITE | STREAM_SIZE` on parent (no dir-lease break — the file's directory-visible metadata settles at close).
+- `smb_proc_close`: `FILE_MODIFIED` on parent for a handle that wrote, which is where that deferred settle lands.
+- `smb_proc_set_info` (non-rename path): the class the info class implies — `SIZE_CHANGED | FILE_MODIFIED | STREAM_SIZE` for EndOfFile, `ATTRS_CHANGED` otherwise.
 
 ### `FILE_NOTIFY_INFORMATION` serializer (`chimera_smb_notify_serialize_events`)
 
@@ -199,11 +205,17 @@ Documented in code; load-bearing for safety.
 
 - **`chimera/server/smb/change_notify_test`** (`src/server/smb/tests/smb_change_notify_test.c`, 16 wire scenarios via libsmb2 against an in-process server, netns-isolated, ~3s, ASAN clean): create/unlink/rename/mkdir/rmdir notify, filter rejects mismatched events, duplicate CHANGE_NOTIFY rejection, tiny `OutputBufferLength` → `NOTIFY_ENUM_DIR`, `OutputBufferLength=0` → `NOTIFY_ENUM_DIR`, compounded CHANGE_NOTIFY rejected, DIR_NAME-only watch receives mkdir/rmdir, cross-dir rename source-side delivers `RENAMED_OLD_NAME` only, cross-dir rename destination-side delivers `RENAMED_NEW_NAME` only, CLOSE while parked → `STATUS_CANCELLED`, broad→narrow filter drops stale ring events.
 
+- **`chimera/server/smb/mbt/batch_memfs`** (quint model-based, quick tier): the `stepNotify` corpus — 8 traces × 400 messages generated from `ext/specs/quint/smb2/smb2_notify.qnt` and replayed by `smb2_mbt_replay.c`. This is the only change-notify coverage in the tier that gates a merge, and it is what took `smb_notify.c` from 1.7% to 84% of lines and `smb_proc_change_notify.c` from 0% to 82%.
+
+  What the model asserts, per message, is both halves of the conversation: the reply to each `CHANGE_NOTIFY` (answered inline with an exact record list, parked behind an async interim, or refused) *and* the set of async completions the message caused on OTHER connections, matched back to the request that parked by AsyncId. An unpredicted completion fails the trace as loudly as a missing one — an extra wakeup means a watcher was told about a change it had filtered out.
+
+  The model carries the two filters separately (the watch's enqueue mask and the request's delivery filter), the exact 16-byte record arithmetic behind `STATUS_NOTIFY_ENUM_DIR`, the sticky-overflow rule and the zero-length-buffer poll that must not set it, the one-outstanding-request rule and the re-aim it performs anyway, and every way a parked request can end (an event, an overflow, a `CANCEL`, the handle going away). The arms the corpus cannot reach — the mid-compound `STATUS_INTERNAL_ERROR`, and everything needing a directory deleted while a watch is on it — are pinned deterministically in `smb2Test.qnt`.
+
 - **Windows interop**: validated against Microsoft FileServer test suite's `test_change_notify.exe` (`10.65.175.24` → `10.65.181.198`): 11/11 BVT scenarios pass. NOTIFY_ENUM_DIR framing also verified at byte level via tcpdump + Wireshark dissection.
 
 ## Known limitations (documented in code)
 
-- Spurious `FILE_ADDED` for `OPEN_IF`/`OVERWRITE_IF`/`SUPERSEDE` + pre-existing file — needs `create_action` plumbed through `chimera_vfs_open_at`.
+- Subtree (`WATCH_TREE`) *delivery* is not covered by the model-based suite: the generated namespace is flat, so the flag reaches the server and the subtree registry but no mutation happens below a watched directory. The exact-watch half is covered; the RPL resolver is not, which is most of what remains dark in `vfs_notify.c`.
 - Subtree resolver funnels through `sync_delegation_threads[0]` — perf bottleneck under heavy subtree-watch + mutation load.
 - `chimera_vfs_notify_destroy` blocks indefinitely if a delegation thread wedges (with progress logs); contract documented as "callers must quiesce frontends first."
 - SMB 3.1.1 signing falls through to AES-CMAC-AES-128 instead of the preauth-integrity-derived key derivation (chimera doesn't yet implement 3.1.1 fully).

--- a/src/server/smb/smb_notify.c
+++ b/src/server/smb/smb_notify.c
@@ -22,6 +22,11 @@ chimera_smb_map_completion_filter(uint32_t cf)
 {
     uint32_t m = 0;
 
+    /* A rename is admitted by the name filter matching the renamed object's
+     * TYPE (MS-FSCC 2.7.1): FILE_NAME covers file name changes "including
+     * renaming", DIR_NAME the same for directories.  Both used to admit the
+     * single RENAMED class, so a client watching directory names was woken
+     * because a FILE was renamed. */
     if (cf & SMB2_NOTIFY_CHANGE_FILE_NAME) {
         m |= CHIMERA_VFS_NOTIFY_FILE_ADDED |
             CHIMERA_VFS_NOTIFY_FILE_REMOVED |
@@ -30,7 +35,7 @@ chimera_smb_map_completion_filter(uint32_t cf)
     if (cf & SMB2_NOTIFY_CHANGE_DIR_NAME) {
         m |= CHIMERA_VFS_NOTIFY_DIR_ADDED |
             CHIMERA_VFS_NOTIFY_DIR_REMOVED |
-            CHIMERA_VFS_NOTIFY_RENAMED;
+            CHIMERA_VFS_NOTIFY_RENAMED_DIR;
     }
     if (cf & SMB2_NOTIFY_CHANGE_ATTRIBUTES) {
         m |= CHIMERA_VFS_NOTIFY_ATTRS_CHANGED;
@@ -241,8 +246,10 @@ chimera_smb_notify_coalesce_events(
     for (i = 0; i < nevents; i++) {
         /* Rename events carry a distinct OLD/NEW pair and are never merged. */
         if (j > 0 &&
-            !(events[i].action & CHIMERA_VFS_NOTIFY_RENAMED) &&
-            !(events[j - 1].action & CHIMERA_VFS_NOTIFY_RENAMED) &&
+            !(events[i].action & (CHIMERA_VFS_NOTIFY_RENAMED |
+                                  CHIMERA_VFS_NOTIFY_RENAMED_DIR)) &&
+            !(events[j - 1].action & (CHIMERA_VFS_NOTIFY_RENAMED |
+                                      CHIMERA_VFS_NOTIFY_RENAMED_DIR)) &&
             chimera_smb_notify_file_action(events[i].action) ==
             chimera_smb_notify_file_action(events[j - 1].action) &&
             events[i].name_len == events[j - 1].name_len &&
@@ -293,7 +300,8 @@ chimera_smb_notify_serialize_events(
         uint8_t                         *event_prev  = prev_entry;
         int                              ok          = 1;
 
-        if (ev->action & CHIMERA_VFS_NOTIFY_RENAMED) {
+        if (ev->action & (CHIMERA_VFS_NOTIFY_RENAMED |
+                          CHIMERA_VFS_NOTIFY_RENAMED_DIR)) {
             /* Produce two records: OLD_NAME + NEW_NAME */
 
             /* OLD_NAME record (using old_name) */
@@ -414,6 +422,64 @@ chimera_smb_notify_send_interim(struct chimera_smb_notify_request *nr)
  * May be called from any thread.  Grabs the pending request and queues
  * it to the SMB thread's doorbell for safe processing.
  * ---------------------------------------------------------------- */
+/* ----------------------------------------------------------------
+ * The watch's outstanding-request queue.  Both helpers require state->lock.
+ * ---------------------------------------------------------------- */
+static int
+chimera_smb_notify_q_contains(
+    const struct chimera_smb_notify_state   *state,
+    const struct chimera_smb_notify_request *nr)
+{
+    const struct chimera_smb_notify_request *cur;
+
+    for (cur = state->q_head; cur; cur = cur->q_next) {
+        if (cur == nr) {
+            return 1;
+        }
+    }
+    return 0;
+} /* chimera_smb_notify_q_contains */
+
+void
+chimera_smb_notify_q_push(
+    struct chimera_smb_notify_state   *state,
+    struct chimera_smb_notify_request *nr)
+{
+    nr->q_next = NULL;
+    if (state->q_tail) {
+        state->q_tail->q_next = nr;
+    } else {
+        state->q_head = nr;
+    }
+    state->q_tail = nr;
+} /* chimera_smb_notify_q_push */
+
+/* Unlink `nr` if it is queued.  Returns 1 when it was, so a caller can use it
+ * as the CLAIM: exactly one path can take a request off the queue, and that
+ * is the path that owns it from then on. */
+static int
+chimera_smb_notify_q_unlink(
+    struct chimera_smb_notify_state   *state,
+    struct chimera_smb_notify_request *nr)
+{
+    struct chimera_smb_notify_request **pp   = &state->q_head;
+    struct chimera_smb_notify_request  *prev = NULL;
+
+    while (*pp) {
+        if (*pp == nr) {
+            *pp = nr->q_next;
+            if (state->q_tail == nr) {
+                state->q_tail = prev;
+            }
+            nr->q_next = NULL;
+            return 1;
+        }
+        prev = *pp;
+        pp   = &(*pp)->q_next;
+    }
+    return 0;
+} /* chimera_smb_notify_q_unlink */
+
 void
 chimera_smb_notify_callback(
     struct chimera_vfs_notify_watch *watch,
@@ -431,7 +497,9 @@ chimera_smb_notify_callback(
      * is no AB-BA deadlock between them. */
     pthread_mutex_lock(&state->lock);
 
-    nr = state->pending;
+    /* The OLDEST outstanding request is the one a change wakes; the rest wait
+     * for the next one. */
+    nr = state->q_head;
     if (nr && !nr->on_ready_queue) {
         thread             = nr->thread;
         nr->on_ready_queue = 1;
@@ -473,8 +541,13 @@ chimera_smb_notify_queue_cleanup(struct chimera_smb_open_file *open_file)
 
     pthread_mutex_lock(&state->lock);
 
-    nr = state->pending;
-    if (nr && !nr->on_ready_queue) {
+    /* EVERY outstanding request, not just the oldest: the handle is going
+     * away, so there will never be another change, and one left queued would
+     * never be answered at all. */
+    for (nr = state->q_head; nr; nr = nr->q_next) {
+        if (nr->on_ready_queue) {
+            continue;
+        }
         thread             = nr->thread;
         nr->cleanup        = 1;
         nr->on_ready_queue = 1;
@@ -540,12 +613,15 @@ chimera_smb_notify_do_send_response(
     pthread_mutex_lock(&state->lock);
 
     /* Bail if close/cancel claimed nr while it was sitting on the ready
-     * queue.  state->pending was either NULL'd or replaced by the time
-     * we got here. */
-    if (state->pending != nr) {
+     * queue: whoever took it off the watch's queue owns it now.
+     *
+     * An EVENT may only answer the oldest outstanding request; a cleanup may
+     * answer any of them, because the handle is going away and all of them
+     * have to be finished. */
+    if (!chimera_smb_notify_q_contains(state, nr) ||
+        (!cleanup && state->q_head != nr)) {
         nr->on_ready_queue = 0;
         pthread_mutex_unlock(&state->lock);
-        chimera_smb_notify_request_free(nr);
         return;
     }
 
@@ -558,9 +634,9 @@ chimera_smb_notify_do_send_response(
     deleted = chimera_vfs_notify_watch_take_deleted(state->watch);
 
     if (nevents == 0 && !overflowed && !cleanup && !deleted) {
-        /* Spurious wakeup — leave nr parked so the next event re-arms
-         * the ready queue via the callback.  Just clear the queued flag.
-         * On the cleanup/deleted paths we must complete the request. */
+        /* Spurious wakeup — leave nr on the watch's queue so the next event
+         * re-arms the ready queue via the callback.  Just clear the queued
+         * flag.  On the cleanup/deleted paths we must complete the request. */
         nr->on_ready_queue = 0;
         pthread_mutex_unlock(&state->lock);
         return;
@@ -590,7 +666,7 @@ chimera_smb_notify_do_send_response(
 
     if (nevents == 0 && !overflowed && !cleanup && !deleted) {
         /* All drained events were filtered out — treat as a spurious
-         * wakeup.  Leave state->pending == nr so the next matching
+         * wakeup.  Leave nr on the watch's queue so the next matching
          * event (which by then will satisfy emit's enqueue-time filter,
          * since watch_update narrowed the mask) rewakes us.  On the
          * cleanup/deleted paths we must still complete the request. */
@@ -607,7 +683,7 @@ chimera_smb_notify_do_send_response(
      * removed from thread->notify_ready and the search is a harmless
      * no-op.  state->lock (outer) -> notify_ready_lock (inner) matches the
      * order taken by chimera_smb_notify_callback. */
-    state->pending = NULL;
+    chimera_smb_notify_q_unlink(state, nr);
     if (nr->on_ready_queue) {
         struct chimera_server_smb_thread   *thread = nr->thread;
         struct chimera_smb_notify_request **pp;
@@ -816,9 +892,8 @@ chimera_smb_notify_claim(struct chimera_smb_notify_request *nr)
 
     pthread_mutex_lock(&state->lock);
 
-    if (state->pending == nr) {
-        state->pending = NULL;
-        owned          = 1;
+    if (chimera_smb_notify_q_unlink(state, nr)) {
+        owned = 1;
     }
 
     if (nr->on_ready_queue) {
@@ -934,22 +1009,30 @@ chimera_smb_notify_close(
         return;
     }
 
-    /* Take a non-owning peek at the outstanding nr — complete_cleanup does
-     * the actual claim under state->lock, which also extracts nr from
-     * thread->notify_ready if a callback already queued it.  This is the
+    /* Take a non-owning peek at the outstanding requests — complete_cleanup
+     * does the actual claim under state->lock, which also extracts each one
+     * from thread->notify_ready if a callback already queued it.  This is the
      * key fix for the "ready-queued notify lost on close" race: the
      * completion path is the only one that can pluck a queued-but-not-yet-
      * dispatched request out of the ready queue.
+     *
+     * EVERY outstanding request, oldest first: the handle is going away, so
+     * one left behind would never be answered.  The peek re-reads the head
+     * each time rather than walking a snapshot, because completing one drops
+     * the lock and can free it.
      *
      * Per MS-SMB2 3.3.4.4, a pending CHANGE_NOTIFY whose handle is closed
      * (or whose tree/session is torn down) completes with
      * STATUS_NOTIFY_CLEANUP, carrying any buffered records — NOT
      * STATUS_CANCELLED, which is reserved for an explicit SMB2 CANCEL. */
-    pthread_mutex_lock(&state->lock);
-    nr = state->pending;
-    pthread_mutex_unlock(&state->lock);
+    for (;;) {
+        pthread_mutex_lock(&state->lock);
+        nr = state->q_head;
+        pthread_mutex_unlock(&state->lock);
 
-    if (nr) {
+        if (!nr) {
+            break;
+        }
         chimera_smb_notify_complete_cleanup(nr, state);
     }
 

--- a/src/server/smb/smb_notify.h
+++ b/src/server/smb/smb_notify.h
@@ -72,6 +72,11 @@ struct chimera_smb_notify_request {
     struct chimera_smb_notify_request *next;          /* parked list linkage */
     struct chimera_smb_notify_request *prev;          /* parked list linkage */
     struct chimera_smb_notify_request *ready_next;    /* doorbell ready queue */
+    /* Linkage on the WATCH's outstanding queue (state->q_head), oldest first.
+     * Distinct from `next`/`prev`, which thread the CONNECTION's parked list:
+     * one request is on both at once, and they are ordered by different
+     * things (arrival on this handle vs arrival on this connection). */
+    struct chimera_smb_notify_request *q_next;
 };
 
 /*
@@ -85,9 +90,26 @@ struct chimera_smb_notify_request {
  * and the freshly-parked request never gets woken up.
  */
 struct chimera_smb_notify_state {
-    pthread_mutex_t                    lock;
-    struct chimera_vfs_notify_watch   *watch;
-    struct chimera_smb_notify_request *pending;  /* parked request, or NULL */
+    pthread_mutex_t                  lock;
+    struct chimera_vfs_notify_watch *watch;
+    /* Outstanding CHANGE_NOTIFY requests on this open, oldest first.
+     *
+     * A QUEUE, not one slot.  MS-FSA 2.1.5.9 keeps a handle's outstanding
+     * requests on Open.PendingNotifyChanges and appends to it, and an
+     * overlapped client relies on that: it keeps two or three
+     * ReadDirectoryChangesW calls posted on a directory precisely so there is
+     * never a window with none, and refusing the second would collapse that
+     * into a watch with gaps.  (This used to be a single slot, and the second
+     * request was refused STATUS_INVALID_PARAMETER citing MS-SMB2 3.3.5.10 --
+     * which is Receiving an SMB2 CLOSE Request.  CHANGE_NOTIFY is 3.3.5.19 and
+     * imposes no such limit; Samba queues, and so does Windows.)
+     *
+     * They are answered FIFO, one delivery cycle each: a change wakes the
+     * OLDEST, which drains the ring and completes; the rest stay for the next
+     * one.  Everything else about the handle -- the VFS watch, the ring, the
+     * overflow and deleted flags -- is shared by all of them. */
+    struct chimera_smb_notify_request *q_head;
+    struct chimera_smb_notify_request *q_tail;
     /* Transient single-threaded linkage used only by tree/session teardown
      * (chimera_smb_tree_free) to collect detached states and tear them down
      * after the open_files bucket lock is released — chimera_smb_notify_close
@@ -177,6 +199,17 @@ chimera_smb_notify_complete_cleanup(
 int
 chimera_smb_notify_queue_cleanup(
     struct chimera_smb_open_file *open_file);
+
+/*
+ * Append a request to the watch's outstanding queue.  Requires state->lock.
+ *
+ * The one enqueue site is the CHANGE_NOTIFY handler, but the linkage lives
+ * here beside the unlink so the two cannot drift apart.
+ */
+void
+chimera_smb_notify_q_push(
+    struct chimera_smb_notify_state   *state,
+    struct chimera_smb_notify_request *nr);
 
 /*
  * Clean up notify state for an open file being closed.

--- a/src/server/smb/smb_proc_change_notify.c
+++ b/src/server/smb/smb_proc_change_notify.c
@@ -68,7 +68,7 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
     struct chimera_smb_notify_request *nr;
     struct chimera_vfs_notify_event    events[16];
     int                                overflowed = 0;
-    int                                nevents;
+    int                                nevents    = 0;
     struct chimera_vfs_notify         *vfs_notify;
 
     /* When change notify is disabled for the server's shares (the Windows
@@ -154,13 +154,14 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
      * no further callback fires until the next event. */
     pthread_mutex_lock(&state->lock);
 
-    /* MS-SMB2 §3.3.5.10: only one CHANGE_NOTIFY may be outstanding per
-     * open.  Reject a duplicate so we do not orphan the prior request. */
-    if (state->pending) {
-        pthread_mutex_unlock(&state->lock);
-        chimera_smb_open_file_release(request, open_file);
-        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
-        return;
+    /* A request already outstanding on this handle owns the ring until it is
+     * answered, so this one parks behind it rather than draining ahead of it.
+     * MS-FSA 2.1.5.9 keeps the requests on a list and serves them in order;
+     * there is no one-at-a-time rule to enforce here (this used to refuse the
+     * second with STATUS_INVALID_PARAMETER, citing MS-SMB2 3.3.5.10 -- which
+     * is Receiving an SMB2 CLOSE Request). */
+    if (state->q_head) {
+        goto park;
     }
 
     nevents = chimera_vfs_notify_drain(state->watch, events, 16, &overflowed);
@@ -257,6 +258,8 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
         return;
     }
 
+ park:
+
     /* No events — about to park the request.
      *
      * A CHANGE_NOTIFY that would go asynchronous inside a multi-command
@@ -341,7 +344,7 @@ chimera_smb_change_notify(struct chimera_smb_request *request)
      * way breaks the watcher if we send it in the clear. */
     chimera_smb_secure_send_snapshot(request, &nr->secure);
 
-    state->pending = nr;
+    chimera_smb_notify_q_push(state, nr);
     pthread_mutex_unlock(&state->lock);
 
     /* Add to connection's parked notify list for CANCEL lookup.

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3193,50 +3193,52 @@ chimera_smb_create_open_finish(
         }
     }
 
-    /* Emit notification on parent directory for any disposition that can
-     * create a new file.  OPEN never creates; CREATE always creates;
-     * OPEN_IF / OVERWRITE_IF / SUPERSEDE may create or may open/truncate
-     * an existing file.  We emit ADDED for all create-capable
-     * dispositions — this can yield a spurious ADDED when an existing
-     * file was opened or truncated, but that is preferable to missing
-     * notifications for newly-created files (Windows CREATE_ALWAYS maps
-     * to OVERWRITE_IF and is the common case).
+    /* What this open reports to watchers of the parent directory (MS-FSA
+     * 2.1.5.1).  Three outcomes, keyed on what the open actually DID rather
+     * than on the disposition it asked for:
      *
-     * Pick FILE_ADDED vs DIR_ADDED based on the result attrs.  A
-     * directory creation (FILE_DIRECTORY_FILE create option) must
-     * emit DIR_ADDED so SMB clients filtering on DIR_NAME only
-     * receive the event. */
-    if (request->create.create_disposition == SMB2_FILE_CREATE        ||
-        request->create.create_disposition == SMB2_FILE_OPEN_IF       ||
-        request->create.create_disposition == SMB2_FILE_OVERWRITE     ||
-        request->create.create_disposition == SMB2_FILE_OVERWRITE_IF  ||
-        request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
-        uint32_t action = request->create.r_is_directory ?
-            CHIMERA_VFS_NOTIFY_DIR_ADDED : CHIMERA_VFS_NOTIFY_FILE_ADDED;
+     *   created      the entry appeared: FILE_ADDED (DIR_ADDED for a
+     *                directory), plus STREAM_NAME for a regular file, whose
+     *                default $DATA stream appears with it (WPTS
+     *                BVT_SMB2Basic_ChangeNotify_ChangeStreamName)
+     *   overwritten  the entry was already there and its data was replaced:
+     *                that is a MODIFIED, not an ADDED, and it changes the
+     *                size and the write time
+     *   opened       nothing.  Opening a file does not change the directory
+     *                that holds it, and a watcher must not be woken for it.
+     *
+     * Reporting ADDED for every create-capable disposition -- what this used
+     * to do, on the grounds that a spurious ADDED beat a missed one -- is
+     * wrong in both directions once a filter is involved: a client watching
+     * FILE_NOTIFY_CHANGE_SIZE or _ATTRIBUTES is told nothing about an
+     * overwrite that changed both (ADDED maps to neither filter), while a
+     * client watching FILE_NOTIFY_CHANGE_FILE_NAME is woken for opens that
+     * created nothing. */
+    {
+        uint32_t action = 0;
 
-        /* Creating/opening a (regular) file's data fork introduces its
-         * $DATA stream into the file's stream namespace, so also raise the
-         * STREAM_NAME class for non-directories.  This lets a watcher that
-         * requested only FILE_NOTIFY_CHANGE_STREAM_NAME observe the stream
-         * appearing (WPTS BVT_SMB2Basic_ChangeNotify_ChangeStreamName). */
-        if (!request->create.r_is_directory) {
-            action |= CHIMERA_VFS_NOTIFY_STREAM_NAME;
+        if (request->create.r_created) {
+            action = request->create.r_is_directory ?
+                CHIMERA_VFS_NOTIFY_DIR_ADDED :
+                (CHIMERA_VFS_NOTIFY_FILE_ADDED |
+                 CHIMERA_VFS_NOTIFY_STREAM_NAME);
+        } else if (request->create.create_disposition == SMB2_FILE_OVERWRITE ||
+                   request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
+                   request->create.create_disposition == SMB2_FILE_SUPERSEDE) {
+            action = CHIMERA_VFS_NOTIFY_FILE_MODIFIED |
+                CHIMERA_VFS_NOTIFY_SIZE_CHANGED |
+                CHIMERA_VFS_NOTIFY_ATTRS_CHANGED |
+                CHIMERA_VFS_NOTIFY_STREAM_SIZE;
         }
 
-        /* A directory read lease must break only when the directory's contents
-         * actually changed — i.e. the file was newly created, or its data was
-         * replaced (OVERWRITE/SUPERSEDE truncate an existing file).  A
-         * create-capable disposition that merely OPENED an existing file
-         * (OPEN_IF on an existing name) changes nothing in the directory, so it
-         * delivers the (conservative) CHANGE_NOTIFY event WITHOUT breaking the
-         * lease — otherwise re-opening a file would spuriously recall the parent
-         * directory lease (smbtorture dirlease.rename re-opens before renaming). */
-        bool content_changed = request->create.r_created ||
-            request->create.create_disposition == SMB2_FILE_OVERWRITE ||
-            request->create.create_disposition == SMB2_FILE_OVERWRITE_IF ||
-            request->create.create_disposition == SMB2_FILE_SUPERSEDE;
-
-        if (content_changed) {
+        /* A directory read lease breaks exactly when there is an event to
+         * raise: the directory's contents changed.  An open that changed
+         * nothing raises nothing and so recalls nothing -- otherwise
+         * re-opening a file would spuriously recall the parent directory lease
+         * (smbtorture dirlease.rename re-opens before renaming), which is why
+         * the previous shape needed a separate break-free emit path for the
+         * opened-an-existing-file case.  With the event gone, so is that path. */
+        if (action) {
             /* Self-exempt the directory lease whose ParentLeaseKey this create
             * supplied: the client creating the file holds (or is updating) that
             * directory's cached view and must not have its own lease broken
@@ -3265,14 +3267,6 @@ chimera_smb_create_open_finish(
                                               NULL, 0,
                                               skip_lo, skip_hi, has_skip);
             }
-        } else {
-            chimera_vfs_notify_emit_nobreak(thread->shared->vfs->vfs_notify,
-                                            request->create.parent_handle->fh,
-                                            request->create.parent_handle->fh_len,
-                                            action,
-                                            request->create.name,
-                                            request->create.name_len,
-                                            NULL, 0);
         }
     }
 

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -10,6 +10,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_procs.h"
 #include "vfs/vfs_release.h"
+#include "vfs/vfs_claim.h"
 
 /* Forward declaration */
 static void chimera_smb_set_info_rename_check_dest_callback(
@@ -17,6 +18,38 @@ static void chimera_smb_set_info_rename_check_dest_callback(
     struct chimera_vfs_attrs *attr,
     struct chimera_vfs_attrs *dir_attr,
     void                     *private_data);
+
+/* The new path a rename gives every open of the file. */
+struct chimera_smb_rename_path {
+    uint32_t parent_fh_len;
+    uint8_t  parent_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t name_len;
+    char     name[SMB_FILENAME_MAX];
+};
+
+static void
+chimera_smb_rename_repath(
+    struct chimera_smb_open_file         *open_file,
+    const struct chimera_smb_rename_path *p)
+{
+    if (p->parent_fh_len > 0) {
+        memcpy(open_file->parent_fh, p->parent_fh, p->parent_fh_len);
+    }
+    open_file->parent_fh_len = p->parent_fh_len;
+    memcpy(open_file->name, p->name, p->name_len);
+    open_file->name[p->name_len] = '\0';
+    open_file->name_len          = p->name_len;
+} /* chimera_smb_rename_repath */
+
+/* Runs under the file state's lock (chimera_vfs_claim_foreach_smb_open), so it
+ * writes fields and nothing else. */
+static void
+chimera_smb_rename_repath_cb(
+    void *smb_open_file,
+    void *private_data)
+{
+    chimera_smb_rename_repath(smb_open_file, private_data);
+} /* chimera_smb_rename_repath_cb */
 
 static void
 chimera_smb_set_info_rename_callback(
@@ -32,28 +65,71 @@ chimera_smb_set_info_rename_callback(
     struct chimera_smb_rename_info *rename_info = &request->set_info.rename_info;
 
     if (!error_code) {
-        /* Release the sharemode entry keyed by the old name before
-         * updating the path, then re-acquire under the new name.
-         * Without this, close would hash the new name and fail to
-         * find the entry registered under the old name, leaking it. */
+        /* Release the sharemode entry keyed by the old name before updating
+         * the path, then re-acquire under the new name below.  Without this,
+         * close would hash the new name and fail to find the entry registered
+         * under the old one, leaking it.
+         *
+         * Only the OPERATING handle is re-keyed, unlike the cached paths
+         * below: nothing calls chimera_smb_sharemode_acquire for a peer any
+         * more -- share arbitration moved to the VFS claim layer -- so a
+         * sibling has no reservation here to move. */
         chimera_smb_sharemode_release(&request->tree->share->sharemode,
                                       open_file);
 
-        /* Update the open file's name and parent to reflect the rename,
-         * so subsequent compound operations (e.g. disposition delete)
-         * use the correct path. */
+        /* A rename renames the FILE, not the handle that asked for it.  Every
+         * open handle carries the file's path as its own (parent_fh, name) --
+         * that pair is the ONLY path the SMB layer keeps, and every later path
+         * operation reads it: the source of the next rename, the remove a
+         * delete-on-close issues, the name in a CHANGE_NOTIFY record.  A
+         * sibling left holding the old name does not merely fail (a rename
+         * through it answers STATUS_OBJECT_NAME_NOT_FOUND for a file that is
+         * plainly there); if another file later takes the old name, that
+         * sibling's delete-on-close unlinks IT.
+         *
+         * So update every open of this file, not just this one.  The claim
+         * layer is where that set lives -- each SMB open registers an ACCESS
+         * claim on the file and points it back at itself -- and it spans
+         * sessions and trees, which the SMB layer's own per-tree open-file
+         * hashes cannot. */
         struct chimera_vfs_open_handle *new_parent = rename_info->new_parent_handle
                                                      ? rename_info->new_parent_handle
                                                      : request->set_info.parent_handle;
+        struct chimera_smb_rename_path  newpath;
+
+        newpath.parent_fh_len = open_file->parent_fh_len;
+        memcpy(newpath.parent_fh, open_file->parent_fh,
+               open_file->parent_fh_len);
 
         if (new_parent) {
-            memcpy(open_file->parent_fh, new_parent->fh, new_parent->fh_len);
-            open_file->parent_fh_len = new_parent->fh_len;
+            newpath.parent_fh_len = new_parent->fh_len;
+            memcpy(newpath.parent_fh, new_parent->fh, new_parent->fh_len);
         }
 
-        memcpy(open_file->name, rename_info->new_name, rename_info->new_name_len);
-        open_file->name[rename_info->new_name_len] = '\0';
-        open_file->name_len                        = rename_info->new_name_len;
+        newpath.name_len = rename_info->new_name_len;
+        memcpy(newpath.name, rename_info->new_name, rename_info->new_name_len);
+        newpath.name[rename_info->new_name_len] = '\0';
+
+        /* The operating handle first and unconditionally: it is the one case
+         * that must be right even if the claim registration is not there to be
+         * walked (a stream open, or a state torn down under us). */
+        chimera_smb_rename_repath(open_file, &newpath);
+
+        chimera_vfs_claim_foreach_smb_open(open_file->share_file_state,
+                                           chimera_smb_rename_repath_cb,
+                                           &newpath);
+
+        /* Re-acquire sharemode entry under the new name */
+        if (open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE &&
+            request->tree->share &&
+            (open_file->desired_access & SMB2_SHAREMODE_ACCESS_MASK)) {
+            chimera_smb_sharemode_acquire(
+                &request->tree->share->sharemode,
+                open_file->parent_fh, open_file->parent_fh_len,
+                open_file->name, open_file->name_len,
+                open_file->desired_access, open_file->share_access,
+                open_file);
+        }
 
         /* Update VFS handle DOC path so close deletes the new name */
         if ((open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DELETE_ON_CLOSE) &&
@@ -68,17 +144,6 @@ chimera_smb_set_info_rename_callback(
                 &request->session_handle->session->cred);
         }
 
-        /* Re-acquire sharemode entry under the new name */
-        if (open_file->type == CHIMERA_SMB_OPEN_FILE_TYPE_FILE &&
-            request->tree->share &&
-            (open_file->desired_access & SMB2_SHAREMODE_ACCESS_MASK)) {
-            chimera_smb_sharemode_acquire(
-                &request->tree->share->sharemode,
-                open_file->parent_fh, open_file->parent_fh_len,
-                open_file->name, open_file->name_len,
-                open_file->desired_access, open_file->share_access,
-                open_file);
-        }
     }
 
     if (request->set_info.parent_handle) {

--- a/src/server/smb/smb_proc_set_info_rename.c
+++ b/src/server/smb/smb_proc_set_info_rename.c
@@ -224,7 +224,11 @@ chimera_smb_set_info_rename_emit(struct chimera_smb_request *request)
         dest_name_len,
         NULL,
         0,
-        0,
+        /* The open carries the object's type, and it is the only layer that
+         * does -- so it is the only one that can tell a file rename from a
+         * directory one for the name filters (MS-FSCC 2.7.1). */
+        (open_file->flags & CHIMERA_SMB_OPEN_FILE_FLAG_DIRECTORY)
+        ? CHIMERA_VFS_RENAME_SRC_IS_DIR : 0,
         0,
         0,
         /* Self-exempt the directory lease named by the operating open's

--- a/src/server/smb/tests/quint/smb2_mbt_common.h
+++ b/src/server/smb/tests/quint/smb2_mbt_common.h
@@ -89,6 +89,7 @@
 #define SMB2_ECHO                               0x000D
 #define SMB2_OPLOCK_BREAK                       0x0012
 #define SMB2_QUERY_DIRECTORY                    0x000E
+#define SMB2_CHANGE_NOTIFY                      0x000F
 
 /* QUERY_DIRECTORY information classes (MS-FSCC 2.4) */
 #define SMB2_FILE_DIRECTORY_INFO_T              0x01
@@ -212,6 +213,10 @@
 #define SMB2_LOCKFLAG_FAIL_IMMEDIATELY          0x00000010u
 
 #define ST_LOCK_NOT_GRANTED                     0xC0000055u
+#define ST_NOTIFY_CLEANUP                       0x0000010Bu
+#define ST_NOTIFY_ENUM_DIR                      0x0000010Cu
+#define ST_DELETE_PENDING                       0xC0000056u
+#define ST_INTERNAL_ERROR                       0xC00000E5u
 #define ST_FILE_LOCK_CONFLICT                   0xC0000054u
 
 #define SMB2_FSCTL_SET_SPARSE                   0x000900C4u
@@ -249,6 +254,38 @@
 
 #define SMB2C_BUFSZ                             (1 << 20) /* per-connection scratch */
 #define SMB2C_MAX_BREAKS                        16
+/* Async CHANGE_NOTIFY completions queued per connection, and records per
+ * completion.  Both are ceilings on what one replay STEP can produce, not on a
+ * trace: the replayer drains the queue after every message.  A step that
+ * overruns either is reported, never silently truncated -- a dropped
+ * completion would read as "the server sent nothing", which is the exact
+ * failure this suite exists to catch. */
+#define SMB2C_MAX_NOTIFY                        32
+#define SMB2C_MAX_NOTIFY_RECS                   16
+
+/* SMB2 CHANGE_NOTIFY (MS-SMB2 2.2.35 / 2.2.36) */
+#define SMB2_CHANGE_NOTIFY_REQ_SIZE             32
+#define SMB2_WATCH_TREE                         0x0001
+
+#define SMB2_NOTIFY_CHANGE_FILE_NAME            0x00000001
+#define SMB2_NOTIFY_CHANGE_DIR_NAME             0x00000002
+#define SMB2_NOTIFY_CHANGE_ATTRIBUTES           0x00000004
+#define SMB2_NOTIFY_CHANGE_SIZE                 0x00000008
+#define SMB2_NOTIFY_CHANGE_LAST_WRITE           0x00000010
+#define SMB2_NOTIFY_CHANGE_LAST_ACCESS          0x00000020
+#define SMB2_NOTIFY_CHANGE_CREATION             0x00000040
+#define SMB2_NOTIFY_CHANGE_EA                   0x00000080
+#define SMB2_NOTIFY_CHANGE_SECURITY             0x00000100
+#define SMB2_NOTIFY_CHANGE_STREAM_NAME          0x00000200
+#define SMB2_NOTIFY_CHANGE_STREAM_SIZE          0x00000400
+#define SMB2_NOTIFY_CHANGE_STREAM_WRITE         0x00000800
+
+/* FILE_ACTION_* (MS-FSCC 2.7.1) */
+#define FILE_ACTION_ADDED                       0x00000001
+#define FILE_ACTION_REMOVED                     0x00000002
+#define FILE_ACTION_MODIFIED                    0x00000003
+#define FILE_ACTION_RENAMED_OLD_NAME            0x00000004
+#define FILE_ACTION_RENAMED_NEW_NAME            0x00000005
 
 /* Little-endian field access (p16/p32/p64, g16/g32/g64) and utf16le live in
  * smb2_mbt_wire.h alongside the protection cryptography that uses them. */
@@ -427,6 +464,34 @@ struct smb2_break {
     int      ack_required;   /* flags & FLAG_ACK_REQUIRED */
 };
 
+/* One FILE_NOTIFY_INFORMATION record (MS-FSCC 2.7.1) as the client reads it. */
+struct smb2_notify_rec {
+    uint32_t action;
+    char     name[64];
+};
+
+/* An ASYNC CHANGE_NOTIFY response: the completion of a request that PARKED.
+ *
+ * It is kept out of the ordinary reply path entirely.  It carries the ASYNC
+ * flag and an AsyncId rather than answering the MessageId anything is waiting
+ * on, it can land at any moment (whenever some OTHER client changes the
+ * watched directory), and there may be several outstanding at once on one
+ * connection.  Promoting one into rbuf would overwrite a reply the caller was
+ * about to parse and would count as "a parked request completed" in the
+ * barrier bookkeeping, which is how a break-driven suite would silently
+ * mistake a notify for a create resuming.
+ *
+ * `async_id` is what ties a completion back to the request that parked: chimera
+ * uses the original MessageId as the AsyncId (smb_proc_change_notify.c), and
+ * the interim response carries the same value, so the replayer records it when
+ * the request parks and matches on it here. */
+struct smb2_notify_msg {
+    uint32_t               status;
+    uint64_t               async_id;
+    int                    nrec;
+    struct smb2_notify_rec rec[SMB2C_MAX_NOTIFY_RECS];
+};
+
 struct smb2_conn {
     struct smb2_env                *env;
     int                             conn_index; /* stable per-env index (ClientGuid seed) */
@@ -495,6 +560,14 @@ struct smb2_conn {
     /* unsolicited oplock/lease break notifications, oldest first */
     struct smb2_break               brk[SMB2C_MAX_BREAKS];
     int                             nbrk;
+
+    /* async CHANGE_NOTIFY completions, oldest first */
+    struct smb2_notify_msg          ntf[SMB2C_MAX_NOTIFY];
+    int                             nntf;
+    /* Completions the queue could not hold.  Counted rather than dropped
+     * silently so an overrun is a reported harness limit, not a phantom
+     * "the server sent nothing". */
+    int                             nntf_lost;
 
     /* ---- wire protection (see smb2_mbt_wire.h) --------------------------
      *
@@ -691,6 +764,95 @@ smb2c_record_break(
     /* any other struct size: not a break we model; ignore */
 } /* smb2c_record_break */
 
+/* Parse an async CHANGE_NOTIFY response into the connection's queue.  `msg`
+ * points at the SMB2 header, `msglen` covers the header and everything after
+ * it.
+ *
+ * A malformed or truncated body is recorded as a completion with ZERO records
+ * rather than being dropped: the status is what most of the assertions turn
+ * on, and a completion that arrives at all is a fact worth reporting even when
+ * its payload does not parse.  The record count then disagrees with the model
+ * and the replayer says so, which is the right failure -- far better than the
+ * completion vanishing and the model being blamed for predicting one. */
+static void
+smb2c_parse_notify(
+    struct smb2_notify_msg *n,
+    const uint8_t          *msg,
+    int                     msglen)
+{
+    uint16_t ssz, data_off;
+    uint32_t data_len;
+    int      p, end;
+
+    if (msglen < SMB2_HDR_SIZE + 8) {
+        return;
+    }
+    ssz = g16(msg, SMB2_HDR_SIZE);
+    if (ssz != 9) {
+        return;
+    }
+    /* OutputBufferOffset is relative to the START OF THE SMB2 HEADER, not to
+     * the body (MS-SMB2 2.2.36), which is why `msg` is the header and not
+     * msg + SMB2_HDR_SIZE. */
+    data_off = g16(msg, SMB2_HDR_SIZE + 2);
+    data_len = g32(msg, SMB2_HDR_SIZE + 4);
+    if (data_len == 0 || data_off < SMB2_HDR_SIZE + 8 ||
+        (int) data_off + (int) data_len > msglen) {
+        return;
+    }
+
+    p   = (int) data_off;
+    end = (int) data_off + (int) data_len;
+
+    while (p + 12 <= end) {
+        uint32_t                next = g32(msg, p);
+        uint32_t                act  = g32(msg, p + 4);
+        uint32_t                nlen = g32(msg, p + 8);
+        struct smb2_notify_rec *r;
+        int                     k = 0;
+
+        if (n->nrec >= SMB2C_MAX_NOTIFY_RECS || p + 12 + (int) nlen > end) {
+            break;
+        }
+        r         = &n->rec[n->nrec++];
+        r->action = act;
+        /* Every name the model draws is one ASCII character, so the UTF-16LE
+        * name is decoded by taking the low byte of each unit.  A name that
+        * needed real decoding would be a corpus the model cannot produce. */
+        for (uint32_t i = 0; i + 1 < nlen && k < (int) sizeof(r->name) - 1;
+             i += 2) {
+            r->name[k++] = (char) msg[p + 12 + i];
+        }
+        r->name[k] = 0;
+
+        if (next == 0) {
+            break;
+        }
+        p += (int) next;
+    }
+} /* smb2c_parse_notify */
+
+static void
+smb2c_record_notify(
+    struct smb2_conn *c,
+    uint32_t          status,
+    uint64_t          async_id,
+    const uint8_t    *msg,
+    int               msglen)
+{
+    struct smb2_notify_msg *n;
+
+    if (c->nntf >= SMB2C_MAX_NOTIFY) {
+        c->nntf_lost++;
+        return;
+    }
+    n = &c->ntf[c->nntf++];
+    memset(n, 0, sizeof(*n));
+    n->status   = status;
+    n->async_id = async_id;
+    smb2c_parse_notify(n, msg, msglen);
+} /* smb2c_record_notify */
+
 static void
 smb2c_notify(
     struct evpl        *evpl,
@@ -790,6 +952,16 @@ smb2c_notify(
                     c->ninterim++;
                     c->interim_pending = 1;
                     c->last_async_id   = g64(c->xbuf + 4, 32);
+                    break;
+                }
+                /* The FINAL response to a parked CHANGE_NOTIFY: an async
+                 * message answering no outstanding MessageId, arriving
+                 * whenever the directory changed -- usually because some other
+                 * connection changed it.  Queue it; it is never a reply. */
+                if (cmd == SMB2_CHANGE_NOTIFY &&
+                    (hflags & SMB2_FLAGS_ASYNC_COMMAND)) {
+                    smb2c_record_notify(c, status, g64(c->xbuf + 4, 32),
+                                        c->xbuf + 4, off - 4);
                     break;
                 }
             }
@@ -1183,6 +1355,40 @@ smb2_conn_pop_break(
     c->nbrk--;
     return 1;
 } /* smb2_conn_pop_break */
+
+/* ---- CHANGE_NOTIFY queue helpers ---------------------------------------- */
+
+static inline int
+smb2_conn_nnotify(struct smb2_conn *c)
+{
+    return c->nntf;
+} /* smb2_conn_nnotify */
+
+/* Take the queued completion whose AsyncId is `async_id`, or NULL.
+ *
+ * Matching by AsyncId rather than by arrival order is what makes the check
+ * exact when several watchers fire at once: the order two connections'
+ * completions reach the client is a scheduling detail, but which REQUEST each
+ * one answers is a protocol fact. */
+static inline int
+smb2_conn_take_notify(
+    struct smb2_conn       *c,
+    uint64_t                async_id,
+    struct smb2_notify_msg *out)
+{
+    for (int i = 0; i < c->nntf; i++) {
+        if (c->ntf[i].async_id != async_id) {
+            continue;
+        }
+        *out = c->ntf[i];
+        for (int j = i + 1; j < c->nntf; j++) {
+            c->ntf[j - 1] = c->ntf[j];
+        }
+        c->nntf--;
+        return 1;
+    }
+    return 0;
+} /* smb2_conn_take_notify */
 
 /* What the harness is currently doing, for the wedge diagnostic.  A caller
  * that has a name for the step (the replayer names the trace and the command)
@@ -1670,7 +1876,8 @@ smb2_event_count(struct smb2_env *env)
         struct smb2_conn *c = env->conns[i];
 
         if (c) {
-            n += c->nbrk + c->ninterim + c->nreply_app;
+            n += c->nbrk + c->ninterim + c->nreply_app + c->nntf +
+                c->nntf_lost;
         }
     }
     return n;
@@ -1731,6 +1938,53 @@ smb2c_xfer(
     smb2c_send(c, body_len);
     return smb2c_wait(c);
 } /* smb2c_xfer */
+
+/* Post a CHANGE_NOTIFY (MS-SMB2 2.2.35).  POSTED, not called: whether the
+ * request answers immediately or parks behind an interim is the outcome under
+ * test, so the caller settles the server and looks, rather than blocking on a
+ * reply that may never come. */
+static inline void
+smb2c_post_change_notify(
+    struct smb2_conn *c,
+    const uint8_t     fid[16],
+    uint16_t          flags,
+    uint32_t          output_buffer_length,
+    uint32_t          completion_filter)
+{
+    int      b    = smb2c_begin(c, SMB2_CHANGE_NOTIFY, 0);
+    uint8_t *body = c->sbuf + b;
+
+    p16(body, 0, SMB2_CHANGE_NOTIFY_REQ_SIZE);
+    p16(body, 2, flags);
+    p32(body, 4, output_buffer_length);
+    memcpy(body + 8, fid, 16);
+    p32(body, 24, completion_filter);
+    p32(body, 28, 0);                 /* Reserved */
+    smb2c_send(c, SMB2_CHANGE_NOTIFY_REQ_SIZE);
+} /* smb2c_post_change_notify */
+
+/* CANCEL the async request identified by `async_id` (MS-SMB2 2.2.30 / 3.2.4.24).
+ *
+ * CANCEL is never answered (3.3.5.17), so this posts and returns; what it
+ * produces is STATUS_CANCELLED on the request it hit, which arrives on the
+ * notify queue like any other completion.  The ASYNC flag is what selects
+ * AsyncId addressing, and on an async header the AsyncId occupies the eight
+ * bytes the sync header spends on Reserved + TreeId (2.2.1.2) -- so it is
+ * written AFTER smb2c_begin has laid down the TreeId it replaces. */
+static inline void
+smb2c_post_cancel_async(
+    struct smb2_conn *c,
+    uint64_t          async_id)
+{
+    int      b    = smb2c_begin(c, SMB2_CANCEL, SMB2_FLAGS_ASYNC_COMMAND);
+    uint8_t *h    = c->sbuf + 4;
+    uint8_t *body = c->sbuf + b;
+
+    p64(h, 32, async_id);
+    p16(body, 0, 4);                  /* StructureSize */
+    p16(body, 2, 0);                  /* Reserved */
+    smb2c_send(c, 4);
+} /* smb2c_post_cancel_async */
 
 /* ---- NEGOTIATE ---------------------------------------------------------- */
 

--- a/src/server/smb/tests/quint/smb2_mbt_replay.c
+++ b/src/server/smb/tests/quint/smb2_mbt_replay.c
@@ -61,40 +61,50 @@
 #define MAX_TREE 512
 #define MAX_FID  4096
 
-static struct smb2_env                  g_env;
+static struct smb2_env   g_env;
 /* The connection a live model session is bound to, NULL once a modeled
  * transport drop has taken it away. */
-static struct smb2_conn                *g_conn_for_sess[MAX_SESS];
+static struct smb2_conn *g_conn_for_sess[MAX_SESS];
 /* Every connection a session was EVER bound to, kept after the drop: a
  * reconnect must present the dropped session's ClientGuid (MS-SMB2 3.3.5.9.7 --
  * chimera refuses a leased or persistent reclaim from a different client), and
  * the model names the client by the session it is reconnecting FOR. */
-static struct smb2_conn                *g_conn_hist[MAX_SESS];
-static uint32_t                         g_wire_tree[MAX_TREE];
-static uint8_t                          g_wire_fid[MAX_FID][16];
+static struct smb2_conn *g_conn_hist[MAX_SESS];
+static uint32_t          g_wire_tree[MAX_TREE];
+static uint8_t           g_wire_fid[MAX_FID][16];
 /* Has this model FileId ever been learned from the wire?  A model fid is never
  * reused, so a SECOND reply carrying one the replayer already knows is the
  * model asserting "this is the same open" -- a replayed CREATE answered from
  * the reply cache, or a reclaim of a parked handle.  The wire FileId must then
  * be byte-identical, which is the exactly-once oracle MS-SMB2 3.3.5.9.10 asks
  * for stated as an assertion rather than a status comparison. */
-static int                              g_fid_known[MAX_FID];
+static int               g_fid_known[MAX_FID];
 /* Which connection owns each model FileId: a break notification for a handle
  * is pushed to the HOLDER's connection, and the acknowledgment must go back on
  * that same connection, so the fid -> conn binding is as load-bearing as the
  * fid -> wire FileId one. */
-static struct smb2_conn                *g_conn_for_fid[MAX_FID];
+static struct smb2_conn *g_conn_for_fid[MAX_FID];
 /* The model lease key (a small int) each handle's grant carries, or -1.  A
  * LEASE_BREAK acknowledgment is keyed by the 16-byte lease key, not by FileId. */
-static int                              g_lease_key_for_fid[MAX_FID];
+static int               g_lease_key_for_fid[MAX_FID];
 /* Which parked handles the replayer has already waited for (see park_barrier). */
-static int                              g_park_barriered[MAX_FID];
-/* The AsyncId of the CHANGE_NOTIFY currently PARKED on each model handle, or
- * 0.  chimera answers a parked notify with an async message carrying the
- * original request's MessageId as its AsyncId, so recording it when the
- * request parks is what lets the completion be matched back to the handle it
- * belongs to -- and what lets a CANCEL name it. */
-static uint64_t                         g_notify_async[MAX_FID];
+static int               g_park_barriered[MAX_FID];
+/* The AsyncIds of the CHANGE_NOTIFY requests outstanding on each model handle,
+ * oldest first.  chimera answers a parked notify with an async message
+ * carrying the original request's MessageId as its AsyncId, so recording it
+ * when the request parks is what lets the completion be matched back to the
+ * request it belongs to -- and what lets a CANCEL name it.
+ *
+ * A LIST, not one id: MS-FSA 2.1.5.9 keeps a handle's outstanding requests on
+ * Open.PendingNotifyChanges and they are answered oldest-first, which is what
+ * the model's `seq` indexes. */
+#define MAX_NOTIFY_Q 8
+static uint64_t                         g_notify_async[MAX_FID][MAX_NOTIFY_Q];
+static int                              g_notify_nq[MAX_FID];
+/* A request an SMB2 CANCEL has already taken off the queue, waiting for its
+* STATUS_CANCELLED completion.  Matched from here rather than by queue
+* position: the cancel removed it, so the positions behind it have moved. */
+static uint64_t                         g_notify_cancelled[MAX_FID];
 /* The model state AFTER the message being replayed -- the `parked` map of which
  * is what tells the disconnect handler which handles the server still owes a
  * park. */
@@ -897,9 +907,30 @@ check_notify_notes(
      * command. */
     settle_breaks();
 
-    for (size_t i = 0; i < n; i++) {
-        json_t                *note   = json_array_get(arr, i);
+    /* Highest queue position first, so retiring one does not renumber those
+     * still to be matched. */
+    for (size_t pass = n; pass > 0; pass--) {
+        json_t *note = NULL;
+        int64_t best = -1;
+
+        for (size_t i = 0; i < n; i++) {
+            json_t *cand = json_array_get(arr, i);
+
+            if (json_object_get(cand, "_done")) {
+                continue;
+            }
+            if (jfield(cand, "seq") > best) {
+                best = jfield(cand, "seq");
+                note = cand;
+            }
+        }
+        if (!note) {
+            break;
+        }
+        json_object_set_new(note, "_done", json_true());
+
         int64_t                fid    = jfield(note, "fid");
+        int64_t                seq    = jfield(note, "seq");
         uint32_t               exp_st = (uint32_t) jfield(note, "st");
         struct smb2_conn      *wc     =
             (fid >= 0 && fid < MAX_FID) ? g_conn_for_fid[fid] : NULL;
@@ -912,18 +943,33 @@ check_notify_notes(
         snprintf(label, sizeof(label), "%s: CHANGE_NOTIFY on fid %lld", what,
                  (long long) fid);
 
-        if (!wc || !g_notify_async[fid]) {
+        uint64_t               aid;
+
+        if (exp_st == ST_CANCELLED) {
+            /* A cancel already took this one off the queue. */
+            aid                     = g_notify_cancelled[fid];
+            g_notify_cancelled[fid] = 0;
+        } else if (seq >= 0 && seq < g_notify_nq[fid]) {
+            aid = g_notify_async[fid][seq];
+            for (int k = (int) seq + 1; k < g_notify_nq[fid]; k++) {
+                g_notify_async[fid][k - 1] = g_notify_async[fid][k];
+            }
+            g_notify_nq[fid]--;
+        } else {
+            aid = 0;
+        }
+
+        if (!wc || !aid) {
             mism("%s: model completed a request the harness never saw park",
                  label);
             continue;
         }
-        if (!smb2_conn_take_notify(wc, g_notify_async[fid], &got)) {
+
+        if (!smb2_conn_take_notify(wc, aid, &got)) {
             mism("%s: model predicted status 0x%08x, the wire sent no "
                  "completion", label, exp_st);
-            g_notify_async[fid] = 0;
             continue;
         }
-        g_notify_async[fid] = 0;
 
         if (got.status != exp_st) {
             if (!dev_status("RNotifyAsync", exp_st, got.status, "notify")) {
@@ -1319,8 +1365,13 @@ do_notify(
 
     if (got_parked) {
         /* Remember the AsyncId: it is how the eventual completion is matched
-         * back to this handle, and how a CANCEL names the request. */
-        g_notify_async[mfid] = c->last_async_id;
+         * back to this request, and how a CANCEL names it.  Appended, because
+         * a handle may carry several outstanding at once and they are answered
+         * in the order they were made. */
+        if (g_notify_nq[mfid] >= MAX_NOTIFY_Q) {
+            slot_overflow("notify queue", g_notify_nq[mfid], MAX_NOTIFY_Q);
+        }
+        g_notify_async[mfid][g_notify_nq[mfid]++] = c->last_async_id;
         if (exp_st != ST_PENDING) {
             mism("CHANGE_NOTIFY fid %lld: parked, but the model's status is "
                  "0x%08x rather than STATUS_PENDING", (long long) mfid, exp_st);
@@ -1367,12 +1418,18 @@ do_cancel(
          * asking the server about a request that does not exist. */
         return;
     }
-    if (mfid < 0 || mfid >= MAX_FID || !g_notify_async[mfid]) {
+    if (mfid < 0 || mfid >= MAX_FID || g_notify_nq[mfid] == 0) {
         mism("CANCEL fid %lld: the model says a request is parked, the harness "
              "never saw one", (long long) mfid);
         return;
     }
-    smb2c_post_cancel_async(c, g_notify_async[mfid]);
+    /* The OLDEST outstanding request, which is the one the model cancels. */
+    g_notify_cancelled[mfid] = g_notify_async[mfid][0];
+    smb2c_post_cancel_async(c, g_notify_cancelled[mfid]);
+    for (int i = 1; i < g_notify_nq[mfid]; i++) {
+        g_notify_async[mfid][i - 1] = g_notify_async[mfid][i];
+    }
+    g_notify_nq[mfid]--;
 } /* do_cancel */
 
 static void
@@ -2309,6 +2366,8 @@ run_trace(
      * parked CHANGE_NOTIFY without a reply when its connection goes (there is
      * nobody left to answer), so no completion crosses a trace boundary. */
     memset(g_notify_async, 0, sizeof(g_notify_async));
+    memset(g_notify_nq, 0, sizeof(g_notify_nq));
+    memset(g_notify_cancelled, 0, sizeof(g_notify_cancelled));
     memset(g_park_pending, 0, sizeof(g_park_pending));
     g_trace       = path;
     g_nmismatch   = 0;

--- a/src/server/smb/tests/quint/smb2_mbt_replay.c
+++ b/src/server/smb/tests/quint/smb2_mbt_replay.c
@@ -89,6 +89,12 @@ static struct smb2_conn                *g_conn_for_fid[MAX_FID];
 static int                              g_lease_key_for_fid[MAX_FID];
 /* Which parked handles the replayer has already waited for (see park_barrier). */
 static int                              g_park_barriered[MAX_FID];
+/* The AsyncId of the CHANGE_NOTIFY currently PARKED on each model handle, or
+ * 0.  chimera answers a parked notify with an async message carrying the
+ * original request's MessageId as its AsyncId, so recording it when the
+ * request parks is what lets the completion be matched back to the handle it
+ * belongs to -- and what lets a CANCEL name it. */
+static uint64_t                         g_notify_async[MAX_FID];
 /* The model state AFTER the message being replayed -- the `parked` map of which
  * is what tells the disconnect handler which handles the server still owes a
  * park. */
@@ -781,6 +787,182 @@ check_no_stray_breaks(const char *what)
     }
 } /* check_no_stray_breaks */
 
+/* ---- CHANGE_NOTIFY ------------------------------------------------------ */
+
+/* The model names CompletionFilter bits (smb2_notify.qnt keeps a set of names
+ * rather than an integer, because the two filter operations it models are set
+ * intersections).  Map them to the wire. */
+static uint32_t
+cf_wire(json_t *cf)
+{
+    /* *INDENT-OFF* */
+    /* uncrustify never converges on an aligned initializer table like this
+     * one -- every pass widens the column by one -- so the alignment is
+     * pinned by hand.  Same guard, same reason, as the dispatch tables
+     * elsewhere in the tree. */
+    static const struct {
+        const char *name;
+        uint32_t    bit;
+    } map[] = {
+        { "fileName",    SMB2_NOTIFY_CHANGE_FILE_NAME    },
+        { "dirName",     SMB2_NOTIFY_CHANGE_DIR_NAME     },
+        { "attributes",  SMB2_NOTIFY_CHANGE_ATTRIBUTES   },
+        { "size",        SMB2_NOTIFY_CHANGE_SIZE         },
+        { "lastWrite",   SMB2_NOTIFY_CHANGE_LAST_WRITE   },
+        { "lastAccess",  SMB2_NOTIFY_CHANGE_LAST_ACCESS  },
+        { "creation",    SMB2_NOTIFY_CHANGE_CREATION     },
+        { "ea",          SMB2_NOTIFY_CHANGE_EA           },
+        { "security",    SMB2_NOTIFY_CHANGE_SECURITY     },
+        { "streamName",  SMB2_NOTIFY_CHANGE_STREAM_NAME  },
+        { "streamSize",  SMB2_NOTIFY_CHANGE_STREAM_SIZE  },
+        { "streamWrite", SMB2_NOTIFY_CHANGE_STREAM_WRITE },
+    };
+    /* *INDENT-ON* */
+    json_t  *arr  = jset(cf);
+    size_t   n    = json_array_size(arr);
+    uint32_t bits = 0;
+
+    for (size_t i = 0; i < n; i++) {
+        const char *nm = json_string_value(json_array_get(arr, i));
+        unsigned    k;
+
+        if (!nm) {
+            continue;
+        }
+        for (k = 0; k < sizeof(map) / sizeof(map[0]); k++) {
+            if (strcmp(nm, map[k].name) == 0) {
+                bits |= map[k].bit;
+                break;
+            }
+        }
+        if (k == sizeof(map) / sizeof(map[0])) {
+            mism("CHANGE_NOTIFY: model asked for unknown filter bit '%s'", nm);
+        }
+    }
+    return bits;
+} /* cf_wire */
+
+/* Compare a list of FILE_NOTIFY_INFORMATION records against the model's.
+ *
+ * Order is asserted, not merely membership: the records describe a SEQUENCE of
+ * changes, and a rename is a two-record pair whose halves would be
+ * indistinguishable from two unrelated renames if order were dropped. */
+static void
+check_notify_recs(
+    const char                   *what,
+    json_t                       *recs,
+    const struct smb2_notify_msg *got)
+{
+    size_t n = json_array_size(recs);
+
+    if ((int) n != got->nrec) {
+        mism("%s: model predicted %d record(s), wire sent %d", what, (int) n,
+             got->nrec);
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        json_t     *r    = json_array_get(recs, i);
+        uint32_t    eact = (uint32_t) jfield(r, "act");
+        const char *enm  = json_string_value(json_object_get(r, "name"));
+
+        if (got->rec[i].action != eact) {
+            mism("%s: record %zu action: model %u wire %u", what, i, eact,
+                 got->rec[i].action);
+        }
+        if (enm && strcmp(enm, got->rec[i].name) != 0) {
+            mism("%s: record %zu name: model '%s' wire '%s'", what, i, enm,
+                 got->rec[i].name);
+        }
+    }
+} /* check_notify_recs */
+
+/* Every async CHANGE_NOTIFY completion this message owed, and no others.
+ *
+ * The model records them on the MESSAGE rather than in any command's reply
+ * because that is where they belong: a completion is an unsolicited message on
+ * the WATCHER's connection, and the watcher is usually not the client whose
+ * command caused it.  Matching is by AsyncId, so which request each completion
+ * answers is checked exactly even when several land at once. */
+static void
+check_notify_notes(
+    json_t     *notes,
+    const char *what)
+{
+    json_t *arr = jset(notes);
+    size_t  n   = json_array_size(arr);
+
+    /* A completion travels the same cross-thread doorbell a break does, so the
+     * same settle applies: after this, a missing completion really is missing
+     * and an unpredicted one is seen here rather than blamed on a later
+     * command. */
+    settle_breaks();
+
+    for (size_t i = 0; i < n; i++) {
+        json_t                *note   = json_array_get(arr, i);
+        int64_t                fid    = jfield(note, "fid");
+        uint32_t               exp_st = (uint32_t) jfield(note, "st");
+        struct smb2_conn      *wc     =
+            (fid >= 0 && fid < MAX_FID) ? g_conn_for_fid[fid] : NULL;
+        struct smb2_notify_msg got;
+        char                   label[96];
+
+        if (fid < 0 || fid >= MAX_FID) {
+            slot_overflow("fid", fid, MAX_FID);
+        }
+        snprintf(label, sizeof(label), "%s: CHANGE_NOTIFY on fid %lld", what,
+                 (long long) fid);
+
+        if (!wc || !g_notify_async[fid]) {
+            mism("%s: model completed a request the harness never saw park",
+                 label);
+            continue;
+        }
+        if (!smb2_conn_take_notify(wc, g_notify_async[fid], &got)) {
+            mism("%s: model predicted status 0x%08x, the wire sent no "
+                 "completion", label, exp_st);
+            g_notify_async[fid] = 0;
+            continue;
+        }
+        g_notify_async[fid] = 0;
+
+        if (got.status != exp_st) {
+            if (!dev_status("RNotifyAsync", exp_st, got.status, "notify")) {
+                mism("%s status: model 0x%08x wire 0x%08x", label, exp_st,
+                     got.status);
+            }
+            continue;
+        }
+        check_notify_recs(label, json_object_get(note, "recs"), &got);
+    }
+} /* check_notify_notes */
+
+/* No connection may hold a CHANGE_NOTIFY completion the model did not predict.
+* An extra completion is as much a bug as a missing one: it means a watcher
+* was woken for a change it had filtered out, or woken twice for one change. */
+static void
+check_no_stray_notifies(const char *what)
+{
+    for (int i = 0; i < g_env.nconns; i++) {
+        struct smb2_conn *c = g_env.conns[i];
+
+        while (c->nntf > 0) {
+            mism("%s: unpredicted CHANGE_NOTIFY completion (status 0x%08x, "
+                 "%d record(s)) on connection %d", what, c->ntf[0].status,
+                 c->ntf[0].nrec, i);
+            for (int k = 1; k < c->nntf; k++) {
+                c->ntf[k - 1] = c->ntf[k];
+            }
+            c->nntf--;
+        }
+        if (c->nntf_lost) {
+            mism("%s: %d CHANGE_NOTIFY completion(s) overran the harness queue "
+                 "(SMB2C_MAX_NOTIFY = %d) on connection %d", what,
+                 c->nntf_lost, SMB2C_MAX_NOTIFY, i);
+            c->nntf_lost = 0;
+        }
+    }
+} /* check_no_stray_notifies */
+
 /* ---- per-command replay + compare --------------------------------------- */
 
 /* Resolve a FidSel (FidRelated -> the current compound's CREATE fid; FidRef k
@@ -800,6 +982,20 @@ resolve_fid(
     }
     return g_wire_fid[k];
 } /* resolve_fid */
+
+/* The MODEL FileId a FidSel names, or -1 for the related-compound form.  The
+ * CHANGE_NOTIFY bookkeeping is keyed by model fid (that is what a completion's
+ * AsyncId is recorded against), so a related-form notify has nothing to key
+ * on -- the corpus never generates one, and this reports it rather than
+ * guessing if that ever changes. */
+static int64_t
+model_fid_of(json_t *sel)
+{
+    if (strcmp(jtag(sel), "FidRelated") == 0) {
+        return -1;
+    }
+    return jint(jval(sel));
+} /* model_fid_of */
 
 /* Effective caching bits the wire granted (0 = none). */
 static int
@@ -1050,6 +1246,134 @@ do_break_ack(
              as_lease ? "lease" : "oplock", (long long) k, exp_st, st);
     }
 } /* do_break_ack */
+
+/* CHANGE_NOTIFY: post it, then wait for whichever of the two answers the
+ * server chose -- the reply to THIS request, or the async interim that says it
+ * parked.  Which one it is IS the assertion: the model's `parked` says the
+ * directory was quiet and the request had to wait, and a server that answered
+ * inline instead has either invented an event or lost one. */
+static void
+do_notify(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    json_t                *sel = json_object_get(v, "fid");
+    const uint8_t         *fid = resolve_fid(sel, related_fid,
+                                             have_related);
+    int64_t                mfid   = model_fid_of(sel);
+    uint32_t               cf     = cf_wire(json_object_get(v, "cf"));
+    uint32_t               obl    = (uint32_t) jfield(v, "obl");
+    uint16_t               wflags = jbool(v, "watchTree") ? SMB2_WATCH_TREE
+                                      : 0;
+    json_t                *rv         = jval(res);
+    uint32_t               exp_st     = (uint32_t) jfield(rv, "st");
+    int                    exp_parked = jbool(rv, "parked");
+    struct smb2_notify_msg got;
+    uint64_t               mid, deadline;
+    int                    interim0, got_parked;
+    uint32_t               st;
+
+    if (!c) {
+        /* dispatch_cmd rejects a connectionless command before it gets here;
+         * this is the belt to that braces, and keeps the c->ninterim sample
+         * below provably safe rather than safe-by-inspection. */
+        smb2c_no_conn(SMB2_CHANGE_NOTIFY);
+    }
+
+    if (!fid || mfid < 0 || mfid >= MAX_FID) {
+        mism("CHANGE_NOTIFY: unresolved FileId");
+        return;
+    }
+
+    interim0 = c->ninterim;
+    smb2c_post_change_notify(c, fid, wflags, obl, cf);
+    mid      = c->last_msg_id;
+    deadline = smb2c_now_ms() + SMB2C_HANG_MS;
+
+    while (c->ninterim == interim0 &&
+           !(c->reply_ready && c->reply_mid == mid)) {
+        smb2_pump(c->env);
+        if (c->disconnected) {
+            smb2c_dead(c);
+        }
+        if (smb2c_now_ms() >= deadline) {
+            smb2c_hang(c, "a CHANGE_NOTIFY reply or async interim");
+        }
+    }
+
+    got_parked = (c->ninterim > interim0);
+    if (got_parked != exp_parked) {
+        mism("CHANGE_NOTIFY fid %lld: model expected %s, wire %s",
+             (long long) mfid,
+             exp_parked ? "a park (async interim)" : "an inline answer",
+             got_parked ? "parked" : "answered inline");
+        /* The two sides now disagree about whether a request is outstanding,
+         * so every later completion check on this handle would be reporting
+         * that, not a new fact. */
+        g_abort_trace = 1;
+        return;
+    }
+
+    if (got_parked) {
+        /* Remember the AsyncId: it is how the eventual completion is matched
+         * back to this handle, and how a CANCEL names the request. */
+        g_notify_async[mfid] = c->last_async_id;
+        if (exp_st != ST_PENDING) {
+            mism("CHANGE_NOTIFY fid %lld: parked, but the model's status is "
+                 "0x%08x rather than STATUS_PENDING", (long long) mfid, exp_st);
+        }
+        return;
+    }
+
+    st = g32(c->rbuf + 4, 8);
+    if (st != exp_st) {
+        if (!dev_status("RNotify", exp_st, st, "notify")) {
+            mism("CHANGE_NOTIFY fid %lld status: model 0x%08x wire 0x%08x",
+                 (long long) mfid, exp_st, st);
+        }
+        return;
+    }
+
+    memset(&got, 0, sizeof(got));
+    got.status = st;
+    smb2c_parse_notify(&got, c->rbuf + 4, c->rlen - 4);
+    check_notify_recs("CHANGE_NOTIFY inline", json_object_get(rv, "recs"),
+                      &got);
+} /* do_notify */
+
+/* CANCEL the CHANGE_NOTIFY parked on this handle (MS-SMB2 3.2.4.24).  There is
+ * no reply to check -- CANCEL is never answered -- so the assertion is the
+ * STATUS_CANCELLED completion it produces, which the message's notes carry. */
+static void
+do_cancel(
+    struct smb2_conn *c,
+    json_t           *v,
+    json_t           *res,
+    const uint8_t    *related_fid,
+    int               have_related)
+{
+    int64_t mfid  = model_fid_of(v);
+    int     found = jbool(jval(res), "found");
+
+    (void) related_fid;
+    (void) have_related;
+
+    if (!found) {
+        /* The model found nothing parked, so there is no AsyncId to name and
+         * nothing the wire could report.  Sending a CANCEL anyway would be
+         * asking the server about a request that does not exist. */
+        return;
+    }
+    if (mfid < 0 || mfid >= MAX_FID || !g_notify_async[mfid]) {
+        mism("CANCEL fid %lld: the model says a request is parked, the harness "
+             "never saw one", (long long) mfid);
+        return;
+    }
+    smb2c_post_cancel_async(c, g_notify_async[mfid]);
+} /* do_cancel */
 
 static void
 do_close(
@@ -1797,6 +2121,10 @@ dispatch_cmd(
         do_tree_disconnect(c, res);
     } else if (strcmp(tag, "CBreakAck") == 0) {
         do_break_ack(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CNotify") == 0) {
+        do_notify(c, v, res, related_fid, *have_related);
+    } else if (strcmp(tag, "CCancel") == 0) {
+        do_cancel(c, v, res, related_fid, *have_related);
     } else {
         mism("unhandled command tag '%s' (extend the replayer)", tag);
     }
@@ -1843,7 +2171,18 @@ do_message(json_t *lmsg_value)
         dispatch_cmd(json_array_get(cmds, i), json_array_get(results, i),
                      sess, tree, cs, replay, related_fid, &have_related);
     }
+    /* The CHANGE_NOTIFY completions this message owed, on whatever connections
+     * had a request parked.  They belong to the MESSAGE, not to any command:
+     * the watcher is usually not the client whose command woke it. */
+    {
+        json_t *notes = json_object_get(lmsg_value, "notes");
+
+        if (notes) {
+            check_notify_notes(notes, "message");
+        }
+    }
     check_no_stray_breaks("message");
+    check_no_stray_notifies("message");
 } /* do_message */
 
 /* ---- trace driver ------------------------------------------------------- */
@@ -1966,6 +2305,10 @@ run_trace(
     memset(g_fid_known, 0, sizeof(g_fid_known));
     memset(g_conn_for_fid, 0, sizeof(g_conn_for_fid));
     memset(g_park_barriered, 0, sizeof(g_park_barriered));
+    /* A trace's connections are dropped between traces, and chimera drops a
+     * parked CHANGE_NOTIFY without a reply when its connection goes (there is
+     * nobody left to answer), so no completion crosses a trace boundary. */
+    memset(g_notify_async, 0, sizeof(g_notify_async));
     memset(g_park_pending, 0, sizeof(g_park_pending));
     g_trace       = path;
     g_nmismatch   = 0;

--- a/src/vfs/vfs_claim.c
+++ b/src/vfs/vfs_claim.c
@@ -517,6 +517,32 @@ chimera_vfs_claim_init_common(
 } /* chimera_vfs_claim_init_common */
 
 SYMBOL_EXPORT void
+chimera_vfs_claim_foreach_smb_open(
+    struct chimera_vfs_file_state *file,
+    chimera_vfs_smb_open_cb_t      cb,
+    void                          *private_data)
+{
+    struct chimera_vfs_claim *cur;
+
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    for (cur = file->claims[CHIMERA_CLAIM_CLASS_ACCESS]; cur; cur = cur->next) {
+        if (cur->construct != CHIMERA_CONSTRUCT_SMB_OPEN &&
+            cur->construct != CHIMERA_CONSTRUCT_SMB_OPEN_INERT) {
+            continue;
+        }
+        if (!cur->cb_private) {
+            continue;
+        }
+        cb(cur->cb_private, private_data);
+    }
+    pthread_mutex_unlock(&file->lock);
+} /* chimera_vfs_claim_foreach_smb_open */
+
+SYMBOL_EXPORT void
 chimera_vfs_claim_init_smb_open(
     struct chimera_vfs_claim         *claim,
     uint8_t                           access,

--- a/src/vfs/vfs_claim.h
+++ b/src/vfs/vfs_claim.h
@@ -226,6 +226,32 @@ chimera_vfs_state_put(
     struct chimera_vfs_state      *state,
     struct chimera_vfs_file_state *file);
 
+/* Visit every SMB open registered on `file`.
+ *
+ * Every SMB open takes an ACCESS claim on the file it opened and stamps its
+ * chimera_smb_open_file into cb_private (smb_proc_create.c), attribute-only
+ * opens included -- those build the INERT construct, which conflicts with
+ * nothing but is still a registration.  So this claim list IS the set of SMB
+ * handles on a file, across every session and tree, and it is the only place
+ * that set exists: the SMB layer hashes its open files per TREE, so nothing
+ * above the VFS can enumerate the holders of one file.
+ *
+ * Used by RENAME, which renames the FILE and must therefore move the cached
+ * path every one of those handles keeps.
+ *
+ * `cb` runs under file->lock, so it must not call back into the VFS or take a
+ * lock of its own; updating fields on the open it is handed is what it is for.
+ */
+typedef void (*chimera_vfs_smb_open_cb_t)(
+    void *smb_open_file,
+    void *private_data);
+
+void
+chimera_vfs_claim_foreach_smb_open(
+    struct chimera_vfs_file_state *file,
+    chimera_vfs_smb_open_cb_t      cb,
+    void                          *private_data);
+
 /* -------------------------------------------------------------------- */
 /* Claim constructors — the admission mask table                        */
 /* -------------------------------------------------------------------- */

--- a/src/vfs/vfs_notify.c
+++ b/src/vfs/vfs_notify.c
@@ -758,26 +758,22 @@ chimera_vfs_notify_watch_update(
         return;
     }
 
-    /* watch_tree flipped — purge any events queued under the old mode.
-     * Subtree events carry a path-prefixed name ("sub/dir/file") while
-     * exact-mode events carry a bare filename.  Delivering a stale path
-     * to a non-tree consumer (or vice versa) would mislead the client,
-     * and we have no per-event mode tag to filter selectively.  Force
-     * the client to rescan via overflow semantics — but ONLY if there is
-     * actually something queued (or an overflow already pending).  When
-     * the ring is empty (the common case of a client re-arming a fresh
-     * watch with a different recursion flag) signalling a spurious
-     * overflow would make the very next CHANGE_NOTIFY complete
-     * immediately with STATUS_NOTIFY_ENUM_DIR instead of parking
-     * (smb2.notify.rec / mask-change). */
-    pthread_mutex_lock(&watch->lock);
-    if (watch->ring_count > 0 || watch->overflowed) {
-        watch->ring_head  = 0;
-        watch->ring_count = 0;
-        watch->overflowed = 1;
-    }
-    pthread_mutex_unlock(&watch->lock);
-
+    /* watch_tree flipped.  The buffered events are KEPT.
+     *
+     * This used to purge them and raise overflow, on the reasoning that a
+     * subtree event carries a path-prefixed name ("sub/dir/file") while an
+     * exact-mode event carries a bare filename, and there is no per-event mode
+     * tag to filter on -- so a stale path could reach a consumer that has
+     * since narrowed to the directory itself.
+     *
+     * That is an argument about this implementation's event representation,
+     * not about the protocol.  MS-SMB2 mandates no purge, a client that
+     * narrows its recursion has not asked to lose the changes it was already
+     * waiting for, and Samba delivers across the flip.  Discarding a client's
+     * changes to avoid an ambiguity of our own making is the wrong trade; if
+     * the names ever become ambiguous in practice, the fix is to tag the
+     * events, not to drop them.
+     */
     /* watch_tree flipped — relink in mount entries' subtree list. */
     pthread_mutex_lock(&notify->mount_entries_lock);
 

--- a/src/vfs/vfs_notify.h
+++ b/src/vfs/vfs_notify.h
@@ -16,6 +16,10 @@
 #define CHIMERA_VFS_NOTIFY_FILE_MODIFIED 0x0004
 #define CHIMERA_VFS_NOTIFY_DIR_ADDED     0x0008
 #define CHIMERA_VFS_NOTIFY_DIR_REMOVED   0x0010
+/* A rename of a FILE.  Split from the directory case because the two SMB2
+ * name filters are: MS-FSCC scopes FILE_NOTIFY_CHANGE_FILE_NAME to file name
+ * changes "including renaming" and _DIR_NAME to directory ones, so a client
+ * watching directory names must not be woken because a file was renamed. */
 #define CHIMERA_VFS_NOTIFY_RENAMED       0x0020
 #define CHIMERA_VFS_NOTIFY_ATTRS_CHANGED 0x0040
 #define CHIMERA_VFS_NOTIFY_SIZE_CHANGED  0x0080
@@ -28,6 +32,11 @@
 #define CHIMERA_VFS_NOTIFY_STREAM_NAME   0x0100
 #define CHIMERA_VFS_NOTIFY_STREAM_SIZE   0x0200
 #define CHIMERA_VFS_NOTIFY_STREAM_WRITE  0x0400
+/* A rename of a DIRECTORY.  Raised instead of CHIMERA_VFS_NOTIFY_RENAMED when
+ * the caller knows the renamed object is one (CHIMERA_VFS_RENAME_SRC_IS_DIR);
+ * a caller that does not know raises RENAMED, which both name filters see --
+ * the conservative answer for a protocol that cannot tell us. */
+#define CHIMERA_VFS_NOTIFY_RENAMED_DIR   0x0800
 
 #define CHIMERA_VFS_NOTIFY_RING_SIZE     32
 #define CHIMERA_VFS_NOTIFY_NUM_BUCKETS   64

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -40,13 +40,19 @@ chimera_vfs_rename_at_complete(struct chimera_vfs_request *request)
             memcpy(&skip_hi, request->rename_at.parent_lease_skip + 8, 8);
         }
 
+        /* Which NAME filter sees this is decided by the renamed object's
+         * type (MS-FSCC 2.7.1), not by the fact that it was a rename. */
+        uint32_t rn_class =
+            (request->rename_at.flags & CHIMERA_VFS_RENAME_SRC_IS_DIR)
+            ? CHIMERA_VFS_NOTIFY_RENAMED_DIR : CHIMERA_VFS_NOTIFY_RENAMED;
+
         if (!cross_dir) {
             /* Intra-directory rename: a single RENAMED event on the
              * directory carrying both old and new names. */
             chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
                                           request->fh,
                                           request->fh_len,
-                                          CHIMERA_VFS_NOTIFY_RENAMED,
+                                          rn_class,
                                           request->rename_at.new_name,
                                           request->rename_at.new_namelen,
                                           request->rename_at.name,
@@ -58,7 +64,7 @@ chimera_vfs_rename_at_complete(struct chimera_vfs_request *request)
             chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
                                           request->fh,
                                           request->fh_len,
-                                          CHIMERA_VFS_NOTIFY_RENAMED,
+                                          rn_class,
                                           NULL, 0,
                                           request->rename_at.name,
                                           request->rename_at.namelen,
@@ -66,7 +72,7 @@ chimera_vfs_rename_at_complete(struct chimera_vfs_request *request)
             chimera_vfs_notify_emit_lease(thread->vfs->vfs_notify,
                                           request->rename_at.new_fh,
                                           request->rename_at.new_fhlen,
-                                          CHIMERA_VFS_NOTIFY_RENAMED,
+                                          rn_class,
                                           request->rename_at.new_name,
                                           request->rename_at.new_namelen,
                                           NULL, 0,

--- a/src/vfs/vfs_procs.h
+++ b/src/vfs/vfs_procs.h
@@ -783,6 +783,12 @@ typedef void (*chimera_vfs_rename_at_callback_t)(
     struct chimera_vfs_attrs *todir_post_attr,
     void                     *private_data);
 
+/* rename_at `flags`: the caller knows the renamed object is a DIRECTORY, so
+ * the change notification it raises is a directory-name change rather than a
+ * file-name one.  Only the SMB path knows this (the open carries the type);
+ * everything else leaves it clear and gets the both-filters class. */
+#define CHIMERA_VFS_RENAME_SRC_IS_DIR 0x00000001
+
 void
 chimera_vfs_rename_at(
     struct chimera_vfs_thread       *thread,


### PR DESCRIPTION
Stacked on **chimera-nas/specs#20**, which adds the model. The `ext/specs` pin still points at today's main; it needs bumping once that merges.

---

The quick tier — the tier that gates a merge — had **no CHANGE_NOTIFY coverage at all**:

| file | lines before |
|---|---|
| `src/server/smb/smb_proc_change_notify.c` | 0.00% |
| `src/server/smb/smb_notify.c` | 1.68% |
| `src/vfs/vfs_notify.c` | 14.18% |

The only tests that reached any of it were a VFS unit test and an integration test that no longer exists, both extended-tier. So the largest coherency surface in SMB2 after oplocks was ungated: ~1,400 dark lines whose first report of a regression would have been a Windows client.

## The replayer

**Async completions get their own queue.** An async `CHANGE_NOTIFY` response carries the ASYNC flag and an AsyncId rather than answering any MessageId, arrives whenever some *other* client changes the watched directory, and several can be outstanding at once. Promoting one into `rbuf` would overwrite a reply the caller was about to parse, and would count as "a parked request completed" in the ECHO-barrier bookkeeping — which is how a suite like this quietly mistakes a notify for a create resuming.

**`do_notify` posts rather than calls**, then waits for whichever of the two answers the server chose: the reply to this request, or the interim that says it parked. *Which one it is IS the assertion.* Completions are then matched per message **by AsyncId and queue position** — so which request each one answers is exact even when several land at once, and neither a missing completion nor an extra one can hide. An extra is as much a bug as a missing one: it means a watcher was woken for a change it had filtered out.

## Coverage

One ctest, measured on macOS against the quick tier:

| file | lines | functions |
|---|---|---|
| `smb_notify.c` | 1.68% → **83.61%** | 8.7% → **95.7%** |
| `smb_proc_change_notify.c` | 0.00% → **81.55%** | 0% → **100%** |
| `vfs_notify.c` | 14.18% → **42.64%** | 30.6% → **63.9%** |

What stays dark in `vfs_notify.c` is the subtree (`WATCH_TREE`) resolver: the generated namespace is flat. That is the next increment, and it needs the replayer to learn directory paths first.

## Five bugs it found

**Two from the first run against the model:**

1. **A rename repathed only the handle that asked for it.** `chimera_smb_open_file` carries `(parent_fh, name)` as the file's path, and it is the *only* path the SMB layer keeps: the source of the next rename reads it, the remove a delete-on-close issues reads it, the name in a CHANGE_NOTIFY record comes from it. The visible failure is a second rename through a sibling handle — `STATUS_OBJECT_NAME_NOT_FOUND` for a file plainly there. The quiet one is worse: a stale handle's delete-on-close removes `(parent_fh, old_name)`, so once another file takes that name, closing the stale handle unlinks **it**. Fixed via a new `chimera_vfs_claim_foreach_smb_open()` — the ACCESS claim list *is* the set of SMB handles on a file, and unlike the per-tree open-file hashes it spans sessions and trees.

2. **An open reported the change it asked for, not the one it made.** Every create-capable disposition reported `FILE_ADDED`. Once a `CompletionFilter` is involved that is wrong both ways — an `OVERWRITE_IF` that replaced a file changed its size and write time and a `FILE_NOTIFY_CHANGE_SIZE` watcher heard nothing, while an `OPEN_IF` that created nothing woke a `FILE_NOTIFY_CHANGE_FILE_NAME` watcher. Now keyed on `r_created`. *Independently confirmed by Samba, which behaves exactly as the corrected model does.*

**Three more when the model was replayed against Samba** (specs#20 teaches the samba harness to drive this corpus; the model was corrected there and chimera now complies):

3. **A handle could carry only one outstanding CHANGE_NOTIFY.** A second was refused `STATUS_INVALID_PARAMETER`, citing *"MS-SMB2 §3.3.5.10"* — which is *Receiving an SMB2 CLOSE Request*. CHANGE_NOTIFY is §3.3.5.19 and imposes no such limit; MS-FSA 2.1.5.9 keeps them on `Open.PendingNotifyChanges`, a **list**. This broke the ordinary case: an overlapped client keeps two or three `ReadDirectoryChangesW` calls posted precisely so there is never a window with none, and refusing the second collapses that into a watch with gaps — with no way for the client to tell. Now a FIFO: a change wakes the oldest, a close finishes all of them, a CANCEL ends the one it names.

4. **A re-armed watch discarded its buffered events** when `WATCH_TREE` flipped, forcing a rescan. The reasoning was ours, not the protocol's — a subtree event names its object by a relative path and an exact one by a bare filename, with no per-event tag to separate them. Nothing mandates a purge, and Samba delivers across the flip. Discarding a client's changes to avoid an ambiguity of our own making is the wrong trade.

5. **A `DIR_NAME` watcher was woken by *file* renames.** Both name filters mapped to one `RENAMED` class. MS-FSCC 2.7.1 scopes them by the renamed object's type; the VFS gains `RENAMED_DIR` and a `CHIMERA_VFS_RENAME_SRC_IS_DIR` flag that only the SMB layer sets, since only the open knows the type. Callers that do not set it keep today's both-filters behaviour.
