### PR TITLE
tests/quint: complete the NFS backend matrix

### DIFF
--- a/src/server/nfs/nfs3_proc_setattr.c
+++ b/src/server/nfs/nfs3_proc_setattr.c
@@ -128,7 +128,23 @@ chimera_nfs3_setattr_open_callback(
         }
 
     } else {
-        res.status = chimera_vfs_error_to_nfsstat3(error_code);
+        /* A size-setting SETATTR asks for a data handle (see the OPEN_PATH
+         * choice in chimera_nfs3_setattr), and a non-regular object refuses
+         * one: ELOOP for a symlink, ENXIO for a device or socket.  RFC 1813
+         * says SETATTR's size is meaningful only for a regular file and any
+         * other type answers NFS3ERR_INVAL, which is what the in-engine
+         * backends return from their own setattr -- they accept the open and
+         * reject the size.  Without this the passthrough backends failed at
+         * the open instead, and the unmapped errno surfaced as
+         * NFS3ERR_SERVERFAULT.  (A directory already arrives as EISDIR, which
+         * maps to NFS3ERR_ISDIR on its own.) */
+        if (args->new_attributes.size.set_it &&
+            (error_code == CHIMERA_VFS_ELOOP ||
+             error_code == CHIMERA_VFS_ENXIO)) {
+            res.status = NFS3ERR_INVAL;
+        } else {
+            res.status = chimera_vfs_error_to_nfsstat3(error_code);
+        }
         chimera_nfs3_set_wcc_data(&res.resfail.obj_wcc, NULL, NULL);
         rc = shared->nfs_v3.send_reply_NFSPROC3_SETATTR(evpl, NULL, &res, req->encoding);
         chimera_nfs_abort_if(rc, "Failed to send RPC2 reply");

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -265,13 +265,35 @@ endif()
 # divergence is both caught and reported where it is created.  It costs roughly
 # a quarter more wall time; the timeout is set for an instrumented build, where
 # it is several times slower than the release run it was measured in.
-add_test(NAME chimera/server/nfs/mbtaux/batch_memfs
-    COMMAND $<TARGET_FILE:nfs_aux_mbt_replay> --paranoid
-            --trace-dir ${SPECS_BUNDLE_DIR}/nfsaux)
-set_tests_properties(chimera/server/nfs/mbtaux/batch_memfs PROPERTIES
-    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_batch_memfs"
-    LABELS "quint;nfsaux_mbt;memfs"
-    TIMEOUT 600)
+#
+# Run against every backend, as the NFS3 and NFS4 batches are.  The auxiliary
+# protocols look server-side, but three of the four reach the VFS: MOUNT
+# resolves an export path to a filehandle, NLM's lock table hangs off the open
+# file the backend handed out, and NSM's notify drops locks held against it.
+# --paranoid re-probes each file's ranges through the backend after every step,
+# so a backend whose handles or open state differ from memfs's diverges here
+# rather than staying invisible until some later collision.  The passthrough
+# pair replays the corpus whole (42/42, no capability skips): nothing in it
+# reaches the host semantics the nfs3/nfs4 corpora need gates for.
+foreach(aback memfs diskfs cairn linux io_uring)
+    if(aback STREQUAL "cairn" AND NOT CAIRN_ENABLED)
+        continue()
+    endif()
+    if(aback STREQUAL "linux" AND NOT CHIMERA_LINUX)
+        continue()
+    endif()
+    if(aback STREQUAL "io_uring" AND NOT CHIMERA_VFS_IO_URING)
+        continue()
+    endif()
+    add_test(NAME chimera/server/nfs/mbtaux/batch_${aback}
+        COMMAND $<TARGET_FILE:nfs_aux_mbt_replay> --paranoid
+                --trace-dir ${SPECS_BUNDLE_DIR}/nfsaux
+                --backend ${aback})
+    set_tests_properties(chimera/server/nfs/mbtaux/batch_${aback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_batch_${aback}"
+        LABELS "quint;nfsaux_mbt;${aback}"
+        TIMEOUT 600)
+endforeach()
 
 # The duplicate-request caches, replayed from the nfsdrc corpus.  Two batches
 # because there are two servers: the NFSv3 cache is off by default and on in the
@@ -284,23 +306,46 @@ set_tests_properties(chimera/server/nfs/mbtaux/batch_memfs PROPERTIES
 # SETATTR and a re-executed one both answer NFS3_OK, and the difference is a
 # size in the directory.  The flag re-reads the working directory after every
 # step and compares it against the model's own.
-add_test(NAME chimera/server/nfs/mbtdrc/batch_memfs
-    COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid
-            --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
-            --exclude-prefix nfsdrcNoV3)
-set_tests_properties(chimera/server/nfs/mbtdrc/batch_memfs PROPERTIES
-    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_memfs"
-    LABELS "quint;nfsdrc_mbt;memfs"
-    TIMEOUT 600)
+#
+# Both batches run against every backend.  A duplicate-request cache is
+# server-side, but what it caches is a reply the backend produced, and
+# --paranoid's re-read of the working directory after every step is what tells a
+# genuine replay from a re-execution -- so the property under test ("the second
+# copy of this request changed nothing") is only as strong as the backend it is
+# checked against.  Adding the passthrough pair found a real one: this corpus is
+# the only one that sets a size on a symlink, and NFS3 SETATTR answered
+# NFS3ERR_SERVERFAULT there instead of NFS3ERR_INVAL (see
+# chimera_nfs3_setattr_open_callback).
+foreach(rback memfs diskfs cairn linux io_uring)
+    if(rback STREQUAL "cairn" AND NOT CAIRN_ENABLED)
+        continue()
+    endif()
+    if(rback STREQUAL "linux" AND NOT CHIMERA_LINUX)
+        continue()
+    endif()
+    if(rback STREQUAL "io_uring" AND NOT CHIMERA_VFS_IO_URING)
+        continue()
+    endif()
+    add_test(NAME chimera/server/nfs/mbtdrc/batch_${rback}
+        COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid
+                --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
+                --exclude-prefix nfsdrcNoV3
+                --backend ${rback})
+    set_tests_properties(chimera/server/nfs/mbtdrc/batch_${rback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_${rback}"
+        LABELS "quint;nfsdrc_mbt;${rback}"
+        TIMEOUT 600)
 
-add_test(NAME chimera/server/nfs/mbtdrc/batch_nodrc_memfs
-    COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid --no-nfs3-drc
-            --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
-            --exclude-prefix nfsdrcRef)
-set_tests_properties(chimera/server/nfs/mbtdrc/batch_nodrc_memfs PROPERTIES
-    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_nodrc_memfs"
-    LABELS "quint;nfsdrc_mbt;memfs"
-    TIMEOUT 600)
+    add_test(NAME chimera/server/nfs/mbtdrc/batch_nodrc_${rback}
+        COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid --no-nfs3-drc
+                --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
+                --exclude-prefix nfsdrcRef
+                --backend ${rback})
+    set_tests_properties(chimera/server/nfs/mbtdrc/batch_nodrc_${rback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_nodrc_${rback}"
+        LABELS "quint;nfsdrc_mbt;${rback}"
+        TIMEOUT 600)
+endforeach()
 
 # SKIP_RETURN_CODE 77 still applies to NFS4: a trace whose capability profile
 # does not match the live server exits 77 individually; the batch reports SKIP
@@ -377,8 +422,21 @@ endif()
 # replays.  Until this batch existed the Deleg instances had no consumer at
 # all: they were generated, skipped silently in the default batch, and the
 # delegation wire paths were covered only by the deterministic deleg_probe.
-foreach(dback memfs diskfs cairn)
+#
+# The passthrough backends are in this list for the same reason they are in the
+# plain nfs4 list above: a delegation is recalled on a conflicting open, and
+# which opens conflict is decided against the handle the backend produced.
+# Measured identical to the native backends -- 14 Deleg traces replay and 51
+# skip on every one of memfs/diskfs/cairn/linux/io_uring -- so the passthrough
+# cells carry the same delegation coverage rather than a thinner one.
+foreach(dback memfs diskfs cairn linux io_uring)
     if(dback STREQUAL "cairn" AND NOT CAIRN_ENABLED)
+        continue()
+    endif()
+    if(dback STREQUAL "linux" AND NOT CHIMERA_LINUX)
+        continue()
+    endif()
+    if(dback STREQUAL "io_uring" AND NOT CHIMERA_VFS_IO_URING)
         continue()
     endif()
     add_test(NAME chimera/server/nfs/mbt4/batch_deleg_${dback}
@@ -415,13 +473,33 @@ set_tests_properties(chimera/server/nfs/mbt4/batch_pnfs_memfs PROPERTIES
 # The same cluster with an on-disk metadata server: diskfs persists the pNFS
 # layout blob as its own b+tree record, so this is the only test that covers
 # that record's write/read-back path.  The data servers stay memfs -- what is
-# under test here is the MDS.  Gated on libaio, diskfs's device type.
-if(HAVE_LIBAIO)
-    add_test(NAME chimera/server/nfs/mbt4/batch_pnfs_diskfs
+# under test here is the MDS.
+#
+# Registered unconditionally, like every other diskfs variant: diskfs takes
+# whichever libevpl block backend the platform has, and libaio is only the
+# Linux-preferred one (see CHIMERA_DISKFS_DEVICE_TYPE at the top level).  This
+# was the last cell still carrying the old if(HAVE_LIBAIO) gate, which had the
+# effect of leaving the layout record untested on every platform without
+# libaio -- macOS among them, where it runs green.
+add_test(NAME chimera/server/nfs/mbt4/batch_pnfs_diskfs
+    COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4pnfs
+            --pnfs 2 --backend diskfs)
+set_tests_properties(chimera/server/nfs/mbt4/batch_pnfs_diskfs PROPERTIES
+    LABELS "quint;nfs4_mbt;pnfs;diskfs"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 300)
+
+# And with a cairn metadata server, which persists the layout blob as its own
+# keyed record (CAIRN_KEY_PNFS).  Until cairn learned to store it, it did not
+# advertise CHIMERA_VFS_CAP_LAYOUT and every trace here skipped with
+# NFS4ERR_LAYOUTUNAVAILABLE -- the whole suite reported SKIP, which reads the
+# same as "registered and passing" in a ctest summary.
+if(CAIRN_ENABLED)
+    add_test(NAME chimera/server/nfs/mbt4/batch_pnfs_cairn
         COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4pnfs
-                --pnfs 2 --backend diskfs)
-    set_tests_properties(chimera/server/nfs/mbt4/batch_pnfs_diskfs PROPERTIES
-        LABELS "quint;nfs4_mbt;pnfs;diskfs"
+                --pnfs 2 --backend cairn)
+    set_tests_properties(chimera/server/nfs/mbt4/batch_pnfs_cairn PROPERTIES
+        LABELS "quint;nfs4_mbt;pnfs;cairn"
         SKIP_RETURN_CODE 77
         TIMEOUT 300)
 endif()

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -76,6 +76,12 @@
  * ffl_stripe_unit (8) + ffl_mirrors<> count (4) + ffm_data_servers<> count (4). */
 #define V4_FF_DEVICEID_OFF  16
 
+/* Offset of the ffds_fh_vers<> element -- the data server handle that names the
+ * backing file -- in the same body: ffds_deviceid (16) + ffds_efficiency (4) +
+ * ffds_stateid (16) + ffds_fh_vers<> count (4) past V4_FF_DEVICEID_OFF.  Points
+ * at the opaque's length prefix; see chimera_nfs4_encode_ff_layout(). */
+#define V4_FF_DSFH_OFF      56
+
 #define E_DELAY             10008
 #define E_DENIED            10010
 #define E_NOTSUPP           10004
@@ -410,6 +416,7 @@ struct v4_res {
     }        segs[4];
     uint8_t         deviceid[16];
     int             has_deviceid;
+    struct mbt_fh   ds_fh;            /* flex-files backing file handle */
     int             lr_present;       /* LAYOUTRETURN */
     int             has_newsize;      /* LAYOUTCOMMIT */
     uint64_t        newsize;
@@ -440,6 +447,13 @@ struct v4_chg {
     int64_t  ino;
     int64_t  abstract;
     uint64_t wire;
+};
+
+/* Where a file's data lives: which data server (deviceid) and which file on
+ * it (the flex-files backing handle).  See oracle.layout_loc. */
+struct v4_layout_loc {
+    struct mbt_fh fh;
+    uint8_t       deviceid[16];
 };
 
 struct v4_hist {
@@ -487,6 +501,22 @@ struct oracle {
 
     uint8_t                deviceid[16];
     int                    has_deviceid;
+
+    /* ino -> the backing location its first LAYOUTGET named.  A metadata
+     * server that persists its per-file layout hands out the same one every
+     * time; one that loses it re-steers, and the round-robin lands the file on
+     * a different data server whose copy is empty -- silently orphaning
+     * everything written through the previous layout.  Nothing else in the
+     * corpus can tell those apart: both answer NFS4_OK with a well-formed
+     * layout covering the requested range, so the invariant is checked here
+     * rather than modeled.
+     *
+     * BOTH halves matter.  The data servers in the test cluster are freshly
+     * mkfs'd instances of one backend, and the backing file is named after the
+     * MDS fileid, so the same file re-created on a different DS gets an
+     * IDENTICAL native handle -- the deviceid is the only thing that says
+     * which server it lives on.  Comparing handles alone silently passes. */
+    struct v4_layout_loc   layout_loc[V4_MAX_INOS];
 
     /* Per-model-client connections (a model client
     * owns its own connection, like a real one). */
@@ -2668,6 +2698,25 @@ decode_resop(
                         memcpy(r->deviceid, body->data + off, 16);
                         r->has_deviceid = 1;
                     }
+
+                    /* The backing file handle, for the layout-stability check
+                     * in check_result().  Flex-files only: a block layout
+                     * names extents on a volume, not a file on a data
+                     * server. */
+                    if (g_layout_type == V4_LAYOUT_FLEX &&
+                        body->len >= V4_FF_DSFH_OFF + 4) {
+                        const uint8_t *q   = body->data + V4_FF_DSFH_OFF;
+                        uint32_t       len = ((uint32_t) q[0] << 24) |
+                            ((uint32_t) q[1] << 16) |
+                            ((uint32_t) q[2] << 8) | q[3];
+
+                        if (len <= sizeof(r->ds_fh.data) &&
+                            body->len >= V4_FF_DSFH_OFF + 4 + len) {
+                            memcpy(r->ds_fh.data, q + 4, len);
+                            r->ds_fh.len = len;
+                            r->ds_fh.has = 1;
+                        }
+                    }
                 }
             }
             break;
@@ -3528,6 +3577,24 @@ check_result(
             if (r->has_deviceid) {
                 memcpy(o->deviceid, r->deviceid, 16);
                 o->has_deviceid = 1;
+            }
+
+            /* Layout stability: the backing location of an ino is fixed for
+             * its lifetime.  See oracle.layout_loc. */
+            if (r->ds_fh.has && r->has_deviceid &&
+                ctx->cur >= 0 && ctx->cur < V4_MAX_INOS) {
+                struct v4_layout_loc *known = &o->layout_loc[ctx->cur];
+
+                if (!known->fh.has) {
+                    known->fh = r->ds_fh;
+                    memcpy(known->deviceid, r->deviceid, 16);
+                } else if (memcmp(known->deviceid, r->deviceid, 16) != 0 ||
+                           !mbt_fh_eq(&known->fh, &r->ds_fh)) {
+                    mism_add(m, "layoutget: backing location changed for ino "
+                             "%" PRId64 " -- the metadata server did not "
+                             "persist its layout and re-steered",
+                             (int64_t) ctx->cur);
+                }
             }
         }
     } else if (strcmp(tag, "SLayoutreturn") == 0) {

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -51,6 +51,7 @@ void rocksdb_flush_wal(
 #define CAIRN_KEY_XATTR          6
 #define CAIRN_KEY_ACL            7
 #define CAIRN_KEY_FS             8
+#define CAIRN_KEY_PNFS           9
 
 /*
  * Storage layout:
@@ -124,6 +125,16 @@ struct cairn_extent_key {
 } __attribute__((packed));
 
 struct cairn_acl_key {
+    uint8_t  keytype;
+    uint64_t inum;
+} __attribute__((packed));
+
+/* Opaque per-file pNFS layout blob (CHIMERA_VFS_ATTR_PNFS_LAYOUT), stored as
+ * its own record rather than widened into cairn_inode: only files a metadata
+ * server has handed a layout for ever have one, and the inode record is read
+ * on every lookup.  Cairn neither produces nor interprets the contents -- the
+ * NFS server packs a deviceid plus a backing filehandle in there. */
+struct cairn_pnfs_key {
     uint8_t  keytype;
     uint64_t inum;
 } __attribute__((packed));
@@ -791,6 +802,91 @@ cairn_remove_symlink_target(
     rocksdb_transaction_delete(txn, (const char *) &key, sizeof(key), &err);
     chimera_cairn_abort_if(err, "Error deleting symlink target: %s\n", err);
 } /* cairn_remove_symlink_target */
+
+static inline void
+cairn_put_pnfs(
+    struct cairn_thread *thread,
+    uint64_t             inum,
+    const void          *blob,
+    uint32_t             blob_len)
+{
+    rocksdb_transaction_t *txn = cairn_get_meta_txn(thread);
+    char                  *err = NULL;
+    struct cairn_pnfs_key  key;
+
+    if (blob_len > CHIMERA_VFS_PNFS_LAYOUT_MAX) {
+        blob_len = CHIMERA_VFS_PNFS_LAYOUT_MAX;
+    }
+
+    key.keytype = CAIRN_KEY_PNFS;
+    key.inum    = inum;
+
+    rocksdb_transaction_put(txn, (const char *) &key, sizeof(key),
+                            (const char *) blob, blob_len, &err);
+    chimera_cairn_abort_if(err, "Error putting pnfs layout: %s\n", err);
+} /* cairn_put_pnfs */
+
+static inline void
+cairn_remove_pnfs(
+    struct cairn_thread *thread,
+    uint64_t             inum)
+{
+    rocksdb_transaction_t *txn = cairn_get_meta_txn(thread);
+    char                  *err = NULL;
+    struct cairn_pnfs_key  key;
+
+    key.keytype = CAIRN_KEY_PNFS;
+    key.inum    = inum;
+
+    rocksdb_transaction_delete(txn, (const char *) &key, sizeof(key), &err);
+    chimera_cairn_abort_if(err, "Error deleting pnfs layout: %s\n", err);
+} /* cairn_remove_pnfs */
+
+/*
+ * Populate attr->va_pnfs when CHIMERA_VFS_ATTR_PNFS_LAYOUT is requested.  A
+ * file with no stored blob leaves the bit clear in va_set_mask, which is how
+ * the metadata server tells "no layout yet" (steer to a data server and create
+ * a backing file) from "here is the one I stored".  Needs the thread for the
+ * RocksDB read, so it is kept out of cairn_map_attrs() like cairn_map_acl().
+ */
+static inline void
+cairn_map_pnfs(
+    struct cairn_thread      *thread,
+    struct chimera_vfs_attrs *attr,
+    const struct cairn_inode *inode)
+{
+    rocksdb_pinnableslice_t *slice;
+    struct cairn_pnfs_key    key;
+    char                    *err = NULL;
+    const char              *blob;
+    size_t                   len;
+
+    if (!(attr->va_req_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT)) {
+        return;
+    }
+
+    key.keytype = CAIRN_KEY_PNFS;
+    key.inum    = inode->inum;
+
+    slice = cairn_meta_get_pinned(thread, &key, sizeof(key), &err);
+    chimera_cairn_abort_if(err, "Error getting pnfs layout: %s\n", err);
+
+    if (!slice) {
+        return;
+    }
+
+    blob = rocksdb_pinnableslice_value(slice, &len);
+
+    if (len > CHIMERA_VFS_PNFS_LAYOUT_MAX) {
+        len = CHIMERA_VFS_PNFS_LAYOUT_MAX;
+    }
+
+    memcpy(attr->va_pnfs, blob, len);
+    attr->va_pnfs_len  = len;
+    attr->va_set_mask |= CHIMERA_VFS_ATTR_PNFS_LAYOUT;
+
+    rocksdb_pinnableslice_destroy(slice);
+} /* cairn_map_pnfs */
 
 /* Scratch big enough to (de)serialize the largest permitted ACL. */
 #define CAIRN_ACL_SCRATCH        (CHIMERA_ACL_SERIAL_HDR + \
@@ -1883,6 +1979,12 @@ cairn_apply_attrs(
 {
     struct timespec now;
     uint64_t        set_mask = attr->va_set_mask;
+    /* See memfs_apply_attrs() for why a layout-blob-only setattr is exempt
+     * from the ctime and change-attribute bumps below: the metadata server
+     * writes the blob while serving a LAYOUTGET, and a client that then saw
+     * the change attribute move would treat its own layout request as someone
+     * else's modification and invalidate its cache. */
+    int             layout_only = (set_mask == CHIMERA_VFS_ATTR_PNFS_LAYOUT);
 
     clock_gettime(CLOCK_REALTIME, &now);
 
@@ -1961,12 +2063,14 @@ cairn_apply_attrs(
     if (set_mask & CHIMERA_VFS_ATTR_CTIME) {
         attr->va_set_mask |= CHIMERA_VFS_ATTR_CTIME;
         chimera_vfs_resolve_set_time(&attr->va_ctime, &now, &inode->ctime);
-    } else {
+    } else if (!layout_only) {
         inode->ctime = now;
     }
 
     /* Any setattr is a metadata change; advance the native change counter. */
-    inode->change++;
+    if (!layout_only) {
+        inode->change++;
+    }
 
 } /* cairn_apply_attrs */
 
@@ -1994,6 +2098,7 @@ cairn_getattr(
     cairn_map_attrs(fs, &request->getattr.r_attr, inode);
     cairn_map_ea_size(thread, inode, &request->getattr.r_attr);
     cairn_map_acl(thread, &request->getattr.r_attr, inode);
+    cairn_map_pnfs(thread, &request->getattr.r_attr, inode);
 
     cairn_inode_handle_release(&ih);
 
@@ -2103,6 +2208,22 @@ cairn_setattr(
                                   CHIMERA_ACL_MAX_ACES) >= 0) {
                 cairn_put_acl(thread, inode->inum, new_acl);
             }
+        }
+    }
+
+    /* pNFS layout blob.  Keyed off orig_set_mask for the same reason the ACL
+     * block above is: cairn_apply_attrs() has already rewritten
+     * set_attr->va_set_mask to what it applied, and it knows nothing about the
+     * blob -- testing the rewritten mask would silently drop every layout a
+     * metadata server ever wrote, leaving the MDS to re-steer on each
+     * LAYOUTGET and orphan the previous backing file. */
+    if (orig_set_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) {
+        struct chimera_vfs_attrs *sa = request->setattr.set_attr;
+
+        if (sa->va_pnfs_len) {
+            cairn_put_pnfs(thread, inode->inum, sa->va_pnfs, sa->va_pnfs_len);
+        } else {
+            cairn_remove_pnfs(thread, inode->inum);
         }
     }
 
@@ -2465,6 +2586,7 @@ cairn_rmfs_delete_inode(
     struct cairn_inode_key   inode_key;
     struct cairn_symlink_key symlink_key;
     struct cairn_acl_key     acl_key;
+    struct cairn_pnfs_key    pnfs_key;
     struct cairn_xattr_key   xattr_start, *xattr_key;
     struct cairn_extent_key  extent_start, *extent_key;
     rocksdb_iterator_t      *iter;
@@ -2484,6 +2606,11 @@ cairn_rmfs_delete_inode(
     acl_key.inum    = inum;
     rocksdb_writebatch_delete(meta_batch,
                               (const char *) &acl_key, sizeof(acl_key));
+
+    pnfs_key.keytype = CAIRN_KEY_PNFS;
+    pnfs_key.inum    = inum;
+    rocksdb_writebatch_delete(meta_batch,
+                              (const char *) &pnfs_key, sizeof(pnfs_key));
 
     xattr_start.keytype = CAIRN_KEY_XATTR;
     xattr_start.inum    = inum;
@@ -3199,6 +3326,7 @@ cairn_remove_at(
 
             cairn_remove_inode(thread, inode);
             cairn_remove_acl(thread, inode->inum);
+            cairn_remove_pnfs(thread, inode->inum);
         } else {
             cairn_put_inode(thread, inode);
         }
@@ -3721,6 +3849,7 @@ cairn_open_at(
     cairn_map_attrs(fs, &request->open_at.r_dir_post_attr, parent_inode);
     cairn_map_attrs(fs, &request->open_at.r_attr, inode);
     cairn_map_acl(thread, &request->open_at.r_attr, inode);
+    cairn_map_pnfs(thread, &request->open_at.r_attr, inode);
 
     cairn_put_inode(thread, parent_inode);
     cairn_put_inode(thread, inode);
@@ -3777,6 +3906,7 @@ cairn_close(
 
         cairn_remove_inode(thread, inode);
         cairn_remove_acl(thread, inode->inum);
+        cairn_remove_pnfs(thread, inode->inum);
     } else {
         cairn_put_inode(thread, inode);
     }
@@ -4931,6 +5061,7 @@ cairn_rename_at(
 
                     cairn_remove_inode(thread, existing_inode);
                     cairn_remove_acl(thread, existing_inode->inum);
+                    cairn_remove_pnfs(thread, existing_inode->inum);
                 } else {
                     cairn_put_inode(thread, existing_inode);
                 }
@@ -5904,7 +6035,8 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_cairn = {
         CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_ACL_NATIVE |
         CHIMERA_VFS_CAP_ATOMIC_HANDLE_STATE |
         CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS |
-        CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS,
+        CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS |
+        CHIMERA_VFS_CAP_LAYOUT,
     .init           = cairn_init,
     .destroy        = cairn_destroy,
     .thread_init    = cairn_thread_init,


### PR DESCRIPTION
The nfsaux, nfsdrc and pNFS suites each ran against exactly one backend, and the
delegation suite skipped the passthrough pair. Nothing gated them: the aux and
drc replayers already accepted `--backend` and simply had no ctest registered for
anything but memfs.

Fifteen new cells. Filling them in took four fixes, two of which are server bugs.

| Suite | memfs | diskfs | cairn | linux | io_uring |
|---|:--:|:--:|:--:|:--:|:--:|
| NFSv3 `mbt/batch_*` | ✓ | ✓ | ✓ | ✓ | ✓ |
| NFSv4 `mbt4/batch_*` | ✓ | ✓ | ✓ | ✓ | ✓ |
| Delegations `mbt4/batch_deleg_*` | ✓ | ✓ | ✓ | **new** | **new** |
| pNFS `mbt4/batch_pnfs_*` | ✓ | ✓ (un-gated) | **new** | — | — |
| AUX (portmap/MOUNT/NLM/NSM) | ✓ | **new** | **new** | **new** | **new** |
| DRC (×2 cache modes) | ✓ | **new** | **new** | **new** | **new** |

### cairn learns the pNFS layout blob

cairn did not persist `CHIMERA_VFS_ATTR_PNFS_LAYOUT`, so it did not advertise
`CHIMERA_VFS_CAP_LAYOUT`, so every nfs4pnfs trace skipped with
`NFS4ERR_LAYOUTUNAVAILABLE`. A suite in which every trace skips reports SKIP,
which in a ctest summary reads much like a pass.

Stored as its own keyed record (`CAIRN_KEY_PNFS`) rather than widened into
`cairn_inode`, following the ACL record: only files a metadata server has handed
a layout for ever have one, and the inode record is read on every lookup. A
layout-blob-only setattr is exempt from the ctime and change-attribute bumps, as
in memfs and diskfs.

### The pNFS cells could not detect the thing they exist to test

After cairn went green I broke its blob readback deliberately, and the suite
still passed clean. Losing the blob makes the MDS re-steer, and the round-robin
lands the file on a *different* data server whose copy is empty — silently
orphaning everything written through the previous layout. Nothing in the corpus
could see it: both outcomes answer `NFS4_OK` with a well-formed layout covering
the requested range. The replayer now pins the invariant directly. Under that
injected fault it fails 19 traces.

The check compares the deviceid **and** the backing handle. Keyed on the handle
alone it still passed: the data servers are freshly mkfs'd instances of one
backend and the backing file is named after the MDS fileid, so the same file
re-created on the other DS gets a byte-identical native handle. The deviceid is
the only thing that says which server it lives on.

### NFS3 SETATTR answered SERVERFAULT for a size on a symlink

A size-setting SETATTR asks for a data handle, which a non-regular object
refuses — ELOOP for a symlink — and ELOOP had no case in the NFS3 mapping table,
so it fell through to `NFS3ERR_SERVERFAULT`. RFC 1813 and the in-engine backends
both say `NFS3ERR_INVAL`. The nfsdrc corpus is the only one that sets a size on a
symlink, so this needed exactly the cell that did not exist. NFSv4 is unaffected;
its SETATTR always opens with `OPEN_PATH`.

### batch_pnfs_diskfs loses its `if(HAVE_LIBAIO)`

Every other diskfs variant was de-gated when diskfs gained the pread device type
(see the comment at the `CHIMERA_DISKFS_DEVICE_TYPE` block). This one was missed,
which left the layout record untested on every platform without libaio.

### Notes for review

Delegation coverage on the passthrough backends was measured rather than
assumed: 14 Deleg traces replay and 51 skip on every one of
memfs/diskfs/cairn/linux/io_uring, so the new cells carry the same coverage as
the native ones rather than a thinner one. The AUX corpus replays whole on the
passthrough pair (42/42, no capability skips).

pNFS on linux/io_uring is deliberately still absent: those backends would need to
persist the blob in a host xattr, which is a backend feature of a different size
from the rest of this.
