### PR TITLE
vfs: free the passthrough mount root at teardown, and re-shard the devcontainer extended run

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -370,39 +370,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # devcontainer. KVM is required ON for amd64, where the suites
-          # actually run, so a regression in availability fails the build
-          # rather than silently skipping. The devcontainer ships only x86
-          # qemu (qemu-system-x86), so KVM acceleration is unavailable on
-          # arm64 -- the suites never ran there, so keep them explicitly OFF.
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            build_type: Release
-            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
-            image_name: devcontainer
-            cmake_extra: "-DKVM_TESTING=ON"
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            build_type: Debug
-            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
-            image_name: devcontainer
-            cmake_extra: "-DKVM_TESTING=ON"
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
-            build_type: Release
-            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
-            image_name: devcontainer
-            cmake_extra: "-DKVM_TESTING=OFF"
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
-            build_type: Debug
-            image_tag_prefix: ghcr.io/chimera-nas/chimera-dev
-            image_name: devcontainer
-            cmake_extra: "-DKVM_TESTING=OFF"
+          # The devcontainer image is NOT in this combined matrix: its extended
+          # run is sharded by test category in the test-dev job below.  See there
+          # for why.
           # ubuntu 26 (no KVM here; disable explicitly so a missing /dev/kvm
           # does not get silently auto-detected)
           - platform: linux/amd64
@@ -609,6 +579,197 @@ jobs:
               ccache --show-stats || true
               /workspace/scripts/cap_ctest_output.sh \
               ctest -C extended --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)"'
