### PR TITLE
nfs: seventeen small conformance fixes

### DIFF
--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -94,7 +94,20 @@ nfs_fh_key_init(
         return;
     }
 
-    if (hexkey && strlen(hexkey) == 32) {
+    if (hexkey && *hexkey) {
+        /* A configured key that is not exactly 32 hex chars is a typo, not a
+         * request to fall back: silently ignoring it would leave each node
+         * with its own persisted/random key, so handles minted on one node
+         * fail verification on another.  Fail the same way a bad hex digit
+         * does, loudly and with signing off. */
+        if (strlen(hexkey) != 32) {
+            chimera_nfs_error("nfs_fh_key must be 32 hex chars (128-bit key), "
+                              "got %zu; disabling FH signing",
+                              strlen(hexkey));
+            shared->fh_sign = 0;
+            return;
+        }
+
         for (i = 0; i < 16; i++) {
             unsigned int byte;
             if (sscanf(hexkey + i * 2, "%2x", &byte) != 1) {

--- a/src/server/nfs/nfs3_proc_create.c
+++ b/src/server/nfs/nfs3_proc_create.c
@@ -75,8 +75,14 @@ chimera_nfs3_create_exclusive_verify(
     uint32_t            verf_atime, verf_mtime;
 
     if (error_code != CHIMERA_VFS_OK) {
+        /* The name is taken and the re-open could not read it back to compare
+         * verifiers.  Whatever the re-open itself hit, the answer the client
+         * needs is that the exclusive CREATE lost, so the status stays EEXIST:
+         * a passthrough backend fails the re-open of an existing directory
+         * with EISDIR, which is not an answer to "did my CREATE succeed".
+         * Carry dir_wcc, which RFC 1813 3.3.8 requires even on failure. */
         chimera_nfs3_create_reply(req, CHIMERA_VFS_EEXIST,
-                                  NULL, NULL, NULL, NULL);
+                                  NULL, NULL, dir_pre_attr, dir_post_attr);
         return;
     }
 
@@ -90,7 +96,7 @@ chimera_nfs3_create_exclusive_verify(
     } else {
         chimera_vfs_release(req->thread->vfs_thread, handle);
         chimera_nfs3_create_reply(req, CHIMERA_VFS_EEXIST,
-                                  NULL, NULL, NULL, NULL);
+                                  NULL, NULL, dir_pre_attr, dir_post_attr);
     }
 } /* chimera_nfs3_create_exclusive_verify */
 

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -205,6 +205,11 @@ chimera_nfs4_attr2mask(
                     case FATTR4_SPACE_USED:
                         attr_mask |= CHIMERA_VFS_ATTR_SPACE_USED;
                         break;
+                    case FATTR4_TIME_CREATE:
+                        /* Birth time is optional in the VFS, so backends fill
+                         * it only when it is asked for by name. */
+                        attr_mask |= CHIMERA_VFS_ATTR_BTIME;
+                        break;
                     default:
                         break;
                 } /* switch */
@@ -505,6 +510,7 @@ chimera_nfs4_marshall_attrs(
                                             (1UL << (FATTR4_SPACE_USED - 32)) |
                                             (1UL << (FATTR4_TIME_ACCESS - 32)) |
                                             (1UL << (FATTR4_TIME_ACCESS_SET - 32)) |
+                                            (1UL << (FATTR4_TIME_CREATE - 32)) |
                                             (1UL << (FATTR4_TIME_MODIFY - 32)) |
                                             (1UL << (FATTR4_TIME_MODIFY_SET - 32)) |
                                             (1UL << (FATTR4_TIME_METADATA - 32)) |
@@ -888,6 +894,20 @@ chimera_nfs4_marshall_attrs(
 
             chimera_nfs4_attr_append_uint64(&attrs, attr->va_atime.tv_sec);
             chimera_nfs4_attr_append_uint32(&attrs, attr->va_atime.tv_nsec);
+        }
+
+        /* time_create (RFC 7530 §5.7) is emitted between time_access (47) and
+         * time_metadata (52) to keep the attribute values in ascending bitmap
+         * order.  Only backends that track a real birth time set BTIME, so a
+         * backend without one simply leaves the bit out of the response
+         * bitmap, as for any other attribute it cannot supply. */
+        if ((req_mask[1] & (1 << (FATTR4_TIME_CREATE - 32))) &&
+            (attr->va_set_mask & CHIMERA_VFS_ATTR_BTIME)) {
+            rsp_mask[1]  |= (1 << (FATTR4_TIME_CREATE - 32));
+            *num_rsp_mask = 2;
+
+            chimera_nfs4_attr_append_uint64(&attrs, attr->va_btime.tv_sec);
+            chimera_nfs4_attr_append_uint32(&attrs, attr->va_btime.tv_nsec);
         }
 
         if ((req_mask[1] & (1 << (FATTR4_TIME_METADATA - 32))) &&

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -241,8 +241,6 @@ chimera_nfs4_mask2attr(
     uint32_t                 *req_mask,
     uint32_t                 *rsp_mask)
 {
-    int max_word_used = 0;
-
     /*
      * num_req_mask is the client-supplied request bitmap length and is
      * unbounded (the XDR decoder does not cap it).  This routine only ever
@@ -259,32 +257,57 @@ chimera_nfs4_mask2attr(
     if (num_req_mask >= 2 &&
         (req_mask[1] & (1 << (FATTR4_MODE - 32))) &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
-        rsp_mask[1]  |= (1 << (FATTR4_MODE - 32));
-        max_word_used = 2;
+        rsp_mask[1] |= (1 << (FATTR4_MODE - 32));
     }
 
     if (num_req_mask >= 1 &&
         (req_mask[0] & (1 << FATTR4_SIZE)) &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_SIZE)) {
-        rsp_mask[0]  |= (1 << FATTR4_SIZE);
-        max_word_used = 1;
+        rsp_mask[0] |= (1 << FATTR4_SIZE);
+    }
+
+    if (num_req_mask >= 1 &&
+        (req_mask[0] & (1 << FATTR4_ACL)) &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_ACL)) {
+        rsp_mask[0] |= (1 << FATTR4_ACL);
+    }
+
+    if (num_req_mask >= 2 &&
+        (req_mask[1] & (1 << (FATTR4_OWNER - 32))) &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_UID)) {
+        rsp_mask[1] |= (1 << (FATTR4_OWNER - 32));
+    }
+
+    if (num_req_mask >= 2 &&
+        (req_mask[1] & (1 << (FATTR4_OWNER_GROUP - 32))) &&
+        (attr->va_set_mask & CHIMERA_VFS_ATTR_GID)) {
+        rsp_mask[1] |= (1 << (FATTR4_OWNER_GROUP - 32));
     }
 
     if (num_req_mask >= 2 &&
         (req_mask[1] & (1 << (FATTR4_TIME_ACCESS_SET - 32))) &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_ATIME)) {
-        rsp_mask[1]  |= (1 << (FATTR4_TIME_ACCESS_SET - 32));
-        max_word_used = 2;
+        rsp_mask[1] |= (1 << (FATTR4_TIME_ACCESS_SET - 32));
     }
 
     if (num_req_mask >= 2 &&
         (req_mask[1] & (1 << (FATTR4_TIME_MODIFY_SET - 32))) &&
         (attr->va_set_mask & CHIMERA_VFS_ATTR_MTIME)) {
-        rsp_mask[1]  |= (1 << (FATTR4_TIME_MODIFY_SET - 32));
-        max_word_used = 2;
+        rsp_mask[1] |= (1 << (FATTR4_TIME_MODIFY_SET - 32));
     }
 
-    return max_word_used;
+    /*
+     * Derive the reply bitmap length from the words actually set rather than
+     * tracking it as each block runs: a per-block assignment is order
+     * dependent, and a word-0 attribute reported after a word-1 one (SIZE after
+     * MODE, say) would shorten the bitmap back to one word and drop the word-1
+     * attributes the client just set.
+     */
+    if (rsp_mask[1]) {
+        return 2;
+    }
+
+    return rsp_mask[0] ? 1 : 0;
 } /* chimera_nfs4_mask2attr */
 
 static inline void

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -167,13 +167,13 @@ chimera_nfs4_attr2mask(
                         attr_mask |= CHIMERA_VFS_ATTR_FSID;
                         break;
                     case FATTR4_FILES_AVAIL:
-                        attr_mask |= CHIMERA_VFS_ATTR_SPACE_AVAIL;
+                        attr_mask |= CHIMERA_VFS_ATTR_FILES_AVAIL;
                         break;
                     case FATTR4_FILES_FREE:
-                        attr_mask |= CHIMERA_VFS_ATTR_SPACE_FREE;
+                        attr_mask |= CHIMERA_VFS_ATTR_FILES_FREE;
                         break;
                     case FATTR4_FILES_TOTAL:
-                        attr_mask |= CHIMERA_VFS_ATTR_SPACE_TOTAL;
+                        attr_mask |= CHIMERA_VFS_ATTR_FILES_TOTAL;
                         break;
                     case FATTR4_UNIQUE_HANDLES:
                         attr_mask |= CHIMERA_VFS_ATTR_INUM;
@@ -758,7 +758,7 @@ chimera_nfs4_marshall_attrs(
         }
 
         if (req_mask[0] & (1 << FATTR4_FILES_AVAIL) &&
-            (attr->va_set_mask & CHIMERA_VFS_ATTR_FILES_FREE)) {
+            (attr->va_set_mask & CHIMERA_VFS_ATTR_FILES_AVAIL)) {
             rsp_mask[0]  |= (1 << FATTR4_FILES_AVAIL);
             *num_rsp_mask = 1;
 

--- a/src/server/nfs/nfs4_op_matrix.h
+++ b/src/server/nfs/nfs4_op_matrix.h
@@ -227,6 +227,14 @@ nfs4_op_check_minor(
         return NFS4ERR_OP_ILLEGAL;
     }
 
+    /* RFC 7530 16.2: in a v4.0 COMPOUND an opnum past the last legal v4.0 op
+     * must be reported OP_ILLEGAL.  This has to precede the "in range but not
+     * in the matrix" NOTSUPP below, which would otherwise claim the 4.1+ ops
+     * we deliberately leave unimplemented (GET_DIR_DELEGATION, WANT_DELEGATION). */
+    if (minor == 0 && op > OP_RELEASE_LOCKOWNER) {
+        return NFS4ERR_OP_ILLEGAL;
+    }
+
     info = &nfs4_op_support[op];
 
     if (info->minors == 0) {

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -290,7 +290,11 @@ chimera_nfs4_encode_ff_layout(
      * §5.1).  ffds_group is constant across iomodes. */
     const char   *ffds_user = (iomode == LAYOUTIOMODE4_RW) ? "0" : "1";
 
-    pnfs_put_u64(&p, NFS4_PNFS_STRIPE_UNIT);          /* ffl_stripe_unit       */
+    /* One mirror holding the whole segment on one data server is a stripe
+     * count of one, and RFC 8435 §5.1 requires ffl_stripe_unit to default to
+     * zero in that case; a non-zero unit would let a strict client compute a
+     * data-server index the layout does not have. */
+    pnfs_put_u64(&p, 0);                              /* ffl_stripe_unit       */
 
     pnfs_put_u32(&p, 1);                              /* ffl_mirrors<> count   */
     pnfs_put_u32(&p, 1);                              /* ffm_data_servers<>    */

--- a/src/server/nfs/nfs4_proc_bind_conn_to_session.c
+++ b/src/server/nfs/nfs4_proc_bind_conn_to_session.c
@@ -46,8 +46,10 @@ chimera_nfs4_bind_conn_to_session(
     channel_dir_from_server4          reply_dir;
 
     /* BIND_CONN_TO_SESSION MUST be the only operation in the COMPOUND
-     * (RFC 8881 §18.34.3, §15.1.3.3); it is never preceded by SEQUENCE. */
-    if (!req->seen_sequence && req->args_compound->num_argarray != 1) {
+     * (RFC 8881 §18.34.3, §15.1.3.3).  The rule is unconditional, so a
+     * SEQUENCE-prefixed compound is rejected too -- SEQUENCE itself already
+     * makes num_argarray > 1. */
+    if (req->args_compound->num_argarray != 1) {
         res->bctsr_status = NFS4ERR_NOT_ONLY_OP;
         chimera_nfs4_compound_complete(req, NFS4ERR_NOT_ONLY_OP);
         return;

--- a/src/server/nfs/nfs4_proc_delegreturn.c
+++ b/src/server/nfs/nfs4_proc_delegreturn.c
@@ -42,6 +42,20 @@ chimera_nfs4_delegreturn(
         return;
     }
 
+    /* A delegation stateid designates state held only by the client it was
+     * granted to, so presenting it from another client names no valid state
+     * and must not tear the delegation down (RFC 7530 §9.1.4 / §16.6). */
+    status = nfs_state_check_client(
+        state_void, state_type,
+        req->session ? req->session->client_unified : NULL);
+    if (status != NFS4_OK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->status = status;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
     deleg = state_void;
 
     /* Release the claim now so a conflicting open/IO awaiting the recall can

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -16,6 +16,7 @@
 #include "vfs/vfs_claim.h"
 #include "vfs/sdk/vfs_access.h"
 #include "vfs/sdk/vfs_acl.h"
+#include "vfs/vfs_idmap.h"
 
 /*
  * Acquire a cross-protocol SHARE reservation in the claim core for a freshly
@@ -151,7 +152,9 @@ chimera_nfs4_open_grant_delegation(
     bool                              exists = false;
     uint8_t                           deleg_type;
     struct nfsace4                   *perms;
-    static const char                 everyone[] = "EVERYONE@";
+    struct chimera_principal          who;
+    char                             *who_str;
+    int                               who_len;
 
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
@@ -299,11 +302,35 @@ chimera_nfs4_open_grant_delegation(
         perms                               = &res->resok4.delegation.read.permissions;
     }
 
+    /* RFC 7530 §16.16: the permissions ACE names the users that may open the
+     * delegated file without an ACCESS call.  It therefore has to name the
+     * principal this delegation was handed to and carry the rights the
+     * delegation actually conveys: an EVERYONE@ ACE invites the client to skip
+     * the server's per-user check for every other local user, and READ_DATA on
+     * a write delegation sends the holder back for an ACCESS round trip to
+     * write -- the very round trip the field exists to eliminate.  The who
+     * string is rendered like FATTR4_OWNER (numeric form, no domain) and lives
+     * in the reply's dbuf so it outlives this frame. */
+    who     = chimera_idmap_uid_principal(req->cred.uid);
+    who_str = xdr_dbuf_alloc_space(CHIMERA_IDMAP_WHO_MAX,
+                                   req->encoding->dbuf);
+    chimera_nfs_abort_if(who_str == NULL, "Failed to allocate space");
+    who_len = chimera_idmap_principal_to_who(&who, NULL, who_str,
+                                             CHIMERA_IDMAP_WHO_MAX);
+
     perms->type        = ACE4_ACCESS_ALLOWED_ACE_TYPE;
     perms->flag        = 0;
-    perms->access_mask = ACE4_READ_DATA;
-    perms->who.len     = sizeof(everyone) - 1;
-    perms->who.data    = (void *) everyone;
+    perms->access_mask = ACE4_GENERIC_READ;
+
+    if (deleg_type == OPEN_DELEGATE_WRITE) {
+        /* The data/attribute rights a write delegation conveys; not WRITE_ACL
+         * or WRITE_OWNER, which it does not. */
+        perms->access_mask |= ACE4_WRITE_DATA | ACE4_APPEND_DATA |
+            ACE4_WRITE_ATTRIBUTES;
+    }
+
+    perms->who.len  = who_len > 0 ? who_len : 0;
+    perms->who.data = who_str;
     return false;
 } /* chimera_nfs4_open_grant_delegation */
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -1131,6 +1131,44 @@ chimera_nfs4_open_claim_fh_complete(
     chimera_nfs4_open_complete(req, NFS4_OK);
 } /* chimera_nfs4_open_claim_fh_complete */
 
+/*
+ * Validate the delegate_stateid an OPEN with CLAIM_DELEGATE_CUR cites (RFC
+ * 7530 §16.16 / §10.4.3).  The claim asserts the caller already holds a
+ * delegation on the file, so the stateid has to resolve to a live delegation
+ * of this very client; a stateid that designates no such state is
+ * NFS4ERR_BAD_STATEID (or STALE_STATEID/EXPIRED, as the table decides) rather
+ * than something to quietly serve as an ordinary open.
+ */
+static nfsstat4
+chimera_nfs4_open_check_delegate_cur(struct nfs_request *req)
+{
+    struct chimera_server_nfs_thread *thread = req->thread;
+    struct OPEN4args                 *args   = &req->args_compound->argarray[req->index].opopen;
+    struct nfs_state_table           *table  = &thread->shared->nfs4_state_table;
+    void                             *state_void;
+    uint8_t                           state_type;
+    nfsstat4                          status;
+
+    status = nfs_state_table_acquire(table,
+                                     &args->claim.delegate_cur_info.delegate_stateid,
+                                     NFS4_SLOT_TYPE_DELEG,
+                                     &state_void,
+                                     &state_type);
+
+    if (status != NFS4_OK) {
+        return status;
+    }
+
+    status = nfs_state_check_client(
+        state_void, state_type,
+        req->session ? req->session->client_unified : NULL);
+
+    nfs_state_table_release(table, state_void, state_type,
+                            thread->vfs_thread);
+
+    return status;
+} /* chimera_nfs4_open_check_delegate_cur */
+
 static void
 chimera_nfs4_open_parent_complete(
     enum chimera_vfs_error          error_code,
@@ -1364,8 +1402,8 @@ chimera_nfs4_open_parent_complete(
             /* RFC 7530 §16.16: open of a file the client already holds a
              * delegation on, identified by name within the current FH's
              * directory.  Treat like CLAIM_NULL using the name carried in
-             * delegate_cur_info; the delegation the client cites is its own,
-             * so no recall is needed. */
+             * delegate_cur_info; the delegation the client cites must be its
+             * own -- verified below -- so no recall is needed. */
             status = chimera_nfs4_validate_name(&args->claim.delegate_cur_info.file);
             if (status != NFS4_OK) {
                 struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
@@ -1374,6 +1412,16 @@ chimera_nfs4_open_parent_complete(
                 chimera_nfs4_open_complete(req, status);
                 return;
             }
+
+            status = chimera_nfs4_open_check_delegate_cur(req);
+            if (status != NFS4_OK) {
+                struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
+                chimera_vfs_release(req->thread->vfs_thread, parent_handle);
+                res->status = status;
+                chimera_nfs4_open_complete(req, status);
+                return;
+            }
+
             if (args->openhow.opentype == OPEN4_NOCREATE) {
                 struct nfs4_open_lookup_regular_ctx *ctx;
 

--- a/src/server/nfs/nfs4_proc_reclaim_complete.c
+++ b/src/server/nfs/nfs4_proc_reclaim_complete.c
@@ -16,6 +16,15 @@ chimera_nfs4_reclaim_complete(
     struct RECLAIM_COMPLETE4args *args = &argop->opreclaim_complete;
     struct RECLAIM_COMPLETE4res  *res  = &resop->opreclaim_complete;
 
+    /* RFC 8881 §18.51.3: the per-filesystem form names its file system by the
+     * current filehandle, so rca_one_fs == TRUE with none established is
+     * NFS4ERR_NOFILEHANDLE.  The global form takes no filehandle at all. */
+    if (args->rca_one_fs && req->fhlen == 0) {
+        res->rcr_status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->rcr_status);
+        return;
+    }
+
     /* RFC 8881 §18.51.4: a second *global* (rca_one_fs == FALSE)
      * RECLAIM_COMPLETE for the same client is NFS4ERR_COMPLETE_ALREADY.  The
      * per-filesystem variant (rca_one_fs == TRUE) does not set that flag. */

--- a/src/server/nfs/nfs4_proc_set_ssv.c
+++ b/src/server/nfs/nfs4_proc_set_ssv.c
@@ -15,12 +15,12 @@
  * chimera declines SP4_SSV at EXCHANGE_ID (see nfs4_set_state_protect, which
  * falls back to SP4_NONE because the SSV-backed GSS credential is not
  * enforced), so a conforming client never negotiates SSV and never reaches
- * SET_SSV.  For any client that issues it anyway this remains a benign no-op:
- * we accept the contribution and complete the exchange.  ssr_digest is the
- * server's proof-of-knowledge over the SEQUENCE reply; it is returned empty
- * because no SSV is in effect (clients that do not verify it -- e.g. pynfs
- * EID50 -- are unaffected).  Full SSV enforcement (storing the SSV, computing
- * the HMAC digest, binding RPCSEC_GSS credentials) is deferred.
+ * SET_SSV.  A client that issues it anyway is told so: §18.47.3 makes SET_SSV
+ * NFS4ERR_INVAL unless the client opted for SP4_SSV, which is what the
+ * negotiated mode recorded on the client record (nfs4_client_sp_how) says.
+ * Full SSV support (storing the SSV, computing the ssr_digest HMAC, binding
+ * RPCSEC_GSS credentials) is deferred; until it exists no client reaches the
+ * success path below.
  */
 void
 chimera_nfs4_set_ssv(
@@ -29,14 +29,35 @@ chimera_nfs4_set_ssv(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct SET_SSV4args *args = &argop->opset_ssv;
-    struct SET_SSV4res  *res  = &resop->opset_ssv;
-
-    (void) thread;
+    struct chimera_server_nfs_shared *shared = thread->shared;
+    struct SET_SSV4args              *args   = &argop->opset_ssv;
+    struct SET_SSV4res               *res    = &resop->opset_ssv;
+    bool                              ssv_negotiated;
 
     /* SET_SSV is only meaningful inside a session (RFC 8881 §18.47.3). */
     if (!req->session) {
         res->ssr_status = NFS4ERR_OP_NOT_IN_SESSION;
+        chimera_nfs4_compound_complete(req, res->ssr_status);
+        return;
+    }
+
+    /* RFC 8881 §18.47.3: SET_SSV MUST NOT be used by a client that did not opt
+     * for SP4_SSV state protection at EXCHANGE_ID; the server returns
+     * NFS4ERR_INVAL. */
+    {
+        struct nfs4_client *c;
+
+        pthread_mutex_lock(&shared->nfs4_shared_clients.nfs4_ct_lock);
+        HASH_FIND(nfs4_client_hh_by_id,
+                  shared->nfs4_shared_clients.nfs4_ct_clients_by_id,
+                  &req->session->nfs4_session_clientid,
+                  sizeof(req->session->nfs4_session_clientid), c);
+        ssv_negotiated = c && c->nfs4_client_sp_how == SP4_SSV;
+        pthread_mutex_unlock(&shared->nfs4_shared_clients.nfs4_ct_lock);
+    }
+
+    if (!ssv_negotiated) {
+        res->ssr_status = NFS4ERR_INVAL;
         chimera_nfs4_compound_complete(req, res->ssr_status);
         return;
     }

--- a/src/server/nfs/nfs4_proc_test_stateid.c
+++ b/src/server/nfs/nfs4_proc_test_stateid.c
@@ -24,6 +24,17 @@ chimera_nfs4_test_stateid(
         sizeof(nfsstat4) * args->num_ts_stateids,
         req->encoding->dbuf);
 
+    /* ts_stateids<> is unbounded on the wire, so a large enough array does not
+     * fit the remaining response buffer.  Report that as REP_TOO_BIG (RFC 8881
+     * §18.48.3; NFS4ERR_RESOURCE is not a 4.1 error) rather than writing the
+     * per-stateid results through a NULL pointer. */
+    if (resok->tsr_status_codes == NULL) {
+        resok->num_tsr_status_codes = 0;
+        res->tsr_status             = NFS4ERR_REP_TOO_BIG;
+        chimera_nfs4_compound_complete(req, res->tsr_status);
+        return;
+    }
+
     for (i = 0; i < args->num_ts_stateids; i++) {
         nfsstat4 st = nfs_state_table_validate(table, &args->ts_stateids[i]);
 

--- a/src/server/nfs/nfs4_root.c
+++ b/src/server/nfs/nfs4_root.c
@@ -31,6 +31,12 @@ nfs4_root_getattr(
 
     memset(attr, 0, sizeof(*attr));
 
+    /* The FSID and statfs fills below are gated on va_req_mask, which the
+     * memset just cleared, so carry the caller's resolved mask into the attrs
+     * -- without it neither block ever runs and the pseudo-root answers a
+     * GETATTR for fsid (a REQUIRED attribute, RFC 7530 §5.6) or for any statfs
+     * attribute with the bit dropped from the returned bitmap. */
+    attr->va_req_mask = attr_mask;
     attr->va_set_mask = CHIMERA_VFS_ATTR_MASK_STAT;
 
     /* Synthetic root directory attribute */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -118,7 +118,10 @@ struct chimera_server_config {
     uint32_t                              anongid;
     uint32_t                              nfs_max_exports;   /* concurrent-export count cap */
     int                                   nfs_fh_sign;       /* sign wire file handles (default on) */
-    char                                  nfs_fh_key[33];    /* optional 32-hex-char (128-bit) signing key */
+    /* Optional 32-hex-char (128-bit) signing key.  Held with room to spare so
+     * an over-long key is not truncated into a well-formed one: NFS init
+     * validates the length and reports the mistake. */
+    char                                  nfs_fh_key[65];
     enum chimera_tcp_flavor               tcp_flavor;
     char                                  nfs_rdma_hostname[256];
     char                                  kv_module[64];

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4142,9 +4142,14 @@ memfs_write(
         left            -= block_len;
     }
 
+    /* Storage is allocated and charged a whole memfs block at a time, so the
+     * reported allocation rounds to the configured block size.  A fixed 4 KiB
+     * rounding understated the charge and disagreed with the truncate path
+     * (num_blocks * block_size), so va_space_used changed across a no-op
+     * truncate. */
     if (*p_size < request->write.offset + request->write.length) {
         *p_size       = request->write.offset + request->write.length;
-        *p_space_used = (*p_size + 4095) & ~4095;
+        *p_space_used = (*p_size + block_mask) & ~(uint64_t) block_mask;
     }
 
     inode->mtime = now;
@@ -5554,9 +5559,10 @@ memfs_write_same(
         block_offset = 0;
     }
 
+    /* Round the reported allocation to the block size, as memfs_write does. */
     if (*p_size < offset + total) {
         *p_size       = offset + total;
-        *p_space_used = (*p_size + 4095) & ~4095;
+        *p_space_used = (*p_size + block_mask) & ~(uint64_t) block_mask;
     }
 
     inode->mtime = now;

--- a/src/vfs/vfs_access.c
+++ b/src/vfs/vfs_access.c
@@ -23,7 +23,10 @@ chimera_vfs_access_check(
     int                       is_dir;
 
     /* AUTH_NONE means the caller did not establish an identity; treat as a
-     * full grant (the protocol layer is responsible for export-level policy). */
+     * full grant (the protocol layer is responsible for export-level policy).
+     * Anonymous access is therefore an export-level decision only: an
+     * ANONYMOUS@ ACE on an object is never consulted for such a caller, so a
+     * DENY ANONYMOUS@ ACE cannot restrict one. */
     if (cred->flavor == CHIMERA_VFS_AUTH_NONE) {
         return requested;
     }

--- a/src/vfs/vfs_acl.c
+++ b/src/vfs/vfs_acl.c
@@ -94,6 +94,14 @@ ace_applies(
                      * AUTH_NONE is short-circuited to a full grant before ACL
                      * evaluation, so a cred reaching here is authenticated. */
                     return cred->flavor != CHIMERA_VFS_AUTH_NONE;
+                case CHIMERA_WHO_ANONYMOUS:
+                    /* ANONYMOUS@ (S-1-5-7) is the complement of AUTHENTICATED@:
+                     * it matches only a caller with no established identity.
+                     * Anonymous policy is enforced at the export level, which
+                     * short-circuits AUTH_NONE to a full grant before ACL
+                     * evaluation, so an ANONYMOUS@ ACE on an object matches no
+                     * caller that reaches here (RFC 7530 §6.2.1.5). */
+                    return cred->flavor == CHIMERA_VFS_AUTH_NONE;
                 case CHIMERA_WHO_OWNER_RIGHTS:
                     /* OWNER RIGHTS matches the caller when it is the owner. */
                     return (uint64_t) cred->uid == owner_uid;


### PR DESCRIPTION
A sweep of the narrowly-scoped NFS issues: 25 candidates investigated, **17 fixed**, one commit each. Nothing here is architectural — every commit is a missing check, a wrong constant, or an attribute that already exists in the VFS and was simply never reported.

### NFSv4 state and session rules
| | |
|---|---|
| #1414 | DELEGRETURN accepted a delegation stateid belonging to another client |
| #1416 | CLAIM_DELEGATE_CUR ignored `delegate_stateid` entirely |
| #1413 | delegation `permissions` ACE was hardcoded `EVERYONE@ ALLOW READ_DATA`; now names the holder and its actual rights |
| #1420 | SET_SSV accepted from a client that never negotiated SP4_SSV |
| #1419 | BIND_CONN_TO_SESSION sole-op rule was skipped whenever SEQUENCE was present |
| #1422 | RECLAIM_COMPLETE `rca_one_fs` didn't require a current filehandle |
| #1418 | TEST_STATEID dereferenced its result array without checking the allocation |

### Attributes and the wire
| | |
|---|---|
| #961 | SETATTR `attrsset` omitted OWNER, OWNER_GROUP and ACL, so a successful chown came back looking ignored |
| #1408 | FATTR4_TIME_CREATE never exposed although the VFS tracks btime and SMB already reports it |
| #1407 | pseudo-root GETATTR dropped the requested mask, so fsid/statfs attributes never came back |
| #996 | VERIFY requested the SPACE_* attributes while checking the FILES_* ones |
| #1379 | `ffl_stripe_unit` advertised 1 MiB for a single-stripe flex layout |
| #1410 | in-range NFSv4.0 opnums absent from the matrix returned NOTSUPP instead of OP_ILLEGAL |
| #1400 | failed EXCLUSIVE CREATE returned empty `wcc_data` and forced EEXIST over the real error |

### VFS and configuration
| | |
|---|---|
| #1482 | memfs rounded write-path `space_used` to a hardcoded 4 KiB while charging a full block, so the value changed under a client after a no-op truncate |
| #1217 | a misconfigured `nfs_fh_key` was silently ignored rather than reported |
| #1406 | ANONYMOUS@ ACEs were inert in the ACL evaluator |

## Notes for review

**#961 goes slightly beyond its issue, deliberately.** Besides adding the three missing attributes it replaces `chimera_nfs4_mask2attr`'s per-block length bookkeeping with a length derived from the words actually set. The old form was order-dependent — a word-0 attribute reported after a word-1 one truncated the bitmap back to one word — and adding an ACL (word 0) block would have made that reachable. All five callers allocate a 4-word buffer. CREATE/OPEN `attrset` replies can now legitimately be two words where they were one.

**#1482 changes a reported value.** memfs `va_space_used` is now block-size granular (64 KiB default) rather than 4 KiB, which is what memfs actually charges and what the truncate path already reported. The quick tier is unaffected; a golden AllocationSize or `used` value in the extended tier is the thing to watch.

**#1408 advertises time_create server-wide** while only memfs/diskfs/cairn set BTIME, so on linux/io_uring it is requested and then omitted from the response bitmap — the same shape as the existing RAWDEV handling.

**#1406 is behaviour-neutral by construction** (an AUTH_NONE cred never reaches the ACL evaluator); it closes a latent case and documents the boundary.

## Not fixed, and why

Seven candidates were investigated and deliberately left alone rather than patched: #1402 and #1429 (need a paired `ext/specs` model change or a new policy constant), #1403 (a runtime default change), #1405 (lives in the libevpl submodule), #1417 and #1431 (documented deliberate behaviour matching Linux nfsd / POSIX `lseek`), and #1480, which turned out to be **already fixed** — the misleading comment it describes is gone, so it can simply be closed.

**#1423 is left out on purpose.** A fix was written, but the repo's own model (`ext/specs/quint/nfs/nfs4_ops.qnt:1442`) reads RFC 8881 §18.50.3 as *requiring* the positional restriction the issue calls over-strict. The issue and the model make opposite claims about the same paragraph, and that needs a decision rather than a patch.

## Testing

Quick tier green (97/97), Debug and Release both build clean, and every commit is uncrustify-clean. Each fix was written against current `main` and cherry-picked onto it.