### PR TITLE
ci: move off the self-hosted runners onto GitHub-hosted ones

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,7 @@ FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 
 FROM ${DOCKER_MIRROR}ubuntu:26.04
 ARG APT_MIRROR
+ARG UBUNTU_MIRROR=""
 ARG ENABLE_XLIO=1
 ARG ENABLE_DOCA=0
 ARG ENABLE_FIO=1
@@ -62,11 +63,32 @@ ENV DEBIAN_FRONTEND=noninteractive
 # The mirrored ccache, ahead of anything the distro might provide on PATH.
 COPY --from=ccache /ccache /usr/local/bin/ccache
 
+# Two mirror mechanisms, both off by default, so a plain `docker build` reaches
+# whatever the base image ships and nothing unexpected.
+#
+# APT_MIRROR=<url> replaces the sources list outright.  The public CI has no
+# such mirror, but private forks do, and this is what they set.
+#
+# UBUNTU_MIRROR=azure instead swaps the archive hosts for Azure's, which is
+# what the public CI passes: the GitHub-hosted runners are Azure VMs -- their
+# own host apt is pointed there for the same reason -- and the public mirrors
+# are periodically caught mid-sync, serving an index whose size disagrees with
+# its Release file, which fails the whole image build.  A host swap rather than
+# a rewritten sources list, so the suites, components and Signed-By the base
+# image chose all survive; archive and security are amd64's two hosts, ports is
+# arm64's, and each keeps its path under the Azure name.
+#
+# APT_MIRROR wins if both are set: a fork that has stood one up means it.
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR resolute main universe" > /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR resolute-updates main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR resolute-security main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     rm -f /etc/apt/sources.list.d/ubuntu.sources; \
+    elif [ "$UBUNTU_MIRROR" = azure ]; then \
+        sed -i -e 's|//archive\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//security\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//ports\.ubuntu\.com|//azure.ports.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources; \
     fi
 
 RUN apt-get -y update && \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -150,6 +150,8 @@ jobs:
           # layer cache that every later build imports.  The push trigger is
           # branch-filtered to main, so the event name alone is the gate.
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-{0},mode=max', matrix.arch) || '' }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
@@ -193,6 +195,8 @@ jobs:
           tags: ${{ env.U26_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }}
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-{0},mode=max', matrix.arch) || '' }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
@@ -236,6 +240,8 @@ jobs:
           tags: ${{ env.U24_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }}
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-{0},mode=max', matrix.arch) || '' }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
@@ -279,6 +285,8 @@ jobs:
           tags: ${{ env.U22_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }}
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-{0},mode=max', matrix.arch) || '' }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
@@ -322,6 +330,8 @@ jobs:
           tags: ${{ env.R9_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }}
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-{0},mode=max', matrix.arch) || '' }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
@@ -365,6 +375,8 @@ jobs:
           tags: ${{ env.R10_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }}
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-{0},mode=max', matrix.arch) || '' }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   # Distro compile + test: configure, build, and run this image's quick-tier
   # ctest, all in one container.  needs is the container images alone -- there

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,11 +5,22 @@
 name: CI
 
 on:
-  # The full build/test matrix runs ONLY in the merge queue, never on raw PRs;
-  # the PR-time half of the gate lives in pr-checks.yml.  There is no
-  # pull_request trigger here, so the jobs below carry no event guards: every
-  # job in this file runs on every event that reaches it.
+  # The full build/test matrix runs in the merge queue and again on the commit
+  # the queue produced, never on raw PRs; the PR-time half of the gate lives in
+  # pr-checks.yml.  There is no pull_request trigger here, so the jobs below
+  # carry no event guards: every job in this file runs on every event that
+  # reaches it.
+  #
+  # The push half is what publishes the shared caches.  A cache saved on a
+  # merge_group ref is unreadable the moment the queue discards that ref -- of
+  # the 131 entries this repo held before the move, 123 (23.6 GB of 25 GB) were
+  # stranded exactly that way.  refs/heads/main is the default branch, so a
+  # cache saved here is readable from every PR and every queue run, which is
+  # the whole point of saving it.
   merge_group:
+  push:
+    branches:
+      - main
   workflow_dispatch:   # allow manual runs
 
 # What gates a merge is the QUICK test tier plus static analysis, run on every
@@ -58,12 +69,25 @@ env:
   # runner cannot reach.
   #
   # Shared compiler cache.  Every job uses a purely *local* ccache directory,
-  # restored before the build from the entry the Extended workflow saved for
-  # that cell and mounted into the container.  That is the same mechanism, and
-  # the same division of labour, the macOS jobs have always used: the scheduled
-  # Extended run on main writes, everything else only reads.  Actions caches are
-  # branch-scoped and a merge_group ref is discarded, so a queue run restoring
-  # here can never usefully save.
+  # restored before the build from the entry the previous push to main saved for
+  # that cell and mounted into the container.  That is the same mechanism the
+  # macOS jobs have always used, but the division of labour has moved: this
+  # workflow's push-to-main run is the sole writer, and everything else -- the
+  # queue runs here, pr-checks.yml, and the whole Extended workflow -- only
+  # reads.
+  #
+  # The writer has to be a ref that other runs can read.  Actions caches are
+  # branch-scoped: an entry saved on a merge_group ref dies with that ref, and
+  # one saved on a PR merge ref is private to that PR, so neither can serve the
+  # next run.  refs/heads/main is the default branch and is readable from
+  # everywhere, which is why the save hangs off the push and not the queue.
+  #
+  # Publishing on every merge rather than on a 6-hourly cron also keeps the
+  # entries close to the tip.  A PR builds the merge of its branch with current
+  # main, so once main moves past what a bundle was built from, every
+  # translation unit including a changed header misses: measured on the same
+  # macOS analysis job either side of four merges, two touching headers, 100%
+  # hits and 113s against 60% and 464s.
   #
   # A miss is a cold build, never a failed job -- which matters more against
   # this store than the last one.  A repository gets 10 GB of Actions cache at
@@ -119,7 +143,13 @@ jobs:
           push: true
           tags: ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }},mode=max
+          # cache-to only from the push to main.  This workflow also accepts
+          # workflow_dispatch, which can name ANY branch, and anyone with write
+          # access -- an outside collaborator included -- can invoke it.  Left
+          # ungated, a dispatch on an arbitrary branch would rewrite the shared
+          # layer cache that every later build imports.  The push trigger is
+          # branch-filtered to main, so the event name alone is the gate.
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-{0},mode=max', matrix.arch) || '' }}
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
@@ -162,7 +192,7 @@ jobs:
           push: true
           tags: ${{ env.U26_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }},mode=max
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-{0},mode=max', matrix.arch) || '' }}
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
@@ -205,7 +235,7 @@ jobs:
           push: true
           tags: ${{ env.U24_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }},mode=max
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-{0},mode=max', matrix.arch) || '' }}
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
@@ -248,7 +278,7 @@ jobs:
           push: true
           tags: ${{ env.U22_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }},mode=max
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-{0},mode=max', matrix.arch) || '' }}
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
@@ -291,7 +321,7 @@ jobs:
           push: true
           tags: ${{ env.R9_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }},mode=max
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-{0},mode=max', matrix.arch) || '' }}
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
@@ -334,7 +364,7 @@ jobs:
           push: true
           tags: ${{ env.R10_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }},mode=max
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-{0},mode=max', matrix.arch) || '' }}
 
   # Distro compile + test: configure, build, and run this image's quick-tier
   # ctest, all in one container.  needs is the container images alone -- there
@@ -491,6 +521,9 @@ jobs:
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.cmake_extra }} /workspace
               ninja
               ccache --show-stats || true
+              # Trim to the configured ceiling before the save, so the entry
+              # the other workflows restore stays a predictable size.
+              ccache --trim-max-size ${CCACHE_MAXSIZE} || true
               start=$(date +%s)
               rc=0
               /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)" --output-junit /workspace/ctest-results/results.xml || rc=$?
@@ -502,6 +535,23 @@ jobs:
       # single CTest test, so their ~500 codes only show up in their own JUnit) +
       # the ctest wall-clock.  if: always() so results publish even when the test
       # step failed (which is exactly when they are most useful).
+      # The container runs as root, so everything it wrote into the bind-mounted
+      # cache is root-owned and the runner user cannot tar it up.
+      - name: Take ownership of the ccache directory
+        if: always() && github.event_name == 'push'
+        run: sudo chown -R "$(id -u):$(id -g)" "${{ runner.temp }}/ccache"
+
+      # Saved even when the job failed: the cache reflects a build that
+      # happened, and withholding it would make every later run pay for a
+      # failure that has nothing to do with compilation.  This is why restore
+      # and save are split -- actions/cache saves only on a successful job.
+      - name: Save the ccache directory
+        if: always() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v6
@@ -655,8 +705,32 @@ jobs:
               python3 /workspace/scripts/analyze_cached.py \
                       --build-dir /build --report-dir /scan-report \
                       --exclude /workspace/ext/ -j "$(nproc)"
-              ccache --show-stats || true' \
+              ccache --show-stats || true
+              # Trimmed AFTER the analyzer, not between the build and it.  The
+              # entries that cost anything to recompute are the --analyze ones,
+              # and they do not exist yet at that point: an early trim once
+              # published a cache holding only the compile entries, and the
+              # first consumer of it hit on every compile and missed on all 838
+              # analyses.  || true because the trim is best-effort.
+              ccache --trim-max-size ${CCACHE_MAXSIZE} || true' \
             2>&1 | tee "${{ github.workspace }}/scan-report/analyzer-output.txt"
+
+      # The container runs as root, so everything it wrote into the bind-mounted
+      # cache is root-owned and the runner user cannot tar it up.
+      - name: Take ownership of the ccache directory
+        if: always() && github.event_name == 'push'
+        run: sudo chown -R "$(id -u):$(id -g)" "${{ runner.temp }}/ccache"
+
+      # Saved even when the job failed: the cache reflects a build that
+      # happened, and withholding it would make every later run pay for a
+      # failure that has nothing to do with compilation.  This is why restore
+      # and save are split -- actions/cache saves only on a successful job.
+      - name: Save the ccache directory
+        if: always() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
@@ -789,11 +863,31 @@ jobs:
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.kvm_cmake }} /workspace
               ninja
               ccache --show-stats || true
+              # Trim to the configured ceiling before the save, so the entry
+              # the other workflows restore stays a predictable size.
+              ccache --trim-max-size ${CCACHE_MAXSIZE} || true
               start=$(date +%s)
               rc=0
               /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)" --output-junit /workspace/ctest-results/results.xml || rc=$?
               echo "$(( $(date +%s) - start ))" > /workspace/ctest-results/duration_seconds
               exit $rc'
+
+      # The container runs as root, so everything it wrote into the bind-mounted
+      # cache is root-owned and the runner user cannot tar it up.
+      - name: Take ownership of the ccache directory
+        if: always() && github.event_name == 'push'
+        run: sudo chown -R "$(id -u):$(id -g)" "${{ runner.temp }}/ccache"
+
+      # Saved even when the job failed: the cache reflects a build that
+      # happened, and withholding it would make every later run pay for a
+      # failure that has nothing to do with compilation.  This is why restore
+      # and save are split -- actions/cache saves only on a successful job.
+      - name: Save the ccache directory
+        if: always() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload test results
         if: always()
@@ -927,6 +1021,9 @@ jobs:
                 -S "${{ github.workspace }}" -B "${{ runner.temp }}/build"
           ninja -C "${{ runner.temp }}/build"
           ccache --show-stats || true
+          # Trim to the configured ceiling before the save, so the entry the
+          # other workflows restore stays a predictable size.
+          ccache --trim-max-size ${CCACHE_MAXSIZE} || true
 
       - name: Test
         run: |
@@ -940,6 +1037,17 @@ jobs:
                   --output-junit "${{ github.workspace }}/ctest-results/results.xml" || rc=$?
           echo "$(( $(date +%s) - start ))" > "${{ github.workspace }}/ctest-results/duration_seconds"
           exit $rc
+
+      # Saved even when the job failed: the cache reflects a build that
+      # happened, and withholding it would make every later run pay for a
+      # failure that has nothing to do with compilation.  This is why restore
+      # and save are split -- actions/cache saves only on a successful job.
+      - name: Save the ccache directory
+        if: always() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload test results
         if: always()
