### PR TITLE
smb: bound READ and WRITE by the size this connection negotiated

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -350,6 +350,7 @@ struct chimera_smb_conn;
 #define CHIMERA_SMB_MAX_RW_SIZE_LARGE_MTU     (8 * 1024 * 1024)
 #define CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT 65536
 
+
 /* Maximum supported file size, matching the Windows/Samba value
  * (0xFFFFFFF0000 == 2^44 - 2^16).  A write, SetEndOfFile or SetAllocation whose
  * size would exceed this is rejected with STATUS_INVALID_PARAMETER. */
@@ -1434,6 +1435,25 @@ struct chimera_smb_conn {
     char                               local_addr[128];
     char                               remote_addr[128];
 };
+
+/* The MaxReadSize/MaxWriteSize this connection actually advertised, for the
+ * READ/WRITE handlers to bound against.
+ *
+ * MS-SMB2 3.3.5.12 and 3.3.5.13 require INVALID_PARAMETER when Length exceeds
+ * MaxReadSize / MaxWriteSize, and that means the value sent in THIS
+ * connection's NEGOTIATE response -- not the largest the server is willing to
+ * advertise to anyone.  READ compared against the LARGE_MTU constant directly,
+ * which is 128x too permissive on a connection that negotiated the
+ * single-credit size, and WRITE did not check at all.  Derived from the same
+ * capability NEGOTIATE branches on, so it cannot drift from what was sent. */
+static inline uint32_t
+chimera_smb_max_rw_size(const struct chimera_smb_conn *conn)
+{
+    return (conn->capabilities & SMB2_GLOBAL_CAP_LARGE_MTU)
+           ? CHIMERA_SMB_MAX_RW_SIZE_LARGE_MTU
+           : CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT;
+} /* chimera_smb_max_rw_size */
+
 
 /*
  * Compute the SMB2 CreditResponse for one response and update the connection's

--- a/src/server/smb/smb_proc_negotiate.c
+++ b/src/server/smb/smb_proc_negotiate.c
@@ -165,14 +165,11 @@ chimera_smb_negotiate(struct chimera_smb_request *request)
     }
     request->negotiate.r_capabilities      = conn->capabilities;
     request->negotiate.r_max_transact_size = CHIMERA_SMB_MAX_TRANSACT_SIZE;
-    if (conn->capabilities & SMB2_GLOBAL_CAP_LARGE_MTU) {
-        request->negotiate.r_max_read_size  = CHIMERA_SMB_MAX_RW_SIZE_LARGE_MTU;
-        request->negotiate.r_max_write_size = CHIMERA_SMB_MAX_RW_SIZE_LARGE_MTU;
-    } else {
-        request->negotiate.r_max_read_size  = CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT;
-        request->negotiate.r_max_write_size = CHIMERA_SMB_MAX_RW_SIZE_SINGLE_CREDIT;
-    }
-    request->negotiate.r_system_time = chimera_nt_time(&now);
+    /* Same helper the READ/WRITE handlers bound against, so what is advertised
+     * and what is enforced cannot diverge. */
+    request->negotiate.r_max_read_size  = chimera_smb_max_rw_size(conn);
+    request->negotiate.r_max_write_size = chimera_smb_max_rw_size(conn);
+    request->negotiate.r_system_time    = chimera_nt_time(&now);
     /* ServerStartTime is the SMB server instance start time (captured once at
      * init), not the OS boot time -- so an in-place chimera restart is visible
      * to clients keying off this field (issue #1225, MS-SMB2 3.3.1.5). */

--- a/src/server/smb/smb_proc_read.c
+++ b/src/server/smb/smb_proc_read.c
@@ -242,10 +242,16 @@ chimera_smb_read(struct chimera_smb_request *request)
      * is NOT a parameter error: the read proceeds and the callback returns
      * END_OF_FILE when fewer than MinimumCount bytes are read.  Because the
      * first clause bounds offset to INT64_MAX, the offset+length sum cannot
