### PR TITLE
ci: fetch the KVM guest images in the shard that needs them

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -608,8 +608,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { arch: amd64, runner: ubuntu-24.04,     build_type: Release, kvm_cmake: "-DKVM_TESTING=ON"  }
-          - { arch: amd64, runner: ubuntu-24.04,     build_type: Debug,   kvm_cmake: "-DKVM_TESTING=ON"  }
+          # KVM_FETCH_IMAGES=OFF: the guest images are ~3.4 GB each and land in
+          # /kvm, outside the build tree this job tars, so fetching them here
+          # downloads several GB that the artifact then excludes.  The kvm
+          # shard fetches them on demand instead -- the split kvm/CMakeLists.txt
+          # documents, and the same pairing build-test.yml's test-dev uses.
+          - { arch: amd64, runner: ubuntu-24.04,     build_type: Release, kvm_cmake: "-DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF" }
+          - { arch: amd64, runner: ubuntu-24.04,     build_type: Debug,   kvm_cmake: "-DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF" }
           - { arch: arm64, runner: ubuntu-24.04-arm, build_type: Release, kvm_cmake: "-DKVM_TESTING=OFF" }
           - { arch: arm64, runner: ubuntu-24.04-arm, build_type: Debug,   kvm_cmake: "-DKVM_TESTING=OFF" }
 
@@ -759,6 +764,21 @@ jobs:
                 rest)       SEL="-LE $EXCL" ;;
                 *)          echo "unknown category $CATEGORY" >&2; exit 1 ;;
               esac
+              # The build job left the guest images unfetched (see build-dev),
+              # and they live in /kvm outside the tree unpacked above, so the
+              # kvm shard has none.  Fetch exactly the images this configure
+              # declares rather than a hardcoded list: the previous incarnation
+              # of this job named three, kvm/CMakeLists.txt now builds four, and
+              # a list that drifts silently fetches the wrong set.
+              if [ "$CATEGORY" = kvm ]; then
+                imgs=$(ninja -t targets all 2>/dev/null \
+                       | grep -oE "^kvm_[a-z0-9_]+_image" | sort -u)
+                if [ -z "$imgs" ]; then
+                  echo "::error::kvm shard: no kvm_*_image targets in this build"
+                  exit 1
+                fi
+                ninja $imgs
+              fi
               # An empty shard is reported, not failed.  It means the label is
               # absent on this platform (pynfs and the KVM guests are not built
               # everywhere), and `rest` picks up anything unlabelled anyway, so


### PR DESCRIPTION
The devcontainer sharding landed with both halves of the KVM image arrangement missing, so it manages to do both wrong things at once: `build-dev` downloads several GB of guest images it then throws away, and the `kvm` shard runs with none.

## What the split is supposed to be

`kvm/CMakeLists.txt` states it:

> When ON (default) the guest images are fetched as part of the default build target (ALL) … **CI's split build job sets this OFF** so the build does not pull ~5GB of images it will not ship in its artifact; **the test jobs then fetch on demand** with `ninja kvm_<image>_image`.

## What the sharding did instead

`build-dev` passed `-DKVM_TESTING=ON` **without** `-DKVM_FETCH_IMAGES=OFF`, so its `ninja` fetched all four images. They land in `${BUILD_ROOT}/kvm` — that is `/kvm`, one level above the `/build` the job tars — so the artifact excluded them exactly as intended, and the download was pure cost.

The `kvm` shard then unpacked a tree with no images and **no way to get them**: the tests do not depend on the image targets, which is the entire point of the on-demand split.

`build-test.yml`'s `test-dev` has carried the correct pairing all along:

```yaml
kvm_cmake: "-DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF"
```

`extended.yml`'s new `build-dev` simply did not copy it.

## The fix

- `build-dev` gains `-DKVM_FETCH_IMAGES=OFF` on the two amd64 cells (arm64 is `KVM_TESTING=OFF` already).
- The `kvm` shard fetches the images before running.

**The image list is queried from the configure, not hardcoded.** The previous incarnation of this job named three images; `kvm/CMakeLists.txt` builds four today. A hardcoded list that drifts fetches the wrong set silently — which is a failure this arrangement has already had once. A shard that finds no `kvm_*_image` targets fails loudly instead: it was configured with `KVM_TESTING=ON`, so their absence means something is wrong rather than merely unavailable.

Only the `kvm` shard needs them: `pnfs` selects `-L ^pnfs$ -LE ^kvm$`, so KVM-labelled pNFS tests land in the `kvm` shard by construction.

## How it was found

By checking what the first sharded extended run actually scheduled — **not** by a failure. That run's `kvm` shard had not started yet, so this would have surfaced hours later as "the KVM suites still don't report", which is precisely the symptom the sharding was meant to cure.

## Verification

- YAML parses; `bash -n` clean on the shard's run block.
- The `ninja -t targets all | grep -oE '^kvm_[a-z0-9_]+_image'` query form checked against a real build tree: `ninja -t targets all` emits `name: rule` lines, phony targets included, and the pattern matches that shape (verified against an existing target, since KVM targets are Linux-only and absent on macOS).
- The unpacked tree keeps the same `/build` path it was configured at, so `ninja` in the shard resolves — the same property the historical job relied on.
