### PR TITLE
nfs: run every NFS quint suite over RPC-over-RDMA, and fix the three reply caches it broke

### DIFF
--- a/src/server/nfs/nfs3_drc.c
+++ b/src/server/nfs/nfs3_drc.c
@@ -18,7 +18,10 @@
 #include "evpl/evpl_rpc2.h"
 #include "evpl/evpl_rpc2_program.h"
 
-#define NFS3_DRC_VALUE_MAGIC 0x33435244u /* "DRC3" */
+/* Bumped from "DRC3" when the cached bytes changed from the whole on-wire
+ * message to the RPC reply alone: an entry written by an older build is not
+ * readable by this one, and a magic mismatch is already treated as a miss. */
+#define NFS3_DRC_VALUE_MAGIC 0x34435244u /* "DRC4" */
 
 /* Most evictions remove a single similarly-sized entry; this caps how many
  * evicted keys one insert reports back for KV cleanup (any beyond it leak in
@@ -453,6 +456,7 @@ nfs3_drc_capture_reply(
     const struct evpl_iovec *iov,
     int                      niov,
     int                      total_length,
+    uint32_t                 rpc_offset,
     void                    *private_data)
 {
     struct nfs3_drc_capture_ctx      *ctx    = private_data;
@@ -460,33 +464,37 @@ nfs3_drc_capture_reply(
     struct nfs3_drc                  *drc    = ctx->drc;
     struct nfs3_drc_keybuf            evicted[NFS3_DRC_EVICT_MAX];
     uint8_t                          *buf;
-    size_t                            offset = 0;
+    uint32_t                          rpc_len;
     uint64_t                          ts;
     int                               i, nev;
 
-    if (total_length <= 0 || (uint32_t) total_length > NFS3_DRC_MAX_REPLY_SIZE) {
+    if (total_length <= (int) rpc_offset ||
+        (uint32_t) total_length > NFS3_DRC_MAX_REPLY_SIZE) {
         return;
     }
 
-    buf = malloc(total_length);
+    rpc_len = (uint32_t) total_length - rpc_offset;
+
+    buf = malloc(rpc_len);
     if (!buf) {
         return;  /* OOM: skip caching this reply (degrade to a cache miss) */
     }
