### PR TITLE
s3: run each request as the identity of the key that authenticated it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,8 @@ reads the file:
 | `buckets` | object | server | S3 buckets. |
 | `fuse_mounts` | object | server | Local kernel FUSE mounts (Linux only). |
 | `users` | array | server + client | Built-in user accounts (uid/gid, passwords). |
-| `s3_access_keys` | array | server | S3 access/secret key pairs. |
+| `s3_access_keys` | array | server | S3 access/secret key pairs, each bound to a user. |
+| `s3_anon` | object | server | Identity an S3 key with no user binding acts as. |
 | `config` | object | client | Client-library settings (the client's analogue of `server`). |
 
 A typical server config wires a **mount** (a VFS backend) and then publishes it
@@ -335,12 +336,46 @@ An **array** of built-in accounts (used by NFS/SMB auth and ownership mapping).
 
 ### `s3_access_keys`
 
-An **array** of S3 credentials. Both keys are required per entry.
+An **array** of S3 credentials. `access_key` and `secret_key` are required per
+entry.
 
 | Key | Type | Description |
 |---|---|---|
 | `access_key` | string | S3 access key ID. |
 | `secret_key` | string | S3 secret access key. |
+| `username` | string | Name of a `users` entry this key acts as. |
+
+Every request authenticated with a key runs against the store as that user's
+uid/gid, and objects and buckets it creates are owned by them. Authorization is
+therefore the store's own ownership and mode bits — the same ones NFS and SMB
+enforce — so a key can only reach what its user could reach over any other
+protocol. Give two tenants two keys bound to two users and neither can read or
+write the other's buckets.
+
+```json
+"users": [
+    { "username": "alice", "uid": 1001, "gid": 1001 },
+    { "username": "bob",   "uid": 1002, "gid": 1002 }
+],
+"s3_access_keys": [
+    { "access_key": "AKIAALICE", "secret_key": "...", "username": "alice" },
+    { "access_key": "AKIABOB",   "secret_key": "...", "username": "bob" }
+]
+```
+
+A key with no `username` — or one naming a user that does not exist — is
+**unbound**: it acts as the anonymous identity below rather than as root, and is
+logged at startup. Such a key authenticates successfully but will be denied
+anything the anonymous user may not do, so bind every key you expect to work.
+
+### `s3_anon`
+
+Identity an unbound S3 access key acts as. Defaults to nobody/nogroup.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `uid` | int | `65534` | POSIX user ID for unbound keys. |
+| `gid` | int | `65534` | POSIX group ID for unbound keys. |
 
 ### Full server example
 
@@ -379,7 +414,7 @@ An **array** of S3 credentials. Both keys are required per entry.
         { "username": "alice", "password": "secret", "uid": 1000, "gid": 1000 }
     ],
     "s3_access_keys": [
-        { "access_key": "AKIDEXAMPLE", "secret_key": "wJalrXUtnFEMI..." }
+        { "access_key": "AKIDEXAMPLE", "secret_key": "wJalrXUtnFEMI...", "username": "alice" }
     ]
 }
 ```

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -997,6 +997,17 @@ main(
         }
     }
 
+    json_t *s3_anon = json_object_get(config, "s3_anon");
+    if (s3_anon && json_is_object(s3_anon)) {
+        json_t *anon_uid = json_object_get(s3_anon, "uid");
+        json_t *anon_gid = json_object_get(s3_anon, "gid");
+
+        chimera_server_config_set_s3_anon_ids(
+            server_config,
+            anon_uid ? (uint32_t) json_integer_value(anon_uid) : CHIMERA_S3_ANON_UID,
+            anon_gid ? (uint32_t) json_integer_value(anon_gid) : CHIMERA_S3_ANON_GID);
+    }
+
     server = chimera_server_init(server_config, chimera_metrics_get(metrics));
 
     json_t *users = json_object_get(config, "users");
@@ -1049,14 +1060,16 @@ main(
         {
             const char *access_key = json_string_value(json_object_get(key_entry, "access_key"));
             const char *secret_key = json_string_value(json_object_get(key_entry, "secret_key"));
+            const char *key_user   = json_string_value(json_object_get(key_entry, "username"));
 
             if (!access_key || !secret_key) {
                 chimera_server_error("S3 access key entry missing access_key or secret_key, skipping");
                 continue;
             }
 
-            chimera_server_info("Adding S3 access key %s", access_key);
-            chimera_server_add_s3_cred(server, access_key, secret_key, 1);
+            chimera_server_info("Adding S3 access key %s (user %s)", access_key,
+                                key_user ? key_user : "<unbound>");
+            chimera_server_add_s3_cred(server, access_key, secret_key, key_user, 1);
         }
     }
 

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -676,7 +676,7 @@ s3_server_dispatch(
     *notify_data     = s3_request;
 
     /* Verify AWS authentication */
-    auth_result = chimera_s3_auth_verify(shared->cred_cache, request);
+    auth_result = chimera_s3_auth_verify(shared->cred_cache, request, &s3_request->cred);
 
     switch (auth_result) {
         case CHIMERA_S3_AUTH_OK:
@@ -1158,7 +1158,7 @@ s3_server_dispatch(
         chimera_s3_request_get(s3_request);
 
         chimera_vfs_lookup(thread->vfs,
-                           &thread->shared->cred,
+                           &s3_request->cred,
                            shared->root_fh,
                            shared->root_fh_len,
                            bucket->path,
@@ -1272,14 +1272,34 @@ chimera_s3_bucket_get_path(const struct s3_bucket *bucket)
 
 SYMBOL_EXPORT int
 chimera_s3_add_cred(
-    void       *s3_shared,
-    const char *access_key,
-    const char *secret_key,
-    int         pinned)
+    void           *s3_shared,
+    const char     *access_key,
+    const char     *secret_key,
+    int             has_identity,
+    uint32_t        uid,
+    uint32_t        gid,
+    uint32_t        ngids,
+    const uint32_t *gids,
+    int             pinned)
 {
     struct chimera_server_s3_shared *shared = s3_shared;
 
-    return chimera_s3_cred_cache_add(shared->cred_cache, access_key, secret_key, pinned);
+    /* A key bound to no user acts as the anonymous identity rather than root:
+     * omitting the binding must not hand out privilege. */
+    if (!has_identity) {
+        chimera_s3_error(
+            "S3 access key %s is not bound to a user; it will act as uid=%u gid=%u "
+            "and can only reach objects those ids may reach. Set \"username\" on "
+            "the key to bind it to a configured user.",
+            access_key, shared->config->anon_uid, shared->config->anon_gid);
+        uid   = shared->config->anon_uid;
+        gid   = shared->config->anon_gid;
+        ngids = 0;
+        gids  = NULL;
+    }
+
+    return chimera_s3_cred_cache_add(shared->cred_cache, access_key, secret_key,
+                                     uid, gid, ngids, gids, pinned);
 } /* chimera_s3_add_cred */
 
 SYMBOL_EXPORT int
@@ -1322,8 +1342,10 @@ s3_server_init(
     shared->tcp_flavor   = chimera_server_config_get_tcp_flavor(config);
     shared->tcp_protocol = chimera_tcp_flavor_to_protocol(shared->tcp_flavor);
 
-    shared->config->port    = chimera_server_config_get_s3_port(config);
-    shared->config->io_size = 128 * 1024;
+    shared->config->port     = chimera_server_config_get_s3_port(config);
+    shared->config->io_size  = 128 * 1024;
+    shared->config->anon_uid = chimera_server_config_get_s3_anon_uid(config);
+    shared->config->anon_gid = chimera_server_config_get_s3_anon_gid(config);
 
     /* Built from the same flavor tcp_protocol came from: a protocol and an
      * endpoint that disagree about whether they are a socket is a listen
@@ -1339,9 +1361,6 @@ s3_server_init(
     shared->cred_cache = chimera_s3_cred_cache_create(64, 3600);
 
     shared->multipart_table = chimera_s3_multipart_table_create(256);
-
-    /* Initialize root credentials for now - TODO: proper credential mapping */
-    chimera_vfs_cred_init_unix(&shared->cred, 0, 0, 0, NULL);
 
     /* Initialize the root file handle for VFS lookups */
     chimera_vfs_get_root_fh(shared->root_fh, &shared->root_fh_len);

--- a/src/server/s3/s3.h
+++ b/src/server/s3/s3.h
@@ -55,10 +55,15 @@ chimera_s3_bucket_get_path(
 
 int
 chimera_s3_add_cred(
-    void       *s3_shared,
-    const char *access_key,
-    const char *secret_key,
-    int         pinned);
+    void           *s3_shared,
+    const char     *access_key,
+    const char     *secret_key,
+    int             has_identity,
+    uint32_t        uid,
+    uint32_t        gid,
+    uint32_t        ngids,
+    const uint32_t *gids,
+    int             pinned);
 
 int
 chimera_s3_remove_cred(

--- a/src/server/s3/s3_auth.c
+++ b/src/server/s3/s3_auth.c
@@ -501,7 +501,8 @@ static enum chimera_s3_auth_result
 verify_signature_v2(
     struct chimera_s3_cred_cache *cred_cache,
     struct evpl_http_request     *request,
-    const char                   *auth_header)
+    const char                   *auth_header,
+    struct chimera_vfs_cred      *out_cred)
 {
     char access_key[128];
     char signature[128];
@@ -542,6 +543,11 @@ verify_signature_v2(
         chimera_s3_debug("Unknown access key: %s", access_key);
         return CHIMERA_S3_AUTH_UNKNOWN_ACCESS_KEY;
     }
+
+    /* Capture the identity while the credential is still RCU-protected; the
+     * pointer must not outlive this read section. */
+    chimera_vfs_cred_init_unix(out_cred, cred->uid, cred->gid,
+                               cred->ngids, cred->gids);
 
     /* Build string to sign */
     sts_len = build_string_to_sign_v2(request, string_to_sign, sizeof(string_to_sign));
@@ -967,7 +973,8 @@ static enum chimera_s3_auth_result
 verify_signature_v4(
     struct chimera_s3_cred_cache *cred_cache,
     struct evpl_http_request     *request,
-    const char                   *auth_header)
+    const char                   *auth_header,
+    struct chimera_vfs_cred      *out_cred)
 {
     const char *amz_date;
     const struct chimera_s3_cred *cred;
@@ -1018,6 +1025,11 @@ verify_signature_v4(
         chimera_s3_debug("Unknown access key: %s", access_key);
         return CHIMERA_S3_AUTH_UNKNOWN_ACCESS_KEY;
     }
+
+    /* Capture the identity while the credential is still RCU-protected; the
+     * pointer must not outlive this read section. */
+    chimera_vfs_cred_init_unix(out_cred, cred->uid, cred->gid,
+                               cred->ngids, cred->gids);
 
     /* Build canonical request */
     cr_len = build_canonical_request_v4(request, signed_headers,
@@ -1070,7 +1082,8 @@ verify_signature_v4(
 enum chimera_s3_auth_result
 chimera_s3_auth_verify(
     struct chimera_s3_cred_cache *cred_cache,
-    struct evpl_http_request     *request)
+    struct evpl_http_request     *request,
+    struct chimera_vfs_cred      *out_cred)
 {
     const char *auth_header;
 
@@ -1085,10 +1098,10 @@ chimera_s3_auth_verify(
     /* Detect signature version and verify */
     if (strncmp(auth_header, "AWS4-HMAC-SHA256 ", 17) == 0) {
         /* AWS Signature Version 4 */
-        return verify_signature_v4(cred_cache, request, auth_header);
+        return verify_signature_v4(cred_cache, request, auth_header, out_cred);
     } else if (strncmp(auth_header, "AWS ", 4) == 0) {
         /* AWS Signature Version 2 */
-        return verify_signature_v2(cred_cache, request, auth_header);
+        return verify_signature_v2(cred_cache, request, auth_header, out_cred);
     } else {
         chimera_s3_debug("Unsupported auth type");
         return CHIMERA_S3_AUTH_INVALID_AUTH_HEADER;

--- a/src/server/s3/s3_auth.h
+++ b/src/server/s3/s3_auth.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "vfs/sdk/vfs_cred.h"
+
 struct evpl_http_request;
 struct chimera_s3_cred_cache;
 
@@ -23,9 +25,15 @@ enum chimera_s3_auth_result {
 /*
  * Verify AWS Signature V4 authentication on an incoming request.
  *
+ * On success, out_cred is filled with the POSIX identity the matched access
+ * key acts as; the caller runs every VFS operation for the request under it.
+ * The identity is copied out here because the cached credential is only valid
+ * inside this call's RCU read section.  out_cred is untouched on failure.
+ *
  * Parameters:
  *   cred_cache: The credential cache to look up access keys
  *   request: The HTTP request to verify
+ *   out_cred: Filled with the authenticated identity on CHIMERA_S3_AUTH_OK
  *
  * Returns:
  *   CHIMERA_S3_AUTH_OK on success, or an error code
@@ -33,7 +41,8 @@ enum chimera_s3_auth_result {
 enum chimera_s3_auth_result
 chimera_s3_auth_verify(
     struct chimera_s3_cred_cache *cred_cache,
-    struct evpl_http_request     *request);
+    struct evpl_http_request     *request,
+    struct chimera_vfs_cred      *out_cred);
 
 /*
  * Get a human-readable error message for an auth result

--- a/src/server/s3/s3_bucket.c
+++ b/src/server/s3/s3_bucket.c
@@ -109,7 +109,7 @@ chimera_s3_create_bucket_mkdir_cb(
 
     /* EEXIST is success in us-east-1: recreating your own bucket is a no-op. */
     if (error_code && error_code != CHIMERA_VFS_EEXIST) {
-        request->status    = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
@@ -151,7 +151,7 @@ chimera_s3_create_bucket_lookup_cb(
 
     if (error_code || !(attr->va_set_mask & CHIMERA_VFS_ATTR_FH)) {
         /* Bucket root path is missing/unresolvable. */
-        request->status    = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
@@ -167,12 +167,12 @@ chimera_s3_create_bucket_lookup_cb(
     request->set_attr.va_set_mask = CHIMERA_VFS_ATTR_MODE |
         CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID;
     request->set_attr.va_mode = S_IFDIR | 0755;
-    request->set_attr.va_uid  = 0;
-    request->set_attr.va_gid  = 0;
+    request->set_attr.va_uid  = request->cred.uid;
+    request->set_attr.va_gid  = request->cred.gid;
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_mkdir(thread->vfs, &thread->shared->cred,
+    chimera_vfs_mkdir(thread->vfs, &request->cred,
                       request->bucket_fh, request->bucket_fhlen,
                       request->bucket_name, request->bucket_namelen,
                       &request->set_attr, CHIMERA_VFS_ATTR_FH,
@@ -196,7 +196,7 @@ chimera_s3_create_bucket(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_lookup(thread->vfs, &shared->cred,
+    chimera_vfs_lookup(thread->vfs, &request->cred,
                        shared->root_fh, shared->root_fh_len,
                        shared->bucket_root_path, shared->bucket_root_pathlen,
                        CHIMERA_VFS_ATTR_FH, CHIMERA_VFS_LOOKUP_FOLLOW,
@@ -335,7 +335,7 @@ chimera_s3_delbucket_remove_next(struct s3_delbucket_ctx *ctx)
     struct chimera_server_s3_shared *shared  = thread->shared;
 
     if (ctx->cur < ctx->ndirs) {
-        chimera_vfs_remove(thread->vfs, &shared->cred,
+        chimera_vfs_remove(thread->vfs, &request->cred,
                            ctx->bucket_fh, ctx->bucket_fhlen,
                            ctx->dirs[ctx->cur], strlen(ctx->dirs[ctx->cur]), 0,
                            chimera_s3_delbucket_dir_removed, ctx);
@@ -343,7 +343,7 @@ chimera_s3_delbucket_remove_next(struct s3_delbucket_ctx *ctx)
     }
 
     /* All scaffolding gone; remove the bucket directory from the bucket root. */
-    chimera_vfs_remove(thread->vfs, &shared->cred,
+    chimera_vfs_remove(thread->vfs, &request->cred,
                        shared->root_fh, shared->root_fh_len,
                        ctx->bucket_path, ctx->bucket_path_len, 0,
                        chimera_s3_delbucket_root_removed, ctx);
@@ -389,7 +389,7 @@ chimera_s3_delbucket_lookup_cb(
     memcpy(ctx->bucket_fh, attr->va_fh, attr->va_fh_len);
     ctx->bucket_fhlen = attr->va_fh_len;
 
-    chimera_vfs_find(thread->vfs, &thread->shared->cred,
+    chimera_vfs_find(thread->vfs, &request->cred,
                      ctx->bucket_fh, ctx->bucket_fhlen,
                      CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
                      chimera_s3_delbucket_filter,
@@ -460,7 +460,7 @@ chimera_s3_delete_bucket(
                                     request->bucket_namelen, request->bucket_name);
 
     /* Resolve the bucket directory, then walk + purge it. */
-    chimera_vfs_lookup(thread->vfs, &shared->cred,
+    chimera_vfs_lookup(thread->vfs, &request->cred,
                        shared->root_fh, shared->root_fh_len,
                        ctx->bucket_path, ctx->bucket_path_len,
                        CHIMERA_VFS_ATTR_FH, CHIMERA_VFS_LOOKUP_FOLLOW,

--- a/src/server/s3/s3_copy.c
+++ b/src/server/s3/s3_copy.c
@@ -255,7 +255,7 @@ chimera_s3_copy_link_callback(
         return;
     }
 
-    chimera_vfs_getattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_getattr(thread->vfs, &ctx->request->cred,
                         ctx->request->file_handle,
                         CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
                         chimera_s3_copy_getattr_callback,
@@ -279,7 +279,7 @@ chimera_s3_copy_rename_callback(
         return;
     }
 
-    chimera_vfs_getattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_getattr(thread->vfs, &ctx->request->cred,
                         ctx->request->file_handle,
                         CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,
                         chimera_s3_copy_getattr_callback,
@@ -340,7 +340,7 @@ chimera_s3_copy_finalize(struct chimera_s3_copy_ctx *ctx)
     if (ctx->tmp_name_len) {
         chimera_vfs_rename_at(
             thread->vfs,
-            &thread->shared->cred,
+            &request->cred,
             request->dir_handle->fh,
             request->dir_handle->fh_len,
             ctx->tmp_name,
@@ -361,7 +361,7 @@ chimera_s3_copy_finalize(struct chimera_s3_copy_ctx *ctx)
     } else {
         chimera_vfs_link_at(
             thread->vfs,
-            &thread->shared->cred,
+            &request->cred,
             request->file_handle->fh,
             request->file_handle->fh_len,
             request->dir_handle->fh,
@@ -482,7 +482,7 @@ chimera_s3_copy_read_callback(
     ctx->rw_niov = niov;
 
     chimera_vfs_write(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &ctx->request->cred,
         ctx->request->file_handle,
         ctx->offset,
         count,
@@ -513,7 +513,7 @@ chimera_s3_copy_step(struct chimera_s3_copy_ctx *ctx)
         case CHIMERA_S3_COPY_CLONE:
             /* Whole remaining range in a single reflink. */
             chimera_vfs_clone_range(
-                thread->vfs, &thread->shared->cred,
+                thread->vfs, &request->cred,
                 ctx->src_handle,
                 ctx->offset,
                 request->file_handle,
@@ -529,7 +529,7 @@ chimera_s3_copy_step(struct chimera_s3_copy_ctx *ctx)
                 chunk = remaining;
             }
             chimera_vfs_copy_range(
-                thread->vfs, &thread->shared->cred,
+                thread->vfs, &request->cred,
                 ctx->src_handle,
                 ctx->offset,
                 request->file_handle,
@@ -547,7 +547,7 @@ chimera_s3_copy_step(struct chimera_s3_copy_ctx *ctx)
             }
             ctx->rw_niov = CHIMERA_S3_IOV_MAX;
             chimera_vfs_read(
-                thread->vfs, &thread->shared->cred,
+                thread->vfs, &request->cred,
                 ctx->src_handle,
                 ctx->offset,
                 chunk,
@@ -670,7 +670,7 @@ chimera_s3_copy_open_dir_callback(
     if (module->capabilities & CHIMERA_VFS_CAP_CREATE_UNLINKED) {
         ctx->tmp_name_len = 0;
         chimera_vfs_create_unlinked(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh->fh,
             oh->fh_len,
             &request->set_attr,
@@ -683,7 +683,7 @@ chimera_s3_copy_open_dir_callback(
                                      (uint64_t) request,
                                      (uint64_t) request->start_time.tv_nsec);
         chimera_vfs_open_at(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh,
             ctx->tmp_name,
             ctx->tmp_name_len,
@@ -712,7 +712,7 @@ chimera_s3_copy_create_dir_callback(
         return;
     }
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &ctx->request->cred,
                         attr->va_fh,
                         attr->va_fh_len,
                         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED |
@@ -771,7 +771,7 @@ chimera_s3_copy_open_src_callback(
     request->set_attr.va_req_mask = 0;
     request->set_attr.va_set_mask = 0;
 
-    chimera_vfs_create(thread->vfs, &thread->shared->cred,
+    chimera_vfs_create(thread->vfs, &request->cred,
                        request->bucket_fh,
                        request->bucket_fhlen,
                        dirpath,
@@ -806,7 +806,7 @@ chimera_s3_copy_lookup_src_callback(
     ctx->src_size  = attr->va_size;
     ctx->src_mtime = attr->va_mtime;
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &ctx->request->cred,
                         attr->va_fh,
                         attr->va_fh_len,
                         0,
@@ -829,7 +829,7 @@ chimera_s3_copy_lookup_src_bucket_callback(
         return;
     }
 
-    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+    chimera_vfs_lookup(thread->vfs, &ctx->request->cred,
                        attr->va_fh,
                        attr->va_fh_len,
                        ctx->src_key,
@@ -892,7 +892,7 @@ chimera_s3_copy(
     src_path = chimera_s3_bucket_get_path(src_bucket);
 
     chimera_vfs_lookup(thread->vfs,
-                       &thread->shared->cred,
+                       &request->cred,
                        shared->root_fh,
                        shared->root_fh_len,
                        src_path,

--- a/src/server/s3/s3_cred_cache.h
+++ b/src/server/s3/s3_cred_cache.h
@@ -11,6 +11,8 @@
 #include <urcu/urcu-qsbr.h>
 #include <xxhash.h>
 
+#include "vfs/sdk/vfs_cred.h"
+
 #define CHIMERA_S3_ACCESS_KEY_MAX 128
 #define CHIMERA_S3_SECRET_KEY_MAX 256
 
@@ -18,6 +20,16 @@ struct chimera_s3_cred {
     int                     access_key_len;
     struct timespec         expiration;
     int                     pinned;
+    /* POSIX identity this access key acts as.  Every VFS operation an
+     * authenticated request issues runs under these ids, so the store's own
+     * ownership and mode bits are what separates one key's data from another's;
+     * the S3 layer performs no authorization of its own.  A key configured
+     * without an identity is mapped to the server's anonymous ids rather than
+     * to root. */
+    uint32_t                uid;
+    uint32_t                gid;
+    uint32_t                ngids;
+    uint32_t                gids[CHIMERA_VFS_CRED_MAX_GIDS];
     struct rcu_head         rcu;
     struct chimera_s3_cred *next;
     char                    access_key[CHIMERA_S3_ACCESS_KEY_MAX];
@@ -235,6 +247,10 @@ chimera_s3_cred_cache_add(
     struct chimera_s3_cred_cache *cache,
     const char                   *access_key,
     const char                   *secret_key,
+    uint32_t                      uid,
+    uint32_t                      gid,
+    uint32_t                      ngids,
+    const uint32_t               *gids,
     int                           pinned)
 {
     struct chimera_s3_cred *cred, *existing;
@@ -251,6 +267,16 @@ chimera_s3_cred_cache_add(
     strncpy(cred->secret_key, secret_key, sizeof(cred->secret_key) - 1);
     cred->access_key_len = access_key_len;
     cred->pinned         = pinned;
+    cred->uid            = uid;
+    cred->gid            = gid;
+
+    if (ngids > CHIMERA_VFS_CRED_MAX_GIDS) {
+        ngids = CHIMERA_VFS_CRED_MAX_GIDS;
+    }
+    cred->ngids = ngids;
+    if (ngids && gids) {
+        memcpy(cred->gids, gids, ngids * sizeof(*gids));
+    }
 
     if (!pinned) {
         chimera_s3_cred_cache_now(cache, &now);

--- a/src/server/s3/s3_delete.c
+++ b/src/server/s3/s3_delete.c
@@ -24,7 +24,7 @@ chimera_s3_delete_remove_callback(
     chimera_vfs_release(thread->vfs, request->dir_handle);
 
     if (error_code) {
-        request->status = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
     }
 
     request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
@@ -46,7 +46,7 @@ chimera_s3_delete_open_callback(
     struct chimera_server_s3_thread *thread  = request->thread;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_vfs_release(thread->vfs, request->dir_handle);
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
@@ -59,7 +59,7 @@ chimera_s3_delete_open_callback(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_remove_at(thread->vfs, &thread->shared->cred,
+    chimera_vfs_remove_at(thread->vfs, &request->cred,
                           oh,
                           request->name,
                           request->name_len,
@@ -85,7 +85,7 @@ chimera_s3_get_lookup_callback(
     struct chimera_server_s3_thread *thread  = request->thread;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(thread->evpl, request);
@@ -97,7 +97,7 @@ chimera_s3_get_lookup_callback(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &request->cred,
                         attr->va_fh,
                         attr->va_fh_len,
                         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_DIRECTORY,
@@ -141,7 +141,7 @@ chimera_s3_delete(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+    chimera_vfs_lookup(thread->vfs, &request->cred,
                        request->bucket_fh,
                        request->bucket_fhlen,
                        dirpath,

--- a/src/server/s3/s3_delete_objects.c
+++ b/src/server/s3/s3_delete_objects.c
@@ -424,7 +424,7 @@ chimera_s3_del_open_cb(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_remove_at(thread->vfs, &thread->shared->cred,
+    chimera_vfs_remove_at(thread->vfs, &request->cred,
                           oh,
                           request->del.cur_name,
                           request->del.cur_name_len,
@@ -459,7 +459,7 @@ chimera_s3_del_lookup_cb(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &request->cred,
                         attr->va_fh,
                         attr->va_fh_len,
                         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_DIRECTORY,
@@ -518,7 +518,7 @@ chimera_s3_del_drive(struct chimera_s3_request *request)
 
         chimera_s3_request_get(request);
 
-        chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+        chimera_vfs_lookup(thread->vfs, &request->cred,
                            request->bucket_fh,
                            request->bucket_fhlen,
                            dirpath,

--- a/src/server/s3/s3_get.c
+++ b/src/server/s3/s3_get.c
@@ -66,7 +66,7 @@ chimera_s3_get_send_callback(
     struct evpl                     *evpl    = thread->evpl;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_s3_io_free(thread, io);
         request->io_pending--;
@@ -122,7 +122,7 @@ chimera_s3_get_send(
     request->io_pending++;
 
     chimera_vfs_read(request->thread->vfs,
-                     &request->thread->shared->cred,
+                     &request->cred,
                      request->file_handle,
                      request->file_cur_offset,
                      left,
@@ -192,7 +192,7 @@ chimera_s3_get_open_callback(
     struct evpl                     *evpl    = thread->evpl;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_vfs_release(thread->vfs, request->dir_handle);
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
@@ -220,7 +220,7 @@ chimera_s3_get_lookup_callback(
     struct evpl                     *evpl    = thread->evpl;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
@@ -324,7 +324,7 @@ chimera_s3_get_lookup_callback(
      * the object is open. The body is only streamed for GET. */
     chimera_s3_request_get(request);
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &request->cred,
                         attr->va_fh,
                         attr->va_fh_len,
                         0,
@@ -342,7 +342,7 @@ chimera_s3_get(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+    chimera_vfs_lookup(thread->vfs, &request->cred,
                        request->bucket_fh,
                        request->bucket_fhlen,
                        request->path,
@@ -376,7 +376,7 @@ chimera_s3_get_object_attributes_lookup_callback(
     char                            *bp, *body_start;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
@@ -446,7 +446,7 @@ chimera_s3_get_object_attributes(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+    chimera_vfs_lookup(thread->vfs, &request->cred,
                        request->bucket_fh,
                        request->bucket_fhlen,
                        request->path,

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -71,6 +71,11 @@ struct chimera_s3_delete_entry {
 struct chimera_s3_config {
     int      port;
     uint64_t io_size;
+    /* Identity used for an access key configured without one.  Defaults to
+     * nobody (65534) rather than root, so a key that was never bound to a user
+     * gets no privilege by omission. */
+    uint32_t anon_uid;
+    uint32_t anon_gid;
 };
 
 struct chimera_s3_io {
@@ -84,6 +89,16 @@ struct chimera_s3_request {
     enum chimera_s3_status           status;
     enum chimera_s3_vfs_state        vfs_state;
     enum chimera_s3_http_state       http_state;
+    /*
+     * The POSIX identity the authenticated access key acts as.  Every VFS
+     * operation this request issues runs under it, so the store's ownership
+     * and mode bits are what keep one key out of another key's objects -- the
+     * S3 layer itself performs no authorization.  Stamped from the matched
+     * credential once authentication succeeds, and never from a server-wide
+     * identity: sharing one privileged credential across requests is what made
+     * every valid key root over every bucket.
+     */
+    struct chimera_vfs_cred          cred;
     const char                      *bucket_name;
     int                              bucket_namelen;
     int                              bucket_fhlen;
@@ -276,7 +291,6 @@ struct chimera_server_s3_shared {
      * built from it too, since the in-process transport is named rather
      * than bound. */
     enum chimera_tcp_flavor            tcp_flavor;
-    struct chimera_vfs_cred            cred;
     uint32_t                           root_fh_len;
     uint8_t                            root_fh[CHIMERA_VFS_FH_SIZE];
     /* VFS path (relative to root_fh) under which dynamically created buckets

--- a/src/server/s3/s3_list.c
+++ b/src/server/s3/s3_list.c
@@ -907,7 +907,7 @@ chimera_s3_list(
      * it. */
     chimera_s3_request_get(request);
 
-    chimera_vfs_find(thread->vfs, &thread->shared->cred,
+    chimera_vfs_find(thread->vfs, &request->cred,
                      request->bucket_fh,
                      request->bucket_fhlen,
                      CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT,

--- a/src/server/s3/s3_metadata.c
+++ b/src/server/s3/s3_metadata.c
@@ -241,7 +241,7 @@ chimera_s3_meta_store_next(struct chimera_s3_meta_store_ctx *ctx)
 
     kv = &ctx->kv[ctx->cur];
 
-    chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_set_xattr(thread->vfs, &ctx->request->cred,
                           ctx->handle,
                           CHIMERA_VFS_XATTR_EITHER,
                           kv->name,
@@ -374,7 +374,7 @@ chimera_s3_meta_attach_next(struct chimera_s3_meta_attach_ctx *ctx)
         return;
     }
 
-    chimera_vfs_get_xattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_get_xattr(thread->vfs, &ctx->request->cred,
                           ctx->handle,
                           ctx->names[ctx->cur],
                           ctx->name_lens[ctx->cur],
@@ -440,7 +440,7 @@ chimera_s3_metadata_attach_headers(
     ctx->done         = done;
     ctx->private_data = private_data;
 
-    chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
+    chimera_vfs_list_xattrs(thread->vfs, &request->cred,
                             handle,
                             0,
                             ctx->list_buf,
@@ -523,7 +523,7 @@ chimera_s3_meta_copy_get_callback(
         return;
     }
 
-    chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_set_xattr(thread->vfs, &ctx->request->cred,
                           ctx->dst_handle,
                           CHIMERA_VFS_XATTR_EITHER,
                           ctx->names[ctx->cur],
@@ -544,7 +544,7 @@ chimera_s3_meta_copy_next(struct chimera_s3_meta_copy_ctx *ctx)
         return;
     }
 
-    chimera_vfs_get_xattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_get_xattr(thread->vfs, &ctx->request->cred,
                           ctx->src_handle,
                           ctx->names[ctx->cur],
                           ctx->name_lens[ctx->cur],
@@ -610,7 +610,7 @@ chimera_s3_metadata_copy(
     ctx->done         = done;
     ctx->private_data = private_data;
 
-    chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
+    chimera_vfs_list_xattrs(thread->vfs, &request->cred,
                             src_handle,
                             0,
                             ctx->list_buf,

--- a/src/server/s3/s3_multipart.c
+++ b/src/server/s3/s3_multipart.c
@@ -275,6 +275,7 @@ chimera_s3_multipart_table_detach(
 /* ----- async part destruction (release handle + unlink tmp file) ----- */
 
 struct chimera_s3_part_destroy_ctx {
+    struct chimera_vfs_cred          cred;
     struct chimera_server_s3_thread *thread;
     struct chimera_s3_part          *part;
     struct chimera_vfs_open_handle  *dir_handle;
@@ -313,7 +314,7 @@ chimera_s3_part_destroy_open_dir_callback(
 
     chimera_vfs_remove_at(
         ctx->thread->vfs,
-        &ctx->thread->shared->cred,
+        &ctx->cred,
         oh,
         ctx->part->tmp_name,
         ctx->part->tmp_name_len,
@@ -348,10 +349,11 @@ chimera_s3_multipart_part_destroy_async(
     ctx         = calloc(1, sizeof(*ctx));
     ctx->thread = thread;
     ctx->part   = part;
+    ctx->cred   = part->cred;
 
     chimera_vfs_open_fh(
         thread->vfs,
-        &thread->shared->cred,
+        &ctx->cred,
         part->dir_fh,
         part->dir_fhlen,
         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED |
@@ -501,6 +503,7 @@ chimera_s3_upload_part_finish(struct chimera_s3_request *request)
     char                                etag_hex[80];
 
     part               = calloc(1, sizeof(*part));
+    part->cred         = request->cred;
     part->part_number  = request->multipart.part_number;
     part->file_handle  = request->file_handle;
     part->size         = request->file_cur_offset;
@@ -632,7 +635,7 @@ chimera_s3_upload_part_write_callback(
     request->io_pending--;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         return;
     }
@@ -733,7 +736,7 @@ chimera_s3_upload_part_recv(
 
     request->io_pending++;
 
-    chimera_vfs_write(thread->vfs, &thread->shared->cred,
+    chimera_vfs_write(thread->vfs, &request->cred,
                       request->file_handle,
                       request->file_cur_offset,
                       avail,
@@ -768,7 +771,7 @@ chimera_s3_upload_part_create_unlinked_callback(
         request->dir_handle = NULL;
         chimera_s3_multipart_upload_release(thread, request->multipart.upload);
         request->multipart.upload = NULL;
-        request->status           = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status           = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(thread->evpl, request);
@@ -802,7 +805,7 @@ chimera_s3_upload_part_create_callback(
         request->dir_handle = NULL;
         chimera_s3_multipart_upload_release(thread, request->multipart.upload);
         request->multipart.upload = NULL;
-        request->status           = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status           = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(thread->evpl, request);
@@ -830,7 +833,7 @@ chimera_s3_upload_part_open_dir_callback(
     if (error_code) {
         chimera_s3_multipart_upload_release(thread, request->multipart.upload);
         request->multipart.upload = NULL;
-        request->status           = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status           = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(thread->evpl, request);
@@ -851,7 +854,7 @@ chimera_s3_upload_part_open_dir_callback(
         chimera_s3_request_get(request);
 
         chimera_vfs_create_unlinked(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh->fh,
             oh->fh_len,
             &request->set_attr,
@@ -869,7 +872,7 @@ chimera_s3_upload_part_open_dir_callback(
         chimera_s3_request_get(request);
 
         chimera_vfs_open_at(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh,
             request->multipart.tmp_name,
             request->multipart.tmp_name_len,
@@ -896,7 +899,7 @@ chimera_s3_upload_part_lookup_callback(
     if (error_code) {
         chimera_s3_multipart_upload_release(thread, request->multipart.upload);
         request->multipart.upload = NULL;
-        request->status           = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status           = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state        = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(thread->evpl, request);
@@ -907,7 +910,7 @@ chimera_s3_upload_part_lookup_callback(
     chimera_s3_request_get(request);
 
     chimera_vfs_open_fh(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &request->cred,
         attr->va_fh,
         attr->va_fh_len,
         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED |
@@ -980,7 +983,7 @@ chimera_s3_upload_part(
     chimera_s3_request_get(request);
 
     chimera_vfs_create(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &request->cred,
         request->bucket_fh,
         request->bucket_fhlen,
         dirpath,
@@ -1272,7 +1275,7 @@ chimera_s3_upc_read_callback(
     ctx->rw_niov = niov;
 
     chimera_vfs_write(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &ctx->request->cred,
         ctx->request->file_handle,
         ctx->copied,           /* destination part offset */
         count,
@@ -1305,7 +1308,7 @@ chimera_s3_upc_step(struct chimera_s3_upload_copy_ctx *ctx)
 
     if (ctx->mode == CHIMERA_S3_UPC_COPY) {
         chimera_vfs_copy_range(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             ctx->src_handle,
             ctx->src_first + ctx->copied,
             request->file_handle,
@@ -1318,7 +1321,7 @@ chimera_s3_upc_step(struct chimera_s3_upload_copy_ctx *ctx)
     } else {
         ctx->rw_niov = CHIMERA_S3_IOV_MAX;
         chimera_vfs_read(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             ctx->src_handle,
             ctx->src_first + ctx->copied,
             chunk,
@@ -1430,7 +1433,7 @@ chimera_s3_upc_open_dir_callback(
     if (module->capabilities & CHIMERA_VFS_CAP_CREATE_UNLINKED) {
         request->multipart.tmp_name_len = 0;
         chimera_vfs_create_unlinked(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh->fh,
             oh->fh_len,
             &request->set_attr,
@@ -1446,7 +1449,7 @@ chimera_s3_upc_open_dir_callback(
             request->multipart.part_number);
 
         chimera_vfs_open_at(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh,
             request->multipart.tmp_name,
             request->multipart.tmp_name_len,
@@ -1475,7 +1478,7 @@ chimera_s3_upc_create_dir_callback(
     }
 
     chimera_vfs_open_fh(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &ctx->request->cred,
         attr->va_fh,
         attr->va_fh_len,
         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED |
@@ -1524,7 +1527,7 @@ chimera_s3_upc_open_src_callback(
     request->set_attr.va_set_mask = 0;
 
     chimera_vfs_create(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &request->cred,
         request->bucket_fh,
         request->bucket_fhlen,
         dirpath,
@@ -1571,7 +1574,7 @@ chimera_s3_upc_lookup_src_callback(
         }
     }
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &ctx->request->cred,
                         attr->va_fh,
                         attr->va_fh_len,
                         0,
@@ -1593,7 +1596,7 @@ chimera_s3_upc_lookup_src_bucket_callback(
         return;
     }
 
-    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+    chimera_vfs_lookup(thread->vfs, &ctx->request->cred,
                        attr->va_fh,
                        attr->va_fh_len,
                        ctx->src_key,
@@ -1686,7 +1689,7 @@ chimera_s3_upload_part_copy(
     src_path = chimera_s3_bucket_get_path(src_bucket);
 
     chimera_vfs_lookup(thread->vfs,
-                       &thread->shared->cred,
+                       &request->cred,
                        shared->root_fh,
                        shared->root_fh_len,
                        src_path,
@@ -2229,7 +2232,7 @@ chimera_s3_complete_rw_read_callback(
     ctx->rw_niov = niov;
 
     chimera_vfs_write(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &request->cred,
         request->file_handle,
         ctx->write_offset,
         count,
@@ -2263,7 +2266,7 @@ chimera_s3_complete_assemble_rw(struct chimera_s3_complete_ctx *ctx)
     ctx->rw_niov = CHIMERA_S3_IOV_MAX;
 
     chimera_vfs_read(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &request->cred,
         part->file_handle,
         ctx->part_offset,
         chunk,
@@ -2301,7 +2304,7 @@ chimera_s3_complete_assemble_next(struct chimera_s3_complete_ctx *ctx)
     switch (ctx->assemble_mode) {
         case CHIMERA_S3_ASSEMBLE_MOVE:
             chimera_vfs_move_range(
-                thread->vfs, &thread->shared->cred,
+                thread->vfs, &request->cred,
                 part->file_handle,
                 ctx->part_offset,
                 request->file_handle,
@@ -2313,7 +2316,7 @@ chimera_s3_complete_assemble_next(struct chimera_s3_complete_ctx *ctx)
             break;
         case CHIMERA_S3_ASSEMBLE_COPY:
             chimera_vfs_copy_range(
-                thread->vfs, &thread->shared->cred,
+                thread->vfs, &request->cred,
                 part->file_handle,
                 ctx->part_offset,
                 request->file_handle,
@@ -2406,7 +2409,7 @@ chimera_s3_complete_finish_common(
     request->multipart.body_cap = 0;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(evpl, request);
@@ -2472,7 +2475,7 @@ chimera_s3_complete_finalize(struct chimera_s3_complete_ctx *ctx)
     if (request->multipart.tmp_name_len) {
         chimera_vfs_rename_at(
             thread->vfs,
-            &thread->shared->cred,
+            &request->cred,
             request->dir_handle->fh,
             request->dir_handle->fh_len,
             request->multipart.tmp_name,
@@ -2493,7 +2496,7 @@ chimera_s3_complete_finalize(struct chimera_s3_complete_ctx *ctx)
     } else {
         chimera_vfs_link_at(
             thread->vfs,
-            &thread->shared->cred,
+            &request->cred,
             request->file_handle->fh,
             request->file_handle->fh_len,
             request->dir_handle->fh,
@@ -2617,7 +2620,7 @@ chimera_s3_complete_open_dir_callback(
         request->multipart.tmp_name_len = 0;
 
         chimera_vfs_create_unlinked(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh->fh,
             oh->fh_len,
             &request->set_attr,
@@ -2633,7 +2636,7 @@ chimera_s3_complete_open_dir_callback(
             (uint64_t) request->start_time.tv_nsec);
 
         chimera_vfs_open_at(
-            thread->vfs, &thread->shared->cred,
+            thread->vfs, &request->cred,
             oh,
             request->multipart.tmp_name,
             request->multipart.tmp_name_len,
@@ -2671,7 +2674,7 @@ chimera_s3_complete_create_root_callback(
     }
 
     chimera_vfs_open_fh(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &ctx->request->cred,
         attr->va_fh,
         attr->va_fh_len,
         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED |
@@ -2691,7 +2694,7 @@ chimera_s3_complete_create_dir(struct chimera_s3_complete_ctx *ctx)
     request->set_attr.va_set_mask = 0;
 
     chimera_vfs_create(
-        thread->vfs, &thread->shared->cred,
+        thread->vfs, &request->cred,
         request->bucket_fh,
         request->bucket_fhlen,
         ctx->dirpath,
@@ -2980,7 +2983,7 @@ chimera_s3_complete_multipart_upload_body_done(
             rctx->combined_etag[1] = combined[1];
             free(client_parts);
 
-            chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+            chimera_vfs_lookup(thread->vfs, &request->cred,
                                request->bucket_fh, request->bucket_fhlen,
                                request->path, request->path_len,
                                CHIMERA_VFS_ATTR_FH,

--- a/src/server/s3/s3_multipart.h
+++ b/src/server/s3/s3_multipart.h
@@ -13,6 +13,10 @@
 struct evpl;
 
 struct chimera_s3_part {
+    /* Identity that staged this part.  The part's temporary file is removed
+     * asynchronously, long after the request is gone, so the cleanup has to
+     * carry its own credential rather than borrow a privileged one. */
+    struct chimera_vfs_cred         cred;
     int                             part_number;
     int                             tmp_name_len;
     int                             dir_fhlen;

--- a/src/server/s3/s3_put.c
+++ b/src/server/s3/s3_put.c
@@ -79,7 +79,7 @@ chimera_s3_put_finish_common(
     }
 
     if (error_code) {
-        request->status = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         if (request->file_handle) {
             chimera_vfs_release(thread->vfs, request->file_handle);
             request->file_handle = NULL;
@@ -97,7 +97,7 @@ chimera_s3_put_finish_common(
     chimera_s3_request_get(request);
 
     chimera_vfs_getattr(thread->vfs,
-                        &thread->shared->cred,
+                        &request->cred,
                         request->file_handle,
                         CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_SIZE |
                         CHIMERA_VFS_ATTR_MTIME,
@@ -149,7 +149,7 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
 
         chimera_vfs_rename_at(
             thread->vfs,
-            &thread->shared->cred,
+            &request->cred,
             request->dir_handle->fh,
             request->dir_handle->fh_len,
             request->put.tmp_name,
@@ -172,7 +172,7 @@ chimera_s3_put_rename(struct chimera_s3_request *request)
 
         chimera_vfs_link_at(
             thread->vfs,
-            &thread->shared->cred,
+            &request->cred,
             request->file_handle->fh,
             request->file_handle->fh_len,
             request->dir_handle->fh,
@@ -211,7 +211,7 @@ chimera_s3_put_recv_callback(
     request->io_pending--;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_INTERNAL_ERROR;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         return;
     }
@@ -311,7 +311,7 @@ chimera_s3_put_recv(
 
     request->io_pending++;
 
-    chimera_vfs_write(request->thread->vfs, &thread->shared->cred,
+    chimera_vfs_write(request->thread->vfs, &request->cred,
                       request->file_handle,
                       request->file_cur_offset,
                       avail,
@@ -374,7 +374,7 @@ chimera_s3_put_create_unlinked_callback(
     struct chimera_server_s3_thread *thread  = request->thread;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_vfs_release(thread->vfs, request->dir_handle);
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
@@ -410,7 +410,7 @@ chimera_s3_put_create_callback(
     struct chimera_server_s3_thread *thread  = request->thread;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         chimera_vfs_release(thread->vfs, request->dir_handle);
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
@@ -443,7 +443,7 @@ chimera_s3_put_open_dir_callback(
     struct chimera_vfs_module       *module;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(thread->evpl, request);
@@ -464,7 +464,7 @@ chimera_s3_put_open_dir_callback(
 
         chimera_s3_request_get(request);
 
-        chimera_vfs_create_unlinked(thread->vfs, &thread->shared->cred,
+        chimera_vfs_create_unlinked(thread->vfs, &request->cred,
                                     oh->fh,
                                     oh->fh_len,
                                     &request->set_attr,
@@ -480,7 +480,7 @@ chimera_s3_put_open_dir_callback(
 
         chimera_s3_request_get(request);
 
-        chimera_vfs_open_at(thread->vfs, &thread->shared->cred,
+        chimera_vfs_open_at(thread->vfs, &request->cred,
                             oh,
                             request->put.tmp_name,
                             request->put.tmp_name_len,
@@ -506,7 +506,7 @@ chimera_s3_put_lookup_callback(
     struct chimera_server_s3_thread *thread  = request->thread;
 
     if (error_code) {
-        request->status    = CHIMERA_S3_STATUS_NO_SUCH_KEY;
+        request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_NO_SUCH_KEY);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
         if (request->http_state == CHIMERA_S3_HTTP_STATE_RECVED) {
             s3_server_respond(thread->evpl, request);
@@ -518,7 +518,7 @@ chimera_s3_put_lookup_callback(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &request->cred,
                         attr->va_fh,
                         attr->va_fh_len,
                         CHIMERA_VFS_OPEN_PATH | CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_DIRECTORY,
@@ -589,7 +589,7 @@ chimera_s3_put(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_create(thread->vfs, &thread->shared->cred,
+    chimera_vfs_create(thread->vfs, &request->cred,
                        request->bucket_fh,
                        request->bucket_fhlen,
                        dirpath,

--- a/src/server/s3/s3_status.h
+++ b/src/server/s3/s3_status.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "vfs/sdk/vfs_error.h"
+
 struct chimera_s3_request;
 
 enum chimera_s3_status {
@@ -34,6 +36,29 @@ enum chimera_s3_status {
     CHIMERA_S3_STATUS_INVALID_TAG,
     CHIMERA_S3_STATUS_NO_SUCH_TAG_SET,
 };
+
+/*
+ * Map a VFS error to the S3 status a handler should report for it, falling back
+ * to whatever that handler would otherwise have used.
+ *
+ * Access failures need this: now that each request runs under the identity of
+ * the access key that authenticated it, the store answers EACCES/EPERM for work
+ * the caller may not do, and reporting that as InternalError would tell a client
+ * the server is broken when it is in fact enforcing permissions.
+ */
+static inline enum chimera_s3_status
+chimera_s3_status_from_vfs(
+    enum chimera_vfs_error error_code,
+    enum chimera_s3_status fallback)
+{
+    switch (error_code) {
+        case CHIMERA_VFS_EACCES:
+        case CHIMERA_VFS_EPERM:
+            return CHIMERA_S3_STATUS_ACCESS_DENIED;
+        default:
+            return fallback;
+    } /* switch */
+} /* chimera_s3_status_from_vfs */
 
 const char *
 chimera_s3_status_to_string(

--- a/src/server/s3/s3_tagging.c
+++ b/src/server/s3/s3_tagging.c
@@ -474,7 +474,7 @@ chimera_s3_tagging_remove_next(
             memcmp(name, CHIMERA_S3_TAG_PREFIX, CHIMERA_S3_TAG_PREFIX_LEN) == 0) {
             chimera_s3_request_get(request);
 
-            chimera_vfs_remove_xattr(thread->vfs, &thread->shared->cred,
+            chimera_vfs_remove_xattr(thread->vfs, &request->cred,
                                      ctx->handle, name, namelen,
                                      chimera_s3_tagging_remove_cb, request);
             return;
@@ -540,7 +540,7 @@ chimera_s3_tagging_clear_existing(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
+    chimera_vfs_list_xattrs(thread->vfs, &request->cred,
                             ctx->handle, 0,
                             ctx->names, CHIMERA_S3_TAG_XATTR_BUFSZ,
                             chimera_s3_tagging_list_for_remove_cb, request);
@@ -594,7 +594,7 @@ chimera_s3_tagging_set_next(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_set_xattr(thread->vfs, &request->cred,
                           ctx->handle, 0 /* create-or-replace */,
                           ctx->set_name, namelen,
                           t->val, strlen(t->val),
@@ -662,7 +662,7 @@ chimera_s3_tagging_get_next(
             ctx->cur     += namelen + 1;
             chimera_s3_request_get(request);
 
-            chimera_vfs_get_xattr(thread->vfs, &thread->shared->cred,
+            chimera_vfs_get_xattr(thread->vfs, &request->cred,
                                   ctx->handle, name, namelen,
                                   ctx->valbuf, CHIMERA_S3_TAG_VAL_BUFSZ - 1,
                                   chimera_s3_tagging_get_value_cb, request);
@@ -766,7 +766,7 @@ chimera_s3_tagging_begin_op(
             }
             chimera_s3_request_get(request);
 
-            chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
+            chimera_vfs_list_xattrs(thread->vfs, &request->cred,
                                     ctx->handle, 0,
                                     ctx->names, CHIMERA_S3_TAG_XATTR_BUFSZ,
                                     chimera_s3_tagging_get_list_cb, request);
@@ -823,7 +823,7 @@ chimera_s3_tagging_lookup_cb(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &request->cred,
                         attr->va_fh, attr->va_fh_len,
                         CHIMERA_VFS_OPEN_INFERRED,
                         chimera_s3_tagging_open_cb, request);
@@ -847,7 +847,7 @@ chimera_s3_tagging_dispatch(
         /* Bucket-level tagging: the bucket directory FH is already in hand. */
         chimera_s3_request_get(request);
 
-        chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+        chimera_vfs_open_fh(thread->vfs, &request->cred,
                             request->bucket_fh, request->bucket_fhlen,
                             CHIMERA_VFS_OPEN_INFERRED | CHIMERA_VFS_OPEN_DIRECTORY,
                             chimera_s3_tagging_open_cb, request);
@@ -856,7 +856,7 @@ chimera_s3_tagging_dispatch(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+    chimera_vfs_lookup(thread->vfs, &request->cred,
                        request->bucket_fh, request->bucket_fhlen,
                        request->path, request->path_len,
                        CHIMERA_VFS_ATTR_FH,
@@ -1024,7 +1024,7 @@ chimera_s3_tagging_store_set_next(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_set_xattr(thread->vfs, &thread->shared->cred,
+    chimera_vfs_set_xattr(thread->vfs, &request->cred,
                           ctx->handle, 0,
                           ctx->set_name, namelen,
                           t->val, strlen(t->val),
@@ -1091,7 +1091,7 @@ chimera_s3_tagging_store_lookup_cb(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &request->cred,
                         attr->va_fh, attr->va_fh_len,
                         CHIMERA_VFS_OPEN_INFERRED,
                         chimera_s3_tagging_store_open_cb, request);
@@ -1120,7 +1120,7 @@ chimera_s3_tagging_store_by_path(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_lookup(thread->vfs, &thread->shared->cred,
+    chimera_vfs_lookup(thread->vfs, &request->cred,
                        request->bucket_fh, request->bucket_fhlen,
                        request->path, request->path_len,
                        CHIMERA_VFS_ATTR_FH,
@@ -1206,7 +1206,7 @@ chimera_s3_tagging_count_open_cb(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_list_xattrs(thread->vfs, &thread->shared->cred,
+    chimera_vfs_list_xattrs(thread->vfs, &request->cred,
                             ctx->handle, 0,
                             ctx->names, CHIMERA_S3_TAG_XATTR_BUFSZ,
                             chimera_s3_tagging_count_list_cb, request);
@@ -1229,7 +1229,7 @@ chimera_s3_tagging_count_for_head(
 
     chimera_s3_request_get(request);
 
-    chimera_vfs_open_fh(thread->vfs, &thread->shared->cred,
+    chimera_vfs_open_fh(thread->vfs, &request->cred,
                         fh, fh_len,
                         CHIMERA_VFS_OPEN_INFERRED,
                         chimera_s3_tagging_count_open_cb, request);

--- a/src/server/s3/tests/quint/s3_mbt_common.h
+++ b/src/server/s3/tests/quint/s3_mbt_common.h
@@ -52,6 +52,7 @@
 #define S3_MBT_BODY_MAX    (64 * 1024 * 1024)
 
 #define S3_MBT_ACCESS_KEY  "quintaccess"
+#define S3_MBT_USER        "quintuser"
 #define S3_MBT_SECRET_KEY  "quintsecret"
 
 /* Fixed signing date: the server never checks it for freshness, and a fixed
@@ -680,8 +681,16 @@ s3_mbt_env_open_module(
      * per-trace mount recreates /share, so the root stays valid across the
      * whole batch), and every request must be signed with a known cred. */
     chimera_server_set_s3_bucket_root(env->server, "/share");
+
+    /* Bind the harness key to a uid-0 user so the model keeps exercising the
+     * same reachable state it did when every key ran as root.  The identity
+     * mapping itself is covered by the s3_identity unit test; extending the
+     * model to a second, unprivileged tenant (and asserting cross-tenant
+     * denial) is follow-on work. */
+    chimera_server_add_user(env->server, S3_MBT_USER, "", "", NULL,
+                            0, 0, 0, NULL, 1);
     chimera_server_add_s3_cred(env->server, S3_MBT_ACCESS_KEY,
-                               S3_MBT_SECRET_KEY, 1);
+                               S3_MBT_SECRET_KEY, S3_MBT_USER, 1);
 
     /* Client half: its own evpl loop; the response callbacks run inside
      * evpl_continue() on this (the only) test thread.  The 1 ms wait bound

--- a/src/server/s3/tests/quint/s3_mbt_probe.c
+++ b/src/server/s3/tests/quint/s3_mbt_probe.c
@@ -616,7 +616,7 @@ main(
                                   .secret_key = "tempsecret" };
 
         CHECK(chimera_server_add_s3_cred(env.server, "tempaccess",
-                                         "tempsecret", 0) == 0,
+                                         "tempsecret", S3_MBT_USER, 0) == 0,
               "add unpinned cred failed");
 
         r = s3_mbt_call(&env, &req);
@@ -625,7 +625,7 @@ main(
 
         /* re-adding the same key replaces the entry (fresh TTL stamp) */
         CHECK(chimera_server_add_s3_cred(env.server, "tempaccess",
-                                         "tempsecret", 0) == 0,
+                                         "tempsecret", S3_MBT_USER, 0) == 0,
               "re-add unpinned cred failed");
         r = s3_mbt_call(&env, &req);
         CHECK(r->status == 200, "replaced-cred GET: got %d want 200",
@@ -652,7 +652,7 @@ main(
         /* a pinned extra credential survives any advance, and explicit
          * removal (not expiry) is what retires it */
         CHECK(chimera_server_add_s3_cred(env.server, "tempaccess",
-                                         "tempsecret", 1) == 0,
+                                         "tempsecret", S3_MBT_USER, 1) == 0,
               "add pinned cred failed");
         chimera_server_advance_s3_cred_clock(env.server, 100000);
         r = s3_mbt_call(&env, &req);

--- a/src/server/s3/tests/quint/s3_mbt_probe.c
+++ b/src/server/s3/tests/quint/s3_mbt_probe.c
@@ -668,6 +668,46 @@ main(
               "double remove should report absence");
     }
 
+    /* ---- per-key identity (#494) ---------------------------------------- */
+
+    /* A valid signature is not authority.  A key bound to no user acts as the
+     * anonymous identity, so it must not be able to write into a bucket owned
+     * by the harness user -- authenticating says who you are, not what you may
+     * touch.  Before per-key identities every key ran as root and this PUT
+     * succeeded. */
+    {
+        struct s3_mbt_req anon_put = { .method     = EVPL_HTTP_REQUEST_TYPE_PUT,
+                                       .path       = "/bk0/anon-object",
+                                       .access_key = "anonaccess",
+                                       .secret_key = "anonsecret",
+                                       .body       = (const uint8_t *) "x",
+                                       .body_len   = 1 };
+        struct s3_mbt_req owner_put = { .method     = EVPL_HTTP_REQUEST_TYPE_PUT,
+                                        .path       = "/bk0/owner-object",
+                                        .access_key = S3_MBT_ACCESS_KEY,
+                                        .secret_key = S3_MBT_SECRET_KEY,
+                                        .body       = (const uint8_t *) "x",
+                                        .body_len   = 1 };
+
+        CHECK(chimera_server_add_s3_cred(env.server, "anonaccess",
+                                         "anonsecret", NULL, 1) == 0,
+              "add unbound cred failed");
+
+        r = s3_mbt_call(&env, &anon_put);
+        CHECK(r->status == 403,
+              "unbound-key PUT into another user's bucket: got %d want 403",
+              r->status);
+
+        /* ...while the key that owns the bucket still writes to it, so the
+         * denial above is authorization and not a blanket breakage. */
+        r = s3_mbt_call(&env, &owner_put);
+        CHECK(r->status == 200,
+              "owner-key PUT into its own bucket: got %d want 200", r->status);
+
+        CHECK(chimera_server_remove_s3_cred(env.server, "anonaccess") == 0,
+              "remove unbound cred failed");
+    }
+
     /* ---- teardown -------------------------------------------------------- */
 
     s3_mbt_env_fs_teardown(&env, "fs0");

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -29,6 +29,7 @@
 #include "vfs/vfs_pnfs.h"
 #include "vfs/vfs_mount_table.h"
 #include "vfs/sdk/vfs_cred.h"
+#include "vfs/vfs_user_cache.h"
 #include "vfs/vfs_release.h"
 #include "common/macros.h"
 #include "common/chimera_tracing.h"
@@ -62,6 +63,10 @@ struct chimera_server_config {
     int                                   nfs_nsm_port;
     int                                   nfs_port;
     int                                   s3_port;
+    /* Identity an S3 access key acts as when its configuration binds it to no
+     * user.  Defaults to nobody/nogroup so an unbound key is unprivileged. */
+    uint32_t                              s3_anon_uid;
+    uint32_t                              s3_anon_gid;
     int                                   smb_port;
     int                                   nfs_enabled;
     int                                   smb_enabled;
@@ -322,6 +327,8 @@ chimera_server_config_init(void)
      * service so a pNFS data server can coexist with an MDS on one host. */
     config->nfs_port        = 2049;
     config->s3_port         = 5000;
+    config->s3_anon_uid     = CHIMERA_S3_ANON_UID;
+    config->s3_anon_gid     = CHIMERA_S3_ANON_GID;
     config->smb_port        = 445;
     config->nfs_data_server = 0;
 
@@ -963,6 +970,28 @@ chimera_server_config_get_s3_port(const struct chimera_server_config *config)
 {
     return config->s3_port;
 } /* chimera_server_config_get_s3_port */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_s3_anon_ids(
+    struct chimera_server_config *config,
+    uint32_t                      uid,
+    uint32_t                      gid)
+{
+    config->s3_anon_uid = uid;
+    config->s3_anon_gid = gid;
+} /* chimera_server_config_set_s3_anon_ids */
+
+SYMBOL_EXPORT uint32_t
+chimera_server_config_get_s3_anon_uid(const struct chimera_server_config *config)
+{
+    return config->s3_anon_uid;
+} /* chimera_server_config_get_s3_anon_uid */
+
+SYMBOL_EXPORT uint32_t
+chimera_server_config_get_s3_anon_gid(const struct chimera_server_config *config)
+{
+    return config->s3_anon_gid;
+} /* chimera_server_config_get_s3_anon_gid */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_port(
@@ -3160,13 +3189,44 @@ chimera_server_add_s3_cred(
     struct chimera_server *server,
     const char            *access_key,
     const char            *secret_key,
+    const char            *username,
     int                    pinned)
 {
+    const struct chimera_vfs_user *user;
+    uint32_t                       uid = 0, gid = 0, gids[CHIMERA_VFS_CRED_MAX_GIDS];
+    uint32_t                       ngids        = 0;
+    int                            has_identity = 0;
+
     if (!server->s3_shared) {
         return -1;
     }
 
-    return chimera_s3_add_cred(server->s3_shared, access_key, secret_key, pinned);
+    /* Resolve the key's user through the same identity store the other
+     * protocols authenticate against, so an S3 key and an SMB or NFS login for
+     * the same person act as one uid.  An unresolvable name is a configuration
+     * error and must not silently fall back to a privileged identity, so it is
+     * reported and left unbound (anonymous). */
+    if (username && *username) {
+        user = chimera_server_get_user(server, username);
+
+        if (user) {
+            uid   = user->uid;
+            gid   = user->gid;
+            ngids = user->ngids;
+            if (ngids > CHIMERA_VFS_CRED_MAX_GIDS) {
+                ngids = CHIMERA_VFS_CRED_MAX_GIDS;
+            }
+            memcpy(gids, user->gids, ngids * sizeof(*gids));
+            has_identity = 1;
+        } else {
+            chimera_server_error(
+                "S3 access key %s names unknown user \"%s\"; leaving it unbound",
+                access_key, username);
+        }
+    }
+
+    return chimera_s3_add_cred(server->s3_shared, access_key, secret_key,
+                               has_identity, uid, gid, ngids, gids, pinned);
 } /* chimera_server_add_s3_cred */
 
 SYMBOL_EXPORT int

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -410,6 +410,26 @@ chimera_server_config_set_s3_port(
     struct chimera_server_config *config,
     int                           port);
 
+/* Identity an S3 access key acts as when its configuration binds it to no
+ * user: nobody/nogroup, the conventional unprivileged pair.  An unbound key
+ * must not inherit privilege by omission. */
+#define CHIMERA_S3_ANON_UID 65534
+#define CHIMERA_S3_ANON_GID 65534
+
+void
+chimera_server_config_set_s3_anon_ids(
+    struct chimera_server_config *config,
+    uint32_t                      uid,
+    uint32_t                      gid);
+
+uint32_t
+chimera_server_config_get_s3_anon_uid(
+    const struct chimera_server_config *config);
+
+uint32_t
+chimera_server_config_get_s3_anon_gid(
+    const struct chimera_server_config *config);
+
 int
 chimera_server_config_get_s3_port(
     const struct chimera_server_config *config);
@@ -967,6 +987,7 @@ chimera_server_add_s3_cred(
     struct chimera_server *server,
     const char            *access_key,
     const char            *secret_key,
+    const char            *username,
     int                    pinned);
 
 int


### PR DESCRIPTION
Fixes #494 — the last of the five `critical` issues, and the only one that was a data-exposure hole rather than a crash.

## The problem

Authentication proved a caller held a valid access key and stopped there. Every VFS operation then ran under a single hard-coded uid-0 credential shared by the whole server (`s3.c`, `cred_init_unix(&shared->cred, 0, 0, 0, NULL)`), so **any valid key could read, overwrite or delete any object in any bucket**. The key was not associated with a tenant at all — `struct chimera_s3_cred` held an access key and a secret and nothing else.

## The approach

Bind each access key to a configured user, and run the request as them. Authorization then falls out of the store's own ownership and mode bits — the same ones NFS and SMB already enforce — rather than a second S3-side policy engine that has to be kept in agreement with them. This is the "S3-on-POSIX object store" reading of the problem, and it reuses the identity model the other protocols already share.

```json
"users": [
    { "username": "alice", "uid": 1001, "gid": 1001 },
    { "username": "bob",   "uid": 1002, "gid": 1002 }
],
"s3_access_keys": [
    { "access_key": "AKIAALICE", "secret_key": "...", "username": "alice" },
    { "access_key": "AKIABOB",   "secret_key": "...", "username": "bob" }
]
```

Three commits: establish the identity (no behaviour change), consume it, then test it. Each builds and tests standalone.

## Notes for review

**Unbound keys.** A key with no `username`, or one naming a user that does not exist, maps to a configurable anonymous identity (`s3_anon`, default nobody/65534) and is logged at startup. It authenticates but is unprivileged. The alternative — keeping root — would have left every un-updated deployment exactly as exposed as before.

**This is a breaking change for existing deployments.** Buckets and objects created before this change are owned by uid 0. After upgrading, a key bound to a non-root user cannot reach them until they are chowned, and an unbound key becomes anonymous rather than root. That is the intended direction, but it is not a silent upgrade.

**Two lifetime hazards.** The cached credential is only valid inside the auth call's RCU read section, so the identity is copied out there rather than returned by pointer. And the staged multipart part outlives its request — its temp file is removed asynchronously — so it carries its own copy of the credential that staged it.

**The server-wide credential is deleted, not just unused.** Once every call site sourced its credential from the request, `shared->cred` had no readers. Leaving a privileged credential reachable in shared state is how a later change quietly reintroduces this bug.

**Error mapping.** Denials are reachable now where they never were before. Without mapping EACCES/EPERM to AccessDenied, a permission denial surfaced as `InternalError` — I hit exactly that writing the test, which returned 500 instead of 403.

## Testing

Quick tier green (97/97), Debug and Release both build clean, each commit verified to build on its own.

The new probe assertion is the one worth reading: an unbound key is denied a PUT into another user's bucket **and** the owning key still succeeds. Without that second half the test would pass equally well if S3 were simply broken. Against the pre-fix code the denied PUT returns 200.

## Scope

AWS-visible bucket ownership and ACLs (`GetBucketAcl`, `x-amz-acl` — #504, #479) are deliberately not here. This establishes the identity those would be expressed in terms of; surfacing them on the wire is a separate piece of work.
