### PR TITLE
ci: pin the GITHUB_TOKEN scope for the lint workflows

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
   merge_group:         # also gate the merge queue
 
+# The lint pass only reads the tree, so the GITHUB_TOKEN needs nothing
+# beyond that.  Without an explicit block a job inherits whatever the
+# repository default happens to be.
+permissions:
+  contents: read
+
 jobs:
   reuse-lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -9,6 +9,12 @@ on:
   merge_group:         # also gate the merge queue
   workflow_dispatch:   # allow manual runs
 
+# uncrustify only reads the tree, so the GITHUB_TOKEN needs nothing
+# beyond that.  Without an explicit block a job inherits whatever the
+# repository default happens to be.
+permissions:
+  contents: read
+
 jobs:
   syntax-check:
     name: Check code formatting with uncrustify


### PR DESCRIPTION
CodeQL's `actions/missing-workflow-permissions` flags every job that runs with
whatever GITHUB_TOKEN scopes the repository default hands out. These were the
last two workflows in the tree without a permissions block — every other one
declares its scopes at the workflow level or per job.

Both `reuse-lint` and `syntax-check` only check out the tree and run a linter
over it, so each gets an explicit workflow-level `contents: read`.

Closes code scanning alerts
[#22](https://github.com/chimera-nas/chimera/security/code-scanning/22) (reuse-compliance) and
[#3](https://github.com/chimera-nas/chimera/security/code-scanning/3) (syntax-check).

Part of a bottom-up sweep of the same alert across the org:
chimera-nas/prometheus-c#3, chimera-nas/xdrzcc#18, chimera-nas/libevpl#155,
chimera-nas/specs#24.
