### PR TITLE
Potential fix for code scanning alert no. 14: Wrong type of arguments to formatting function

### DIFF
--- a/src/posix/tests/fsx.c
+++ b/src/posix/tests/fsx.c
@@ -2377,8 +2377,8 @@ writefileimage()
         if (iret == -1) {
             prterr("writefileimage: write");
         } else {
-            prt("short write: 0x%x bytes instead of 0x%llx\n",
-                iret, (unsigned long long) file_size);
+            prt("short write: 0x%zx bytes instead of 0x%llx\n",
+                (size_t) iret, (unsigned long long) file_size);
         }
         report_failure(172);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/chimera-nas/chimera/security/code-scanning/14](https://github.com/chimera-nas/chimera/security/code-scanning/14)

The best fix is to make the format specifier match `iret`’s actual type (`ssize_t`) while preserving behavior. Since the message currently prints in hexadecimal (`0x...`), use `%zx`, which is the C99 length modifier for `size_t` in hex, and cast `iret` to `size_t` in this branch (`iret != -1`, so non-negative). Keep `file_size` formatting unchanged.

Edit only `src/posix/tests/fsx.c` in `writefileimage()` at the `prt("short write ...")` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
