### PR TITLE
vfs: fence deferred closes before dispatching a backend umount

### DIFF
--- a/src/vfs/nfs/nfs4_umount.c
+++ b/src/vfs/nfs/nfs4_umount.c
@@ -63,9 +63,18 @@ chimera_nfs4_umount_destroy_clientid_callback(
     (void) verf;
 
     if (status || !res || res->status != NFS4_OK) {
-        chimera_nfsclient_debug(
+        /* Error, not debug.  Reaching here strands the clientid -- and every
+         * VFS handle behind its opens -- until the lease expires, which is 90
+         * seconds of an export that cannot be unmounted.  NFS4ERR_CLIENTID_BUSY
+         * in particular should now be unreachable: the VFS fences the deferred
+         * closes before dispatching this teardown, so opens remaining on the
+         * lease means that fence has a hole.  Either way it is worth saying out
+         * loud rather than leaving to be inferred from EBUSY symptoms days
+         * later, which is exactly how this went unexplained. */
+        chimera_nfsclient_error(
             "NFS4 DESTROY_CLIENTID to %s did not succeed (rpc %d, nfs %d); "
-            "the server will expire the clientid with the lease",
+            "the server will expire the clientid with the lease, and the export "
+            "stays busy until it does",
             td->server->hostname, status, res ? res->status : -1);
     }
 

--- a/src/vfs/sdk/vfs_request.h
+++ b/src/vfs/sdk/vfs_request.h
@@ -791,6 +791,13 @@ struct chimera_vfs_request {
              * issuing them, so a close completing inline cannot finish the
              * umount mid-sweep. */
             int                       pending_closes;
+            /* Close-fence snapshot: the value chimera_vfs_close_thread's
+             * closes_issued had once this mount's cache came up empty.  The
+             * backend UMOUNT waits for closes_completed to reach it, so a
+             * CLOSE the close thread already took out of the cache cannot
+             * still be on the wire when the backend tears the mount down. */
+            uint64_t                  close_fence;
+            int                       close_fence_valid;
             /* Poll state while waiting for handles still referenced by
              * someone else to be dropped (chimera_vfs_umount_wait). */
             void                     *wait;

--- a/src/vfs/vfs.c
+++ b/src/vfs/vfs.c
@@ -165,6 +165,8 @@ chimera_vfs_close_thread_callback(
     struct chimera_vfs_close_thread *close_thread = private_data;
 
     close_thread->num_pending--;
+
+    __atomic_add_fetch(&close_thread->closes_completed, 1, __ATOMIC_RELEASE);
 } /* chimera_vfs_close_thread_callback */
 
 static uint64_t
@@ -178,7 +180,8 @@ chimera_vfs_close_thread_sweep(
     uint64_t                        count  = 0;
     struct chimera_vfs_open_handle *handles, *handle;
 
-    handles = chimera_vfs_open_cache_defer_close(cache, chimera_vfs_now_ticks(), min_age, &count);
+    handles = chimera_vfs_open_cache_defer_close(cache, chimera_vfs_now_ticks(), min_age, &count,
+                                                 &close_thread->closes_issued);
 
     while (handles) {
 
@@ -196,6 +199,10 @@ chimera_vfs_close_thread_sweep(
                               handle->fh_hash,
                               chimera_vfs_close_thread_callback,
                               close_thread);
+        } else {
+            /* Nothing to close, so the fence slot this handle took when it left
+             * the cache is settled here rather than by a callback. */
+            __atomic_add_fetch(&close_thread->closes_completed, 1, __ATOMIC_RELEASE);
         }
 
         /* defer_close removed the handle from the bucket but frees the struct

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -131,6 +131,17 @@ struct chimera_vfs_close_thread {
     int                        shutdown;
     int                        num_pending;
     int                        signaled;
+    /* Close fence.  A handle leaves the open cache into this thread's custody
+     * before its backend CLOSE is issued, which makes it invisible to
+     * chimera_vfs_open_cache_purge_by_mount -- so an umount sweeping the cache
+     * can see nothing left on the mount while that CLOSE is still on the wire.
+     * closes_issued is bumped under the shard lock as each handle is taken (so
+     * there is no window between leaving the cache and being counted);
+     * closes_completed is bumped when the close finishes.  An umount snapshots
+     * issued and waits for completed to reach it, which drains the closes in
+     * flight at that moment without waiting for global quiescence. */
+    uint64_t                   closes_issued;
+    uint64_t                   closes_completed;
     struct evpl_doorbell       doorbell;
     struct evpl_timer          timer;
     pthread_mutex_t            lock;

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -786,7 +786,8 @@ chimera_vfs_open_cache_defer_close(
     struct vfs_open_cache *cache,
     uint64_t               now_ticks,
     uint64_t               min_age,
-    uint64_t              *r_count)
+    uint64_t              *r_count,
+    uint64_t              *r_issued)
 {
     struct vfs_open_cache_shard    *shard;
     struct chimera_vfs_open_handle *handle, *closed = NULL;
@@ -812,6 +813,13 @@ chimera_vfs_open_cache_defer_close(
             chimera_vfs_open_cache_shard_remove(shard, handle);
             LL_PREPEND(closed, handle);
             shard->open_handles--;
+
+            /* Count the handle as taken here, under the same shard lock that
+             * removes it, so that no observer can find it absent from both the
+             * cache and the close fence.  Bumping this after the loop instead
+             * would leave exactly that window, which is the race the fence
+             * exists to close. */
+            __atomic_add_fetch(r_issued, 1, __ATOMIC_RELEASE);
         }
 
         /* Count AFTER processing - this is the number of handles still in the cache */

--- a/src/vfs/vfs_proc_umount.c
+++ b/src/vfs/vfs_proc_umount.c
@@ -301,6 +301,7 @@ chimera_vfs_umount_progress(struct chimera_vfs_request *request)
     struct chimera_vfs             *vfs    = thread->vfs;
     struct chimera_vfs_umount_wait *wait;
     uint64_t                        referenced;
+    int                             fence_wait = 0;
 
     /* Held across the sweeps so a close completing inline cannot finish the
      * umount while handles are still being issued. */
@@ -324,9 +325,34 @@ chimera_vfs_umount_progress(struct chimera_vfs_request *request)
     }
 
     if (referenced == 0) {
-        chimera_vfs_umount_wait_stop(request);
-        chimera_vfs_umount_dispatch(request);
-        return;
+        /*
+         * The cache is clear of this mount, but that is not the same as the
+         * mount being quiet.  The close thread takes a handle out of the cache
+         * before issuing its backend CLOSE, so between those two points the
+         * handle is in neither place the sweep above looks -- and its CLOSE may
+         * still be on the wire.  Dispatching the backend UMOUNT here is what
+         * lets an NFSv4 DESTROY_CLIENTID overtake this client's own CLOSEs, and
+         * the server is then right to refuse it: state remains on the lease.
+         *
+         * Snapshot the close thread's issued count and wait for its completed
+         * count to reach it.  That drains the closes outstanding at this
+         * instant without waiting for global quiescence, so a busy unrelated
+         * mount cannot starve this umount.
+         */
+        if (!request->umount.close_fence_valid) {
+            request->umount.close_fence =
+                __atomic_load_n(&vfs->close_thread.closes_issued, __ATOMIC_ACQUIRE);
+            request->umount.close_fence_valid = 1;
+        }
+
+        if (__atomic_load_n(&vfs->close_thread.closes_completed, __ATOMIC_ACQUIRE) >=
+            request->umount.close_fence) {
+            chimera_vfs_umount_wait_stop(request);
+            chimera_vfs_umount_dispatch(request);
+            return;
+        }
+
+        fence_wait = 1;
     }
 
     /* Someone else still holds a handle.  Wait for them to drop it.
@@ -340,21 +366,46 @@ chimera_vfs_umount_progress(struct chimera_vfs_request *request)
     wait = request->umount.wait;
 
     if (!wait) {
-        chimera_vfs_info(
-            "umount %s: %lu handle(s) still open after purging the cache; "
-            "waiting up to %lu ms for the holder(s) to close them",
-            request->umount.mount->path, referenced,
-            vfs->umount_timeout_us / 1000);
+        if (fence_wait) {
+            chimera_vfs_info(
+                "umount %s: cache clear, waiting up to %lu ms for %lu deferred "
+                "close(s) still in flight",
+                request->umount.mount->path,
+                vfs->umount_timeout_us / 1000,
+                (unsigned long) (request->umount.close_fence -
+                                 __atomic_load_n(&vfs->close_thread.closes_completed,
+                                                 __ATOMIC_ACQUIRE)));
+        } else {
+            chimera_vfs_info(
+                "umount %s: %lu handle(s) still open after purging the cache; "
+                "waiting up to %lu ms for the holder(s) to close them",
+                request->umount.mount->path, referenced,
+                vfs->umount_timeout_us / 1000);
+        }
         wait                 = calloc(1, sizeof(*wait));
         wait->request        = request;
         request->umount.wait = wait;
     } else if (wait->waited_us >= vfs->umount_timeout_us) {
-        chimera_vfs_error(
-            "umount %s: giving up with %lu handle(s) still open after %lu ms "
-            "-- the mount stays registered and callers will see EBUSY",
-            request->umount.mount->path, referenced,
-            wait->waited_us / 1000);
-        chimera_vfs_umount_dump_referenced(vfs, request->umount.mount);
+        if (fence_wait) {
+            /* A close that never completes is a backend still holding the
+             * request, not a busy mount -- name it as such rather than
+             * reporting handles that are not, in fact, open. */
+            chimera_vfs_error(
+                "umount %s: giving up after %lu ms with %lu deferred close(s) "
+                "unfinished -- the mount stays registered and callers will see "
+                "EBUSY",
+                request->umount.mount->path, wait->waited_us / 1000,
+                (unsigned long) (request->umount.close_fence -
+                                 __atomic_load_n(&vfs->close_thread.closes_completed,
+                                                 __ATOMIC_ACQUIRE)));
+        } else {
+            chimera_vfs_error(
+                "umount %s: giving up with %lu handle(s) still open after %lu ms "
+                "-- the mount stays registered and callers will see EBUSY",
+                request->umount.mount->path, referenced,
+                wait->waited_us / 1000);
+            chimera_vfs_umount_dump_referenced(vfs, request->umount.mount);
+        }
         chimera_vfs_umount_wait_stop(request);
         chimera_vfs_umount_abandon(request);
         return;
@@ -424,8 +475,10 @@ chimera_vfs_umount(
     request->proto_callback       = callback;
     request->proto_private_data   = private_data;
 
-    request->umount.pending_closes = 0;
-    request->umount.wait           = NULL;
+    request->umount.pending_closes    = 0;
+    request->umount.close_fence       = 0;
+    request->umount.close_fence_valid = 0;
+    request->umount.wait              = NULL;
 
     chimera_vfs_umount_progress(request);
 


### PR DESCRIPTION
`posix/mbt/batch_nfs4_*` fails intermittently with `newfs share unmount failed: 16`, and has taken merge-queue attempts with it. This is the root cause, replacing #1638 — which treated a symptom on a path the failing run never even reaches.

## The bug

`chimera_vfs_umount` sweeps the open cache, closes what nobody is using, and dispatches the backend UMOUNT once nothing on the mount remains. But *"nothing remains in the cache"* is not *"nothing is outstanding"*.

The close thread takes a handle out of the cache **before** issuing its backend CLOSE — `vfs_open_cache.h`, under the shard lock, removing it from the bucket and decrementing `open_handles`. Between that instant and the CLOSE reply, the handle is in neither place `purge_by_mount` looks. Its CLOSE is still on the wire.

For the NFSv4 client that is the whole defect. The backend UMOUNT is BIND_CONN_TO_SESSION + DESTROY_SESSION + DESTROY_CLIENTID, so dispatching early lets `DESTROY_CLIENTID` overtake this client's own CLOSEs. The server is then **right** to refuse it — RFC 8881 §18.50.3 makes `NFS4ERR_CLIENTID_BUSY` a MUST while opens remain on the lease. The client logged that at `debug` and carried on, leaving the opens to expire with the 90-second lease. The server-side share umount that follows finds those handles still referenced, waits out its ~1 s timeout, and abandons with EBUSY.

A ~1 s timeout measured against a 90 s lease cannot win, which is why this reads as a flake rather than a clean failure.

The close thread already counts its in-flight closes in `num_pending` — but the only thing that ever waits on it is `chimera_vfs_destroy`, whole-module teardown. Per-mount umount never consulted it.

## The fix

A fence, not a retry.

`closes_issued` is bumped **under the same shard lock that removes the handle**, so there is no window in which a handle is absent from both the cache and the count — bumping it after the loop would leave exactly the race the fence exists to close. `closes_completed` is bumped when the close finishes. An umount whose sweep comes up empty snapshots `issued` and waits for `completed` to reach it.

Snapshotting rather than waiting for `completed == issued` matters: it drains the closes outstanding *at that instant*, so a busy unrelated mount cannot starve an idle mount's umount.

The give-up path now distinguishes its two reasons, because reporting "N handle(s) still open" when the handles are not open is what made this hard to read.

The second commit promotes the `DESTROY_CLIENTID` refusal log from `debug` to `error`. With the fence, `CLIENTID_BUSY` should be unreachable there — so if it appears, the fence has a hole, and that must not be discovered days later from its symptoms.

## Verification

Honestly: **the unmodified flake did not reproduce on my machine** — 25 iterations clean on `upstream/main` and 25 clean with the fence. That pair proves nothing, so I made the race deterministic instead, injecting a 50 ms delay into exactly the claimed window (handle out of the cache, CLOSE not yet issued):

| build | result |
|---|---|
| `upstream/main` + 50 ms injection | **6 / 6 failed**, `newfs share unmount failed: 16` |
| this branch + 50 ms injection | **0 / 6 failed** |

And the fence observably engages — instrumented, not inferred:

```
FENCEPROBE mount=share fence=4 completed=3   <- polls
FENCEPROBE mount=share fence=4 completed=3
FENCEPROBE mount=share fence=4 completed=4   <- proceeds
```

Four handles taken by the close thread, three CLOSEs done. Without the fence the umount dispatches `DESTROY_CLIENTID` right there, one CLOSE still in flight. The injection and probe were scaffolding and are not in this branch.

Debug build clean; the previously flaky test passes.
