### PR TITLE
ci: stop analysis building the MBT corpus, and fix ccache key shadowing

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -708,7 +708,7 @@ jobs:
               # really 945 of 947, 99.8%.  Zero them so the number means what it
               # looks like it means.
               ccache -z > /dev/null
-              cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF ${{ matrix.cmake_extra }} -B /build -S /workspace -G Ninja
+              cmake -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF -D SPECS_BUNDLE=NONE ${{ matrix.cmake_extra }} -B /build -S /workspace -G Ninja
               # The analyzer reads compile_commands.json, and several entries
               # include generated headers (xdrzcc, ndrzcc, flex, bison), so the
               # tree has to be built before it can run.  Against a primed cache
@@ -1140,6 +1140,7 @@ jobs:
           cmake -G Ninja -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                 \
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -D SPECS_BUNDLE=NONE \
                 -S "$GITHUB_WORKSPACE" -B "$BUILD_DIR"
           # compile_commands.json is not enough on its own: several entries
           # include generated headers, so the tree has to be built first.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,6 +82,18 @@ env:
   # next run.  refs/heads/main is the default branch and is readable from
   # everywhere, which is why the save hangs off the push and not the queue.
   #
+  # The -v2- in every key is a scheme version, and it is load-bearing.  Writing
+  # to a readable ref is necessary but NOT sufficient: a run searches its OWN
+  # cache scope before the base branch, so an entry left in refs/pull/N/merge by
+  # the previous regime -- when PR and queue runs still saved -- matches the same
+  # restore-keys prefix and WINS over the fresh entry on main.  Measured on the
+  # first PR run after the switchover: it restored a two-day-old 231 MB PR-scoped
+  # cache instead of that morning's main entry and hit 15 of 1754 compiles
+  # (0.86%), paying the download in full for nothing.  Versioning the prefix
+  # makes those stale entries unmatchable, so the search falls through to main.
+  # Bump it again on any change that invalidates the contents; do not reuse a
+  # version.
+  #
   # Publishing on every merge rather than on a 6-hourly cron also keeps the
   # entries close to the tip.  A PR builds the merge of its branch with current
   # main, so once main moves past what a bundle was built from, every
@@ -506,9 +518,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
+            ccache-v2-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Configure, build, and test inside the container
         run: |
@@ -562,7 +574,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload test results
         if: always()
@@ -682,9 +694,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
+            ccache-v2-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Run the clang static analyzer
         id: static-analysis
@@ -742,7 +754,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}
@@ -848,9 +860,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-
+            ccache-v2-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Configure, build, and test inside the container
         run: |
@@ -899,7 +911,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload test results
         if: always()
@@ -976,9 +988,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-macos-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-macos-${{ matrix.build_type }}-
+            ccache-v2-macos-${{ matrix.build_type }}-
 
       # quint from the mirrored darwin payload rather than the npm registry and
       # the GitHub releases endpoint.  Only the Rust evaluator is platform
@@ -1059,7 +1071,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-macos-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload test results
         if: always()
@@ -1121,9 +1133,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-macos-analyze-${{ matrix.build_type }}-
+            ccache-v2-macos-analyze-${{ matrix.build_type }}-
 
       - name: Run the clang static analyzer
         id: static-analysis
@@ -1168,7 +1180,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
 
       - name: Upload static analysis report
         if: ${{ failure() && steps.static-analysis.outcome == 'failure' }}

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -581,9 +581,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
+            ccache-v2-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       - name: Configure, build, and test inside the container
         run: |
@@ -667,9 +667,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-macos-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-macos-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-macos-${{ matrix.build_type }}-
+            ccache-v2-macos-${{ matrix.build_type }}-
 
       # quint from the mirrored darwin payload rather than the npm registry and
       # the GitHub releases endpoint.  Only the Rust evaluator is platform
@@ -786,9 +786,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-macos-analyze-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-macos-analyze-${{ matrix.build_type }}-
+            ccache-v2-macos-analyze-${{ matrix.build_type }}-
 
       - name: Run the clang static analyzer
         id: static-analysis
@@ -1098,9 +1098,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          key: ccache-v2-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
-            ccache-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
+            ccache-v2-analyze-${{ matrix.image_name }}-${{ matrix.arch }}-${{ matrix.build_type }}-
 
       # Drives the analyzer per TU instead of through scan-build, so the results
       # are cacheable.  See build-test.yml for why scan-build cannot be.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -175,7 +175,7 @@ jobs:
               # --show-stats below describes this run rather than this run plus
               # the Extended run that produced the cache.
               ccache -z > /dev/null