@@ -1033,6 +1141,21 @@ jobs:
                   -j "$(sysctl -n hw.ncpu)" \
             2>&1 | tee "$GITHUB_WORKSPACE/scan-report/analyzer-output.txt"
           ccache --show-stats || true
+          # Trimmed AFTER the analyzer, not between the build and it: the
+          # entries worth keeping are the --analyze ones, and they do not exist
+          # yet at that point.  || true because the trim is best-effort.
+          ccache --trim-max-size ${CCACHE_MAXSIZE} || true
+
+      # Saved even when the job failed: the cache reflects a build that
+      # happened, and withholding it would make every later run pay for a
+      # failure that has nothing to do with compilation.  This is why restore
+      # and save are split -- actions/cache saves only on a successful job.
+      - name: Save the ccache directory
+        if: always() && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,45 +38,41 @@ on:
 # Phase 2 has no internal barrier: compile and test are a single job, and the
 # analysis starts beside them rather than behind them.  There is exactly one
 # test job per compile now, so handing a build tree between two jobs bought
-# nothing and cost a tar, a Nexus round trip, and a second checkout -- and
+# nothing and cost a tar, a round trip to a shared store, and a second
+# checkout -- and
 # scan-build does its own instrumented compile, so it never wanted that build
 # tree at all.  Everything downstream of the container images starts at once.
 
 env:
-  DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
-  U26_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
-  U24_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
-  U22_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
-  R9_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky9
-  R10_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky10
-  # Internal pull-through cache for the mirrored ccache image (mirrors
-  # ghcr.io/chimera-nas/ccache, republished from upstream by
-  # .github/workflows/mirror-ccache.yml).  Public default lives in the
-  # Dockerfiles, so an image still builds outside this infrastructure.
-  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
-  # Internal pull-through for the mirrored quint toolchain (mirrors
-  # ghcr.io/chimera-nas/quint).  Public default lives in the Dockerfiles.
-  QUINT_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/quint
-  # Internal pull-through cache for the prebuilt KVM guest images (mirrors
-  # ghcr.io/chimera-nas/kvm-test-base). Public default lives in CMake.
-  KVM_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/kvm-test-base
-  APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
-  DOCKER_MIRROR: repository.mdh.quantum.com/
-  # Shared compiler cache.  Every job here uses a purely *local* ccache, primed
-  # before the build from a bundle the Extended workflow published for that cell.
+  DEV_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-dev
+  U26_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-ubuntu26
+  U24_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-ubuntu24
+  U22_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-ubuntu22
+  R9_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-rocky9
+  R10_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-rocky10
+  # The mirrored ccache binary, the quint toolchain and the KVM guest images now
+  # come straight from their public GHCR packages.  Those are the defaults
+  # already compiled into the Dockerfiles and into kvm/CMakeLists.txt, so
+  # nothing here has to name them: the overrides that used to sit here existed
+  # only to route those pulls through an internal proxy, which a GitHub-hosted
+  # runner cannot reach.
   #
-  # This replaces ccache's HTTP remote backend, which fetched each object over
-  # the network as the build asked for it.  That put ~950 round trips per job on
-  # the critical path -- against a Nexus being hit by a dozen jobs at once --
-  # and its 100ms default connect timeout turned the tail of that into misses:
-  # on run 33270040519, ubuntu24 Debug lost 358 of its 410 misses to timeouts
-  # and finished at 57% while its Release twin sat at 91%.
+  # Shared compiler cache.  Every job uses a purely *local* ccache directory,
+  # restored before the build from the entry the Extended workflow saved for
+  # that cell and mounted into the container.  That is the same mechanism, and
+  # the same division of labour, the macOS jobs have always used: the scheduled
+  # Extended run on main writes, everything else only reads.  Actions caches are
+  # branch-scoped and a merge_group ref is discarded, so a queue run restoring
+  # here can never usefully save.
   #
-  # One bundle fetch per job costs one round trip and leaves the build reading a
-  # local directory, which cannot time out.  Same shape macOS uses with
-  # actions/cache, and the same division of labour: the scheduled Extended run
-  # writes, everything else only reads.
-  NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
+  # A miss is a cold build, never a failed job -- which matters more against
+  # this store than the last one.  A repository gets 10 GB of Actions cache at
+  # no cost and evicts least-recently-used entries to stay inside it; the limit
+  # is raisable, but only on a paid plan and as billed storage, so treat 10 GB
+  # as the working budget.  Eviction discards by oldest last-access and a
+  # restore-keys prefix match wants the newest, so the two agree; losing that
+  # race costs a slow job and nothing else.
+  CCACHE_MAXSIZE: 2G
 
 jobs:
   build-devcontainer:
@@ -84,15 +80,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:
@@ -105,9 +102,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the dev container image
         uses: docker/build-push-action@v7
@@ -117,25 +118,21 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
 
     steps:
@@ -148,9 +145,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ubuntu26 CI image
         uses: docker/build-push-action@v7
@@ -160,25 +161,21 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.U26_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu26:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu26:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
 
     steps:
@@ -191,9 +188,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ubuntu24 CI image
         uses: docker/build-push-action@v7
@@ -203,25 +204,21 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.U24_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu24:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu24:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
 
     steps:
@@ -234,9 +231,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ubuntu22 CI image
         uses: docker/build-push-action@v7
@@ -246,24 +247,21 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.U22_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu22:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu22:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }},mode=max
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
 
     steps:
@@ -276,9 +274,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the rocky9 CI image
         uses: docker/build-push-action@v7
@@ -288,23 +290,21 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.R9_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky9:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky9:${{ matrix.arch }},mode=max
-          build-args: |
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }},mode=max
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
 
     steps:
@@ -317,9 +317,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the rocky10 CI image
         uses: docker/build-push-action@v7
@@ -329,12 +333,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.R10_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky10:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky10:${{ matrix.arch }},mode=max
-          build-args: |
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }},mode=max
 
   # Distro compile + test: configure, build, and run this image's quick-tier
   # ctest, all in one container.  needs is the container images alone -- there
@@ -346,6 +346,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -355,77 +356,77 @@ jobs:
           # not part of this distro matrix.
           # ubuntu 26 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 24 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 22 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 9 (io_uring disabled: kernel 5.14 + ASAN causes timeouts, see #197)
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 10 (amd64 only on PR; arm64 runs in the extended workflow)
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: "-DKVM_TESTING=OFF"
 
@@ -435,6 +436,17 @@ jobs:
         with:
           submodules: recursive
 
+      # A hosted runner has far less disk than the ARC hosts this used to run
+      # on, and these images are large; see the action for what it reclaims.
+      # The CI images are GHCR packages of this repository, so the pull below
+      # is authenticated with the run's own token.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # KVM guest images are pulled from GHCR (chimera-nas/kvm-test-base) with
       # oras at configure time, instead of being built via inner dind.  Fetch
       # the static oras binary on the runner and mount it into the container.
@@ -443,50 +455,45 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
-      # Best-effort: a missing bundle (a new cell, an object aged out of scratch,
-      # the first run after a key change) means a cold build, never a failed job.
-      - name: Restore the ccache bundle
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
-          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
-            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
-            -o ccache-bundle.tar.gz \
-            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
-            || echo "no ccache bundle for ${key}; this build starts cold"
+      # Restored but never saved.  Actions caches are branch-scoped, and this
+      # workflow only ever runs on merge_group, whose gh-readonly-queue ref is
+      # discarded -- so anything saved here could never be read back.  The entry
+      # that matters is the one extended.yml writes on main, which every run can
+      # read.  A miss is a cold build, never a failed job.
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Configure, build, and test inside the container
         run: |
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
-            -e CCACHE_DIR=/build/ccache \
-            -e CCACHE_MAXSIZE=2G \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE \
+            -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              mkdir -p /workspace/ctest-results /build/ccache
-              if [ -f /workspace/ccache-bundle.tar.gz ]; then
-                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
-              fi
+              mkdir -p /workspace/ctest-results
               # ccache keeps its counters inside the cache directory, so a
-              # restored bundle carries the statistics of the run that made it.
+              # restored cache carries the statistics of the run that made it.
               # Left alone, --show-stats reports both runs summed: the first
               # consumer read showed "945/1894 (49.89%)" for a build that was
               # really 945 of 947, 99.8%.  Zero them so the number means what it
               # looks like it means.
               ccache -z > /dev/null
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.cmake_extra }} /workspace
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.cmake_extra }} /workspace
               ninja
               ccache --show-stats || true
               start=$(date +%s)
               rc=0
-              /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32 --output-junit /workspace/ctest-results/results.xml || rc=$?
+              /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)" --output-junit /workspace/ctest-results/results.xml || rc=$?
               echo "$(( $(date +%s) - start ))" > /workspace/ctest-results/duration_seconds
               exit $rc'
 
@@ -530,6 +537,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -538,52 +546,52 @@ jobs:
           # here (see the test job); the devcontainer is the one built for both
           # arches, so it is the only one analysed on arm64 too.
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: ""
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: ""
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: ""
     steps:
@@ -592,18 +600,29 @@ jobs:
         with:
           submodules: recursive
 
-      # Best-effort, as elsewhere; a miss just means a cold analysis.
-      - name: Restore the ccache bundle
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
-          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
-            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
-            -o ccache-bundle.tar.gz \
-            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
-            || echo "no ccache bundle for ${key}; this analysis starts cold"
+      # A hosted runner has far less disk than the ARC hosts this used to run
+      # on, and these images are large; see the action for what it reclaims.
+      # The CI images are GHCR packages of this repository, so the pull below
+      # is authenticated with the run's own token.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restored but never saved.  Actions caches are branch-scoped, and this
+      # workflow only ever runs on merge_group, whose gh-readonly-queue ref is
+      # discarded -- so anything saved here could never be read back.  The entry
+      # that matters is the one extended.yml writes on main, which every run can
+      # read.  A miss is a cold build, never a failed job.
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Run the clang static analyzer
         id: static-analysis
@@ -611,22 +630,17 @@ jobs:
           set -o pipefail
           mkdir -p "${{ github.workspace }}/scan-report"
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
-            -e CCACHE_DIR=/build/ccache \
-            -e CCACHE_MAXSIZE=2G \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE \
+            -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/scan-report:/scan-report" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              mkdir -p /build/ccache
-              if [ -f /workspace/ccache-bundle.tar.gz ]; then
-                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
-              fi
               # ccache keeps its counters inside the cache directory, so a
-              # restored bundle carries the statistics of the run that made it.
+              # restored cache carries the statistics of the run that made it.
               # Left alone, --show-stats reports both runs summed: the first
               # consumer read showed "945/1894 (49.89%)" for a build that was
               # really 945 of 947, 99.8%.  Zero them so the number means what it
@@ -662,7 +676,7 @@ jobs:
     name: Report
     needs: [test, test-dev, macos]
     if: ${{ always() }}
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
       contents: read
@@ -707,19 +721,31 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { arch: amd64, runner: arc-amd64, build_type: Release, kvm_cmake: "-DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF" }
-          - { arch: amd64, runner: arc-amd64, build_type: Debug,   kvm_cmake: "-DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF" }
-          - { arch: arm64, runner: arc-arm64, build_type: Release, kvm_cmake: "-DKVM_TESTING=OFF" }
-          - { arch: arm64, runner: arc-arm64, build_type: Debug,   kvm_cmake: "-DKVM_TESTING=OFF" }
+          - { arch: amd64, runner: ubuntu-24.04, build_type: Release, kvm_cmake: "-DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF" }
+          - { arch: amd64, runner: ubuntu-24.04, build_type: Debug,   kvm_cmake: "-DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF" }
+          - { arch: arm64, runner: ubuntu-24.04-arm, build_type: Release, kvm_cmake: "-DKVM_TESTING=OFF" }
+          - { arch: arm64, runner: ubuntu-24.04-arm, build_type: Debug,   kvm_cmake: "-DKVM_TESTING=OFF" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      # A hosted runner has far less disk than the ARC hosts this used to run
+      # on, and these images are large; see the action for what it reclaims.
+      # The CI images are GHCR packages of this repository, so the pull below
+      # is authenticated with the run's own token.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # oras is needed at configure time: KVM_TESTING=ON probes for it.
       - name: Fetch oras CLI
@@ -727,50 +753,45 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
-      # Best-effort: a missing bundle (a new cell, an object aged out of scratch,
-      # the first run after a key change) means a cold build, never a failed job.
-      - name: Restore the ccache bundle
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}"
-          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
-            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
-            -o ccache-bundle.tar.gz \
-            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
-            || echo "no ccache bundle for ${key}; this build starts cold"
+      # Restored but never saved.  Actions caches are branch-scoped, and this
+      # workflow only ever runs on merge_group, whose gh-readonly-queue ref is
+      # discarded -- so anything saved here could never be read back.  The entry
+      # that matters is the one extended.yml writes on main, which every run can
+      # read.  A miss is a cold build, never a failed job.
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Configure, build, and test inside the container
         run: |
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
-            -e CCACHE_DIR=/build/ccache \
-            -e CCACHE_MAXSIZE=2G \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE \
+            -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              mkdir -p /workspace/ctest-results /build/ccache
-              if [ -f /workspace/ccache-bundle.tar.gz ]; then
-                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
-              fi
+              mkdir -p /workspace/ctest-results
               # ccache keeps its counters inside the cache directory, so a
