### PR TITLE
tests: keep the ASan preload out of the netns wrapper's own shell

### DIFF
--- a/scripts/netns_test_wrapper.sh
+++ b/scripts/netns_test_wrapper.sh
@@ -6,10 +6,27 @@
 
 set -e
 
-# Save and clear LD_PRELOAD immediately to avoid ASAN interference with
-# system binaries (date, ip, etc.) which exit non-zero under ASAN.
-# LD_PRELOAD is restored only for the actual test command.
-SAVED_LD_PRELOAD="${LD_PRELOAD:-}"
+# The preload a test needs arrives as CHIMERA_TEST_LD_PRELOAD, not LD_PRELOAD,
+# and is applied to the test command alone (see the exec at the end).
+#
+# It has to be a separate variable.  Clearing LD_PRELOAD here cleans what the
+# helpers below inherit -- date, ip -- but cannot unload anything from THIS
+# shell: bash was already exec'd with it by then.  A bash running under ASAN
+# then reports its own parser allocations at exit and fails the test with them:
+#
+#     ==NNN==ERROR: LeakSanitizer: detected memory leaks
+#         #1 make_if_command (/usr/bin/bash+0x449f3)
+#         #2 yyparse ... #6 main (/usr/bin/bash+0x351f5)
+#
+# which is a leak in bash, not in anything under test.  Never putting the
+# preload in this process's environment is the only way to avoid it; a
+# suppression would have to name bash's parser internals, and disabling leak
+# detection outright would throw away the coverage the suppressions file exists
+# to keep.
+#
+# LD_PRELOAD is still honoured for callers that have not moved over, and still
+# cleared for the helpers, so behaviour there is unchanged.
+SAVED_LD_PRELOAD="${CHIMERA_TEST_LD_PRELOAD:-${LD_PRELOAD:-}}"
 unset LD_PRELOAD
 
 if [ $# -lt 1 ]; then

--- a/src/elbencho/tests/CMakeLists.txt
+++ b/src/elbencho/tests/CMakeLists.txt
@@ -99,8 +99,11 @@ if(ELBENCHO_BIN)
     endif()
 
     # In Debug builds the plugin .so is ASan-instrumented but the elbencho host
-    # is not, so preload the ASan runtime (the netns wrapper restores LD_PRELOAD
-    # for the test process only). Mirrors src/fio/tests.
+    # is not, so preload the ASan runtime.  CHIMERA_TEST_LD_PRELOAD rather than
+    # LD_PRELOAD: the wrapper applies it to the test process alone and never
+    # loads it into its own shell, which would otherwise report bash's parser
+    # allocations as leaks.  Masked here today by detect_leaks=0, but the same
+    # hazard as src/fio/tests, where it is not.  Mirrors src/fio/tests.
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
             set(ASAN_LIB_DIRS "/usr/lib/aarch64-linux-gnu" "/usr/lib64")
@@ -119,7 +122,7 @@ if(ELBENCHO_BIN)
         if(ASAN_LIB)
             set_tests_properties(${ELBENCHO_TEST_NAMES}
                 PROPERTIES ENVIRONMENT
-                "LD_PRELOAD=${ASAN_LIB};ASAN_OPTIONS=detect_leaks=0")
+                "CHIMERA_TEST_LD_PRELOAD=${ASAN_LIB};ASAN_OPTIONS=detect_leaks=0")
         endif()
     endif()
 endif()

--- a/src/fio/tests/CMakeLists.txt
+++ b/src/fio/tests/CMakeLists.txt
@@ -41,18 +41,18 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     endif()
 
     set_tests_properties(chimera/fio/fio_memfs_basic PROPERTIES
-        ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
+        ENVIRONMENT "CHIMERA_TEST_LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
     )
 
     if(IO_URING_ENABLED)
         set_tests_properties(chimera/fio/fio_diskfs_io_uring_basic PROPERTIES
-            ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
+            ENVIRONMENT "CHIMERA_TEST_LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
         )
     endif()
 
     if(HAVE_LIBAIO)
         set_tests_properties(chimera/fio/fio_diskfs_aio_basic PROPERTIES
-            ENVIRONMENT "LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
+            ENVIRONMENT "CHIMERA_TEST_LD_PRELOAD=${ASAN_LIB};LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/suppressions.txt"
         )
     endif()
 endif()


### PR DESCRIPTION
The three `chimera/fio/*` tests failed on devcontainer amd64 Debug with leaks that belong to **bash**:

```
==35554==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #1 make_if_command (/usr/bin/bash+0x449f3)
    #2 yyparse (/usr/bin/bash+0x3e831)
    ...
    #6 main (/usr/bin/bash+0x351f5)
SUMMARY: AddressSanitizer: 427 byte(s) leaked in 23 allocation(s).
```

That is `netns_test_wrapper.sh`'s own shell, not anything under test.

## Why the existing guard could not work

The wrapper already saved and cleared `LD_PRELOAD` at the top, with a comment explaining why — so `date` and `ip` do not run under ASan. That works for the **helpers**, which inherit the cleared environment.

It cannot work for **the shell itself**. bash was `exec`'d with `LD_PRELOAD` already set, so the runtime is loaded before the first line of the script runs; unsetting the variable afterwards does not unload it. LSan then reports bash's parser allocations at exit, and the test fails on them.

## The fix

The preload arrives as `CHIMERA_TEST_LD_PRELOAD` and is applied to the test command alone. Nothing puts it in the wrapper's environment, so there is nothing to unload.

`LD_PRELOAD` is still honoured as a fallback, so any caller not yet moved behaves exactly as before.

## Why not the alternatives

- **A suppression** would have to name bash's parser internals (`make_if_command`, `yyparse`). That says nothing about what the test covers and breaks whenever bash changes.
- **Disabling leak detection** is what `src/elbencho/tests` does (`ASAN_OPTIONS=detect_leaks=0`) — and is exactly why elbencho never hit this. For fio it would discard the detection `suppressions.txt` exists to preserve: that file suppresses fio's *known intentional* leaks (`parse_options`, `log_io_piece`, `options_mem_dupe`) precisely so the rest still count.

elbencho moves to the same variable. Its `detect_leaks=0` masks the hazard rather than avoiding it, and there's no reason for the two to differ.

## Verification

- Precedence checked: new variable wins, `LD_PRELOAD` still works alone, empty when neither is set.
- `bash -n` clean; cmake configures; no `ENVIRONMENT "LD_PRELOAD=..."` remains in any CMakeLists.

## Not fixed here

The same cell also shows the test command dying with **SIGILL**, with no ASan diagnostic attached. It is amd64 **Debug** only — amd64 Release runs the same fio on the same runners and passes, and arm64 is clean in both — so it is plausibly the same preload, but that is a hypothesis. Settling it needs a Linux reproduction with ASan, which I could not do here.

**This change removes a defect that is understood; it may not turn that cell green on its own.**

Worth noting for context: these tests were not newly broken by the extended-run sharding. fio passed on arm64 in the previous run, and the amd64 devcontainer cells were killed at the 6-hour wall in every recent run, so fio-on-amd64-Debug simply had not reported in a long time.
