### PR TITLE
Potential fix for code scanning alert no. 15: Wrong type of arguments to formatting function

### DIFF
--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -1055,7 +1055,7 @@ check_eofpage(
          should_be_zero < last_page + page_size;
          should_be_zero++) {
         if (*(char *) should_be_zero) {
-            prt("Mapped %s: non-zero data past EOF (0x%llx) page offset 0x%x is 0x%04x\n",
+            prt("Mapped %s: non-zero data past EOF (0x%llx) page offset 0x%lx is 0x%04x\n",
                 s, file_size - 1, should_be_zero & page_mask,
                 short_at(should_be_zero));
             report_failure(205);


### PR DESCRIPTION
Potential fix for [https://github.com/chimera-nas/chimera/security/code-scanning/15](https://github.com/chimera-nas/chimera/security/code-scanning/15)

The fix is to make the format specifier match the actual argument type. Since `should_be_zero & page_mask` is `unsigned long`, the format should use `%lx` instead of `%x` for that argument.

Best minimal fix (no functional change): in `src/posix/tests/fsx.c`, update the `prt(...)` format string inside `check_eofpage()` so the “page offset” placeholder is `0x%lx`. No new imports, helper methods, or variable changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