-              # restored bundle carries the statistics of the run that made it.
+              # restored cache carries the statistics of the run that made it.
               # Left alone, --show-stats reports both runs summed: the first
               # consumer read showed "945/1894 (49.89%)" for a build that was
               # really 945 of 947, 99.8%.  Zero them so the number means what it
               # looks like it means.
               ccache -z > /dev/null
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.kvm_cmake }} /workspace
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DPYNFS_JUNIT_DIR=/workspace/ctest-results/pynfs-junit -DSMBTORTURE_JUNIT_DIR=/workspace/ctest-results/smbtorture-junit -DWPTS_JUNIT_DIR=/workspace/ctest-results/wpts-junit -DPIKE_JUNIT_DIR=/workspace/ctest-results/pike-junit ${{ matrix.kvm_cmake }} /workspace
               ninja
               ccache --show-stats || true
               start=$(date +%s)
               rc=0
-              /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32 --output-junit /workspace/ctest-results/results.xml || rc=$?
+              /workspace/scripts/cap_ctest_output.sh ctest --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)" --output-junit /workspace/ctest-results/results.xml || rc=$?
               echo "$(( $(date +%s) - start ))" > /workspace/ctest-results/duration_seconds
               exit $rc'
 
@@ -813,8 +834,6 @@ jobs:
 
       - name: Install dependencies
         env:
-          # Public GHCR: a GitHub-hosted runner cannot reach the internal
-          # pull-through proxy the ARC runners use.
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
           brew update
@@ -840,10 +859,6 @@ jobs:
           install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
           ccache --version | head -1
 
-      # The Nexus cache the Linux cells share is unreachable from a
-      # GitHub-hosted runner, so macOS uses GitHub's own cache for the ccache
-      # directory instead.
-      #
       # Note where the writes come from.  Actions caches are branch-scoped: a
       # run reads its own ref and the default branch's.  This workflow only ever
       # runs on merge_group, and that gh-readonly-queue/... ref is discarded, so
@@ -852,7 +867,7 @@ jobs:
       # stale, which for ccache means a slightly lower hit rate and nothing
       # worse.
       - name: Restore the ccache directory
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
@@ -983,7 +998,7 @@ jobs:
       # Written by extended.yml, which runs on main; a merge_group ref is thrown
       # away, so the queue restores but never usefully saves.
       - name: Restore the ccache directory
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
@@ -1046,7 +1061,7 @@ jobs:
       - macos
       - analyze-macos
     if: ${{ always() }}
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,11 +18,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Internal pull-through cache for the mirrored ccache image (mirrors
-  # ghcr.io/chimera-nas/ccache).  Public default lives in the Dockerfiles.
-  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
-  APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
-  DOCKER_MIRROR: repository.mdh.quantum.com/
+  # The mirrored ccache binary comes from its public GHCR package, which is
+  # already the Dockerfile's default; nothing here has to name it.
 
 jobs:
   build-and-push:
@@ -37,7 +34,7 @@ jobs:
         include:
           # Ubuntu 24.04 builds
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
             os: ubuntu24.04
@@ -45,7 +42,7 @@ jobs:
             tag: latest-amd64
             publish: true
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
             os: ubuntu24.04
@@ -53,7 +50,7 @@ jobs:
             tag: latest-debug-amd64
             publish: true
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
             os: ubuntu24.04
@@ -61,7 +58,7 @@ jobs:
             tag: latest-arm64
             publish: true
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Debug
             os: ubuntu24.04
@@ -75,8 +72,10 @@ jobs:
         with:
           submodules: recursive
 
+      # Unconditional, where it used to be push-only: the layer cache below
+      # lives in GHCR now, and a merge_group run that never publishes still has
+      # to authenticate to read it.
       - name: Log in to the Container registry
-        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -87,9 +86,6 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
 
       - name: Extract metadata for Docker
         id: meta
@@ -107,18 +103,15 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' && matrix.publish }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera:${{ matrix.os }}-${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera:${{ matrix.os }}-${{ matrix.arch }},mode=max
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-build-cache:${{ matrix.os }}-${{ matrix.arch }}
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-build-cache:{0}-{1},mode=max', matrix.os, matrix.arch) || '' }}
           build-args: |
             BUILD_TYPE=${{ matrix.build_type }}
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
 
   merge-manifests:
     if: github.event_name == 'push'
     needs: build-and-push
-    runs-on: arc-amd64
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     steps:
@@ -147,7 +140,7 @@ jobs:
     name: Docker build complete
     needs: build-and-push
     if: ${{ always() }}
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,6 +106,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-build-cache:${{ matrix.os }}-${{ matrix.arch }}
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/chimera-nas/chimera-build-cache:{0}-{1},mode=max', matrix.os, matrix.arch) || '' }}
           build-args: |
+            UBUNTU_MIRROR=azure
             BUILD_TYPE=${{ matrix.build_type }}
 
   merge-manifests:

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -116,6 +116,8 @@ jobs:
           # No cache-to.  This workflow is a pure consumer now: the shared
           # layer cache is published by the push-to-main run of
           # build-test.yml, which is the ref every other run can read.
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
@@ -162,6 +164,9 @@ jobs:
           tags: ${{ env.U26_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }}
 
+          build-args: |
+            UBUNTU_MIRROR=azure
+
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
@@ -206,6 +211,9 @@ jobs:
           push: true
           tags: ${{ env.U24_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }}
+
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
@@ -252,6 +260,9 @@ jobs:
           tags: ${{ env.U22_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }}
 
+          build-args: |
+            UBUNTU_MIRROR=azure
+
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
@@ -297,6 +308,9 @@ jobs:
           tags: ${{ env.R9_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }}
 
+          build-args: |
+            UBUNTU_MIRROR=azure
+
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
@@ -341,6 +355,9 @@ jobs:
           push: true
           tags: ${{ env.R10_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }}
+
+          build-args: |
+            UBUNTU_MIRROR=azure
 
   test:
     name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -6,14 +6,13 @@ name: Extended
 
 on:
   schedule:
-    # Every six hours rather than once a day.  This workflow is the sole writer
-    # of every shared ccache, and a bundle is only as useful as it is fresh: a
-    # PR builds the merge of its branch with current main, so once main has
-    # moved past what the bundle was built from, every translation unit that
-    # includes a changed header misses.  Measured on the same macOS analysis
-    # job either side of four merges to main, two of them touching headers:
-    # 100% hits and 113s against 60% and 464s.  Running four times a day keeps
-    # the caches within a few hours of the tip instead of up to a day behind.
+    # Every six hours rather than once a day.  This workflow no longer writes
+    # any shared cache -- build-test.yml's push-to-main run does that, on every
+    # merge, which keeps the entries far closer to the tip than any cron could.
+    # What the cadence buys now is discovery latency on the extended tier
+    # itself: four sweeps a day means a break in pynfs, smbtorture, wpts or the
+    # KVM suites surfaces within hours of the merge that caused it rather than
+    # the following morning.
     - cron: '0 1,7,13,19 * * *'  # 01:00, 07:00, 13:00, 19:00 UTC
   workflow_dispatch:     # allow manual runs
     # Scope the smbtorture matrix for a manual run.  All three default to the
@@ -49,20 +48,24 @@ env:
   # that used to sit here pointed at an internal pull-through proxy, which a
   # GitHub-hosted runner cannot reach.
   #
-  # This workflow is the WRITER for every shared ccache.  It runs on a schedule
-  # against main, builds the extended tier (so it touches more of the tree than
-  # the queue does), and saves each cell's local cache into the default-branch
-  # Actions cache scope that every other run restores from.  Nothing else saves.
+  # This workflow only ever READS the shared ccache.  build-test.yml's
+  # push-to-main run is the sole writer: it saves on refs/heads/main, the
+  # default-branch scope every other run restores from, and it publishes on
+  # every merge rather than on this cron, so the entries track the tip.
   #
-  # A repository gets 10 GB of Actions cache at no cost, evicting
-  # least-recently-used entries to stay inside it.  This workflow saves ~39
-  # entries per run at roughly 250 MB each, so one run very nearly IS the free
-  # budget: the steady state is that the newest run's caches are present and
-  # anything older has been evicted, which is what the restore-keys prefix
-  # wants anyway.  Two levers exist if that gets tight -- a paid plan can raise
-  # the eviction limit as billed storage, or these bundles could move to GHCR
-  # as OCI artifacts under a fixed tag per cell, which is free for a public
-  # repository and would not accumulate at all.
+  # A save from here would be worse than useless.  It would land in this
+  # workflow's own cache scope, where the queue and PR runs cannot read it,
+  # while still consuming the repository's 10 GB allowance and evicting the
+  # entries that ARE readable.
+  #
+  # CCACHE_MAXSIZE still applies: it bounds each cell's local cache during the
+  # run.  Nothing here saves that cache, so the ceiling costs nothing, but a
+  # restored entry that grew unbounded would still be slower to unpack.
+  #
+  # Note the arm64 distro cells below restore keys nobody writes: build-test's
+  # distro matrix is amd64-only, so ubuntu22/24/26 and rocky9/10 on arm64 build
+  # cold here.  If that ever costs more than it is worth, the fix is to widen
+  # the push-to-main matrix, not to start saving from this workflow.
   CCACHE_MAXSIZE: 2G
 
 jobs:
@@ -110,7 +113,9 @@ jobs:
           push: true
           tags: ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }},mode=max