-              cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF -B /build -S /workspace -G Ninja
+              cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D IO_URING_NVME_ENABLED=OFF -D SPECS_BUNDLE=NONE -B /build -S /workspace -G Ninja
               ninja -C /build
               python3 /workspace/scripts/analyze_cached.py \
                       --build-dir /build --report-dir /scan-report \
@@ -415,6 +415,7 @@ jobs:
           ccache -z > /dev/null
           cmake -G Ninja -D CMAKE_BUILD_TYPE=Release \
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -D SPECS_BUNDLE=NONE \
                 -S "$GITHUB_WORKSPACE" -B "$BUILD_DIR"
           # compile_commands.json is not sufficient alone: several entries
           # include generated headers, so the tree has to be built first.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -152,9 +152,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-analyze-devcontainer-amd64-Release-${{ github.sha }}
+          key: ccache-v2-analyze-devcontainer-amd64-Release-${{ github.sha }}
           restore-keys: |
-            ccache-analyze-devcontainer-amd64-Release-
+            ccache-v2-analyze-devcontainer-amd64-Release-
 
       - name: Run the clang static analyzer
         id: static-analysis
@@ -391,9 +391,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/ccache
-          key: ccache-macos-analyze-Release-${{ github.sha }}
+          key: ccache-v2-macos-analyze-Release-${{ github.sha }}
           restore-keys: |
-            ccache-macos-analyze-Release-
+            ccache-v2-macos-analyze-Release-
 
       - name: Run the clang static analyzer
         id: static-analysis

--- a/cmake/SpecsBundle.cmake
+++ b/cmake/SpecsBundle.cmake
@@ -24,23 +24,43 @@
 #                      available, otherwise build locally (the default)
 #   SPECS_BUNDLE=ON    require the fetched bundle (configure error if missing)
 #   SPECS_BUNDLE=OFF   always build locally, never fetch
+#   SPECS_BUNDLE=NONE  acquire no corpus at all -- neither fetch nor build
+#
+# NONE is not "off" in the sense OFF means here: OFF still produces a corpus,
+# by building it.  NONE produces none, and is for builds that never replay a
+# trace.  Static analysis is the case that motivated it: scan-build compiles
+# the tree only to give the analyzer its generated headers, then excludes
+# ext/ from the analysis outright, so generating the corpus there is pure
+# cost.  Without oras on PATH -- which the analysis jobs have no other reason
+# to install -- AUTO falls through to the local provider and elaborates every
+# quint model to produce ~700 traces that are then thrown away.
 #
 # On success this sets, in the including scope:
 #   SPECS_BUNDLE_AVAILABLE  ON, and
 #   SPECS_BUNDLE_DIR        the per-suite trace root.
 # If neither a bundle nor quint is available it leaves SPECS_BUNDLE_AVAILABLE
 # OFF; the quint suites then still build their C harnesses but skip the
-# trace-driven replay ctests.
+# trace-driven replay ctests.  NONE takes that same path deliberately, so the
+# harnesses still compile and the analyzer still sees them.
 
 set(SPECS_BUNDLE "AUTO" CACHE STRING
-    "MBT trace corpus provider: AUTO (fetch-if-clean else build), ON (fetch), OFF (build)")
-set_property(CACHE SPECS_BUNDLE PROPERTY STRINGS AUTO ON OFF)
+    "MBT trace corpus provider: AUTO (fetch-if-clean else build), ON (fetch), OFF (build), NONE (no corpus)")
+set_property(CACHE SPECS_BUNDLE PROPERTY STRINGS AUTO ON OFF NONE)
 
 set(SPECS_REGISTRY "ghcr.io/chimera-nas/specs" CACHE STRING
     "OCI registry reference the specs trace bundle is published under")
 
 set(SPECS_BUNDLE_AVAILABLE OFF)
 set(_specs_src ${CMAKE_CURRENT_SOURCE_DIR}/ext/specs)
