### PR TITLE
ci: size the smbtorture matrix to the runner, and bump libevpl for the Darwin connect fix

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -896,10 +896,38 @@ jobs:
         env:
           SMBTORTURE_BACKENDS: ${{ inputs.smbtorture_backends }}
           SMBTORTURE_FILTER: ${{ inputs.smbtorture_filter }}
-          SMBTORTURE_PARALLEL: ${{ inputs.smbtorture_parallel || '32' }}
+          # Empty means "size it from the runner"; the dispatch input still
+          # overrides.  See the run step below for why this is no longer 32.
+          SMBTORTURE_PARALLEL: ${{ inputs.smbtorture_parallel }}
         run: |
           rm -rf smbt-report
           mkdir -p smbt-report
+          # 32 was sized for the ARC hosts.  A cell is a chimera server plus an
+          # smbtorture client, and for the diskfs backends the server also lays
+          # down ten 1 GB device images; thirty-two of those at once on a
+          # four-vCPU, 16 GB hosted runner ran the machine out of memory.  The
+          # servers then died during startup --
+          #
+          #   io_uring_queue_init_params() failed: Cannot allocate memory (-12)
+          #
+          # -- before their test ran, and smbtorture recorded the cell as
+          # failed.  That is what turned this job red the first time it ran on
+          # hosted runners: 53 "newly failing" cells, 45 of them on
+          # diskfs_io_uring (io_uring rings AND the device images), and none at
+          # all on memfs, linux or plain io_uring.  The same run took 36 minutes
+          # against 16 before the move, at identical concurrency -- the machine
+          # was thrashing, not the tests regressing.
+          #
+          # Two per vCPU keeps the overlap these cells actually benefit from --
+          # they spend most of their time waiting on a daemon, which is why
+          # oversubscribing at all is right -- without the 8x that broke them.
+          # regen.sh's own default is 12, for reference.  Derived rather than
+          # hardcoded so a runner change does not silently reintroduce this.
+          if [ -z "${SMBTORTURE_PARALLEL}" ]; then
+            SMBTORTURE_PARALLEL=$(( $(nproc) * 2 ))
+          fi
+          export SMBTORTURE_PARALLEL
+          echo "smbtorture concurrency: ${SMBTORTURE_PARALLEL} cells ($(nproc) vCPU)"
           docker run --rm --privileged \
             -e SMBTORTURE_BACKENDS \
             -e SMBTORTURE_FILTER \


### PR DESCRIPTION
Two commits: the smbtorture matrix's concurrency, and the libevpl bump that clears the macOS conformance failures.

# 1. The smbtorture matrix was out of memory, not regressing

The job turned red the first time it ran on hosted runners, reporting **53 newly failing cells**. They are not protocol regressions — the servers were failing to start:

```
io_uring_queue_init_params() failed: Cannot allocate memory (-12)
... Aborted (core dumped)
```

A cell is a chimera server plus an smbtorture client, and for the diskfs backends the server also lays down **ten 1 GB device images**. Thirty-two of those at once on a four-vCPU, 16 GB runner ran the machine out of memory; the server died during startup and smbtorture recorded the cell as failed before its test ever ran.

## The shape of the failures says the same thing

| backend | newly failing |
|---|---|
| **diskfs_io_uring** (io_uring rings **and** device images) | **45** |
| diskfs_aio | 6 |
| cairn | 2 |
| memfs, linux, io_uring | **0** |

And the timing is unambiguous:

| run | duration | result |
|---|---|---|
| 09-04 05:30 (last pre-migration) | **16.1 min** | success |
| 09-04 16:43 (first post-migration) | **36.0 min** | failure |

Identical concurrency, 2.2× the wall clock. The machine was thrashing.

## Nothing else in the report moved

`733 failing` decomposes exactly:

```
609 still failing (baseline) + 42 failing-disabled + 29 timing out + 53 newly failing = 733
```

The recorded baseline of known divergences is unchanged; only the 53 are new, and they are this.

## The change

Concurrency is derived from the runner — **two cells per vCPU** — rather than hardcoded at 32. These cells spend most of their time waiting on a daemon, which is why oversubscribing at all is right; 8× is not. `regen.sh`'s own default is 12, for reference. Deriving it means a future runner change cannot silently reintroduce this, and the `workflow_dispatch` input still overrides for a scoped manual run.

**Wall clock will go up before it comes down.** A slower job that measures what it claims to measure beats a faster one whose failures are its own harness.

# 2. Bump libevpl for the Darwin connect fix (libevpl#151)

`conformance_STREAM_SOCKET_TCP` failed every defect case on macOS — 155 of 155 unexpected, the first a well-formed request with no defect injected — and was two of the three failures in chimera's macOS extended job.

The harness's raw socket is `O_NONBLOCK`, so `connect()` returns `EINPROGRESS`. Linux finishes a loopback connect inside `connect()` itself; Darwin does not, and returned `ENOTCONN`, which `send_all` treated as fatal. The request was never written, and the case timed out waiting for a reply the server had never been asked for.

Also picks up libevpl#149 and #150 — already on chimera main via #1618, and libevpl's own CI move respectively.

## Verified against this tree

- Full build succeeds on the new pin (so #149's `rpc_offset` consumer is present).
- `libevpl/rpc2`: **51/51 pass**; all **12 conformance variants** pass.
- Defect cases: **155 unexpected → 0** (149 matched spec, 6 known divergences).
- Accept accounting comes out even, 156 of 156 — it had been 116, because cases that gave up closed their connections before the server ever accepted them.

# Caveats

- The concurrency value is reasoned, not measured: I can't tell ENOMEM-from-`RLIMIT_MEMLOCK` apart from genuine memory exhaustion in one log, and lowering concurrency addresses both. If two-per-vCPU still thrashes, the next lever is `--ulimit memlock=-1` on the container, or `nproc` flat.
- `libevpl/unix/bulk_stream_unix_*` fail locally on long build paths (105-byte unix socket path against a 103 limit) and pass in CI. Unrelated to either commit; the library returns NULL correctly and the *test* does not check it, so a clear error becomes a SEGV. Worth its own fix.