+          # No cache-to.  This workflow is a pure consumer now: the shared
+          # layer cache is published by the push-to-main run of
+          # build-test.yml, which is the ref every other run can read.
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
@@ -156,7 +161,6 @@ jobs:
           push: true
           tags: ${{ env.U26_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
@@ -202,7 +206,6 @@ jobs:
           push: true
           tags: ${{ env.U24_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
@@ -248,7 +251,6 @@ jobs:
           push: true
           tags: ${{ env.U22_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }},mode=max
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
@@ -294,7 +296,6 @@ jobs:
           push: true
           tags: ${{ env.R9_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }},mode=max
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
@@ -340,7 +341,6 @@ jobs:
           push: true
           tags: ${{ env.R10_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }},mode=max
 
   test:
     name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
@@ -556,11 +556,10 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
-      # This workflow is the WRITER for every shared ccache: it runs on a
-      # schedule against main, so its save lands in the default-branch scope
-      # that a merge-queue run and a PR run can both read.  Restore and save
-      # are split rather than using actions/cache, because the save has to
-      # carry `if: always()` -- see the end of this job for why.
+      # Restore only.  This workflow is a pure consumer of the shared ccache:
+      # build-test.yml's push-to-main run is the sole writer, and an entry
+      # saved from here would land in this workflow's own scope where the
+      # queue and PR runs could not read it anyway.
       - name: Restore the ccache directory
         uses: actions/cache/restore@v4
         with:
@@ -591,28 +590,9 @@ jobs:
               cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON ${{ matrix.cmake_extra }} /workspace
               ninja
               ccache --show-stats || true
-              # Trim to the configured ceiling before the save, so the entry
-              # the other workflows restore stays a predictable size.
-              ccache --trim-max-size ${CCACHE_MAXSIZE} || true
               /workspace/scripts/cap_ctest_output.sh \
               ctest -C extended --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)"'
 
-      # The container runs as root, so everything it wrote into the bind-mounted
-      # cache is root-owned and the runner user cannot tar it up.
-      - name: Take ownership of the ccache directory
-        if: always()
-        run: sudo chown -R "$(id -u):$(id -g)" "${{ runner.temp }}/ccache"
-
-      # Saved even when ctest failed: the cache reflects a build that happened,
-      # and withholding it would make every later run pay for a test failure
-      # that has nothing to do with compilation.  This is why restore and save
-      # are split -- actions/cache saves only on a successful job.
-      - name: Save the ccache directory
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ runner.temp }}/ccache
-          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
   # macOS: the extended tier on a GitHub-hosted arm64 runner.  Nothing here is
   # containerised and none of the Linux-only pieces exist (io_uring, libaio,
@@ -663,13 +643,11 @@ jobs:
           install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
           ccache --version | head -1
 
-      # This job is what populates the macOS ccache for everything else.
-      # Actions caches are branch-scoped, and build-test.yml only runs on
-      # merge_group, whose ref is thrown away -- so a queue run can restore but
-      # never usefully save.  This one runs on a schedule against main, so its
-      # save lands in the default-branch scope that every other run can read.
+      # Restore only.  The macOS ccache is populated by build-test.yml's
+      # push-to-main run, which saves on refs/heads/main -- the default-branch
+      # scope every other run can read.
       - name: Restore the ccache directory
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
@@ -787,8 +765,8 @@ jobs:
           install -m 0755 "${RUNNER_TEMP}/ccache-darwin" /usr/local/bin/ccache
           ccache --version | head -1
 
-      - name: Restore and save the ccache directory
-        uses: actions/cache@v4
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
@@ -1095,11 +1073,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # This workflow is the WRITER for every shared ccache: it runs on a
-      # schedule against main, so its save lands in the default-branch scope
-      # that a merge-queue run and a PR run can both read.  Restore and save
-      # are split rather than using actions/cache, because the save has to
-      # carry `if: always()` -- see the end of this job for why.
+      # Restore only.  This workflow is a pure consumer of the shared ccache:
+      # build-test.yml's push-to-main run is the sole writer, and an entry
+      # saved from here would land in this workflow's own scope where the
+      # queue and PR runs could not read it anyway.
       - name: Restore the ccache directory
         uses: actions/cache/restore@v4
         with:
@@ -1137,32 +1114,9 @@ jobs:
               python3 /workspace/scripts/analyze_cached.py \
                       --build-dir /build --report-dir /scan-report \
                       --exclude /workspace/ext/ -j "$(nproc)"
-              ccache --show-stats || true
-              # Trimmed AFTER the analyzer, not between the build and it.  The
-              # entries that cost anything to recompute are the --analyze ones,
-              # and they do not exist yet at that point: an early trim once
-              # published a cache holding only the compile entries, and the
-              # first consumer of it hit on every compile and missed on all 838
-              # analyses.  || true because the trim is best-effort.
-              ccache --trim-max-size ${CCACHE_MAXSIZE} || true' \
+              ccache --show-stats || true' \
             2>&1 | tee "${{ github.workspace }}/scan-report/analyzer-output.txt"
 
-      # The container runs as root, so everything it wrote into the bind-mounted
-      # cache is root-owned and the runner user cannot tar it up.
-      - name: Take ownership of the ccache directory
-        if: always()
-        run: sudo chown -R "$(id -u):$(id -g)" "${{ runner.temp }}/ccache"
-
-      # Saved even when ctest failed: the cache reflects a build that happened,
-      # and withholding it would make every later run pay for a test failure
-      # that has nothing to do with compilation.  This is why restore and save
-      # are split -- actions/cache saves only on a successful job.
-      - name: Save the ccache directory
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ runner.temp }}/ccache
-          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -37,28 +37,33 @@ on:
         default: '32'
 
 env:
-  DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
-  U26_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
-  U24_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
-  U22_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
-  R9_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky9
-  R10_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-rocky10
-  # Internal pull-through cache for the mirrored ccache image (mirrors
-  # ghcr.io/chimera-nas/ccache).  Public default lives in the Dockerfiles.
-  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
-  # Internal pull-through for the mirrored quint toolchain (mirrors
-  # ghcr.io/chimera-nas/quint).  Public default lives in the Dockerfiles.
-  QUINT_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/quint
+  DEV_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-dev
+  U26_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-ubuntu26
+  U24_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-ubuntu24
+  U22_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-ubuntu22
+  R9_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-rocky9
+  R10_IMAGE_TAG_PREFIX: ghcr.io/chimera-nas/chimera-rocky10
+  # The mirrored ccache binary, the quint toolchain and the KVM guest images
+  # come straight from their public GHCR packages -- the defaults already
+  # compiled into the Dockerfiles and into kvm/CMakeLists.txt.  The overrides
+  # that used to sit here pointed at an internal pull-through proxy, which a
+  # GitHub-hosted runner cannot reach.
+  #
   # This workflow is the WRITER for every shared ccache.  It runs on a schedule
   # against main, builds the extended tier (so it touches more of the tree than
-  # the queue does), and publishes each cell's local cache as a bundle the
-  # merge-queue jobs restore.  Nothing else uploads.
-  NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
-  # Internal pull-through cache for the prebuilt KVM guest images (mirrors
-  # ghcr.io/chimera-nas/kvm-test-base). Public default lives in CMake.
-  KVM_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/kvm-test-base
-  APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
-  DOCKER_MIRROR: repository.mdh.quantum.com/
+  # the queue does), and saves each cell's local cache into the default-branch
+  # Actions cache scope that every other run restores from.  Nothing else saves.
+  #
+  # A repository gets 10 GB of Actions cache at no cost, evicting
+  # least-recently-used entries to stay inside it.  This workflow saves ~39
+  # entries per run at roughly 250 MB each, so one run very nearly IS the free
+  # budget: the steady state is that the newest run's caches are present and
+  # anything older has been evicted, which is what the restore-keys prefix
+  # wants anyway.  Two levers exist if that gets tight -- a paid plan can raise
+  # the eviction limit as billed storage, or these bundles could move to GHCR
+  # as OCI artifacts under a fixed tag per cell, which is free for a public
+  # repository and would not accumulate at all.
+  CCACHE_MAXSIZE: 2G
 
 jobs:
   build-devcontainer:
@@ -66,15 +71,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:
@@ -87,9 +93,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the dev container image
         uses: docker/build-push-action@v7
@@ -99,28 +109,24 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-dev:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu26:
     name: Build ubuntu26 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:
@@ -133,9 +139,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ubuntu26 CI image
         uses: docker/build-push-action@v7
@@ -145,28 +155,24 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.U26_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu26:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu26:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu26:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu24:
     name: Build ubuntu24 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:
@@ -179,9 +185,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ubuntu24 CI image
         uses: docker/build-push-action@v7
@@ -191,28 +201,24 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.U24_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu24:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu24:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu24:buildcache-${{ matrix.arch }},mode=max
 
   build-ubuntu22:
     name: Build ubuntu22 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:
@@ -225,9 +231,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the ubuntu22 CI image
         uses: docker/build-push-action@v7
@@ -237,27 +247,24 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.U22_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu22:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-ubuntu22:${{ matrix.arch }},mode=max
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-ubuntu22:buildcache-${{ matrix.arch }},mode=max
 
   build-rocky9:
     name: Build rocky9 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:
@@ -270,9 +277,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the rocky9 CI image
         uses: docker/build-push-action@v7