+
+
+  # Devcontainer extended run: build once per cell, then shard the tests by
+  # category.
+  #
+  # This is the shape build-test.yml carried before the quick/extended tier
+  # split collapsed it (0ec73987, "split the devcontainer into build +
+  # per-category test shards").  It is worth restoring because the runners
+  # changed underneath it: the devcontainer carries by far the widest test set
+  # -- it is the only image with pynfs, smbtorture, wpts, the KVM guests and
+  # the full quint corpus -- and running all of it in one job on a four-vCPU
+  # hosted runner takes hours of wall clock, serialised behind itself.
+  #
+  # The shards do not rebuild.  Rebuilding per category would multiply the
+  # compile by the number of shards, which on a capped concurrency budget costs
+  # more than the serialisation it removes, so build-dev tars the tree once per
+  # (arch, build_type) and each shard unpacks it.  Retention is a day: these
+  # artifacts exist only to cross the job boundary.
+  build-dev:
+    name: Build devcontainer ${{ matrix.arch }} ${{ matrix.build_type }}
+    needs: [build-devcontainer]
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: amd64, runner: ubuntu-24.04,     build_type: Release, kvm_cmake: "-DKVM_TESTING=ON"  }
+          - { arch: amd64, runner: ubuntu-24.04,     build_type: Debug,   kvm_cmake: "-DKVM_TESTING=ON"  }
+          - { arch: arm64, runner: ubuntu-24.04-arm, build_type: Release, kvm_cmake: "-DKVM_TESTING=OFF" }
+          - { arch: arm64, runner: ubuntu-24.04-arm, build_type: Debug,   kvm_cmake: "-DKVM_TESTING=OFF" }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch oras CLI
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Restore the ccache directory
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-v2-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ github.sha }}
+          restore-keys: |
+            ccache-v2-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-
+
+      - name: Configure and build inside the container
+        run: |
+          docker run --rm --privileged \
+            -e CCACHE_DIR=/ccache \
+            -e CCACHE_MAXSIZE \
+            -v "${{ runner.temp }}/ccache:/ccache" \
+            -v "${{ github.workspace }}:/workspace" \
+            -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
+            -v /build \
+            -w /build \
+            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }} \
+            bash -euxc '
+              ccache -z > /dev/null
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREQUIRE_NETNS_TESTS=ON ${{ matrix.kvm_cmake }} /workspace
+              ninja
+              ccache --show-stats || true
+              # Ship the build tree to the test shards (minus the local ccache;
+              # KVM guest images live under /kvm, outside /build, so they are
+              # already excluded).
+              tar -C /build --exclude=./ccache -czf /workspace/build-dev.tar.gz .'
+
+      - name: Upload build tree
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-dev-${{ matrix.arch }}-${{ matrix.build_type }}
+          path: build-dev.tar.gz
+          retention-days: 1
+
+  test-dev:
+    name: Test devcontainer ${{ matrix.arch }} ${{ matrix.build_type }} ${{ matrix.category }}
+    needs: [build-dev]
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        build_type: [Release, Debug]
+        # One shard per label family.  `rest` is the complement of the others,
+        # so every extended test lands in exactly one shard and nothing is
+        # silently dropped when a family is added -- a new label with no shard
+        # of its own still runs, in `rest`.
+        category: [pynfs, smbtorture, wpts, pjd, posix, s3, quint, pnfs, kvm, rest]
+        include:
+          - { arch: amd64, runner: ubuntu-24.04     }
+          - { arch: arm64, runner: ubuntu-24.04-arm }
+        exclude:
+          # The devcontainer ships only qemu-system-x86, so KVM acceleration
+          # is unavailable on arm64 and the guests never ran there.
+          - { arch: arm64, category: kvm }
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The KVM shard fetches guest images from GHCR with oras; the others do
+      # not, but the mount is uniform so the command below stays one shape.
+      - name: Fetch oras CLI
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Download build tree
+        uses: actions/download-artifact@v4
+        with:
+          name: build-dev-${{ matrix.arch }}-${{ matrix.build_type }}
+
+      - name: Unpack and run the category
+        run: |
+          docker run --rm --privileged \
+            -e CATEGORY=${{ matrix.category }} \
+            -v "${{ github.workspace }}:/workspace" \
+            -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
+            -v /build \
+            -w /build \
+            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-${{ matrix.arch }} \
+            bash -euxc '
+              tar -C /build -xzf /workspace/build-dev.tar.gz
+              # ctest -L takes a REGEX, not a literal label, so every
+              # selector here is anchored.  Unanchored, "-L posix" also matches
+              # posix_mbt and "-L s3" matches s3_mbt -- the quint corpus -- so
+              # those tests would run in two shards and be excluded from `rest`
+              # twice over.  Measured on a real configure: -L posix selected 11
+              # tests, -L "^posix$" selected 0.
+              #
+              # EXCL is the same anchored set, so `rest` is exactly the
+              # complement: every extended test lands in one shard, and a label
+              # that does not exist on this platform simply leaves its shard
+              # empty without stranding anything -- the -LE cannot exclude what
+              # is not there.
+              EXCL="^pynfs$|^smbtorture$|^wpts$|^pjdfstest$|^posix$|^s3$|^quint$|^pnfs$|^kvm$"
+              case "$CATEGORY" in
+                pynfs)      SEL="-L ^pynfs$" ;;
+                smbtorture) SEL="-L ^smbtorture$" ;;
+                wpts)       SEL="-L ^wpts$" ;;
+                pjd)        SEL="-L ^pjdfstest$" ;;
+                # pjd tests carry both labels; keep them in one shard only.
+                posix)      SEL="-L ^posix$ -LE ^pjdfstest$" ;;
+                s3)         SEL="-L ^s3$" ;;
+                # The pnfs MBT batches carry `quint` too, and the KVM pnfs
+                # guests carry `kvm`; peel them off in a fixed order so each
+                # test lands in exactly one shard: kvm wins over pnfs, pnfs
+                # wins over quint.
+                quint)      SEL="-L ^quint$ -LE ^pnfs$" ;;
+                pnfs)       SEL="-L ^pnfs$ -LE ^kvm$" ;;
+                kvm)        SEL="-L ^kvm$" ;;
+                rest)       SEL="-LE $EXCL" ;;
+                *)          echo "unknown category $CATEGORY" >&2; exit 1 ;;
+              esac
+              # An empty shard is reported, not failed.  It means the label is
+              # absent on this platform (pynfs and the KVM guests are not built
+              # everywhere), and `rest` picks up anything unlabelled anyway, so
+              # nothing is lost -- but a shard that silently runs zero tests is
+              # worth seeing in the log.
+              if [ "$(ctest -C extended -N $SEL | tail -1 | grep -oE "[0-9]+" | tail -1)" = "0" ]; then
+                echo "::notice::category $CATEGORY selected no tests on ${{ matrix.arch }}"
+                exit 0
+              fi
+              /workspace/scripts/cap_ctest_output.sh \
+              ctest -C extended $SEL --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)"'
 
 
   # macOS: the extended tier on a GitHub-hosted arm64 runner.  Nothing here is

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -150,6 +150,11 @@ struct chimera_io_uring_shared {
     struct chimera_io_uring_range_file *range_files;
     struct chimera_io_uring_range      *ranges;
     uint64_t                            range_next_token;
+
+    /* Mount roots handed out as mount_private, so destroy can free the ones
+     * no UMOUNT reclaimed.  See chimera_linux_mount_root. */
+    pthread_mutex_t                     mount_lock;
+    struct chimera_linux_mount_root    *mount_roots;
 };
 
 /*
@@ -274,6 +279,7 @@ chimera_io_uring_init(
     }
 
     pthread_mutex_init(&shared->range_lock, NULL);
+    pthread_mutex_init(&shared->mount_lock, NULL);
 
     if (cfgdata && cfgdata[0] != '\0') {
         json_error_t json_error;
@@ -299,6 +305,12 @@ chimera_io_uring_destroy(void *private_data)
     struct chimera_io_uring_shared     *shared = private_data;
     struct chimera_io_uring_range_file *file;
     struct chimera_io_uring_range      *range;
+    struct chimera_linux_mount_root    *root;
+
+    while ((root = shared->mount_roots)) {
+        LL_DELETE(shared->mount_roots, root);
+        free(root);
+    }
 
     while ((range = shared->ranges)) {
         LL_DELETE(shared->ranges, range);
@@ -1429,9 +1441,15 @@ chimera_io_uring_mount(
 
         if (fstat(mount_fd, &st) == 0 &&
             (root = calloc(1, sizeof(*root))) != NULL) {
+            struct chimera_io_uring_thread *thread = private_data;
+
             root->dev                      = st.st_dev;
             root->ino                      = st.st_ino;
             request->mount.r_mount_private = root;
+
+            pthread_mutex_lock(&thread->shared->mount_lock);
+            LL_PREPEND(thread->shared->mount_roots, root);
+            pthread_mutex_unlock(&thread->shared->mount_lock);
         }
     }
 
@@ -1447,7 +1465,15 @@ chimera_io_uring_umount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    free(request->umount.mount_private);
+    struct chimera_io_uring_thread  *thread = private_data;
+    struct chimera_linux_mount_root *root   = request->umount.mount_private;
+
+    if (root) {
+        pthread_mutex_lock(&thread->shared->mount_lock);
+        LL_DELETE(thread->shared->mount_roots, root);
+        pthread_mutex_unlock(&thread->shared->mount_lock);
+        free(root);
+    }
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_io_uring_umount */

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -107,6 +107,11 @@ struct chimera_linux_shared {
     struct chimera_linux_range_file *range_files;
     struct chimera_linux_range      *ranges;
     uint64_t                         range_next_token;
+
+    /* Mount roots handed out as mount_private, so destroy can free the ones
+     * no UMOUNT reclaimed.  See chimera_linux_mount_root. */
+    pthread_mutex_t                  mount_lock;
+    struct chimera_linux_mount_root *mount_roots;
 };
 
 struct chimera_linux_thread {
@@ -127,6 +132,7 @@ chimera_linux_init(
     shared = calloc(1, sizeof(*shared));
 
     pthread_mutex_init(&shared->range_lock, NULL);
+    pthread_mutex_init(&shared->mount_lock, NULL);
 
     if (cfgdata && cfgdata[0] != '\0') {
         json_error_t json_error;
@@ -152,10 +158,16 @@ chimera_linux_destroy(void *private_data)
     struct chimera_linux_shared     *shared = private_data;
     struct chimera_linux_range_file *file;
     struct chimera_linux_range      *range;
+    struct chimera_linux_mount_root *root;
 
     while ((range = shared->ranges)) {
         LL_DELETE(shared->ranges, range);
         free(range);
+    }
+
+    while ((root = shared->mount_roots)) {
+        LL_DELETE(shared->mount_roots, root);
+        free(root);
     }
 
     while ((file = shared->range_files)) {
@@ -529,9 +541,15 @@ chimera_linux_mount(
 
         if (fstat(mount_fd, &st) == 0 &&
             (root = calloc(1, sizeof(*root))) != NULL) {
+            struct chimera_linux_thread *thread = private_data;
+
             root->dev                      = st.st_dev;
             root->ino                      = st.st_ino;
             request->mount.r_mount_private = root;
+
+            pthread_mutex_lock(&thread->shared->mount_lock);
+            LL_PREPEND(thread->shared->mount_roots, root);
+            pthread_mutex_unlock(&thread->shared->mount_lock);
         }
     }
 
@@ -547,7 +565,15 @@ chimera_linux_umount(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    free(request->umount.mount_private);
+    struct chimera_linux_thread     *thread = private_data;
+    struct chimera_linux_mount_root *root   = request->umount.mount_private;
+
+    if (root) {
+        pthread_mutex_lock(&thread->shared->mount_lock);
+        LL_DELETE(thread->shared->mount_roots, root);
+        pthread_mutex_unlock(&thread->shared->mount_lock);
+        free(root);
+    }
     request->status = CHIMERA_VFS_OK;
     request->complete(request);
 } /* chimera_linux_umount */

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -373,10 +373,24 @@ linux_mount_table_destroy(struct chimera_linux_mount_table *mount_table)
 
 /* Identity of a chimera mount's backing (root) directory, allocated at MOUNT
  * and handed back as mount_private, so per-op code can recognize the mount
- * root without holding an fd. */
+ * root without holding an fd.
+ *
+ * UMOUNT frees it, but a process that exits with the mount still up never
+ * issues one: chimera_vfs_destroy tears the delegation threads down before the
+ * mount table, so no request can be dispatched by then, and
+ * chimera_vfs_mount_table_destroy frees the mount without touching the
+ * module-owned mount_private (it cannot -- the shape is the module's).  So
+ * every mount left standing at teardown leaked this.  The other backends do
+ * not: their mount_private points at a filesystem object owned by the module's
+ * own registry, not at an allocation the mount alone owns.
+ *
+ * `next` threads them onto the module's shared list so module destroy can
+ * sweep whatever UMOUNT did not, the same way it already sweeps ranges and
+ * range_files. */
 struct chimera_linux_mount_root {
-    dev_t dev;
-    ino_t ino;
+    dev_t                            dev;
+    ino_t                            ino;
+    struct chimera_linux_mount_root *next;
 };
 
 /* True when `name` is ".." and `parent_fd` is the mount's root directory:


### PR DESCRIPTION
Two changes, both aimed at the Extended workflow, which has failed **25 of its 50 jobs** in every run since at least 09-02.

# 1. The mount-root leak

Almost the entire failure population was one 16-byte allocation.

`chimera_linux_lookup_path` calloc's a `chimera_linux_mount_root` — the backing directory's dev/ino, so lookups can clamp `..` at the mount root — and hands it back as `mount_private`. UMOUNT frees it, but **a process that exits with the mount still up never issues one**: `chimera_vfs_destroy` tears down the delegation threads before the mount table, so nothing can be dispatched by then, and `chimera_vfs_mount_table_destroy` frees the mount's `path`/`module_path`/`options` without touching `mount_private` — it cannot, the shape belongs to the module.

```
Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #1 chimera_linux_mount   src/vfs/linux/linux.c:531
```

## Why it looked so much bigger than it is

LeakSanitizer fails the process, so **every test touching that backend failed with it**. Release has no LSan and macOS has none at all, so it presented as "Debug is broken":

| job | failed / total |
|---|---|
| ubuntu22 amd64 **Debug** | 658 / 3692 |
| devcontainer arm64 **Debug** | 1791 / 8537 |
| ubuntu26 amd64 **Release** | 1 / 5392 |

Release runs the *same* 143 `pjd nfs4_linux` tests and passes all 143. Every failure was on a `_linux` or `_io_uring` backend; **memfs, cairn and diskfs never failed anywhere**, because their `mount_private` points at a filesystem object owned by the module's own registry rather than an allocation the mount alone owns.

Exactly two leak origins across both Debug jobs — `chimera_linux_mount` (52/68) and `chimera_io_uring_mount` (22). Nothing else leaked.

## The fix

Both passthroughs thread their mount roots onto a list in module shared state, so module destroy frees whatever UMOUNT did not — the same way each already sweeps its `ranges` and `range_files`. UMOUNT unlinks before freeing, so the two paths cannot double-free. io_uring reuses the linux struct, so `next` lands in `linux_common.h` and serves both.

# 2. Re-sharding the devcontainer's extended run

The devcontainer carries by far the widest test set — 8537 tests against ubuntu22's 3692, and the only image with pynfs, smbtorture, wpts, the KVM guests and the full quint corpus. The extended tier runs all of it in **one job**. That was fine on the ARC hosts; on a four-vCPU hosted runner it is hours of wall clock and the long pole of the workflow.

This restores the shape `build-test.yml` had before the quick/extended split collapsed it (`0ec73987`). `build-dev` builds once per (arch, build_type) and tars the tree; `test-dev` unpacks it and runs one label family per shard. **The shards do not rebuild** — rebuilding per category would multiply the compile by the shard count, which on a capped concurrency budget costs more than the serialisation it removes.

20 cells stay in the combined `test` matrix (the five distro images); 4 builds and 38 shards here.

## Anchoring is load-bearing

`ctest -L` takes a **regex**, not a literal label. Unanchored, `-L posix` also matches `posix_mbt` and `-L s3` matches `s3_mbt` — the quint corpus — so those tests would run in two shards each *and* be excluded from `rest` twice over. Measured on a real configure: `-L posix` selected **11** tests, `-L "^posix$"` selected **0**.

Three label pairs overlap, so shards peel them off in a fixed order: **kvm** before **pnfs** (KVM pnfs guests carry both), **pnfs** before **quint** (pnfs MBT batches carry both), **pjdfstest** before **posix** (pjd tests carry both).

`rest` is the exact complement of the anchored set, so the partition is total — verified against a real configure:

```
pjdfstest 862 · posix 684 · rest 331 · quint 62 · pnfs 3 · (pynfs/smbtorture/wpts/s3/kvm 0 on macOS)
sum = 1942   total = 1942   PARTITION OK
```

Every extended test in exactly one shard, none twice, none dropped. A label absent on a platform leaves its shard empty without stranding anything (`-LE` cannot exclude what is not there); that is reported as a notice rather than failed, since pynfs and the KVM guests genuinely are not built everywhere.

# Verification

- Partition proven by enumeration against a configured tree, as above.
- `bash -n` clean on both new run blocks; YAML parses; matrix expands to 4 + 38 as intended.
- The leak fix could **not** be compiled locally: both files are Linux-only and the local container VM is out of disk. It follows the existing `thread = private_data` and `LL_DELETE` patterns already used in both files, but CI is the first real compile — flagging that rather than implying otherwise.

# Not here

`libevpl/rpc2/conformance_STREAM_SOCKET_TCP_{kqueue,select}` fail on macOS (~11 defect cases: `expected SUCCESS, got STALLED`, `expected AUTH_ERROR, got MALFORMED_REPLY`). That is in `ext/libevpl` and gets its own PR.
