### PR TITLE
ci: keep the sharded devcontainer run's ctest results

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -788,8 +788,24 @@ jobs:
                 echo "::notice::category $CATEGORY selected no tests on ${{ matrix.arch }}"
                 exit 0
               fi
+              mkdir -p /workspace/ctest-results
               /workspace/scripts/cap_ctest_output.sh \
-              ctest -C extended $SEL --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)"'
+              ctest -C extended $SEL --output-on-failure --test-output-size-failed 65536 --timeout 300 -j "$(nproc)" \
+                    --output-junit /workspace/ctest-results/$CATEGORY.xml'
+
+      # A shard that fails is a shard someone has to diagnose, and the console
+      # log caps per-test output at 64 KB -- which is how a timeout arrives with
+      # its own reason truncated away.  The JUnit carries the full per-test
+      # record.  if: always() because a failing shard is exactly the one whose
+      # results are worth keeping.
+      - name: Upload ctest results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ctest-devcontainer-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.category }}
+          path: ctest-results/
+          if-no-files-found: warn
+          retention-days: 7
 
 
   # macOS: the extended tier on a GitHub-hosted arm64 runner.  Nothing here is


### PR DESCRIPTION
The devcontainer shards produce no machine-readable results and upload nothing, so a failure there can only be read from the console log — which caps per-test output at 64 KB (`--test-output-size-failed`).

That cap is not theoretical. Diagnosing `smb2.maxfid` timing out on `diskfs_io_uring` was only possible because the separate smbtorture **matrix** job keeps its own per-cell logs; the shard's own output showed nothing but `***Timeout 600.00 sec`. A shard failure outside a suite with that arrangement has nothing to go on.

Each shard now writes `--output-junit` for its category and uploads it, with `if: always()` so the failing shard — the one whose results are actually wanted — is the one that keeps them. Artifacts are named by arch, build type and category so the 41 entries a full run produces stay distinguishable, with a 7-day retention.

## Not a regression

To be clear about what this is: the **unsharded** job did not upload results either, and neither does the distro `test` job. I checked the pre-sharding `extended.yml` — zero `upload-artifact`/`output-junit` references in that job. Sharding did not remove anything; it made the absence easier to notice by multiplying the places a failure can hide.