@@ -282,26 +293,24 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.R9_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky9:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky9:${{ matrix.arch }},mode=max
-          build-args: |
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky9:buildcache-${{ matrix.arch }},mode=max
 
   build-rocky10:
     name: Build rocky10 ${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
 
     steps:
@@ -314,9 +323,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the rocky10 CI image
         uses: docker/build-push-action@v7
@@ -326,12 +339,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.R10_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky10:${{ matrix.arch }}
-          cache-to: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-rocky10:${{ matrix.arch }},mode=max
-          build-args: |
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          cache-from: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/chimera-nas/chimera-rocky10:buildcache-${{ matrix.arch }},mode=max
 
   test:
     name: Test ${{ matrix.image_name }} ${{ matrix.arch }} ${{ matrix.build_type }}
@@ -339,6 +348,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -349,177 +359,177 @@ jobs:
           # qemu (qemu-system-x86), so KVM acceleration is unavailable on
           # arm64 -- the suites never ran there, so keep them explicitly OFF.
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: "-DKVM_TESTING=ON"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: "-DKVM_TESTING=ON"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 26 (no KVM here; disable explicitly so a missing /dev/kvm
           # does not get silently auto-detected)
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 24
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: "-DKVM_TESTING=OFF"
           # ubuntu 22
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 9 (io_uring disabled: kernel 5.14 + ASAN causes timeouts, see #197)
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF -DKVM_TESTING=OFF"
           # rocky 10
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: "-DKVM_TESTING=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Debug
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: "-DKVM_TESTING=OFF"
 
@@ -529,72 +539,80 @@ jobs:
         with:
           submodules: recursive
 
+      # A hosted runner has far less disk than the ARC hosts this used to run
+      # on, and these images are large; see the action for what it reclaims.
+      # The CI images are GHCR packages of this repository, so the pull below
+      # is authenticated with the run's own token.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # KVM guest images are pulled from GHCR with oras (see build-test.yml).
       - name: Fetch oras CLI
         uses: ./.github/actions/fetch-oras
         with:
           arch: ${{ matrix.arch }}
 
-      - name: Restore the ccache bundle
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
-          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
-            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
-            -o ccache-bundle.tar.gz \
-            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
-            || echo "no ccache bundle for ${key}; starting cold"
+      # This workflow is the WRITER for every shared ccache: it runs on a
+      # schedule against main, so its save lands in the default-branch scope
+      # that a merge-queue run and a PR run can both read.  Restore and save
+      # are split rather than using actions/cache, because the save has to
+      # carry `if: always()` -- see the end of this job for why.
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Configure, build, and test inside the container
         run: |
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
-            -e CCACHE_DIR=/build/ccache \
-            -e CCACHE_MAXSIZE=2G \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE \
+            -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              mkdir -p /build/ccache
-              if [ -f /workspace/ccache-bundle.tar.gz ]; then
-                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
-              fi
               # ccache keeps its counters inside the cache directory, so a
-              # restored bundle carries the statistics of the run that made it.
+              # restored cache carries the statistics of the run that made it.
               # Left alone, --show-stats reports both runs summed: the first
               # consumer read showed "945/1894 (49.89%)" for a build that was
               # really 945 of 947, 99.8%.  Zero them so the number means what it
               # looks like it means.
               ccache -z > /dev/null
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON -DKVM_IMAGE_REGISTRY=${{ env.KVM_IMAGE_REGISTRY }} ${{ matrix.cmake_extra }} /workspace
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON ${{ matrix.cmake_extra }} /workspace
               ninja
               ccache --show-stats || true
-              # Trim to the configured ceiling before packing, so the bundle the
-              # queue downloads stays a predictable size.
-              ccache --trim-max-size 2G || true
-              tar -C /build/ccache -czf /workspace/ccache-bundle.tar.gz .
+              # Trim to the configured ceiling before the save, so the entry
+              # the other workflows restore stays a predictable size.
+              ccache --trim-max-size ${CCACHE_MAXSIZE} || true
               /workspace/scripts/cap_ctest_output.sh \
-              ctest -C extended --output-on-failure --test-output-size-failed 65536 --timeout 300 -j 32'
+              ctest -C extended --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)"'
 
-      # Published even when ctest failed: the cache reflects a build that
-      # happened, and withholding it would make the next queue run pay for a
-      # test failure that has nothing to do with compilation.
-      - name: Publish the ccache bundle
-        if: ${{ always() && hashFiles('ccache-bundle.tar.gz') != '' }}
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
-          curl -fsS --retry 5 --retry-all-errors --retry-delay 5 \
-            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
-            -T ccache-bundle.tar.gz \
-            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz"
+      # The container runs as root, so everything it wrote into the bind-mounted
+      # cache is root-owned and the runner user cannot tar it up.
+      - name: Take ownership of the ccache directory
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" "${{ runner.temp }}/ccache"
+
+      # Saved even when ctest failed: the cache reflects a build that happened,
+      # and withholding it would make every later run pay for a test failure
+      # that has nothing to do with compilation.  This is why restore and save
+      # are split -- actions/cache saves only on a successful job.
+      - name: Save the ccache directory
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
   # macOS: the extended tier on a GitHub-hosted arm64 runner.  Nothing here is
   # containerised and none of the Linux-only pieces exist (io_uring, libaio,
@@ -814,9 +832,10 @@ jobs:
   smbtorture-matrix:
     name: smbtorture matrix (informational)
     needs: [build-devcontainer]
-    runs-on: arc-amd64
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
+      packages: read
     # Passing cells cost ~0.6s, but a hung cell burns the full 300s timeout and
     # there are ~880 non-passing cells across the matrix; 3h leaves headroom.
     timeout-minutes: 180
@@ -825,6 +844,17 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      # A hosted runner has far less disk than the ARC hosts this used to run
+      # on, and these images are large; see the action for what it reclaims.
+      # The CI images are GHCR packages of this repository, so the pull below
+      # is authenticated with the run's own token.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # --privileged: the netns wrapper needs CAP_NET_ADMIN.  smbtorture itself
       # ships in the devcontainer image (samba-testsuite).
@@ -876,8 +906,6 @@ jobs:
           rm -rf smbt-report
           mkdir -p smbt-report
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
             -e SMBTORTURE_BACKENDS \
             -e SMBTORTURE_FILTER \
             -e SMBTORTURE_PARALLEL \
@@ -960,93 +988,94 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
         include:
           # devcontainer
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-dev
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
             image_name: devcontainer
             cmake_extra: ""
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: ""
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu26
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu26
             image_name: ubuntu26
             cmake_extra: ""
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: ""
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu24
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu24
             image_name: ubuntu24
             cmake_extra: ""
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-ubuntu22
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-ubuntu22
             image_name: ubuntu22
             cmake_extra: "-DIO_URING_ENABLED=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF"
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky9
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky9
             image_name: rocky9
             cmake_extra: "-DIO_URING_ENABLED=OFF"
           - platform: linux/amd64
-            runner: arc-amd64
+            runner: ubuntu-24.04
             arch: amd64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: ""
           - platform: linux/arm64
-            runner: arc-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
             build_type: Release
-            image_tag_prefix: repository.mdh.quantum.com:5004/cache/chimera-rocky10
+            image_tag_prefix: ghcr.io/chimera-nas/chimera-rocky10
             image_name: rocky10
             cmake_extra: ""
     steps:
@@ -1055,17 +1084,29 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Restore the ccache bundle
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
-          curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
-            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
-            -o ccache-bundle.tar.gz \
-            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz" \
-            || echo "no ccache bundle for ${key}; starting cold"
+      # A hosted runner has far less disk than the ARC hosts this used to run
+      # on, and these images are large; see the action for what it reclaims.
+      # The CI images are GHCR packages of this repository, so the pull below
+      # is authenticated with the run's own token.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # This workflow is the WRITER for every shared ccache: it runs on a
+      # schedule against main, so its save lands in the default-branch scope
+      # that a merge-queue run and a PR run can both read.  Restore and save
+      # are split rather than using actions/cache, because the save has to
+      # carry `if: always()` -- see the end of this job for why.
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       # Drives the analyzer per TU instead of through scan-build, so the results
       # are cacheable.  See build-test.yml for why scan-build cannot be.
@@ -1075,22 +1116,17 @@ jobs:
           set -o pipefail
           mkdir -p "${{ github.workspace }}/scan-report"
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
-            -e CCACHE_DIR=/build/ccache \
-            -e CCACHE_MAXSIZE=2G \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE \
+            -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/scan-report:/scan-report" \
             -v /build \
             -w /build \
             ${{ matrix.image_tag_prefix }}:${{ github.sha }}-${{ matrix.arch }} \
             bash -euxc '
-              mkdir -p /build/ccache
-              if [ -f /workspace/ccache-bundle.tar.gz ]; then
-                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
-              fi
               # ccache keeps its counters inside the cache directory, so a
-              # restored bundle carries the statistics of the run that made it.
+              # restored cache carries the statistics of the run that made it.
               # Left alone, --show-stats reports both runs summed: the first
               # consumer read showed "945/1894 (49.89%)" for a build that was
               # really 945 of 947, 99.8%.  Zero them so the number means what it
@@ -1102,27 +1138,31 @@ jobs:
                       --build-dir /build --report-dir /scan-report \
                       --exclude /workspace/ext/ -j "$(nproc)"
               ccache --show-stats || true
-              # Pack AFTER the analyzer, not between the build and it.  Packing
-              # early published a bundle holding only the compile entries, so a
-              # consumer hit on every compile and missed on every --analyze --
-              # which is the half that costs anything.  Measured on the first PR
-              # that restored one: 963 hits, 838 misses, and the 838 were the
-              # analyses.  || true on the trim because it is best-effort.
-              ccache --trim-max-size 2G || true
-              tar -C /build/ccache -czf /workspace/ccache-bundle.tar.gz .' \
+              # Trimmed AFTER the analyzer, not between the build and it.  The
+              # entries that cost anything to recompute are the --analyze ones,
+              # and they do not exist yet at that point: an early trim once
+              # published a cache holding only the compile entries, and the
+              # first consumer of it hit on every compile and missed on all 838
+              # analyses.  || true because the trim is best-effort.
+              ccache --trim-max-size ${CCACHE_MAXSIZE} || true' \
             2>&1 | tee "${{ github.workspace }}/scan-report/analyzer-output.txt"
 
-      - name: Publish the ccache bundle
-        if: ${{ always() && hashFiles('ccache-bundle.tar.gz') != '' }}
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}"
-          curl -fsS --retry 5 --retry-all-errors --retry-delay 5 \
-            -u "${NEXUS_USER}:${NEXUS_PASSWORD}" \
-            -T ccache-bundle.tar.gz \
-            "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz"
+      # The container runs as root, so everything it wrote into the bind-mounted
+      # cache is root-owned and the runner user cannot tar it up.
+      - name: Take ownership of the ccache directory
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" "${{ runner.temp }}/ccache"
+
+      # Saved even when ctest failed: the cache reflects a build that happened,
+      # and withholding it would make every later run pay for a test failure
+      # that has nothing to do with compilation.  This is why restore and save
+      # are split -- actions/cache saves only on a successful job.
+      - name: Save the ccache directory
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}

--- a/.github/workflows/mirror-ccache.yml
+++ b/.github/workflows/mirror-ccache.yml
@@ -7,8 +7,7 @@ name: Mirror ccache
 # Republish an upstream ccache release into GHCR so the CI images can install a
 # current ccache without any build reaching ccache.dev or the ccache GitHub
 # releases -- exactly the arrangement the KVM guest images already use
-# (chimera-nas/kvm-test-base, pulled from GHCR, proxied inside ARC by the
-# repository.mdh.quantum.com:5009 pull-through).
+# (chimera-nas/kvm-test-base, also pulled from GHCR).
 #
 # Why not the distro package: the remote cache is unusable on the older ones.
 # CCACHE_REMOTE_STORAGE arrived in ccache 4.7; rocky9 and ubuntu22 ship 4.6,
@@ -37,7 +36,7 @@ on:
 jobs:
   mirror:
     name: Mirror ccache ${{ inputs.version }} to GHCR
-    runs-on: arc-amd64
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -58,9 +57,9 @@ jobs:
             docker_arch="${pair%%:*}"
             rel_arch="${pair##*:}"
             name="ccache-${V}-linux-${rel_arch}-musl-static"
-            # .tar.gz, not the .tar.xz upstream also publishes: the ARC
-            # runners are minimal hosts and carry no xz, so `tar xJf` dies with
-            # "xz: Cannot exec". gzip is always there, and upstream ships both.
+            # .tar.gz, not the .tar.xz upstream also publishes.  Upstream
+            # ships both and gzip is present on every runner and image this
+            # has to work on, xz is not.
             curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
                  -o "${name}.tar.gz" "${base}/${name}.tar.gz"
             tar xzf "${name}.tar.gz"

--- a/.github/workflows/mirror-quint.yml
+++ b/.github/workflows/mirror-quint.yml
@@ -6,9 +6,7 @@ name: Mirror quint
 
 # Build the node + quint toolchain once and publish it to GHCR, so the CI images
 # install it with a COPY --from instead of reaching nodejs.org and the npm
-# registry on every image build.  Same arrangement as Mirror ccache, and it is
-# proxied inside ARC by the repository.mdh.quantum.com:5009 pull-through the
-# same way.
+# registry on every image build.  Same arrangement as Mirror ccache.
 #
 # Why this matters beyond build time: without quint on PATH, libevpl's
 # Core/HTTP/RPC2 conformance suites and its quint_model checks disable
@@ -39,7 +37,7 @@ on:
 jobs:
   mirror:
     name: Mirror quint ${{ inputs.quint_version }} to GHCR
