### PR TITLE
vfs/nfs: retry DESTROY_CLIENTID while the client's own CLOSEs drain

### DIFF
--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -22,6 +22,23 @@
  * transports are already gone.
  */
 
+/*
+ * DESTROY_CLIENTID can arrive while this client's own CLOSEs are still in
+ * flight, and the server must refuse it then: RFC 8881 s18.50.3 makes
+ * NFS4ERR_CLIENTID_BUSY a MUST while opens remain on the lease.  That refusal
+ * is transient -- the opens being counted are ones this client has already
+ * closed, whose CLOSEs have not yet been processed -- so retry briefly rather
+ * than accept it.
+ *
+ * Accepting it is expensive out of all proportion to the window.  Giving up
+ * leaves the clientid, and every VFS handle behind its opens, held until the
+ * lease expires (90s by default), which is exactly the "cannot unmount the
+ * export" state the comment above says this teardown exists to prevent.  The
+ * cost of getting it wrong is 90 seconds; the cost of waiting is milliseconds.
+ */
+#define NFS4_UMOUNT_DESTROY_RETRY_US     50000    /* 50ms between attempts */
+#define NFS4_UMOUNT_DESTROY_MAX_ATTEMPTS 40       /* ~2s, well under the lease */
+
 struct chimera_nfs4_umount_teardown {
     struct chimera_nfs_thread          *thread;
     struct chimera_nfs_shared          *shared;
@@ -29,10 +46,27 @@ struct chimera_nfs4_umount_teardown {
     struct chimera_nfs_client_server   *server;
     struct chimera_nfs4_client_session *session;
     struct evpl_rpc2_conn              *conn;
+    struct evpl_timer                   retry_timer;
+    int                                 destroy_attempts;
 };
 
 static void chimera_nfs4_umount_send_destroy_session(
     struct chimera_nfs4_umount_teardown *td);
+static void chimera_nfs4_umount_send_destroy_clientid(
+    struct chimera_nfs4_umount_teardown *td);
+
+static void
+chimera_nfs4_umount_destroy_retry_timer(
+    struct evpl       *evpl,
+    struct evpl_timer *timer)
+{
+    struct chimera_nfs4_umount_teardown *td =
+        container_of(timer, struct chimera_nfs4_umount_teardown, retry_timer);
+
+    (void) evpl;
+
+    chimera_nfs4_umount_send_destroy_clientid(td);
+} /* chimera_nfs4_umount_destroy_retry_timer */
 
 static void
 chimera_nfs4_umount_teardown_done(struct chimera_nfs4_umount_teardown *td)
@@ -62,11 +96,27 @@ chimera_nfs4_umount_destroy_clientid_callback(
     (void) evpl;
     (void) verf;
 
+    /* Transient: our own CLOSEs have not landed yet.  Wait for them rather
+     * than stranding the clientid -- and every handle behind its opens --
+     * for the rest of the lease. */
+    if (!status && res && res->status == NFS4ERR_CLIENTID_BUSY &&
+        ++td->destroy_attempts < NFS4_UMOUNT_DESTROY_MAX_ATTEMPTS) {
+        evpl_add_oneshot_timer(td->thread->evpl, &td->retry_timer,
+                               chimera_nfs4_umount_destroy_retry_timer,
+                               NFS4_UMOUNT_DESTROY_RETRY_US);
+        return;
+    }
+
     if (status || !res || res->status != NFS4_OK) {
-        chimera_nfsclient_debug(
-            "NFS4 DESTROY_CLIENTID to %s did not succeed (rpc %d, nfs %d); "
-            "the server will expire the clientid with the lease",
-            td->server->hostname, status, res ? res->status : -1);
+        /* Error, not debug: reaching here means the export cannot be
+         * unmounted until the lease expires, which is a minute and a half of
+         * EBUSY that otherwise has to be inferred from its symptoms. */
+        chimera_nfsclient_error(
+            "NFS4 DESTROY_CLIENTID to %s did not succeed after %d attempt(s) "
+            "(rpc %d, nfs %d); the server will expire the clientid with the "
+            "lease, and the export stays busy until it does",
+            td->server->hostname, td->destroy_attempts + 1, status,
+            res ? res->status : -1);
     }
 
     chimera_nfs4_umount_teardown_done(td);


### PR DESCRIPTION
`posix/mbt/batch_nfs4_*` fails intermittently and has taken **two of the last five merge-queue attempts** with it — including #1632's:

```
posix_driver: newfs share unmount failed: 16
newfs reset failed before .../nfs4_stepPerms_128_0x1_0.itf.json
batch: 29 replayed, 1 failed, 0 unhandled of 53 trace(s)
```

## The chain

Confirmed by instrumenting both ends, not inferred:

1. The per-trace filesystem recycle unmounts the client, then the server-side share. The share unmount returns **EBUSY (16)** because the NFSv4 server still holds VFS handles.
2. It holds them because `DESTROY_CLIENTID` was **refused**. A diagnostic on the refusal path fires on exactly the runs that fail and on **none** that pass. A second diagnostic naming the leased-state category reports **`opens`** — not delegations, layouts or locks.
3. **The refusal is correct.** RFC 8881 §18.50.3 makes `NFS4ERR_CLIENTID_BUSY` a MUST while opens remain on the lease — and opens did remain: this client's own CLOSEs had not been processed when `DESTROY_CLIENTID` overtook them.
4. `chimera_nfs4_umount_destroy_clientid_callback` logged that at **debug** and carried on. Its own comment says what that costs: *"the server will expire the clientid with the lease."*
5. `nfs_client_expire_state` has exactly one caller — the lease reaper — and `NFS4_LEASE_TIME_DEFAULT_S` is **90**.
6. The harness retries the share unmount 15 times against a ~1 s umount timeout, giving up after **~15 s**. Against a 90 s lease it cannot win.

## The fix

A `CLIENTID_BUSY` at umount is retried — 50 ms apart, up to 40 attempts (~2 s) — rather than accepted.

That is the right response **specifically because the residue is in-flight CLOSEs**: the condition clears itself in milliseconds. Had it been genuinely held state, retrying would spin to the same lease expiry and change nothing — which is why identifying the category mattered before writing this.

The bound sits far inside both the harness's ~15 s and the 90 s lease, so a client that really is holding state falls through to the existing behaviour after ~2 s rather than hanging.

The give-up log moves from `debug` to `error`. Reaching it means the export cannot be unmounted for the next 90 seconds — worth stating rather than leaving to be inferred from EBUSY symptoms two days later, which is exactly how this went unexplained.

## Verification — honestly

**This was not reproduced-and-fixed locally.** The race needs contention: it fired 4 times in ~50 runs while the machine was loaded, then went **30-for-30 clean** when idle, and a run under synthetic load produced **zero** `CLIENTID_BUSY` refusals — so the retry path never executed and that run proved nothing. CI reproduces this far more readily than my machine does.

What *is* verified:
- the mechanism above, end to end, from both client and server;
- the nfs4 MBT batch and nfs4 suites still pass with the change;
- the retry is bounded, so a wrong guess about transience costs 2 seconds, not a hang.

**Whether the flake stops is for CI to answer.** I'm proposing it now rather than holding for a local repro because it is actively blocking the merge queue.
