### PR TITLE
Fix four critical remote-crash defects in the NFSv3 and SMB wire paths

### DIFF
--- a/src/server/nfs/nfs3_proc_fsinfo.c
+++ b/src/server/nfs/nfs3_proc_fsinfo.c
@@ -21,7 +21,7 @@ chimera_nfs3_fsinfo_complete(
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct evpl                      *evpl   = thread->evpl;
     struct FSINFO3res                 res;
-    uint64_t                          max_xfer = 1024 * 1024;
+    uint64_t                          max_xfer = CHIMERA_NFS3_MAX_XFER;
     int                               rc;
 
     res.status = chimera_vfs_error_to_nfsstat3(error_code);

--- a/src/server/nfs/nfs3_proc_read.c
+++ b/src/server/nfs/nfs3_proc_read.c
@@ -125,6 +125,14 @@ chimera_nfs3_read(
         return;
     }
 
+    /* RFC 1813 3.3.6: a count above rtmax is served as a short read rather than
+     * an error.  The clamp is load-bearing -- the read dispatch sizes its iovec
+     * allocation from this count and aborts if the allocation fails, so an
+     * unclamped wire count would take the daemon down. */
+    if (args->count > CHIMERA_NFS3_MAX_XFER) {
+        args->count = CHIMERA_NFS3_MAX_XFER;
+    }
+
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,
                         req->fh,
                         req->fhlen,

--- a/src/server/nfs/nfs3_proc_write.c
+++ b/src/server/nfs/nfs3_proc_write.c
@@ -141,6 +141,15 @@ chimera_nfs3_write(
     if (res.status == NFS3_OK) {
         res.status = chimera_nfs3_check_rofs(req, req->export_id);
     }
+
+    /* count and the opaque data<> are independent wire fields, so a client can
+     * claim more bytes than it supplied.  The backends drive an iovec cursor
+     * over the supplied iovecs for count bytes and abort() once the source is
+     * exhausted, so a disagreeing pair has to be refused here. */
+    if (res.status == NFS3_OK && args->count > args->data.length) {
+        res.status = NFS3ERR_INVAL;
+    }
+
     if (res.status != NFS3_OK) {
         nfsstat3 fh_status = res.status;
         memset(&res, 0, sizeof(res));
@@ -155,6 +164,12 @@ chimera_nfs3_write(
         evpl_iovecs_release(evpl, args->data.iov, args->data.niov);
         nfs_request_free(thread, req);
         return;
+    }
+
+    /* RFC 1813 3.3.7: a count above wtmax is served as a short write, with the
+     * reply reporting how much was actually written. */
+    if (args->count > CHIMERA_NFS3_MAX_XFER) {
+        args->count = CHIMERA_NFS3_MAX_XFER;
     }
 
     chimera_vfs_open_fh(thread->vfs_thread, &req->cred,

--- a/src/server/nfs/nfs3_procs.h
+++ b/src/server/nfs/nfs3_procs.h
@@ -7,6 +7,14 @@
 #include "nfs_common.h"
 
 /*
+ * Largest payload chimera will move in a single NFSv3 READ or WRITE.  FSINFO
+ * advertises this as rtmax/rtpref and wtmax/wtpref, and READ and WRITE clamp
+ * the wire count to it, so the advertised limit and the enforced limit cannot
+ * drift apart.  RFC 1813 3.3.6/3.3.7 permit the resulting short read or write.
+ */
+#define CHIMERA_NFS3_MAX_XFER (1024 * 1024)
+
+/*
  * Decode a wire NFSv3 filehandle into req->fh and translate a decode failure to
  * the appropriate NFSv3 status.  A security-policy rejection -- the request's
  * RPC auth flavor is not permitted by the target export's sec= list -- maps to

--- a/src/server/smb/smb_ntlm.c
+++ b/src/server/smb/smb_ntlm.c
@@ -18,6 +18,7 @@
 #include "smb_wbclient.h"
 #include "smb_internal.h"
 #include "common/logging.h"
+#include "common/macros.h"
 #include "vfs/vfs.h"
 #include "vfs/vfs_user_cache.h"
 
@@ -374,9 +375,10 @@ compute_ntlmv2_hash(
     return 0;
 } /* compute_ntlmv2_hash */
 
-// Parse UTF-16LE field from NTLM message
-static char *
-parse_ntlm_utf16_field(
+// Parse UTF-16LE field from NTLM message.
+/* Exposed for unit tests in tests/smb_harden_test.c. */
+SYMBOL_EXPORT char *
+smb_ntlm_parse_utf16_field(
     const uint8_t *buf,
     size_t         buf_len,
     size_t         field_offset)
@@ -397,7 +399,12 @@ parse_ntlm_utf16_field(
         return strdup("");
     }
 
-    if (offset + len > buf_len) {
+    /* offset is a full 32-bit wire field and len is 16-bit, so the sum must be
+     * widened before the comparison: computed in uint32_t it wraps, and an
+     * offset near UINT32_MAX would pass this check and then read far out of
+     * bounds below.  The LM/NT response and session-key checks widen the same
+     * way. */
+    if ((size_t) offset + len > buf_len) {
         return NULL;
     }
 
@@ -413,7 +420,7 @@ parse_ntlm_utf16_field(
     result[len / 2] = '\0';
 
     return result;
-} /* parse_ntlm_utf16_field */
+} /* smb_ntlm_parse_utf16_field */
 
 // Get message type from NTLM blob
 static int
@@ -871,21 +878,21 @@ validate_authenticate(
     }
 
     // Parse username (offset 36)
-    username = parse_ntlm_utf16_field(buf, buf_len, 36);
+    username = smb_ntlm_parse_utf16_field(buf, buf_len, 36);
     if (!username) {
         smb_ntlm_error("Failed to parse NTLM username");
         goto cleanup;
     }
 
     // Parse domain (offset 28)
-    domain = parse_ntlm_utf16_field(buf, buf_len, 28);
+    domain = smb_ntlm_parse_utf16_field(buf, buf_len, 28);
     if (!domain) {
         smb_ntlm_error("Failed to parse NTLM domain");
         goto cleanup;
     }
 
     // Parse workstation (offset 44)
-    workstation = parse_ntlm_utf16_field(buf, buf_len, 44);
+    workstation = smb_ntlm_parse_utf16_field(buf, buf_len, 44);
 
     smb_ntlm_debug("NTLM auth: user='%s' domain='%s' workstation='%s'",
                    username, domain, workstation ? workstation : "");

--- a/src/server/smb/smb_ntlm.h
+++ b/src/server/smb/smb_ntlm.h
@@ -42,6 +42,19 @@
 struct chimera_vfs;
 struct chimera_smb_auth_config;
 
+/*
+ * Decode one NTLM *Fields descriptor (Len/MaxLen/BufferOffset) at field_offset
+ * in an AUTHENTICATE message and return its UTF-16LE payload as a NUL-terminated
+ * ASCII string the caller must free, or NULL if the descriptor does not lie
+ * wholly within buf_len.  Exposed for the hardening tests, which drive it with
+ * adversarial offsets; production callers reach it through smb_ntlm_process().
+ */
+char *
+smb_ntlm_parse_utf16_field(
+    const uint8_t *buf,
+    size_t         buf_len,
+    size_t         field_offset);
+
 /* Names the server advertises in the CHALLENGE target info.  Domain
  * controllers validate the target info echoed back inside the client's NTLMv2
  * response against the machine account on the netlogon channel (NTLM relay

--- a/src/server/smb/smb_proc_ioctl.c
+++ b/src/server/smb/smb_proc_ioctl.c
@@ -145,6 +145,17 @@ chimera_smb_ioctl(struct chimera_smb_request *request)
                 return;
             }
 
+            /* Only named-pipe opens carry a transceive handler; a normal file
+             * open leaves it NULL.  MS-SMB2 3.3.5.15 wants an FSCTL that is
+             * invalid for the file type rejected rather than dispatched, which
+             * is also what the ncacn_np READ and WRITE paths do. */
+            if (unlikely(open_file->type != CHIMERA_SMB_OPEN_FILE_TYPE_PIPE)) {
+                chimera_smb_open_file_release(request, open_file);
+                evpl_iovecs_release(thread->evpl, request->ioctl.input_iov, request->ioctl.input_niov);
+                chimera_smb_complete_request(request, SMB2_STATUS_INVALID_DEVICE_REQUEST);
+                return;
+            }
+
             evpl_iovec_alloc(
                 thread->evpl,
                 65535,

--- a/src/server/smb/tests/smb_harden_test.c
+++ b/src/server/smb/tests/smb_harden_test.c
@@ -20,6 +20,7 @@
 #include "common/evpl_iovec_cursor.h"
 #include "server/smb/smb_internal.h"
 #include "server/smb/smb_procs.h"
+#include "server/smb/smb_ntlm.h"
 
 static int passed = 0;
 static int failed = 0;
@@ -340,6 +341,80 @@ test_create_ctx_name_overflow(void)
           "CREATE ctx: oversized NameLength rejected");
 } /* test_create_ctx_name_overflow */
 
+/* ------------------------------------------------------------------ *
+*  NTLM AUTHENTICATE *Fields bounds                                   *
+* ------------------------------------------------------------------ */
+
+/* Build an NTLM *Fields descriptor (Len, MaxLen, BufferOffset) at off. */
+static void
+put_ntlm_field(
+    uint8_t *buf,
+    uint32_t off,
+    uint16_t len,
+    uint32_t buf_offset)
+{
+    put_le16(buf, off, len);
+    put_le16(buf, off + 2, len);
+    put_le32(buf, off + 4, buf_offset);
+} /* put_ntlm_field */
+
+/* A BufferOffset near UINT32_MAX must not wrap the (offset + len) bounds check.
+ * The descriptor offset is a full 32-bit wire field while Len is 16-bit, so
+ * computing the sum in uint32_t wraps to a small value that passes the check --
+ * and the field payload is then read from far outside the message.  This is
+ * reachable pre-authentication, from the AUTHENTICATE username/domain/
+ * workstation fields. */
+static void
+test_ntlm_field_offset_uint32_overflow(void)
+{
+    uint8_t buf[128] = { 0 };
+    char   *result;
+
+    /* offset + len wraps: 0xFFFFFFFE + 4 == 2 (mod 2^32), which is <= buf_len. */
+    put_ntlm_field(buf, 36, 4, 0xFFFFFFFE);
+
+    result = smb_ntlm_parse_utf16_field(buf, sizeof(buf), 36);
+
+    CHECK(result == NULL, "NTLM field: UINT32-overflow BufferOffset rejected (no OOB)");
+    free(result);
+} /* test_ntlm_field_offset_uint32_overflow */
+
+/* A descriptor that runs past the end of the message without wrapping must also
+ * be rejected -- the plain in-bounds case the wrap above bypasses. */
+static void
+test_ntlm_field_offset_past_end(void)
+{
+    uint8_t buf[128] = { 0 };
+    char   *result;
+
+    put_ntlm_field(buf, 36, 64, sizeof(buf) - 8);
+
+    result = smb_ntlm_parse_utf16_field(buf, sizeof(buf), 36);
+
+    CHECK(result == NULL, "NTLM field: offset+len past end rejected");
+    free(result);
+} /* test_ntlm_field_offset_past_end */
+
+/* A well-formed descriptor must still decode, so the bounds fix cannot have
+ * turned every AUTHENTICATE into a rejection. */
+static void
+test_ntlm_field_valid_decodes(void)
+{
+    uint8_t buf[128] = { 0 };
+    char   *result;
+
+    /* "ab" as UTF-16LE at offset 64. */
+    buf[64] = 'a';
+    buf[66] = 'b';
+    put_ntlm_field(buf, 36, 4, 64);
+
+    result = smb_ntlm_parse_utf16_field(buf, sizeof(buf), 36);
+
+    CHECK(result != NULL && strcmp(result, "ab") == 0,
+          "NTLM field: in-bounds descriptor still decodes");
+    free(result);
+} /* test_ntlm_field_valid_decodes */
+
 int
 main(
     int   argc,
@@ -368,6 +443,11 @@ main(
     test_create_ctx_datalen_uint32_overflow();
     test_create_ctx_next_uint32_overflow();
     test_create_ctx_name_overflow();
+
+    fprintf(stderr, "=== SMB parse hardening: NTLM AUTHENTICATE field bounds ===\n");
+    test_ntlm_field_offset_uint32_overflow();
+    test_ntlm_field_offset_past_end();
+    test_ntlm_field_valid_decodes();
 
     fprintf(stderr, "\nTotal: %d passed, %d failed\n", passed, failed);
     return failed == 0 ? 0 : 1;


### PR DESCRIPTION
Fixes the four `critical` open issues, all of which are unvalidated wire input reaching something that aborts or dereferences wildly. Each is independently reachable and takes the whole daemon down, so every tenant on the server is affected.

| Issue | Defect | Reachable by |
|---|---|---|
| #1364 | NFSv3 READ count forwarded unclamped; the read dispatch sizes an iovec allocation from it and `chimera_vfs_abort_if`s when the allocation fails | any mounting client, one READ |
| #1365 | NFSv3 WRITE `count` never checked against the supplied `data<>`; the iovec cursor `abort()`s when the source runs dry | any mounting client, one WRITE |
| #1366 | `FSCTL_PIPE_TRANSCEIVE` calls `open_file->pipe_transceive()` with no type check; a regular-file open leaves it NULL | any authenticated client, one IOCTL |
| #1367 | NTLM AUTHENTICATE `*Fields` bounds check computed in `uint32_t` and wrapped, so an offset near `UINT32_MAX` passed and the payload was read far out of bounds | **unauthenticated**, during session setup |

One commit per issue.

### Notes for review

**#1364 / #1365** — the 1 MiB limit was a bare literal inside the FSINFO handler while READ and WRITE enforced nothing. It moves to `CHIMERA_NFS3_MAX_XFER` in `nfs3_procs.h` and is now used by all three, so the advertised `rtmax`/`wtmax` and the enforced limit cannot drift apart. Over-large counts become short reads/writes, which RFC 1813 §3.3.6/§3.3.7 permit; a WRITE whose `count` exceeds the data it actually carries is a different thing — the two wire fields contradict each other — and is refused with `NFS3ERR_INVAL` before the file is opened.

**#1366** — the guard sits ahead of the 64 KiB output-buffer allocation, so the rejection path allocates nothing. The ncacn_np READ and WRITE paths already gated on this same type; only IOCTL did not.

**#1367** — `23f7db16` (#956) fixed exactly this bug in the LM/NT response and session-key checks by widening to `size_t`, but missed this helper, which `validate_authenticate` uses for the username, domain and workstation fields before any credential check. Same fix, same shape.

### Testing

The quick tier is green (97/97) and both Debug and Release build clean.

#1367 gets three regression cases in `smb_harden_test.c` — the wrapping offset, a plain past-the-end descriptor, and a well-formed one that must still decode. The wrap case was confirmed to **fail against the unpatched helper**, so it genuinely pins the bug rather than just passing. Driving it needs the helper exported, which follows the existing `SYMBOL_EXPORT` convention used for `chimera_smb_parse_create_contexts`.

The other three are dispatch-level guards that need a live session to exercise, so they have no unit-test home; the natural coverage is the quint model, which does not currently model oversized/contradictory transfer counts or an FSCTL issued against the wrong handle type. Worth adding there as a follow-up so a regression is caught by the quick tier rather than by review.

### Not included

#494 (S3: any valid key is root over every bucket) is the fifth `critical`. It is an `effort:extra-large` architectural change — a real authorization model with bucket ownership and policy evaluation — and does not belong in a PR of bounds checks. It needs its own design discussion.