-    runs-on: arc-amd64
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -141,6 +141,8 @@ jobs:
           load: true
           tags: ${{ env.DEV_IMAGE }}
           cache-from: type=registry,ref=${{ env.DEV_IMAGE_CACHE }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
       # Unlike the store this replaced, the Actions cache is readable from a
       # fork's pull_request run -- a run may read its own ref's scope and the
@@ -233,6 +235,8 @@ jobs:
           load: true
           tags: ${{ env.DEV_IMAGE }}
           cache-from: type=registry,ref=${{ env.DEV_IMAGE_CACHE }}
+          build-args: |
+            UBUNTU_MIRROR=azure
 
       # Captured on the runner rather than in the container below: the
       # bind-mounted checkout is not owned by the container's root, so git

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -50,25 +50,30 @@ permissions:
   contents: read
 
 env:
-  DEV_IMAGE_TAG_PREFIX: repository.mdh.quantum.com:5004/cache/chimera-dev
-  # Internal pull-through cache for the mirrored ccache image (mirrors
-  # ghcr.io/chimera-nas/ccache).  Public default lives in the Dockerfiles.
-  CCACHE_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/ccache
-  # Internal pull-through for the mirrored quint toolchain (mirrors
-  # ghcr.io/chimera-nas/quint).  Public default lives in the Dockerfiles.
-  QUINT_IMAGE_REGISTRY: repository.mdh.quantum.com:5009/chimera-nas/quint
-  # Where the Extended workflow publishes ccache bundles.  Not a secret -- the same
-  # literal is in build-test.yml -- so a fork PR can at least attempt a read.
-  NEXUS_SCRATCH_URL: http://repository.mdh.quantum.com/repository/scratch
-  APT_MIRROR: http://repository.mdh.quantum.com/repository/pkgs/ubuntu
-  DOCKER_MIRROR: repository.mdh.quantum.com/
+  # Unlike the merge queue, this workflow builds the devcontainer image inside
+  # each job that needs it and loads it into that runner's docker daemon; it
+  # never pushes.  This is the one workflow reachable from a fork, and a fork's
+  # pull_request run gets a read-only GITHUB_TOKEN that cannot write a package
+  # -- so a build-once-push-once shape would leave the pre-merge signal broken
+  # for exactly the contributors it exists to serve.  There are only two
+  # consumers here, so building twice costs less than the alternative.
+  #
+  # Only the layer cache crosses the network, and only to be read: the merge
+  # queue owns that tag and a PR must not be able to poison it.  With an
+  # unchanged Dockerfile the "build" is a layer pull.
+  DEV_IMAGE: chimera-dev:${{ github.sha }}
+  DEV_IMAGE_CACHE: ghcr.io/chimera-nas/chimera-dev:buildcache-amd64
+  # The mirrored ccache binary and the quint toolchain come from their public
+  # GHCR packages, which are the Dockerfiles' own defaults; nothing here has to
+  # name them.
+  CCACHE_MAXSIZE: 2G
 
 jobs:
   ci-complete:
     name: CI complete
-    needs: [build-devcontainer, analyze-dev, quint-coverage, analyze-macos]
+    needs: [analyze-dev, quint-coverage, analyze-macos]
     if: ${{ always() }}
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     steps:
       - name: Verify every pre-merge job succeeded
         run: |
@@ -86,23 +91,22 @@ jobs:
 
   docker-build-complete:
     name: Docker build complete
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     steps:
       - name: PR placeholder
         run: echo "No docker image is built at PR time; the real check runs in the merge queue."
 
   # ---------------------------------------------------------------------------
-  # Pre-merge signal.  The devcontainer image is built once here and consumed by
-  # both container jobs below, mirroring the merge queue's
-  # build-devcontainer -> {static-analysis, test-dev} shape.  It is tagged with
-  # github.sha, which on a pull_request event is the PR's merge commit and so
-  # never collides with the queue's own tags.
+  # Pre-merge signal.  Both jobs below build the devcontainer image for
+  # themselves -- see the DEV_IMAGE comment in env -- and then mirror the merge
+  # queue's {static-analysis, test-dev} pair.
   # ---------------------------------------------------------------------------
-  build-devcontainer:
-    name: Build devcontainer amd64 (pre-merge)
-    runs-on: arc-amd64
+  analyze-dev:
+    name: Analyze devcontainer amd64 Release (pre-merge)
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
+      packages: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -113,72 +117,42 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["repository.mdh.quantum.com:5001"]
 
-      # cache-from only (no cache-to): the merge queue owns that cache, and a PR
-      # must not be able to poison it.  An unchanged Dockerfile is therefore a
-      # layer pull rather than a rebuild.
-      - name: Build and push the dev container image
+      # The layer cache is a GHCR package of this repository.  Authenticating
+      # with the run's own token means the import works whether or not the
+      # package has been made public; a fork's pull_request token is read-only,
+      # which is all an import needs.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # load, not push, and cache-from without cache-to: nothing this run
+      # produces leaves the runner, and the merge queue keeps sole ownership of
+      # the cache tag.
+      - name: Build the dev container image
         uses: docker/build-push-action@v7
         with:
           context: .devcontainer
           file: .devcontainer/Dockerfile
           platforms: linux/amd64
-          push: true
-          tags: ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64
-          cache-from: type=registry,ref=repository.mdh.quantum.com:5004/cache/chimera-dev:amd64
-          build-args: |
-            APT_MIRROR=${{ env.APT_MIRROR }}
-            DOCKER_MIRROR=${{ env.DOCKER_MIRROR }}
-            CCACHE_REGISTRY=${{ env.CCACHE_IMAGE_REGISTRY }}
-            QUINT_REGISTRY=${{ env.QUINT_IMAGE_REGISTRY }}
+          load: true
+          tags: ${{ env.DEV_IMAGE }}
+          cache-from: type=registry,ref=${{ env.DEV_IMAGE_CACHE }}
 
-  analyze-dev:
-    name: Analyze devcontainer amd64 Release (pre-merge)
-    needs: [build-devcontainer]
-    runs-on: arc-amd64
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      # Unlike the store this replaced, the Actions cache is readable from a
+      # fork's pull_request run -- a run may read its own ref's scope and the
+      # default branch's.  extended.yml writes that scope on main, so this is a
+      # warm cache on every PR rather than one only same-repo PRs could reach.
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
         with:
-          submodules: recursive
-
-      # Try to prime from the same bundle the queue uses.  Whether this can
-      # work is an open question and the point of trying: org secrets are
-      # withheld from a fork's pull_request run, so NEXUS_SCRATCH_USER is empty
-      # here and the request goes out unauthenticated.  If the scratch repo
-      # allows anonymous reads -- as the internal registry on :5004 evidently
-      # does, since pr-checks pushes images to it with no credentials at all --
-      # this lands a warm cache on every PR.  If it refuses, the step says so
-      # and the build runs cold exactly as it does today.
-      #
-      # -u is passed only when a user actually exists: `-u ":"` sends an empty
-      # Authorization header, which a server can reject outright even where it
-      # would have served the object anonymously.
-      - name: Restore the ccache bundle
-        env:
-          NEXUS_USER: ${{ secrets.NEXUS_SCRATCH_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_SCRATCH_PASSWORD }}
-        run: |
-          key="analyze-devcontainer-amd64-Release"
-          auth=()
-          if [ -n "${NEXUS_USER:-}" ]; then
-            auth=(-u "${NEXUS_USER}:${NEXUS_PASSWORD}")
-            echo "restoring ${key} with credentials"
-          else
-            echo "no scratch credentials (expected on a fork PR); trying anonymously"
-          fi
-          if curl -fsS --retry 3 --retry-all-errors --retry-delay 5 \
-               "${auth[@]}" -o ccache-bundle.tar.gz \
-               "${{ env.NEXUS_SCRATCH_URL }}/chimera/ccache/${key}.tar.gz"; then
-            echo "restored $(stat -c%s ccache-bundle.tar.gz) bytes"
-          else
-            echo "no ccache bundle for ${key}; this analysis starts cold"
-          fi
+          path: ${{ runner.temp }}/ccache
+          key: ccache-analyze-devcontainer-amd64-Release-${{ github.sha }}
+          restore-keys: |
+            ccache-analyze-devcontainer-amd64-Release-
 
       - name: Run the clang static analyzer
         id: static-analysis
@@ -186,22 +160,18 @@ jobs:
           set -o pipefail
           mkdir -p "${{ github.workspace }}/scan-report"
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
-            -e CCACHE_DIR=/build/ccache \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE \
+            -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/scan-report:/scan-report" \
             -v /build \
             -w /build \
-            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
+            ${{ env.DEV_IMAGE }} \
             bash -euxc '
-              mkdir -p /build/ccache
-              if [ -f /workspace/ccache-bundle.tar.gz ]; then
-                tar -C /build/ccache -xzf /workspace/ccache-bundle.tar.gz
-              fi
-              # Zero the counters the bundle brought with it, so --show-stats
-              # below describes this run rather than this run plus the Extended run
-              # that produced the cache.
+              # Zero the counters the restored cache brought with it, so
+              # --show-stats below describes this run rather than this run plus
+              # the Extended run that produced the cache.
               ccache -z > /dev/null
               cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF -B /build -S /workspace -G Ninja
               ninja -C /build
@@ -222,10 +192,10 @@ jobs:
 
   quint-coverage:
     name: Quint coverage devcontainer amd64
-    needs: [build-devcontainer]
-    runs-on: arc-amd64
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
+      packages: read
       pull-requests: write
     steps:
       - name: Checkout repository
@@ -237,6 +207,32 @@ jobs:
           # exactly this PR's diff, and depth 2 is all it takes to have it.
           # The default depth 1 has no parent at all.
           fetch-depth: 2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker-container
+
+      # The layer cache is a GHCR package of this repository.  Authenticating
+      # with the run's own token means the import works whether or not the
+      # package has been made public; a fork's pull_request token is read-only,
+      # which is all an import needs.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the dev container image
+        uses: docker/build-push-action@v7
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.DEV_IMAGE }}
+          cache-from: type=registry,ref=${{ env.DEV_IMAGE_CACHE }}
 
       # Captured on the runner rather than in the container below: the
       # bind-mounted checkout is not owned by the container's root, so git
@@ -276,8 +272,6 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           docker run --rm --privileged \
-            -e DOCKER_MIRROR=${{ env.DOCKER_MIRROR }} \
-            -e APT_MIRROR=${{ env.APT_MIRROR }} \
             -e RUN_URL="$RUN_URL" \
             -e GH_REPO="$GH_REPO" \
             -e PR_HEAD_SHA="$PR_HEAD_SHA" \
@@ -285,7 +279,7 @@ jobs:
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
-            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
+            ${{ env.DEV_IMAGE }} \
             bash -euxc '
               # Ubuntu ships these versioned; the unversioned names are not
               # always on PATH, and coverage-report.sh honours the overrides.
@@ -388,9 +382,9 @@ jobs:
       # Unlike the Linux half of this workflow, this needs no secrets: the
       # Actions cache is available to a fork's pull_request run, and a run can
       # read the default branch's scope.  extended.yml writes that scope on main,
-      # so this restores a cache a PR could never reach through Nexus.
+      # so this restores what the scheduled run on main left behind.
       - name: Restore the ccache directory
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
           key: ccache-macos-analyze-Release-${{ github.sha }}

--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -50,7 +50,7 @@ jobs:
     # artifact guard below covers a run that failed before rendering.
     if: ${{ github.event.workflow_run.event == 'pull_request'
             && github.event.workflow_run.conclusion != 'cancelled' }}
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the default branch
         uses: actions/checkout@v5

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   reuse-lint:
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     
     steps:
     - name: Checkout repository
@@ -26,8 +26,8 @@ jobs:
         
     - name: Install reuse tool
       run: |
-        pip install --upgrade pip -i http://repository.mdh.quantum.com/repository/pypi-proxy/simple/ --trusted-host repository.mdh.quantum.com
-        pip install 'reuse[charset-normalizer]' -i http://repository.mdh.quantum.com/repository/pypi-proxy/simple/ --trusted-host repository.mdh.quantum.com
+        pip install --upgrade pip
+        pip install 'reuse[charset-normalizer]'
         
     - name: Run REUSE lint
       run: |

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   syntax-check:
     name: Check code formatting with uncrustify
-    runs-on: arc-small
+    runs-on: ubuntu-24.04
     
     steps:
       - name: Checkout repository
@@ -20,22 +20,15 @@ jobs:
         with:
           submodules: recursive
       
-      - name: Configure APT mirror
-        run: |
-          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-            sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://repository.mdh.quantum.com/repository/pkgs/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-            sudo sed -i 's|http://security.ubuntu.com/ubuntu|http://repository.mdh.quantum.com/repository/pkgs/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
-            sudo sed -i 's/Components:.*$/Components: main universe/' /etc/apt/sources.list.d/ubuntu.sources
-            sudo sed -i 's/\s*[a-z]*-backports//' /etc/apt/sources.list.d/ubuntu.sources
-          else
-            sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://repository.mdh.quantum.com/repository/pkgs/ubuntu|g' /etc/apt/sources.list
-            sudo sed -i 's|http://security.ubuntu.com/ubuntu|http://repository.mdh.quantum.com/repository/pkgs/ubuntu|g' /etc/apt/sources.list
-          fi
-
+      # ubuntu-24.04 ships uncrustify 0.78.1, which is the version make
+      # syntax-check is calibrated against; a newer one reformats function
+      # pointer parameter lists differently and would fail this check on lines
+      # nobody touched.  Pinning the runner image is what pins the tool.
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y uncrustify make
-      
+          uncrustify --version
+
       - name: Run syntax check
         run: make syntax-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,38 @@ FROM ${CCACHE_REGISTRY}:${CCACHE_VERSION} AS ccache
 FROM ${DOCKER_MIRROR}ubuntu:26.04 AS build
 ARG BUILD_TYPE=Release
 ARG APT_MIRROR
+ARG UBUNTU_MIRROR=""
 ARG ENABLE_XLIO=0
 
 # The mirrored ccache, ahead of anything the distro might provide on PATH.
 COPY --from=ccache /ccache /usr/local/bin/ccache
 
+# Two mirror mechanisms, both off by default, so a plain `docker build` reaches
+# whatever the base image ships and nothing unexpected.
+#
+# APT_MIRROR=<url> replaces the sources list outright.  The public CI has no
+# such mirror, but private forks do, and this is what they set.
+#
+# UBUNTU_MIRROR=azure instead swaps the archive hosts for Azure's, which is
+# what the public CI passes: the GitHub-hosted runners are Azure VMs -- their
+# own host apt is pointed there for the same reason -- and the public mirrors
+# are periodically caught mid-sync, serving an index whose size disagrees with
+# its Release file, which fails the whole image build.  A host swap rather than
+# a rewritten sources list, so the suites, components and Signed-By the base
+# image chose all survive; archive and security are amd64's two hosts, ports is
+# arm64's, and each keeps its path under the Azure name.
+#
+# APT_MIRROR wins if both are set: a fork that has stood one up means it.
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR resolute main universe" > /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR resolute-updates main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR resolute-security main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     rm -f /etc/apt/sources.list.d/ubuntu.sources; \
+    elif [ "$UBUNTU_MIRROR" = azure ]; then \
+        sed -i -e 's|//archive\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//security\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//ports\.ubuntu\.com|//azure.ports.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources; \
     fi
 
 RUN apt-get -y update && \

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -38,16 +38,38 @@ FROM ${DOCKER_MIRROR}ubuntu:22.04
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=0
 ARG APT_MIRROR=""
+ARG UBUNTU_MIRROR=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # The mirrored ccache, ahead of anything the distro might provide on PATH.
 COPY --from=ccache /ccache /usr/local/bin/ccache
 