-     * overflow uint64. */
+     * overflow uint64.
+     *
+     * MaxReadSize is this connection's negotiated value, not the largest the
+     * server ever advertises: without SMB2_GLOBAL_CAP_LARGE_MTU it is 64 KiB,
+     * and the 8 MiB literal this used to compare against accepted reads 128x
+     * over the advertised limit. */
     if (request->read.offset > 0x7FFFFFFFFFFFFFFFULL ||
         request->read.offset + request->read.length > 0x7FFFFFFFFFFFFFFFULL ||
-        request->read.length > (8 * 1024 * 1024)) {
+        request->read.length >
+        chimera_smb_max_rw_size(request->compound->conn)) {
         chimera_smb_open_file_release(request, request->read.open_file);
         chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
         return;

--- a/src/server/smb/smb_proc_write.c
+++ b/src/server/smb/smb_proc_write.c
@@ -282,6 +282,19 @@ chimera_smb_write(struct chimera_smb_request *request)
         return;
     }
 
+    /* MS-SMB2 3.3.5.13: Length greater than MaxWriteSize is INVALID_PARAMETER.
+     * This was missing entirely -- the clause above bounds where the write
+     * lands, not how much it carries -- so a write of any size the transport
+     * would deliver was accepted, whatever this connection advertised.  The
+     * bound is the negotiated value: without SMB2_GLOBAL_CAP_LARGE_MTU that is
+     * 64 KiB, not the 8 MiB a LARGE_MTU connection gets. */
+    if (request->write.length > chimera_smb_max_rw_size(request->compound->conn)) {
+        evpl_iovecs_release(evpl, request->write.iov, request->write.niov);
+        chimera_smb_open_file_release(request, request->write.open_file);
+        chimera_smb_complete_request(request, SMB2_STATUS_INVALID_PARAMETER);
+        return;
+    }
+
     /* MS-SMB2 §3.3.5.13: an RDMA channel is only valid over an RDMA transport.
     * The Channel field is client-controlled; honoring RDMA_V1 on a plain-TCP
     * connection would dispatch evpl_rdma_read on a non-RDMA bind.  Reject with


### PR DESCRIPTION
Six WPTS credit-management cases fail, all saying the same thing:

```
CreditMgmtTestCaseS776 / S801 / S861:
    Server SHOULD fail the request with STATUS_INVALID_PARAMETER
    if exceeds max write data
CreditMgmtTestCaseS836 / S909 / S1110:
    Server SHOULD fail the request with STATUS_INVALID_PARAMETER
    if exceeds max read size
```

## What the spec requires

MS-SMB2 **3.3.5.12** and **3.3.5.13** require `INVALID_PARAMETER` when `Length` exceeds `MaxReadSize` / `MaxWriteSize` — and those are the values sent in **this connection's** NEGOTIATE response. NEGOTIATE picks between two (MS-SMB2 3.2.4.1.5):

| connection | advertised |
|---|---|
| `SMB2_GLOBAL_CAP_LARGE_MTU` | **8 MiB** |
| without it (one credit per request) | **64 KiB** |

## What the server did

**READ** compared against the 8 MiB constant directly:

```c
request->read.length > (8 * 1024 * 1024)
```

so on a connection that negotiated the single-credit size it accepted reads **128× over what it had advertised**.

**WRITE did not check length at all.** The bound it had governs *where* the write lands — offset within the maximum file size — not *how much* it carries, so any length the transport would deliver was accepted regardless of what was negotiated.

## The fix

Both bound against `chimera_smb_max_rw_size(conn)`, which derives the value from the same capability NEGOTIATE branches on. NEGOTIATE uses the helper too, so the advertised number and the enforced number cannot drift apart — that drift is precisely what this bug was.

**No behaviour change for a LARGE_MTU connection** (every dialect ≥ 2.1 with multi-credit enabled): the helper returns the same 8 MiB the READ path already used, and WRITE gains the check it never had.

## Verification

- **56 of 56 smb tests pass**, including the posix-over-SMB loopback and the SMB MBT batches.
- Build clean.

## Not fixed here

`BVT_SMB2Basic_ChangeNotify_ChangeStreamName`, the other WPTS failure in this shard. Renaming a stream emits no CHANGE_NOTIFY at all: `vfs_proc_rename_at` handles the intra-directory and cross-directory shapes, and a stream rename is neither. That needs the MS-FSA filter semantics read properly — `FILE_NOTIFY_CHANGE_STREAM_NAME` is a distinct filter bit reported against a different object — rather than a guess that WPTS would still reject.

## Context

These WPTS failures are **not** new. The amd64 devcontainer cells were killed at the 6-hour job limit in every recent extended run, so WPTS-on-amd64 had not reported at all until the run was sharded. Same category as the KVM suites and the fio failures: newly visible, not newly broken.