-    for (i = 0; i < niov; i++) {
-        memcpy(buf + offset, iov[i].data, iov[i].length);
-        offset += iov[i].length;
+
+    if (nfs_drc_copy_rpc_reply(iov, niov, rpc_offset, buf, rpc_len) != rpc_len) {
+        free(buf);
+        return;
     }
 
     ts = nfs_lease_now_ns();
 
     pthread_mutex_lock(&drc->lock);
-    nev = nfs3_drc_cache_insert_locked(drc, &ctx->key, buf, total_length, ts,
+    nev = nfs3_drc_cache_insert_locked(drc, &ctx->key, buf, rpc_len, ts,
                                        evicted, NFS3_DRC_EVICT_MAX);
     pthread_mutex_unlock(&drc->lock);
 
     if (!drc->persistence_disabled) {
         nfs3_drc_kv_put(thread->vfs_thread, drc->kv_type, &ctx->key, buf,
-                        total_length, ts);
+                        rpc_len, ts);
         for (i = 0; i < nev; i++) {
             nfs3_drc_kv_delete(thread->vfs_thread, drc->kv_type, &evicted[i]);
         }
@@ -783,9 +791,15 @@ nfs3_drc_dispatch(
     struct nfs3_drc                  *drc    = &thread->shared->nfs3_drc;
     struct nfs3_drc_keybuf            key;
 
-    /* The cached reply is the TCP on-wire form; RDMA framing differs, so leave
-    * RDMA requests (and idempotent procs) to the real dispatcher untouched. */
-    if (conn->rdma || !nfs3_drc_proc_cacheable(proc)) {
+    /* Idempotent procs are safe to re-execute, so they bypass the cache.
+     *
+     * RDMA connections used to bypass it too, because the cached reply was the
+     * TCP on-wire form and RDMA framing differs.  The cache now stores the RPC
+     * reply with the transport framing stripped (nfs3_drc_capture_reply), so a
+     * retransmit over RDMA is served like any other -- which it has to be: a
+     * duplicate-request cache that quietly disables itself on one transport
+     * re-executes non-idempotent operations there. */
+    if (!nfs3_drc_proc_cacheable(proc)) {
         return drc->orig_dispatch(evpl, conn, encoding, proc, program_data,
                                   cred, iov, niov, length, private_data);
     }

--- a/src/server/nfs/nfs4_drc.c
+++ b/src/server/nfs/nfs4_drc.c
@@ -16,7 +16,9 @@
 #include "vfs/vfs_procs.h"
 
 #define NFS4_DRC_SESSION_MAGIC   0x3153534Eu /* "NSS1" */
-#define NFS4_DRC_REPLY_MAGIC     0x3150524Eu /* "NRP1" */
+/* Bumped from "NRP1" when the cached bytes changed from the whole on-wire
+ * message to the RPC reply alone; a magic mismatch is already read as a miss. */
+#define NFS4_DRC_REPLY_MAGIC     0x3250524Eu /* "NRP2" */
 
 /* Session-record value: fixed header before the variable principal+owner. */
 #define NFS4_DRC_SESSION_HDR_LEN 100u

--- a/src/server/nfs/nfs4_proc_compound.c
+++ b/src/server/nfs/nfs4_proc_compound.c
@@ -30,17 +30,33 @@ nfs4_send_cached_reply(
 static void
 nfs4_release_write_args(
     struct chimera_server_nfs_thread *thread,
+    struct nfs_request               *req,
     struct COMPOUND4args             *args)
 {
+    const struct evpl_rpc2_rdma_chunk *rc = req->encoding->read_chunk;
+
     for (uint32_t i = 0; i < args->num_argarray; i++) {
         struct nfs_argop4 *ap = &args->argarray[i];
 
-        if (ap->argop == OP_WRITE && ap->opwrite.data.niov) {
-            evpl_iovecs_release(thread->evpl,
-                                ap->opwrite.data.iov,
-                                ap->opwrite.data.niov);
-            ap->opwrite.data.niov = 0;
+        if (ap->argop != OP_WRITE || !ap->opwrite.data.niov) {
+            continue;
         }
+
+        /* Over RDMA the payload arrived in an RFC 8166 Read chunk and
+         * opwrite.data.iov points straight at it rather than at XDR clones
+         * (see the take_read_chunk call in chimera_nfs4_write).  The rpc2
+         * request still owns those iovecs on this path, because the WRITE
+         * handler that would have taken ownership never runs -- so releasing
+         * them here would drop a reference the request frees again, which
+         * ASAN catches as a use-after-free on the very next retransmit. */
+        if (rc && rc->niov && ap->opwrite.data.iov == rc->iov) {
+            continue;
+        }
+
+        evpl_iovecs_release(thread->evpl,
+                            ap->opwrite.data.iov,
+                            ap->opwrite.data.niov);
+        ap->opwrite.data.niov = 0;
     }
 } /* nfs4_release_write_args */
 
@@ -157,7 +173,7 @@ chimera_nfs4_compound_process(
         /* XDR clones a +1 ref on every WRITE4args.data; the retransmit
          * we are about to discard had its args unmarshalled but will
          * never dispatch, so release any cloned iovecs here. */
-        nfs4_release_write_args(thread, req->args_compound);
+        nfs4_release_write_args(thread, req, req->args_compound);
         rc = nfs4_send_cached_reply(thread, req);
         chimera_nfs_abort_if(rc, "Failed to send cached RPC2 reply");
         /* Release the slot the retransmit path claimed (IN_PROGRESS) back to

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -12,6 +12,7 @@
 #include "nfs4_state.h"
 #include "nfs4_callback.h"
 #include "nfs4_drc.h"
+#include "nfs_drc_reply.h"
 #include "nfs_internal.h"
 #include "nfs_nlm_state.h"
 #include "nfs_common.h"
@@ -1514,22 +1515,29 @@ nfs4_replay_capture_reply(
     const struct evpl_iovec *iov,
     int                      niov,
     int                      total_length,
+    uint32_t                 rpc_offset,
     void                    *private_data)
 {
     struct nfs_request      *req     = private_data;
     struct nfs4_session     *session = req->replay_session;
     struct nfs4_replay_slot *slot    = req->replay_slot;
     uint8_t                 *buf;
-    size_t                   offset = 0;
-    size_t                   total  = (size_t) total_length;
+    uint32_t                 rpc_len;
+    size_t                   total;
     size_t                   cur;
-    int                      i;
 
-    if (!slot || !session || total_length <= 0) {
+    if (!slot || !session || total_length <= (int) rpc_offset) {
         return;
     }
 
-    if ((uint32_t) total_length > session->replay_maxresp_cached) {
+    /* Store the RPC reply, not the whole outgoing message: rpc_offset bytes of
+     * transport framing are rebuilt for the retransmit anyway, and keeping them
+     * made a reply captured over RDMA unparseable on replay -- which
+     * nfs4_send_cached_reply's caller turns into a fatal abort. */
+    rpc_len = (uint32_t) total_length - rpc_offset;
+    total   = rpc_len;
+
+    if (rpc_len > session->replay_maxresp_cached) {
         return;
     }
 
@@ -1546,7 +1554,7 @@ nfs4_replay_capture_reply(
                  &session->replay_bytes_in_use, &cur, cur + total,
                  memory_order_relaxed, memory_order_relaxed));
 
-    buf = malloc(total_length);
+    buf = malloc(rpc_len);
     if (!buf) {
         atomic_fetch_sub_explicit(&session->replay_bytes_in_use, total,
                                   memory_order_relaxed);
@@ -1556,17 +1564,19 @@ nfs4_replay_capture_reply(
     /* Concatenate iovecs into a single contiguous buffer.  Loses
      * zerocopy on replay; acceptable since cachethis=true is rare for
      * iovec-heavy ops (READ/READLINK) and replay is rare in general. */
-    for (i = 0; i < niov; i++) {
-        memcpy(buf + offset, iov[i].data, iov[i].length);
-        offset += iov[i].length;
+    if (nfs_drc_copy_rpc_reply(iov, niov, rpc_offset, buf, rpc_len) != rpc_len) {
+        free(buf);
+        atomic_fetch_sub_explicit(&session->replay_bytes_in_use, total,
+                                  memory_order_relaxed);
+        return;
     }
 
     /* Same thread runs finalize next, which release-publishes these via the
      * state_word store -- a later reader that observes CACHED sees them. */
     slot->cached_buf = buf;
-    slot->cached_len = total_length;
+    slot->cached_len = rpc_len;
 
-    nfs4_replay_bytes_delta(req, total_length);
+    nfs4_replay_bytes_delta(req, rpc_len);
 } /* nfs4_replay_capture_reply */
 
 /*

--- a/src/server/nfs/nfs4_v40_drc.c
+++ b/src/server/nfs/nfs4_v40_drc.c
@@ -358,26 +358,31 @@ nfs4_v40_drc_capture_reply(
     const struct evpl_iovec *iov,
     int                      niov,
     int                      total_length,
+    uint32_t                 rpc_offset,
     void                    *private_data)
 {
     struct nfs4_v40_drc_capture_ctx *ctx = private_data;
     uint8_t                         *buf;
-    size_t                           offset = 0;
+    uint32_t                         rpc_len;
     uint32_t                         body_offset;
-    int                              i;
 
-    if (total_length <= 0 ||
+    if (total_length <= (int) rpc_offset ||
         (uint32_t) total_length > NFS4_V40_DRC_MAX_REPLY_SIZE) {
         return;
     }
 
-    buf = malloc(total_length);
+    /* Store the RPC reply without its transport framing; see
+     * nfs_drc_copy_rpc_reply. */
+    rpc_len = (uint32_t) total_length - rpc_offset;
+
+    buf = malloc(rpc_len);
     if (!buf) {
         return;  /* OOM: skip caching this reply (degrade to a cache miss) */
     }
-    for (i = 0; i < niov; i++) {
-        memcpy(buf + offset, iov[i].data, iov[i].length);
-        offset += iov[i].length;
+
+    if (nfs_drc_copy_rpc_reply(iov, niov, rpc_offset, buf, rpc_len) != rpc_len) {
+        free(buf);
+        return;
     }
 
     /* Only a MSG_ACCEPTED/SUCCESS reply can ever be replayed --
@@ -387,9 +392,9 @@ nfs4_v40_drc_capture_reply(
      * reaching chimera_nfs4_compound, so nothing disarms the capture, and an
      * unauthenticated peer could otherwise evict every real entry with a stream
      * of malformed requests. */
-    if (nfs_drc_reply_body_offset(buf, total_length, &body_offset)) {
+    if (nfs_drc_reply_body_offset(buf, rpc_len, &body_offset)) {
         nfs4_v40_drc_cache_insert(ctx->drc, ctx->conn, ctx->xid, ctx->cksum,
-                                  buf, total_length);
+                                  buf, rpc_len);
     }
 
     free(buf);
@@ -432,10 +437,15 @@ nfs4_v40_drc_dispatch(
     uint32_t                          cached_len, mv;
     uint64_t                          cksum;
 
-    /* Only minorversion-0 COMPOUNDs over TCP use this cache.  NULL, RDMA, and
-     * 4.1+ COMPOUNDs (the session reply cache covers those) pass through.  The
-     * cached reply is the TCP on-wire form, so RDMA framing would not match. */
-    if (conn->rdma || proc != NFS4_PROC_COMPOUND ||
+    /* Only minorversion-0 COMPOUNDs use this cache; NULL and 4.1+ COMPOUNDs
+     * (the session reply cache covers those) pass through.
+     *
+     * RDMA connections used to pass through as well, because the cached reply
+     * was the TCP on-wire form and RDMA framing would not match.  The cache now
+     * stores the RPC reply with the framing stripped
+     * (nfs4_v40_drc_capture_reply), so an RDMA retransmit is served like any
+     * other -- it has to be, or a non-idempotent COMPOUND re-executes there. */
+    if (proc != NFS4_PROC_COMPOUND ||
         !nfs4_v40_peek_minorversion(iov, niov, &mv) || mv != 0) {
         return drc->orig_dispatch(evpl, conn, encoding, proc, program_data,
                                   cred, iov, niov, length, private_data);

--- a/src/server/nfs/nfs_drc_reply.c
+++ b/src/server/nfs/nfs_drc_reply.c
@@ -19,6 +19,56 @@ nfs_drc_be32(const uint8_t *p)
            (uint32_t) p[3];
 } /* nfs_drc_be32 */
 
+/* Copy the RPC reply out of the outgoing message, skipping rpc_offset bytes of
+ * transport framing (record marker or RPC-over-RDMA header).  What is stored is
+ * therefore transport-independent, which is what lets a reply captured over one
+ * transport be replayed at all -- and is required for RDMA, whose header is
+ * variable-length.  Returns the number of bytes written, or 0. */
+uint32_t
+nfs_drc_copy_rpc_reply(
+    const struct evpl_iovec *iov,
+    int                      niov,
+    uint32_t                 rpc_offset,
+    uint8_t                 *buf,
+    uint32_t                 buf_len)
+{
+    uint32_t skip = rpc_offset;
+    uint32_t off  = 0;
+    int      i;
+
+    for (i = 0; i < niov; i++) {
+        const uint8_t *src = iov[i].data;
+        uint32_t       n   = iov[i].length;
+
+        if (skip) {
+            if (skip >= n) {
+                skip -= n;
+                continue;
+            }
+            src += skip;
+            n   -= skip;
+            skip = 0;
+        }
+
+        if (off + n > buf_len) {
+            return 0;
+        }
+        memcpy(buf + off, src, n);
+        off += n;
+    }
+
+    return off;
+} /* nfs_drc_copy_rpc_reply */
+
+/*
+ * buf is the RPC reply message itself -- no transport framing.  The capture
+ * callbacks strip that off before storing (see the rpc_offset argument of
+ * evpl_rpc2_reply_capture_cb_t), because the framing is rebuilt for the
+ * retransmit anyway and differs per transport: a 4-byte record marker over a
+ * stream, a variable-length RPC-over-RDMA header over RDMA.  This parser used
+ * to begin by validating a record marker, which made a cached reply captured
+ * over RDMA unparseable -- and its callers turn that into a fatal abort.
+ */
 bool
 nfs_drc_reply_body_offset(
     const uint8_t *buf,
@@ -26,14 +76,10 @@ nfs_drc_reply_body_offset(
     uint32_t      *offset)
 {
     uint32_t v, verf_len, pad;
-    uint32_t pos = 4; /* TCP record marker */
+    uint32_t pos = 0;
 
-    if (len < 28) {
-        return false;
-    }
-
-    v = nfs_drc_be32(buf);
-    if ((v & 0x80000000u) == 0 || (v & 0x7fffffffu) + 4 != len) {
+    /* xid(4) mtype(4) reply_stat(4) verf_flavor(4) verf_len(4) accept_stat(4) */
+    if (len < 24) {
         return false;
     }
 

--- a/src/server/nfs/nfs_drc_reply.h
+++ b/src/server/nfs/nfs_drc_reply.h
@@ -9,27 +9,48 @@
 
 struct chimera_server_nfs_thread;
 struct evpl_rpc2_encoding;
+struct evpl_iovec;
 
 /*
  * Shared helpers for the NFSv3/NFSv4 duplicate-request caches.
  *
- * A captured reply (from the rpc2 reply_capture_cb) is the full on-wire TCP
- * reply: [record-mark(4)][RPC reply header][procedure result body].  Both DRCs
- * cache only the procedure-result body and re-emit it through the rpc2 reply
- * path on replay, so the RPC header (xid, verifier) and transport framing are
- * regenerated for the current connection -- which may differ from the one the
- * reply was first captured on (a different transport, or, after a restart, a
- * brand-new connection entirely).
+ * The rpc2 reply_capture_cb hands over the whole outgoing message plus the
+ * length of the transport framing in front of the RPC reply.  Both DRCs store
+ * what is behind that framing -- [RPC reply header][procedure result body] --
+ * and cache only the procedure-result body, re-emitting it through the rpc2
+ * reply path on replay.  The RPC header (xid, verifier) and the framing are
+ * regenerated for the current connection, which may differ from the one the
+ * reply was first captured on: a different transport, or, after a restart, a
+ * brand-new connection entirely.
+ *
+ * Keeping the framing instead would tie an entry to its original transport.
+ * It used to, and a reply captured over RPC-over-RDMA was then unparseable on
+ * replay -- fatal for the NFSv4.1 session cache, and the reason the NFSv3
+ * cache disabled itself on RDMA connections outright.
  */
 
-/* Parse a captured on-wire reply and yield the offset of the procedure-result
- * body within it.  Returns false unless the buffer is a well-formed
- * MSG_ACCEPTED / SUCCESS reply (the only kind worth replaying). */
+/* Parse a captured RPC reply and yield the offset of the procedure-result body
+ * within it.  Returns false unless the buffer is a well-formed MSG_ACCEPTED /
+ * SUCCESS reply (the only kind worth replaying). */
 bool
 nfs_drc_reply_body_offset(
     const uint8_t *buf,
     uint32_t       len,
     uint32_t      *offset);
+
+/*
+ * Copy the RPC reply out of a captured outgoing message, skipping rpc_offset
+ * bytes of transport framing.  See evpl_rpc2_reply_capture_cb_t for what that
+ * offset is; storing what it skips would tie a cached reply to the transport
+ * it was captured on.  Returns bytes written, or 0 if buf_len is too small.
+ */
+uint32_t
+nfs_drc_copy_rpc_reply(
+    const struct evpl_iovec *iov,
+    int                      niov,
+    uint32_t                 rpc_offset,
+    uint8_t                 *buf,
+    uint32_t                 buf_len);
 
 /* Strip the cached reply down to its procedure-result body and send it as the
  * reply for `encoding`'s request.  Returns 0 on success. */

--- a/src/server/nfs/tests/CMakeLists.txt
+++ b/src/server/nfs/tests/CMakeLists.txt
@@ -31,7 +31,9 @@ add_executable(test_replay_slot
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_recovery.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_drc.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_callback.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_cb.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs4_cb.c
+    # nfs4_session.c's reply capture strips transport framing through this.
+    ${CMAKE_CURRENT_SOURCE_DIR}/../nfs_drc_reply.c)
 target_include_directories(test_replay_slot PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_SOURCE_DIR}/src

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -396,30 +396,33 @@ foreach(rback memfs diskfs cairn linux io_uring)
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_nodrc_${rback}"
         LABELS "quint;nfsdrc_mbt;${rback}"
         TIMEOUT 600)
-endforeach()
 
-# NOTE: the NFS4 and duplicate-request-cache suites have no --rdma twin yet,
-# and the omission is deliberate rather than an oversight.  Both replay
-# retransmits, and retransmit handling is broken over RPC-over-RDMA in two
-# separate ways that have to be fixed before those cells can be green:
-#
-#   1. The NFSv4.1 session reply cache FATALLY ABORTS the server.  A retransmit
-#      on a cached slot reaches nfs4_send_cached_reply, which asks
-#      nfs_drc_reply_body_offset() to find the RPC body; that parser requires a
-#      TCP record marker, and over RDMA the captured reply begins with the
-#      RPC-over-RDMA header instead (observed: xid, vers=1, credits=1,
-#      proc=0/RDMA_MSG).  The parse fails, and the caller's chimera_nfs_abort_if
-#      turns it into an abort -- reachable by any client that retransmits over
-#      NFS/RDMA.  The reply-capture callback is handed the whole outgoing
-#      message, so a fix needs libevpl to say where the RPC message starts (the
-#      RDMA header is variable-length, so chimera cannot compute it).
-#
-#   2. The NFSv3 duplicate-request cache never recognizes a retransmit at all:
-#      the lookup misses, the request re-executes, and the model sees a second
-#      execution where it expected a replayed reply.  Not yet root-caused; the
-#      cache is keyed on (address, procedure, xid, checksum).
-#
-# Reproduce either with --rdma on the corresponding replayer.
+    # Over RPC-over-RDMA.  This suite is the one that most needs the transport
+    # varied: both duplicate-request caches used to skip RDMA connections
+    # outright, on the grounds that the cached reply was the TCP on-wire form,
+    # which silently turned every non-idempotent retransmit over RDMA into a
+    # second execution.  The caches now store the RPC reply without its framing
+    # and serve RDMA like any other transport; these cells are what says so.
+    add_test(NAME chimera/server/nfs/mbtdrc/batch_rdma_${rback}
+        COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid
+                --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
+                --exclude-prefix nfsdrcNoV3
+                --backend ${rback} --rdma)
+    set_tests_properties(chimera/server/nfs/mbtdrc/batch_rdma_${rback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_rdma_${rback}"
+        LABELS "quint;nfsdrc_mbt;rdma;${rback}"
+        TIMEOUT 600)
+
+    add_test(NAME chimera/server/nfs/mbtdrc/batch_nodrc_rdma_${rback}
+        COMMAND $<TARGET_FILE:nfs_drc_mbt_replay> --paranoid --no-nfs3-drc
+                --trace-dir ${SPECS_BUNDLE_DIR}/nfsdrc
+                --exclude-prefix nfsdrcRef
+                --backend ${rback} --rdma)
+    set_tests_properties(chimera/server/nfs/mbtdrc/batch_nodrc_rdma_${rback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsdrc_batch_nodrc_rdma_${rback}"
+        LABELS "quint;nfsdrc_mbt;rdma;${rback}"
+        TIMEOUT 600)
+endforeach()
 
 # SKIP_RETURN_CODE 77 still applies to NFS4: a trace whose capability profile
 # does not match the live server exits 77 individually; the batch reports SKIP
@@ -487,6 +490,35 @@ if(CHIMERA_VFS_IO_URING)
         SKIP_RETURN_CODE 77
         TIMEOUT 600)
 endif()
+
+# The same corpus over RPC-over-RDMA, as the NFS3 suite runs above.  A WRITE
+# compound sends its payload in a Read chunk and a READ compound advertises a
+# Write chunk, so the chunk paths are covered here and not just the framing.
+#
+# These cells are also the only test of a retransmit over RDMA, which is where
+# the NFSv4.1 session reply cache used to abort the server outright: it stored
+# the reply with its transport framing, and the replay path could not parse an
+# RPC-over-RDMA header.  Both that and the double release of a Read chunk's
+# iovecs on the replay path are fixed; either one regressing takes these red.
+foreach(rback memfs diskfs cairn linux io_uring)
+    if(rback STREQUAL "cairn" AND NOT CAIRN_ENABLED)
+        continue()
+    endif()
+    if(rback STREQUAL "linux" AND NOT CHIMERA_LINUX)
+        continue()
+    endif()
+    if(rback STREQUAL "io_uring" AND NOT CHIMERA_VFS_IO_URING)
+        continue()
+    endif()
+    add_test(NAME chimera/server/nfs/mbt4/batch_rdma_${rback}
+        COMMAND $<TARGET_FILE:nfs4_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs4
+                --backend ${rback} --rdma)
+    set_tests_properties(chimera/server/nfs/mbt4/batch_rdma_${rback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs4_batch_rdma_${rback}"
+        LABELS "quint;nfs4_mbt;rdma;${rback}"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 600)
+endforeach()
 
 # The same corpus with delegations SERVED.  The corpus's Deleg instances
 # assume grants and skip against the default (delegations-off) server above;

--- a/src/server/nfs/tests/quint/CMakeLists.txt
+++ b/src/server/nfs/tests/quint/CMakeLists.txt
@@ -252,6 +252,43 @@ if(CHIMERA_VFS_IO_URING)
         TIMEOUT 300)
 endif()
 
+# The same corpus again, carried over RPC-over-RDMA instead of plain RPC record
+# marking (--rdma; see mbt_env_opts.rdma).  The inproc transport's
+# DATAGRAM_INPROC protocol reports itself RDMA-capable and performs real
+# one-sided transfers against a registered-memory table, so this is not an
+# emulation: rpc2 selects RFC 8166 framing, WRITE hands its payload over in a
+# Read chunk for the server to pull, and READ advertises a Write chunk the
+# server places the reply into -- the same two things chimera's own NFS client
+# asks for (vfs/nfs/nfs4_write.c, nfs4_read.c).
+#
+# Measured on memfs: 73 RDMA reads and 26 RDMA writes across the corpus,
+# against zero for the stream cells above.  That count is the check that keeps
+# these honest -- without the chunk requests an RDMA run still passes, having
+# exercised the framing but never a one-sided transfer.
+foreach(rback memfs diskfs cairn linux io_uring)
+    if(rback STREQUAL "cairn" AND NOT CAIRN_ENABLED)
+        continue()
+    endif()
+    if(rback STREQUAL "linux" AND NOT CHIMERA_LINUX)
+        continue()
+    endif()
+    if(rback STREQUAL "io_uring" AND NOT CHIMERA_VFS_IO_URING)
+        continue()
+    endif()
+    set(rextra "")
+    if(rback STREQUAL "linux" OR rback STREQUAL "io_uring")
+        set(rextra --max-attr-skip-rate 0.5)
+    endif()
+    add_test(NAME chimera/server/nfs/mbt/batch_rdma_${rback}
+        COMMAND $<TARGET_FILE:nfs3_mbt_replay> --trace-dir ${SPECS_BUNDLE_DIR}/nfs3
+                --backend ${rback} --rdma ${rextra})
+    set_tests_properties(chimera/server/nfs/mbt/batch_rdma_${rback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfs3_batch_rdma_${rback}"
+        LABELS "quint;nfs3_mbt;rdma;${rback}"
+        SKIP_RETURN_CODE 77
+        TIMEOUT 300)
+endforeach()
+
 # The auxiliary protocols (portmap/rpcbind, MOUNT, NLM, NSM) replayed from the
 # nfsaux corpus.  One batch: the four protocols share one model because they
 # share state (a granted lock monitors its holder, a notify drops its locks),
@@ -292,6 +329,20 @@ foreach(aback memfs diskfs cairn linux io_uring)
     set_tests_properties(chimera/server/nfs/mbtaux/batch_${aback} PROPERTIES
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_batch_${aback}"
         LABELS "quint;nfsaux_mbt;${aback}"
+        TIMEOUT 600)
+
+    # Over RPC-over-RDMA, as the NFS3 corpus runs above.  Only the NFS service
+    # moves: MOUNT, NLM, NSM and portmap keep the stream endpoint, which is how
+    # a real NFS/RDMA deployment is arranged.  This corpus has no READ or WRITE
+    # in it, so unlike the NFS3 pair these cells cover the RFC 8166 framing and
+    # the auxiliary protocols' behavior beside it, not the chunk paths.
+    add_test(NAME chimera/server/nfs/mbtaux/batch_rdma_${aback}
+        COMMAND $<TARGET_FILE:nfs_aux_mbt_replay> --paranoid
+                --trace-dir ${SPECS_BUNDLE_DIR}/nfsaux
+                --backend ${aback} --rdma)
+    set_tests_properties(chimera/server/nfs/mbtaux/batch_rdma_${aback} PROPERTIES
+        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=nfsaux_batch_rdma_${aback}"
+        LABELS "quint;nfsaux_mbt;rdma;${aback}"
         TIMEOUT 600)
 endforeach()
 
@@ -346,6 +397,29 @@ foreach(rback memfs diskfs cairn linux io_uring)
         LABELS "quint;nfsdrc_mbt;${rback}"
         TIMEOUT 600)
 endforeach()
+
+# NOTE: the NFS4 and duplicate-request-cache suites have no --rdma twin yet,
+# and the omission is deliberate rather than an oversight.  Both replay
+# retransmits, and retransmit handling is broken over RPC-over-RDMA in two
+# separate ways that have to be fixed before those cells can be green:
+#
+#   1. The NFSv4.1 session reply cache FATALLY ABORTS the server.  A retransmit
+#      on a cached slot reaches nfs4_send_cached_reply, which asks
+#      nfs_drc_reply_body_offset() to find the RPC body; that parser requires a
+#      TCP record marker, and over RDMA the captured reply begins with the
+#      RPC-over-RDMA header instead (observed: xid, vers=1, credits=1,
+#      proc=0/RDMA_MSG).  The parse fails, and the caller's chimera_nfs_abort_if
+#      turns it into an abort -- reachable by any client that retransmits over
+#      NFS/RDMA.  The reply-capture callback is handed the whole outgoing
+#      message, so a fix needs libevpl to say where the RPC message starts (the
+#      RDMA header is variable-length, so chimera cannot compute it).
+#
+#   2. The NFSv3 duplicate-request cache never recognizes a retransmit at all:
+#      the lookup misses, the request re-executes, and the model sees a second
+#      execution where it expected a replayed reply.  Not yet root-caused; the
+#      cache is keyed on (address, procedure, xid, checksum).
+#
+# Reproduce either with --rdma on the corresponding replayer.
 
 # SKIP_RETURN_CODE 77 still applies to NFS4: a trace whose capability profile
 # does not match the live server exits 77 individually; the batch reports SKIP

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -45,27 +45,34 @@
 #include "evpl/evpl.h"
 #include "evpl/evpl_rpc2.h"
 
-#define MBT_MAX_ENTRIES  512    /* readdir entries copied out per reply */
-#define MBT_NAME_MAX     256
-#define MBT_MAX_DATA     (4 << 20) /* read payload copy-out bound */
+#define MBT_MAX_ENTRIES   512   /* readdir entries copied out per reply */
+#define MBT_NAME_MAX      256
+#define MBT_MAX_DATA      (4 << 20) /* read payload copy-out bound */
 
 /* Must match NFS_MOUNT_PORT in nfs_external_portmap.h: under inproc the
  * port number is only a service name ("chimera-inproc-20048"), but it
  * still has to be the name the server registered.  The auxiliary services
  * follow the same rule: 111 is hardwired in nfs.c, the other two are the
  * nfs_lockmgr_port / nfs_nsm_port defaults (server.c). */
-#define MBT_MOUNT_PORT   20048
-#define MBT_PORTMAP_PORT 111
-#define MBT_NLM_PORT     32803
-#define MBT_NSM_PORT     32765
+#define MBT_MOUNT_PORT    20048
+#define MBT_PORTMAP_PORT  111
+#define MBT_NLM_PORT      32803
+#define MBT_NSM_PORT      32765
+
+/* The NFS/RDMA service (mbt_env_opts.rdma), which the server puts on its own
+ * endpoint alongside the stream one.  Must match the nfs_rdma_port default in
+ * server.c, for the same reason MBT_MOUNT_PORT must match NFS_MOUNT_PORT.
+ * Only the NFS service has an RDMA endpoint: MOUNT, NLM, NSM and portmap stay
+ * on the stream protocol, exactly as they do over real hardware. */
+#define MBT_NFS_RDMA_PORT 20049
 
 /* pNFS topology (see mbt_env_opts.pnfs_num_ds): the data servers are
  * additional chimera servers in THIS process, each on its own inproc
  * service name, so the whole MDS+DS cluster is one test binary with no
  * ports, namespaces or daemons.  Their port numbers only have to avoid
  * the MDS's own services above. */
-#define MBT_MAX_DS       4
-#define MBT_DS_PORT_BASE 12050
+#define MBT_MAX_DS        4
+#define MBT_DS_PORT_BASE  12050
 
 struct mbt_fh {
     int      has;
@@ -142,6 +149,16 @@ struct mbt_env_opts {
      * the NFS3/NFS4 suites never touch them, and connecting three more
      * inproc services per replay process is pure overhead there. */
     int         aux;
+    /* Carry NFS over RPC-over-RDMA instead of plain RPC record marking.
+     *
+     * The inproc transport has two protocols: STREAM_INPROC, and
+     * DATAGRAM_INPROC which reports itself RDMA-capable and performs real
+     * one-sided transfers against a registered-memory table (see
+     * evpl_inproc_rdma_xfer).  rpc2 keys its framing off evpl_bind_is_rdma(),
+     * so pointing the client at the server's RDMA endpoint exercises the read
+     * and write chunk paths -- the RDMA framing is genuinely under test here,
+     * not emulated away. */
+    int         rdma;
     /* server.portmap_hostname: when set, portmap universal addresses are
      * built from this host instead of the connection's local address.  The
      * aux suite uses it to make the uaddr predictable (the inproc local
@@ -190,6 +207,8 @@ struct mbt_env {
      * every other suite. */
     struct evpl_http_agent    *rest_agent;
     const char                *module;   /* backend for mkfs/mount/rmfs */
+
+    int                        rdma;     /* NFS carried over RPC-over-RDMA */
 
     struct evpl               *evpl;
     struct evpl_rpc2_thread   *rpc2_thread;
@@ -419,6 +438,14 @@ mbt_env_open_opts(
     chimera_server_config_set_tcp_flavor(config, CHIMERA_TCP_FLAVOR_INPROC);
     chimera_server_config_set_nfs_enabled(config, 1);
 
+    /* The RDMA listener is additional, not instead: the server keeps its
+     * stream endpoint, and the client below chooses which one to use. */
+    env->rdma = (opts && opts->rdma);
+    if (env->rdma) {
+        chimera_server_config_set_nfs_rdma(config, 1);
+        chimera_server_config_set_nfs_rdma_port(config, MBT_NFS_RDMA_PORT);
+    }
+
     env->module = (opts && opts->module) ? opts->module : "memfs";
 
     /* Deliberately NOT raising common.umount_timeout_ms here.
@@ -623,12 +650,17 @@ mbt_env_open_opts(
     /* Endpoint names must match what the server derived from its ports
      * (chimera-inproc-<port>); build them through the same helper. */
     nfs_ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
-                                                "127.0.0.1", 2049);
+                                                "127.0.0.1",
+                                                env->rdma ? MBT_NFS_RDMA_PORT
+                                                : 2049);
     mount_ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
                                                   "127.0.0.1", MBT_MOUNT_PORT);
 
+    /* DATAGRAM_INPROC is the RDMA-capable inproc protocol; rpc2 picks its
+     * RDMA framing from the bind, so this one choice switches both ends. */
     env->nfs_conn = evpl_rpc2_client_connect(env->rpc2_thread,
-                                             EVPL_STREAM_INPROC,
+                                             env->rdma ? EVPL_DATAGRAM_INPROC
+                                             : EVPL_STREAM_INPROC,
                                              nfs_ep, NULL, 0, NULL);
     env->mount_conn = evpl_rpc2_client_connect(env->rpc2_thread,
                                                EVPL_STREAM_INPROC,
@@ -1556,10 +1588,17 @@ mbt_write(
     args.data.length    = len;
 
     /* Marshalling MOVES the data iovec (xdr_iovec_move_private), so
-     * ownership passes to the rpc2 layer here -- no release on our side. */
+     * ownership passes to the rpc2 layer here -- no release on our side.
+     *
+     * ddp=1 under RDMA puts the payload in an RFC 8166 Read chunk for the
+     * server to pull, instead of inline in the request.  It is what drives
+     * the server's read-chunk path (evpl_rpc2_encoding_take_read_chunk in
+     * nfs3_proc_write.c); without it an RDMA run still gets RPC-over-RDMA
+     * framing but never a one-sided transfer, and the chunk handling would
+     * go untested. */
     env->nfs_v3.send_call_NFSPROC3_WRITE(&env->nfs_v3.rpc2, env->evpl,
                                          env->nfs_conn, &env->cred, &args,
-                                         0, 0, NULL, 0, 0,
+                                         env->rdma, 0, NULL, 0, 0,
                                          mbt_write_cb, env);
     mbt_call_wait(env);
     return &env->res;
@@ -1589,9 +1628,20 @@ mbt_read_cb(
             /* The reply's data iovecs are handed to this callback WITH
              * their references (the vfs/nfs proxy passes them on to the
              * VFS layer, which releases them); we only copy, so release
-             * them here or evpl's teardown leak check aborts. */
+             * them here or evpl's teardown leak check aborts.
+             *
+             * resok.count bounds the copy, and the iovec lengths do not.
+             * Inline they agree, but an RDMA Write chunk is returned at the
+             * size the client ADVERTISED, not the size the server filled --
+             * a short read into a full-size chunk hands back a longer iovec
+             * whose tail is undefined.  count is the authoritative length,
+             * which is what chimera's own client uses (nfs3_read.c).  Every
+             * iovec is still released, copied from or not. */
             for (i = 0; i < reply->resok.data.niov; i++) {
                 n = reply->resok.data.iov[i].length;
+                if (off + n > reply->resok.count) {
+                    n = reply->resok.count - off;
+                }
                 if (off + n > MBT_MAX_DATA) {
                     n = MBT_MAX_DATA - off;
                 }
@@ -1620,9 +1670,13 @@ mbt_read(
     args.file.data.len  = fh->len;
     args.offset         = offset;
     args.count          = count;
+    /* The mirror of the WRITE above: advertising a Write chunk of the read
+     * size lets the server place the payload directly with an RDMA write
+     * rather than sending it inline. */
     env->nfs_v3.send_call_NFSPROC3_READ(&env->nfs_v3.rpc2, env->evpl,
                                         env->nfs_conn, &env->cred, &args,
-                                        0, 0, NULL, 0, 0,
+                                        0, env->rdma ? (int) count : 0,
+                                        NULL, 0, 0,
                                         mbt_read_cb, env);
     mbt_call_wait(env);
     return &env->res;

--- a/src/server/nfs/tests/quint/nfs3_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_replay.c
@@ -1712,6 +1712,8 @@ main(
           'v'                                                                                                                                                                                                },
         { "backend",            required_argument,              0,
           'B'                                                                           },
+        { "rdma",               no_argument,                    0,
+          'R'                                                                           },
         { 0,                    0,                              0,                             0 },
     };
     char               **traces;
@@ -1721,6 +1723,7 @@ main(
     int                  dry_run            = 0;
     int                  verbose            = 0;
     const char          *backend            = "memfs";
+    int                  rdma               = 0;
     int                  failures           = 0;
     int                  c;
     int                  i;
@@ -1736,7 +1739,7 @@ main(
      * error, and skips them here (the 't'/'D'/'X' cases). */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:b:r:nvB:", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:b:r:nvB:R", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -1758,12 +1761,15 @@ main(
             case 'B':
                 backend = optarg;
                 break;
+            case 'R':
+                rdma = 1;
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
                         "[--block-size N] [--max-attr-skip-rate F] "
                         "[--backend memfs|diskfs|cairn|linux|io_uring] "
-                        "[--dry-run] [--verbose]\n", argv[0]);
+                        "[--rdma] [--dry-run] [--verbose]\n", argv[0]);
                 mbt_free_traces(traces, ntraces);
                 return 2;
         } /* switch */
@@ -1781,7 +1787,7 @@ main(
      * isolation.  A single-fs backend (linux/io_uring) would instead clear the
      * backing directory between traces. */
     if (!dry_run) {
-        struct mbt_env_opts opts = { .module = backend };
+        struct mbt_env_opts opts = { .module = backend, .rdma = rdma };
         mbt_env_open_opts(&env, &opts);
     }
 

--- a/src/server/nfs/tests/quint/nfs4_deleg_probe.c
+++ b/src/server/nfs/tests/quint/nfs4_deleg_probe.c
@@ -335,9 +335,13 @@ pc_setup(
 
     cb_programs[0] = &env->nfs_v4_cb.rpc2;
     ep             = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
-                                                        "127.0.0.1", 2049);
+                                                        "127.0.0.1",
+                                                        env->rdma
+                                                        ? MBT_NFS_RDMA_PORT
+                                                        : 2049);
     pc->conn = evpl_rpc2_client_connect(env->rpc2_thread,
-                                        EVPL_STREAM_INPROC, ep,
+                                        env->rdma ? EVPL_DATAGRAM_INPROC
+                                        : EVPL_STREAM_INPROC, ep,
                                         cb_programs, 1, pc);
 
     memset(&op, 0, sizeof(op));

--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -947,10 +947,20 @@ conn_for(
     }
     if (!o->conns[model_client]) {
         cb_programs[0] = &o->env->nfs_v4_cb.rpc2;
-        ep             = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
-                                                            "127.0.0.1", 2049);
+        /* Follow the env's transport.  These per-model-client connections
+         * carry every stateful compound the trace issues -- conn_for() only
+         * falls back to env->nfs_conn for a compound with no client -- so
+         * leaving them on the stream endpoint would put most of an --rdma run
+         * back on plain RPC. */
+        ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
+                                                "127.0.0.1",
+                                                o->env->rdma
+                                                ? MBT_NFS_RDMA_PORT
+                                                : 2049);
         o->conns[model_client] =
-            evpl_rpc2_client_connect(o->env->rpc2_thread, EVPL_STREAM_INPROC,
+            evpl_rpc2_client_connect(o->env->rpc2_thread,
+                                     o->env->rdma ? EVPL_DATAGRAM_INPROC
+                                     : EVPL_STREAM_INPROC,
                                      ep, cb_programs, 1, o);
         if (!o->conns[model_client]) {
             fprintf(stderr, "failed to open connection for model client "
@@ -2415,8 +2425,16 @@ decode_resop(
 
                 r->eof  = rop->opread.resok4.eof != 0;
                 r->data = o->arena + o->arena_used;
+                /* data.length, not the iovec lengths: an RDMA Write chunk
+                 * comes back at the size the client ADVERTISED, not the size
+                 * the server filled, so a short read hands back a longer
+                 * iovec whose tail is undefined.  chimera's own client reads
+                 * the same field (vfs/nfs/nfs4_read.c). */
                 for (i = 0; i < rop->opread.resok4.data.niov; i++) {
                     n = rop->opread.resok4.data.iov[i].length;
+                    if (off + n > rop->opread.resok4.data.length) {
+                        n = rop->opread.resok4.data.length - off;
+                    }
                     if (o->arena_used + off + n > V4_DATA_ARENA) {
                         n = V4_DATA_ARENA - o->arena_used - off;
                     }
@@ -3787,6 +3805,8 @@ run_compound(
     uint32_t             retry_slot = 0;
     int                  retry_sess = 0;
     int                  has_seq    = 0;
+    int                  cd_ddp     = 0;
+    int                  cd_wchunk  = 0;
 
     o->status_dev              = 0;
     o->cur_open_clientid_known = 0;
@@ -3817,6 +3837,25 @@ run_compound(
     {
         if (encode_op(o, op, &argarray[i], &scratch[i], m) < 0) {
             return -1;
+        }
+
+        /* RDMA chunk eligibility for this compound, mirroring what chimera's
+         * own v4 client asks for (vfs/nfs/nfs4_write.c, nfs4_read.c): a WRITE
+         * puts its payload in a Read chunk for the server to pull (ddp), and a
+         * READ advertises a Write chunk the server can place the reply data
+         * into.  Without these an RDMA run gets RPC-over-RDMA framing but never
+         * a one-sided transfer, and the server's chunk handling goes untested.
+         *
+         * Accumulated here, as each op is encoded, rather than in a second pass
+         * over argarray: only the ops this loop has written are initialized,
+         * and a later pass bounded by nops cannot show the analyzer that. */
+        if (o->env->rdma) {
+            if (argarray[i].argop == OP_WRITE) {
+                cd_ddp = 1;
+            } else if (argarray[i].argop == OP_READ &&
+                       (int) argarray[i].opread.count > cd_wchunk) {
+                cd_wchunk = (int) argarray[i].opread.count;
+            }
         }
     }
 
@@ -3895,7 +3934,8 @@ run_compound(
         o->env->nfs_v4.send_call_NFSPROC4_COMPOUND(&o->env->nfs_v4.rpc2,
                                                    o->env->evpl, conn,
                                                    &o->env->cred, &args,
-                                                   0, 0, NULL, 0, 0,
+                                                   cd_ddp, cd_wchunk,
+                                                   NULL, 0, 0,
                                                    v4_compound_cb, &cctx);
         while (!rep.done) {
             evpl_continue(o->env->evpl);
@@ -4715,6 +4755,7 @@ main(
         { "backend",        required_argument, 0, 'b' },
         { "pnfs",           required_argument, 0, 'p' },
         { "delegations",    no_argument,       0, 'g' },
+        { "rdma",           no_argument,       0, 'R' },
         { "dry-run",        no_argument,       0, 'n' },
         { "verbose",        no_argument,       0, 'v' },
         { 0,                0,                 0, 0   },
@@ -4754,7 +4795,7 @@ main(
      * shared helper; getopt only recognizes them so it does not error. */
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:M:b:p:gnv", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:M:b:p:gnvR", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -4794,11 +4835,14 @@ main(
                     return 2;
                 }
                 break;
+            case 'R':
+                opts.rdma = 1;
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
                         "[--backend memfs|diskfs|cairn|linux|io_uring] "
-                        "[--pnfs N] [--delegations] "
+                        "[--pnfs N] [--delegations] [--rdma] "
                         "[--mandatory CAP] [--dry-run] [--verbose]\n",
                         argv[0]);
                 mbt_free_traces(traces, ntraces);

--- a/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
@@ -1711,6 +1711,8 @@ main(
           'p'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 },
         { "backend",        required_argument,          0,
           'B'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          },
+        { "rdma",           no_argument,                0,
+          'R'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          },
         { 0,                0,                          0,                         0 },
     };
     char               **traces;
@@ -1718,6 +1720,7 @@ main(
     int                  dry_run  = 0;
     int                  verbose  = 0;
     const char          *backend  = "memfs";
+    int                  rdma     = 0;
     int                  failures = 0;
     int                  c, i;
     struct mbt_env       env;
@@ -1725,7 +1728,7 @@ main(
 
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:nvpB:", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:nvpB:R", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -1744,10 +1747,14 @@ main(
             case 'B':
                 backend = optarg;
                 break;
+            case 'R':
+                rdma = 1;
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
-                        "[--backend memfs|diskfs|cairn] [--dry-run] "
+                        "[--backend memfs|diskfs|cairn|linux|io_uring] "
+                        "[--rdma] [--dry-run] "
                         "[--verbose] [--paranoid]\n", argv[0]);
                 mbt_free_traces(traces, ntraces);
                 return 2;
@@ -1764,6 +1771,7 @@ main(
     if (!dry_run) {
         memset(&opts, 0, sizeof(opts));
         opts.module = backend;
+        opts.rdma   = rdma;
         /* The universal addresses rpcbind reports are built from this rather
          * than from the connection's local address, which under inproc is a
          * service name rather than an IP. */

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_common.h
@@ -129,9 +129,17 @@ drc_conn_open(struct drc_ctx *c)
     struct evpl_endpoint  *ep;
     struct evpl_rpc2_conn *conn;
 
+    /* Follow the env's transport.  These are the connections the suite
+     * actually tests on -- the model's connection ids map to them -- so
+     * leaving them on the stream endpoint would make an --rdma run a
+     * verbatim repeat of the stream one. */
     ep = chimera_tcp_flavor_endpoint_create(CHIMERA_TCP_FLAVOR_INPROC,
-                                            "127.0.0.1", 2049);
-    conn = evpl_rpc2_client_connect(c->env->rpc2_thread, EVPL_STREAM_INPROC,
+                                            "127.0.0.1",
+                                            c->env->rdma ? MBT_NFS_RDMA_PORT
+                                            : 2049);
+    conn = evpl_rpc2_client_connect(c->env->rpc2_thread,
+                                    c->env->rdma ? EVPL_DATAGRAM_INPROC
+                                    : EVPL_STREAM_INPROC,
                                     ep, NULL, 0, NULL);
     if (!conn) {
         fprintf(stderr, "drc: failed to open an NFS connection\n");

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
@@ -869,6 +869,7 @@ main(
         { "paranoid",       no_argument,       0, 'p' },
         { "no-nfs3-drc",    no_argument,       0, 'N' },
         { "backend",        required_argument, 0, 'B' },
+        { "rdma",           no_argument,       0, 'R' },
         { 0,                0,                 0, 0   },
     };
     /* *INDENT-ON* */
@@ -878,6 +879,7 @@ main(
     int                 verbose  = 0;
     int                 nfs3_drc = 1;
     const char         *backend  = "memfs";
+    int                 rdma     = 0;
     int                 failures = 0;
     int                 c, i;
     struct mbt_env      env;
@@ -887,7 +889,7 @@ main(
 
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
-    while ((c = getopt_long(argc, argv, "t:D:X:nvpNB:", long_options,
+    while ((c = getopt_long(argc, argv, "t:D:X:nvpNB:R", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 't':
@@ -909,10 +911,14 @@ main(
             case 'B':
                 backend = optarg;
                 break;
+            case 'R':
+                rdma = 1;
+                break;
             default:
                 fprintf(stderr,
                         "usage: %s [--trace FILE ...] [--trace-dir DIR] "
-                        "[--backend memfs|diskfs|cairn] [--no-nfs3-drc] "
+                        "[--backend memfs|diskfs|cairn|linux|io_uring] "
+                        "[--rdma] [--no-nfs3-drc] "
                         "[--dry-run] [--verbose] [--paranoid]\n", argv[0]);
                 mbt_free_traces(traces, ntraces);
                 return 2;
@@ -929,6 +935,7 @@ main(
     if (!dry_run) {
         memset(&opts, 0, sizeof(opts));
         opts.module = backend;
+        opts.rdma   = rdma;
         /* The corpus generated from the nfsdrcNoV3 profile is replayed with the
          * NFSv3 cache off, which is the server's own default; everything else
          * needs it on.  The NFSv4.0 cache has no switch. */

--- a/src/server/nfs/tests/test_nfs_persist.c
+++ b/src/server/nfs/tests/test_nfs_persist.c
@@ -711,9 +711,13 @@ test_nfs4_v40_compound_cacheable(void)
     printf("ok: nfs4_v40_compound_cacheable\n");
 } /* test_nfs4_v40_compound_cacheable */
 
-/* Build a minimal well-formed on-wire reply: record mark, xid, REPLY,
- * MSG_ACCEPTED, an empty verifier, SUCCESS, then `body`.  This is the shape the
- * rpc2 capture hook delivers and that nfs_drc_reply_body_offset accepts. */
+/* Build a minimal well-formed RPC reply: xid, REPLY, MSG_ACCEPTED, an empty
+ * verifier, SUCCESS, then `body`.
+ *
+ * No record marker: the capture hooks strip the transport framing before
+ * storing (see nfs_drc_copy_rpc_reply), because it differs per transport and is
+ * rebuilt for the retransmit anyway.  nfs_drc_reply_body_offset therefore
+ * parses from the RPC message. */
 static uint32_t
 v40_make_reply(
     uint8_t   *out,
@@ -723,24 +727,17 @@ v40_make_reply(
     uint32_t   accept_stat)
 {
     uint32_t body_len = (uint32_t) strlen(body);
-    uint32_t len      = 28 + body_len;
-    uint32_t mark;
+    uint32_t len      = 24 + body_len;
 
     CHECK(out_size >= len);
     memset(out,0,len);
 
-    mark   = 0x80000000u | (len - 4);
-    out[0] = (uint8_t) (mark >> 24);
-    out[1] = (uint8_t) (mark >> 16);
-    out[2] = (uint8_t) (mark >> 8);
-    out[3] = (uint8_t) mark;
-
-    out[7]  = (uint8_t) xid;    /* xid (low byte is enough for a fixture)     */
-    out[11] = 1;                /* mtype      = REPLY                        */
-    /* [12..15] reply_stat = MSG_ACCEPTED (0), [16..19] verf flavor = AUTH_NONE,
-     * [20..23] verf len   = 0 -- all already zero. */
-    out[27] = (uint8_t) accept_stat;
-    memcpy(out + 28,body,body_len);
+    out[3] = (uint8_t) xid;     /* xid (low byte is enough for a fixture)     */
+    out[7] = 1;                 /* mtype      = REPLY                        */
+    /* [8..11] reply_stat = MSG_ACCEPTED (0), [12..15] verf flavor = AUTH_NONE,
+     * [16..19] verf len  = 0 -- all already zero. */
+    out[23] = (uint8_t) accept_stat;
+    memcpy(out + 24,body,body_len);
     return len;
 } /* v40_make_reply */
 
@@ -850,7 +847,7 @@ test_nfs4_v40_reply_filter(void)
     /* SUCCESS: accepted, and the body starts right after the header. */
     len = v40_make_reply(buf,sizeof(buf),7,"CREATE4res NFS4_OK",0);
     CHECK(nfs_drc_reply_body_offset(buf,len,&offset) == true);
-    CHECK(offset == 28);
+    CHECK(offset == 24);
 
     /* GARBAGE_ARGS (accept_stat 4) is MSG_ACCEPTED but not SUCCESS. */
     len = v40_make_reply(buf,sizeof(buf),7,"",4);
@@ -860,14 +857,14 @@ test_nfs4_v40_reply_filter(void)
     len = v40_make_reply(buf,sizeof(buf),7,"",1);
     CHECK(nfs_drc_reply_body_offset(buf,len,&offset) == false);
 
-    /* MSG_DENIED: reply_stat at [12..15] is non-zero. */
+    /* MSG_DENIED: reply_stat at [8..11] is non-zero. */
     len     = v40_make_reply(buf,sizeof(buf),7,"body",0);
-    buf[15] = 1;
+    buf[11] = 1;
     CHECK(nfs_drc_reply_body_offset(buf,len,&offset) == false);
 
     /* A CALL, not a REPLY. */
-    len     = v40_make_reply(buf,sizeof(buf),7,"body",0);
-    buf[11] = 0;
+    len    = v40_make_reply(buf,sizeof(buf),7,"body",0);
+    buf[7] = 0;
     CHECK(nfs_drc_reply_body_offset(buf,len,&offset) == false);
 
     /* Truncated below a bare header. */


### PR DESCRIPTION
> Carries a libevpl submodule bump to chimera-nas/libevpl#149, now merged.

libevpl's inproc transport has two protocols: `STREAM_INPROC`, and
`DATAGRAM_INPROC`, which reports itself RDMA-capable and performs real one-sided
transfers against a registered-memory table. rpc2 selects its framing from
`evpl_bind_is_rdma()`, so pointing the client at the server's RDMA endpoint puts a
whole suite on RFC 8166 framing with no hardware and no emulation.

Every NFS quint suite now runs on both transports — **25 RDMA cells on Linux, 15
on macOS**. Standing them up found three server defects, all of which had been
sitting in the reply caches.

## The reply caches were all broken over RDMA

All three stored the reply as it went on the wire, transport framing included.

**The NFSv4.1 session reply cache aborted the server.** A retransmit on a cached
slot replays through `nfs_drc_reply_body_offset()`, which began by validating a
4-byte record marker; over RDMA the captured reply starts with the RPC-over-RDMA
header instead, so the parse failed — and the caller turns that into
`chimera_nfs_abort_if`. Any client that retransmits over NFS/RDMA could take the
server down.

**The NFSv3 and NFSv4.0 caches instead disabled themselves.** `if (conn->rdma)`
handed the request straight to the real dispatcher, with a comment naming the same
framing problem. That is quieter and worse: a non-idempotent CREATE, REMOVE or
RENAME retransmitted over RDMA simply ran a second time — the exact failure a
duplicate-request cache exists to prevent.

The framing was never worth keeping. Both the RPC header and the transport framing
are regenerated for the retransmit — only the procedure result body is replayed —
so storing them bought nothing and tied every entry to the transport it was
captured on. The caches now store the RPC reply alone, using the `rpc_offset`
libevpl reports, and RDMA needs no special case anywhere. Both persisted record
magics are bumped since the stored bytes changed shape; a mismatch already reads
as a cache miss.

**Fixing the abort exposed a second bug underneath.** On the 4.1 replay path
`nfs4_release_write_args()` released `WRITE4args.data` unconditionally — right for
the XDR clones an inline write produces, wrong over RDMA, where `opwrite.data.iov`
points into the request's own Read chunk and the rpc2 request still owns it (the
WRITE handler that would have taken ownership never runs on a replay). ASAN caught
the double release as a heap-use-after-free on the next retransmit.

## Three of the harness fixes exist because the obvious version is vacuous

**Chunks have to be asked for.** RPC-over-RDMA sends small messages inline; Read
and Write chunks are opt-in per call. With the framing alone the suite passed while
performing **zero** one-sided transfers. WRITE now sets `ddp` and READ advertises a
Write chunk, matching what chimera's own client asks for. Measured on memfs: **73
RDMA reads and 26 writes** across the NFS3 corpus, against **zero** for the stream
cells.

**Every connection has to follow the env.** The nfs4 replayer opens a connection
per model client and the drc suite one per model connection; both hardcoded the
stream endpoint. Left alone, an `--rdma` run of either would have been a verbatim
repeat of its stream twin — 601 stream connections and 0 RDMA ones for nfs4.

**A reply's length is not the sum of its iovec lengths.** An RDMA Write chunk comes
back at the size the client *advertised*, not the size the server filled. Both
replayers reported 16384 bytes where 8192 were read; they now use the authoritative
length, as chimera's client already did.

## Verification

macOS 80/80, Linux container with the passthrough backends on ext4 111/111, plus
`test_replay_slot` and `test_nfs_persist` on both. The DRC cells are the load-bearing
ones: they are the only tests that retransmit, and they are what would have caught
any of this.