+# Two mirror mechanisms, both off by default, so a plain `docker build` reaches
+# whatever the base image ships and nothing unexpected.
+#
+# APT_MIRROR=<url> replaces the sources list outright.  The public CI has no
+# such mirror, but private forks do, and this is what they set.
+#
+# UBUNTU_MIRROR=azure instead swaps the archive hosts for Azure's, which is
+# what the public CI passes: the GitHub-hosted runners are Azure VMs -- their
+# own host apt is pointed there for the same reason -- and the public mirrors
+# are periodically caught mid-sync, serving an index whose size disagrees with
+# its Release file, which fails the whole image build.  A host swap rather than
+# a rewritten sources list, so the suites, components and Signed-By the base
+# image chose all survive; archive and security are amd64's two hosts, ports is
+# arm64's, and each keeps its path under the Azure name.
+#
+# APT_MIRROR wins if both are set: a fork that has stood one up means it.
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR jammy main universe" > /etc/apt/sources.list && \
     echo "deb $APT_MIRROR jammy-updates main universe" >> /etc/apt/sources.list && \
     echo "deb $APT_MIRROR jammy-security main universe" >> /etc/apt/sources.list; \
+    elif [ "$UBUNTU_MIRROR" = azure ]; then \
+        sed -i -e 's|//archive\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//security\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//ports\.ubuntu\.com|//azure.ports.ubuntu.com|g' \
+            /etc/apt/sources.list; \
     fi
 
 RUN apt-get -y update && \

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -32,6 +32,7 @@ FROM ${DOCKER_MIRROR}ubuntu:24.04
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=1
 ARG APT_MIRROR=""
+ARG UBUNTU_MIRROR=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -47,11 +48,32 @@ COPY --from=quint /opt/quint   /opt/quint
 COPY --from=quint /quint-home  /root/.quint
 ENV PATH=/opt/quint/bin:${PATH}
 
+# Two mirror mechanisms, both off by default, so a plain `docker build` reaches
+# whatever the base image ships and nothing unexpected.
+#
+# APT_MIRROR=<url> replaces the sources list outright.  The public CI has no
+# such mirror, but private forks do, and this is what they set.
+#
+# UBUNTU_MIRROR=azure instead swaps the archive hosts for Azure's, which is
+# what the public CI passes: the GitHub-hosted runners are Azure VMs -- their
+# own host apt is pointed there for the same reason -- and the public mirrors
+# are periodically caught mid-sync, serving an index whose size disagrees with
+# its Release file, which fails the whole image build.  A host swap rather than
+# a rewritten sources list, so the suites, components and Signed-By the base
+# image chose all survive; archive and security are amd64's two hosts, ports is
+# arm64's, and each keeps its path under the Azure name.
+#
+# APT_MIRROR wins if both are set: a fork that has stood one up means it.
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR noble main universe" > /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR noble-updates main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR noble-security main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     rm -f /etc/apt/sources.list.d/ubuntu.sources; \
+    elif [ "$UBUNTU_MIRROR" = azure ]; then \
+        sed -i -e 's|//archive\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//security\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//ports\.ubuntu\.com|//azure.ports.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources; \
     fi
 
 RUN apt-get -y update && \

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -32,6 +32,7 @@ FROM ${DOCKER_MIRROR}ubuntu:26.04
 ARG ENABLE_XLIO=1
 ARG ENABLE_FIO=1
 ARG APT_MIRROR=""
+ARG UBUNTU_MIRROR=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -47,11 +48,32 @@ COPY --from=quint /opt/quint   /opt/quint
 COPY --from=quint /quint-home  /root/.quint
 ENV PATH=/opt/quint/bin:${PATH}
 
+# Two mirror mechanisms, both off by default, so a plain `docker build` reaches
+# whatever the base image ships and nothing unexpected.
+#
+# APT_MIRROR=<url> replaces the sources list outright.  The public CI has no
+# such mirror, but private forks do, and this is what they set.
+#
+# UBUNTU_MIRROR=azure instead swaps the archive hosts for Azure's, which is
+# what the public CI passes: the GitHub-hosted runners are Azure VMs -- their
+# own host apt is pointed there for the same reason -- and the public mirrors
+# are periodically caught mid-sync, serving an index whose size disagrees with
+# its Release file, which fails the whole image build.  A host swap rather than
+# a rewritten sources list, so the suites, components and Signed-By the base
+# image chose all survive; archive and security are amd64's two hosts, ports is
+# arm64's, and each keeps its path under the Azure name.
+#
+# APT_MIRROR wins if both are set: a fork that has stood one up means it.
 RUN if [ -n "$APT_MIRROR" ]; then \
     echo "deb $APT_MIRROR resolute main universe" > /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR resolute-updates main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     echo "deb $APT_MIRROR resolute-security main universe" >> /etc/apt/sources.list.d/local-mirror.list && \
     rm -f /etc/apt/sources.list.d/ubuntu.sources; \
+    elif [ "$UBUNTU_MIRROR" = azure ]; then \
+        sed -i -e 's|//archive\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//security\.ubuntu\.com|//azure.archive.ubuntu.com|g' \
+               -e 's|//ports\.ubuntu\.com|//azure.ports.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources; \
     fi
 
 RUN apt-get -y update && \

--- a/cmake/SpecsBundle.cmake
+++ b/cmake/SpecsBundle.cmake
@@ -151,7 +151,7 @@ if(_use_fetch)
         COMMAND ${CMAKE_COMMAND} -E make_directory ${_bundle_root}
         COMMAND ${CMAKE_COMMAND} -E env ORAS=${ORAS_BIN}
                 bash ${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_specs_bundle.sh
-                ${_specs_ref} ${_bundle_root}
+                ${_specs_ref} ${_bundle_root} ${_specs_sha}
         COMMAND ${CMAKE_COMMAND} -E touch ${_stamp}
         COMMENT "specs: fetching prebuilt trace bundle ${_specs_ref}"
         VERBATIM)

--- a/cmake/fetch_specs_bundle.sh
+++ b/cmake/fetch_specs_bundle.sh
@@ -8,15 +8,18 @@
 # cmake/SpecsBundle.cmake only in the fetch path (clean submodule + a bundle
 # available for its SHA); local spec development uses the in-tree build instead.
 #
-# Usage: fetch_specs_bundle.sh <oci-ref> <bundle-root>
+# Usage: fetch_specs_bundle.sh <oci-ref> <bundle-root> [expected-sha]
 #   <oci-ref>      e.g. ghcr.io/chimera-nas/specs:<sha>
 #   <bundle-root>  destination dir; traces land in <bundle-root>/traces/<suite>/
+#   [expected-sha] the submodule commit this build is pinned to; when given,
+#                  the bundle must say it was generated from it
 # ORAS may override the oras binary (defaults to `oras` on PATH).
 
 set -euo pipefail
 
-REF="${1:?usage: fetch_specs_bundle.sh <oci-ref> <bundle-root>}"
-ROOT="${2:?usage: fetch_specs_bundle.sh <oci-ref> <bundle-root>}"
+REF="${1:?usage: fetch_specs_bundle.sh <oci-ref> <bundle-root> [expected-sha]}"
+ROOT="${2:?usage: fetch_specs_bundle.sh <oci-ref> <bundle-root> [expected-sha]}"
+EXPECT_SHA="${3:-}"
 ORAS="${ORAS:-oras}"
 
 TRACES="$ROOT/traces"
@@ -47,5 +50,45 @@ fi
 rm -rf "$TRACES"
 mkdir -p "$TRACES"
 tar xzf "$tarball" -C "$TRACES"
+
+# Provenance, not just arrival.  The bundle's manifest records the specs commit
+# its traces were generated from, and that is checked against the commit this
+# build is pinned to rather than inferred from the tag it was fetched under.
+#
+# Today the two cannot disagree: the reference is built from the submodule SHA,
+# so a tag mismatch is impossible.  The check is here for the coordinate that
+# CAN disagree -- specs also publishes release-versioned bundles, and a version
+# names the last tagged commit, so anything resolving one while pinned past
+# that tag would get an older corpus and replay it against models it was not
+# generated from.  That failure is silent, which is the only kind worth
+# spending a check on; a corpus that does not match its models produces
+# confident, wrong results.
+if [ -n "$EXPECT_SHA" ]; then
+    manifest="$TRACES/manifest.json"
+
+    if [ ! -f "$manifest" ]; then
+        # Bundles published before the manifest carried provenance have no
+        # source_sha.  Say so and continue: refusing them would break every
+        # older pin for a check that could not have been satisfied then.
+        echo "fetch_specs_bundle: $REF has no manifest.json; skipping the" \
+             "provenance check (bundle predates it)" >&2
+    else
+        got="$(sed -n 's/.*"source_sha"[[:space:]]*:[[:space:]]*"\([0-9a-f]*\)".*/\1/p' \
+               "$manifest" | head -1)"
+
+        if [ -z "$got" ]; then
+            echo "fetch_specs_bundle: $REF records no source_sha; skipping the" \
+                 "provenance check (bundle predates it)" >&2
+        elif [ "$got" != "$EXPECT_SHA" ]; then
+            echo "fetch_specs_bundle: $REF was generated from $got, but this" \
+                 "build is pinned to $EXPECT_SHA -- refusing to replay a corpus" \
+                 "against models it was not generated from" >&2
+            rm -rf "$TRACES"
+            exit 1
+        else
+            echo "fetch_specs_bundle: provenance ok (generated from $got)"
+        fi
+    fi
+fi
 
 echo "fetch_specs_bundle: unpacked $REF into $TRACES"