+
+# Before anything else, including the submodule and oras probes: NONE means the
+# corpus is not wanted, so there is nothing to resolve and nothing to warn about.
+if(SPECS_BUNDLE STREQUAL "NONE")
+    message(STATUS
+        "specs: SPECS_BUNDLE=NONE; no trace corpus fetched or built, "
+        "MBT replay ctests disabled")
+    return()
+endif()
 
 if(NOT EXISTS ${_specs_src}/CMakeLists.txt)
     message(STATUS


### PR DESCRIPTION
scan-build compiles the tree for exactly one reason: several `compile_commands.json` entries include generated headers (xdrzcc, ndrzcc, flex, bison), so the analyzer cannot run against an unbuilt tree. It then analyses with `--exclude /workspace/ext/`, discarding everything the submodules produced.

The analysis jobs were building the entire quint trace corpus inside that build.

## Why it happens

None of the analysis jobs install `oras` — they have no other use for it. So `SPECS_BUNDLE=AUTO` fails its `ORAS_BIN` check, falls through to the local provider, and `add_subdirectory(ext/specs)` puts `specs_traces ALL` on the critical path. The 12:09 analysis run says so in its own log:

```
-- specs: building trace corpus locally from ext/specs
```

~700 traces, elaborated and then excluded from the analysis.

**It is not cheap at the current pin.** `80ef02f` predates the one-elaboration-per-family batching, so the corpus is still generated as ~147 separate quint invocations, each re-elaborating its model. Building `specs_traces` alone on a ten-core laptop ran past ten minutes before I stopped it; a four-vCPU hosted runner is worse — and this lands in the job that is already the longest pole in the pre-merge gate.

## The change

`SPECS_BUNDLE` gains a `NONE` value: acquire no corpus, neither fetched nor built.

That is deliberately **not** what `OFF` means here — `OFF` still produces a corpus, by building it — so the two are documented against each other rather than left to be guessed at.

`NONE` returns before the submodule and oras probes, leaving `SPECS_BUNDLE_AVAILABLE` off. That is the path the quint suites already handle: the C harnesses still compile and only the trace-driven replay ctests drop out. That distinction is the point — the analyzer still sees the harness code, it just doesn't wait for traces it will never replay.

Applied to the four jobs that analyse and never replay a trace:

| workflow | job |
|---|---|
| `build-test.yml` | `static-analysis`, `analyze-macos` |
| `pr-checks.yml` | `analyze-dev`, `analyze-macos` |

The macOS **test** job keeps `SPECS_BUNDLE=ON` — it actually runs the corpus.

## Verification

- `SPECS_BUNDLE=NONE` configures clean: no `ext/specs` subdirectory, no `specs_traces`/`specs_bundle` target, and still **85 quint/mbt build targets** so the analyzer's view of the harnesses is unchanged.
- The `AUTO` default still resolves a corpus (2 specs targets) — the existing behaviour for every other job is untouched.
- Confirmed the four edits landed in the analyze jobs only, and that the macOS test job still carries `SPECS_BUNDLE=ON`.

## Not here

Fetching a bundle in the analysis jobs instead (installing `oras` and letting `AUTO` succeed) would also avoid the local build, but it trades a pointless build for a pointless download — the traces are still never replayed there.


---

# Second commit: version the ccache keys

Added after measuring the first PR run following the runner migration. Unrelated to the specs change above, but the same class of problem — CI work that costs time and returns nothing.

## The bug

Moving the cache writer to the push on `main` (#1620) made entries *readable*. It did not make them *reachable*.

**A run searches its own cache scope before the base branch.** Every PR that ran under the old regime — when PR and merge-queue runs still saved — left entries in `refs/pull/N/merge`, and those match the same `restore-keys` prefix the new main entries do. The PR-scoped entry wins, however stale.

Measured on the first PR run after the switchover. The macOS analysis job restored

```
ccache-macos-analyze-Release-57447576…   (refs/pull/1616/merge, Sep 2)
```

instead of the entry that morning's push to main had written, and got:

```
Cacheable calls:  1754 / 1754 (100.0%)
  Hits:             15 / 1754 (  0.86%)
  Misses:         1739 / 1754 ( 99.14%)
```

231 MB downloaded to miss on everything — **strictly worse than no cache**, because a cold job at least skips the transfer. This is why job durations after #1620 looked unchanged.

## The fix

The key scheme gains a version: `ccache-v2-`. Old entries cannot match the new prefix, so the search falls through to `main`, which is where the only writer writes. That makes **14 PR-scoped and 21 queue-scoped entries inert**, and nothing recreates them: all five saves are gated on `github.event_name == 'push'` and `build-test.yml` is the only writer left.

## Why not just delete the stale entries

Deleting by hand also works, and would preserve the 33 current main entries this discards. It isn't what landed because it needs repository admin, it only fixes the entries that exist the moment someone runs it, and it leaves nothing in the tree explaining why. A version in the key is reviewable, self-enforcing, and reusable next time the contents are invalidated.

The cost is **one cold cycle** until the next push to main republishes under the new prefix.

## Verification

- Reader/writer graph re-checked across all three workflows after the rename: six key families, zero written-but-never-read, zero read-but-never-written.
- 16 keys + 11 restore-keys renamed; the `ccache-darwin` / `ccache-<arch>` binary names in `mirror-ccache.yml` are **not** cache keys and are untouched.