--- a/src/server/rest/tests/quint/CMakeLists.txt
+++ b/src/server/rest/tests/quint/CMakeLists.txt
@@ -85,16 +85,31 @@ target_link_libraries(ctl_mbt_replay
 # Trace corpus
 # ---------------------------------------------------------------------------
 #
-# --backend=typescript on every quint invocation here, deliberately.  The
-# default `rust` backend downloads its evaluator from GitHub on first use, so
-# a build depends on an anonymous release fetch -- which is rate-limited, and
-# when it fails quint aborts rather than falling back (a macOS merge-queue run
-# died on exactly that, in `quint test`, 176 build steps in).  This model is
-# small enough that the interpreter costs nothing: measured here the self-test
-# is FASTER under typescript (8.6s vs 12.4s) and generation is a wash, because
-# the evaluator's startup dominates at this size.  The traces are what the
-# replay and the coverage gate consume, and both are generated and consumed
-# within one build, so the backend only has to be self-consistent.
+# --backend=rust, quint's default, pinned explicitly so a future change of that
+# default cannot move the corpus silently.
+#
+# This was typescript, for two reasons that have both since expired.  The first
+# was that the rust backend downloads its evaluator from GitHub on first use --
+# rate-limited, and quint aborts rather than falling back, which killed a macOS
+# merge-queue run 176 build steps in.  Nothing downloads it now: the CI images
+# take the pre-warmed evaluator from the mirrored ghcr.io/chimera-nas/quint
+# image, and the macOS jobs place it from that image's darwin payload.  The
+# second was that typescript measured faster at this size (self-test 8.6s
+# against 12.4s).  Re-measured on this model today, the two are level on the
+# self-test (1.03s each) and rust is ahead on generation (4.06s against 4.41s).
+#
+# Which way it should go from here is not close.  These models grow, and the
+# gap widens with them -- on libevpl's larger models rust is 2.4x faster -- and
+# both ext/specs and libevpl generate their corpora with rust, so this is also
+# the consistent answer.
+#
+# Switching backends changes the corpus: the same seed walks differently under
+# each.  That is safe here because the traces are generated and consumed within
+# one build, and it was checked rather than assumed -- the coverage gate below
+# reports 39/39 buckets over 32 traces under either backend.
+#
+# It does mean the evaluator has to be present.  Every image that carries quint
+# carries it; a developer box without it will fetch it once on the first build.
 #
 # Generated at build time by quint.  When quint is not installed the probes
 # above still build and run -- they need no corpus -- and only the replay
@@ -144,7 +159,7 @@ set(CTL_QNT
 # at its source instead of producing traces that assert the wrong thing.
 set(CTL_SELFTEST ${CMAKE_CURRENT_BINARY_DIR}/ctlTest.stamp)
 add_custom_command(OUTPUT ${CTL_SELFTEST}
-    COMMAND ${QUINT_BIN} test --backend=typescript
+    COMMAND ${QUINT_BIN} test --backend=rust
             --main=ctlTestRef ${CTL_Q}/ctlTest.qnt > /dev/null
     COMMAND ${CMAKE_COMMAND} -E touch ${CTL_SELFTEST}
     DEPENDS ${CTL_QNT} ${CTL_Q}/ctlTest.qnt
@@ -186,7 +201,7 @@ foreach(b ${CTL_BATCHES})
 
     add_custom_command(OUTPUT ${batch}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CTL_T}
-        COMMAND ${QUINT_BIN} run --backend=typescript
+        COMMAND ${QUINT_BIN} run --backend=rust
                 ${CTL_Q}/ctl_run.qnt --main=${prof}
                 --step=${flavor} --max-steps=${steps}
                 --max-samples=${ntraces} --n-traces=${ntraces} --seed=${seed}


### PR DESCRIPTION
Third and last of the set, after chimera-nas/specs#22, chimera-nas/specs#23 and chimera-nas/libevpl#150, which are all merged.

**This one unblocks the queue.** The ARC runners are down, so nothing can merge until CI runs somewhere else — including #1618, which is why its libevpl bump is deliberately not here (see the end).

## Runners

`repository.mdh.quantum.com` was doing five separate jobs: the CI image registry, an apt mirror, a docker.io pull-through, pull-through proxies for the mirrored ccache / quint / KVM-guest packages, and the Nexus scratch repo holding the shared ccache bundles. None of it is reachable from a GitHub-hosted runner, so this is not a label swap.

`arc-small`/`arc-amd64` → `ubuntu-24.04`, `arc-arm64` → `ubuntu-24.04-arm` (free — the repo is public).

## Images

CI images move to `ghcr.io/chimera-nas/chimera-{dev,ubuntu2x,rockyN}`, tagged by commit as before, with the buildx layer cache in a `:buildcache-<arch>` tag beside them. That is GitHub Packages storage — free for a public repo and not subject to the 10 GB Actions cache cap — so the large-image layer cache competes with nothing.

`build-test.yml` and `extended.yml` still build once and push: neither is reachable from a fork (merge queue and schedule respectively) and 21 consumers is too many to rebuild. **`pr-checks.yml` cannot do that** — it runs on `pull_request`, and a fork's read-only `GITHUB_TOKEN` cannot write a package, which is how our own PRs arrive. Its two jobs build the devcontainer for themselves with `load: true` and import the queue's cache read-only; the separate `build-devcontainer` job is gone.

## Mirrors

`APT_MIRROR`, `DOCKER_MIRROR`, the docker.io registry mirror and the CCACHE/QUINT/KVM registry overrides were each overriding a public `ghcr.io/chimera-nas` default already compiled into the Dockerfiles and `kvm/CMakeLists.txt`. Removing the override restores the default.

`APT_MIRROR` itself is **kept** — the public fork has no mirror to point it at, but private forks do. Alongside it, `UBUNTU_MIRROR=azure` swaps the archive hosts for Azure's, which the public CI now passes: the runners are Azure VMs (GitHub points their own host apt there for the same reason), and the public mirrors are periodically caught mid-sync, which killed four image builds in one afternoon during this work. Both default to empty; `APT_MIRROR` wins if both are set.

## ccache and the layer cache: published by the post-merge run on main

The Nexus bundle — curl down, untar in the container, tar back up, PUT on the way out — becomes the pattern the macOS jobs already used: a directory restored with `actions/cache`, bind mounted at `/ccache`.

**Who writes it changed, because the old writers were on refs nothing could read.** Of the 131 entries this repo held, **123 — 23.6 GB of 25 GB — sat on a merge-queue ref that is discarded, or a PR merge ref private to that PR**. Only 1.36 GB, on `refs/heads/main`, was doing any work at all.

So `build-test.yml` gains a `push` trigger on `main` and becomes the **sole writer of both stores** — container layers in GHCR and ccache in the Actions cache. `refs/heads/main` is the default branch, readable from every PR and every queue run, which is the entire point of saving an entry. Publishing on every merge instead of a 6-hourly cron also keeps entries near the tip: a PR builds the merge of its branch with current `main`, so once `main` moves past what an entry was built from, every TU including a changed header misses.

The five ccache jobs (`test`, `static-analysis`, `test-dev`, `macos`, `analyze-macos`) each gain a `save` beside their `restore`, carrying `if: always()` so a cache still publishes when ctest failed — the cache reflects a build that happened, and withholding it makes every later run pay for a test failure that has nothing to do with compilation. They also gain the trim a writer owes, placed **after** the analyzer in the two analysis jobs for the reason Extended recorded: an early trim once published a cache holding only the compile entries, and its first consumer hit on every compile and missed on all 838 analyses.

**Extended stops writing entirely.** It keeps its restores; its cadence now buys discovery latency on the extended tier rather than cache freshness. This does mean every merge-queue job also runs post-merge on `main`, which is the accepted cost of having a readable writer.

Reader/writer graph checked mechanically across all three workflows: six key families, **zero written-but-never-read, zero read-but-never-written**. One asymmetry is deliberate and documented where it bites — build-test's distro matrix is amd64-only, so Extended's arm64 `ubuntu22/24/26` and `rocky9/10` cells restore keys nobody writes and build cold. Widening the post-merge matrix is the fix if that ever costs more than it saves; saving from Extended is not, since those entries land in a scope no other run can read.

Budget: a repo gets 10 GB free and evicts LRU. The push-to-main run saves ~30 entries at ~250 MB each, so one run fits inside the allowance and the steady state is "the newest run's caches are present" — what a `restore-keys` prefix match wants anyway.

## Disk: nothing needed reclaiming

An earlier revision of this PR carried a `free-disk-space` action that deleted preinstalled toolchains and relocated docker's data root, on the assumption that a hosted runner is tight on space. **Measured, that assumption was wrong**, so the action is gone:

| | Size | Used | Avail |
|---|---|---|---|
| before reclaim | 145G | 59G | **87G** |
| after reclaim | 145G | 27G | 118G |

The runner starts with **87 GB free**, and the step cost 37–308 s per job to turn that into 118 GB for a sub-1 GB image. `df` also showed `/mnt` and `/` are the **same filesystem** on these runners, so the data-root relocation moved docker's storage onto the disk it was already on. If an extended cell ever does run out of space, the answer is to shard that cell across runners, not to scavenge on all ~60 jobs.

## Parallelism

`ctest -j 32` → `$(nproc)`. These runners have four vCPUs, and 32-way oversubscription against a 300 s per-test timeout is how a green suite turns into timeouts. The smbtorture matrix keeps its concurrency input at 32 — its cells mostly wait on a daemon — but it is the job most likely to need a second look once its wall clock here is known.

## Only the trusted event writes the shared cache

`build-test.yml` and `extended.yml` both accept `workflow_dispatch`, both hold `packages: write`, and both wrote `cache-to` unconditionally. Anyone with write access — which now deliberately includes outside collaborators who review and merge — could dispatch either against a branch of their choosing and overwrite the `:buildcache-<arch>` tag every later build imports, putting arbitrary layers into all subsequent CI.

The write is now gated on the single event that owns the tag: `github.event_name == 'push'`, and the `push` trigger is branch-filtered to `main`, so the event name alone is the gate. A `workflow_dispatch` on an arbitrary branch cannot write. Extended writes nothing at all now, so its gate is gone rather than tightened. Reads are unchanged.

## specs bundle: verify what it says it was built from

specs records provenance in its bundles now — `manifest.json` carries the `source_sha` the traces were generated from. `fetch_specs_bundle.sh` checks that against the commit this build is pinned to and refuses the corpus if they disagree, removing what it unpacked rather than leaving a half-trusted one behind.

Today they cannot disagree, because the reference is built from the submodule SHA. The check is for the coordinate that **can**: specs also publishes release-versioned bundles, and a version names the last tagged commit, so anything resolving one while pinned past that tag would replay an older corpus against models it was not generated from. That failure is silent, which is the only kind worth spending a check on. Bundles predating the field are accepted with a note, so bisecting older pins still works — verified against the pinned `80ef02f` bundle, whose `manifest.json` has no `source_sha`.

**The pin does not move here.** An earlier revision advanced `ext/specs` to specs `main`, which quietly took specs#20's CHANGE_NOTIFY model (+1953 lines across 7 smb2 files) *without* the server-side work meant to land with it. That work is #1616, which moves the pin to `d513b57` itself. The result was two red SMB MBT cells: the reshaped corpus (72 → 86 smb2 traces) walks into **CD-3**, a pre-existing and already-registered defect where a truncating CREATE refused with `STATUS_SHARING_VIOLATION` truncates the file anyway — `smb_proc_create.c` hands `CHIMERA_VFS_OPEN_TRUNCATE` to `chimera_vfs_open_at` before the share-mode claim is arbitrated. The old corpus never reached it. (The NFSv4 analog was fixed long ago in `nfs4: do not truncate on an OPEN that goes on to fail`; the SMB path never got the same treatment.)

So the pin stays at `80ef02f` and #1616 carries its own bump — the same reasoning applied to `ext/libevpl` below.

## ctl model → rust backend

The control-plane quint invocations were pinned to `typescript` for two reasons that have both expired. The evaluator download that killed a macOS merge-queue run no longer happens — the CI images take the pre-warmed evaluator from the mirrored quint image, and macOS places it from that image's darwin payload. And typescript measured faster at the time (self-test 8.6 s vs 12.4 s); re-measured today they are level at 1.03 s and rust is ahead on generation, 4.06 s vs 4.41 s. The models grow and the gap widens with them — rust is 2.4× faster on libevpl's larger models — and both ext/specs and libevpl generate with rust.

Switching backends changes the corpus, so it was checked rather than assumed: the coverage gate reports **39/39 buckets over 32 traces under either backend**.

## Verification

- `actionlint` clean; every inline `run:` block parses under `bash -n`; all Dockerfiles resolve their stages under `buildx --call outline`.
- Cache reader/writer graph expanded across every matrix cell and checked mechanically over all three workflows: six key families, **zero written-but-never-read, zero read-but-never-written**, every writer in `build-test.yml`'s push-to-main run. The two families pr-checks reads by literal key (`ccache-analyze-devcontainer-amd64-Release`, `ccache-macos-analyze-Release`) were confirmed to resolve onto real matrix cells.
- The provenance check exercised both ways: matching sha exits 0 with 693 traces unpacked; mismatched sha **exits 1 and removes the corpus**. The shipped pin's bundle (`80ef02f`, 7.4 MB) was pulled and inspected directly: no `source_sha`, so it takes the documented accept-with-a-note path.
- Full local configure + build: bundle fetches and verifies, `ctl_traces` builds on rust in 3.0 s, ctl coverage gate passes.
- Disk headroom measured on a real runner before deleting the reclaim action: 87 GB free on `/` at job start, and `/mnt` on the same filesystem as `/`.
- YAML re-validated after the restructure; the cache model survived a 12-conflict cherry-pick intact (6 push gates, 0 merge_group gates, 5 saves, 0 saves in Extended, no duplicate `build-args` keys).
- The Azure mirror built in all four flag combinations, including precedence, plus a separate check against a real amd64 `ubuntu.sources` (an arm64 host resolves to `ports.ubuntu.com` and cannot exercise the archive/security pair).

## Not here, deliberately

**`ext/libevpl` is not bumped.** libevpl main now declares the reply-capture callback with a `rpc_offset` argument (#149), and the matching consumer lives in #1618, not on `main`. Bumping here would break the build. Nothing chimera needs is in the libevpl commits above the current pin — its CI changes only ever run in libevpl's own CI — so the pin stays at `b27b5e87` and #1618 carries its own bump, which is the right place for it.

**`ext/specs` is not bumped either.** The pin stays at `80ef02f`; #1616 owns the move to `d513b57`, together with the server-side changes that belong with specs#20's model. See the specs bundle section above for what taking the model without that work does.

**A fix for CD-3.** The truncate-before-share-arbitration defect is real, registered, and non-reconcilable, but it is not this PR's to fix — this one unblocks the queue. It is `smb_proc_create.c` opening with `CHIMERA_VFS_OPEN_TRUNCATE` before the claim is arbitrated; the registered entry already carries a candidate fix, and the named-stream path needs the same treatment.

**The one-elaboration-per-model batching** that ext/specs and libevpl gained. It pays there because elaborating `nfs4_run.qnt` costs 13–21 s. `ctl_run.qnt` is 105 lines and elaborates in 0.82 s, so collapsing its seven invocations saves about half a second of wall clock and costs an umbrella model, a node driver and a CMake restructure. Worth revisiting when the control-plane models are large enough to notice.
