### PR TITLE
nfs: thirty NFSv3/v4 conformance and state-machine fixes

### DIFF
--- a/src/nfs_common/nfs3_attr.h
+++ b/src/nfs_common/nfs3_attr.h
@@ -260,11 +260,15 @@ chimera_nfs3_set_wcc_data(
         wcc->before.attributes_follow = 0;
     }
 
-    if (post_attr && post_attr->va_set_mask & CHIMERA_VFS_ATTR_ATOMIC) {
-        chimera_nfs3_set_post_op_attr(&wcc->after, post_attr);
-    } else {
-        wcc->after.attributes_follow = 0;
-    }
+    /* 'after' is an ordinary post_op_attr (RFC 1813 2.6): return it whenever
+     * the server has the post-operation attributes.  Atomicity governs only
+     * 'before' -- whether the pair can be trusted for strict cache
+     * consistency -- so gating 'after' on it would drop the whole wcc_data
+     * for every backend that cannot stat atomically with the operation
+     * (linux, io_uring), which is exactly the case where the client most
+     * needs the post-op state.  set_post_op_attr already suppresses itself
+     * when the backend did not actually fetch the attributes. */
+    chimera_nfs3_set_post_op_attr(&wcc->after, post_attr);
 } /* chimera_nfs3_set_wcc_data */
 
 static inline void

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -199,7 +199,8 @@ nfs_server_init(
 
     /* RPCSEC_GSS (Kerberos): register the acceptor keytab once at startup.
      * Per-thread provider registration happens in nfs_server_thread_init. */
-    if (chimera_server_config_get_nfs_kerberos_enabled(config)) {
+    shared->gss_enabled = chimera_server_config_get_nfs_kerberos_enabled(config);
+    if (shared->gss_enabled) {
         chimera_nfs_gss_init(chimera_server_config_get_nfs_kerberos_keytab(config));
         chimera_nfs_info("RPCSEC_GSS: Kerberos authentication enabled");
     }

--- a/src/server/nfs/nfs3_proc_access.c
+++ b/src/server/nfs/nfs3_proc_access.c
@@ -32,8 +32,15 @@ chimera_nfs3_access3_to_mask(uint32_t access)
     if (access & ACCESS3_EXTEND) {
         mask |= CHIMERA_ACE_APPEND_DATA;
     }
+    /* RFC 1813 §3.3.4: ACCESS3_DELETE is "delete an existing directory entry",
+     * a property of the directory being queried -- not of deleting that
+     * directory itself.  POSIX governs it with write+execute on the directory,
+     * which the engine exposes as DELETE_CHILD (CHIMERA_ACE_DELETE would ask
+     * whether the caller may unlink the directory from *its* parent, which an
+     * ACCESS on the directory cannot answer).  Matches knfsd's NFSD_MAY_REMOVE
+     * mapping in its nfs3_diraccess table. */
     if (access & ACCESS3_DELETE) {
-        mask |= CHIMERA_ACE_DELETE;
+        mask |= CHIMERA_ACE_DELETE_CHILD;
     }
     if (access & ACCESS3_EXECUTE) {
         mask |= CHIMERA_ACE_EXECUTE;
@@ -100,7 +107,7 @@ chimera_nfs3_access_complete(
         if ((access & ACCESS3_EXTEND) && (granted & CHIMERA_ACE_APPEND_DATA)) {
             res.resok.access |= ACCESS3_EXTEND;
         }
-        if ((access & ACCESS3_DELETE) && (granted & CHIMERA_ACE_DELETE)) {
+        if ((access & ACCESS3_DELETE) && (granted & CHIMERA_ACE_DELETE_CHILD)) {
             res.resok.access |= ACCESS3_DELETE;
         }
         if ((access & ACCESS3_EXECUTE) && (granted & CHIMERA_ACE_EXECUTE)) {

--- a/src/server/nfs/nfs3_proc_readdir.c
+++ b/src/server/nfs/nfs3_proc_readdir.c
@@ -77,6 +77,13 @@ chimera_nfs3_readdir_complete(
 
     res->status = chimera_vfs_error_to_nfsstat3(error_code);
 
+    /* RFC 1813 3.3.16: if count was too small to hold even a single entry and
+     * we are not at end-of-directory, report TOOSMALL.  An empty, non-eof
+     * reply would leave a paging client retrying the same request forever. */
+    if (res->status == NFS3_OK && !eof && cursor->entries == NULL) {
+        res->status = NFS3ERR_TOOSMALL;
+    }
+
     if (res->status == NFS3_OK) {
         chimera_nfs3_set_post_op_attr(&res->resok.dir_attributes, dir_attr);
         res->resok.reply.eof     = !!eof;

--- a/src/server/nfs/nfs3_proc_readdirplus.c
+++ b/src/server/nfs/nfs3_proc_readdirplus.c
@@ -105,6 +105,14 @@ chimera_nfs3_readdirplus_complete(
 
     res->status = chimera_vfs_error_to_nfsstat3(error_code);
 
+    /* RFC 1813 3.3.17: if maxcount/dircount were too small to hold even a
+     * single entry (dircount == 0 being the degenerate case) and we are not at
+     * end-of-directory, report TOOSMALL rather than an empty, non-eof reply
+     * that a paging client would retry forever. */
+    if (res->status == NFS3_OK && !eof && cursor->entries == NULL) {
+        res->status = NFS3ERR_TOOSMALL;
+    }
+
     if (res->status == NFS3_OK) {
         chimera_nfs3_set_post_op_attr(&res->resok.dir_attributes, dir_attr);
         res->resok.reply.eof     = !!eof;

--- a/src/server/nfs/nfs4_access.h
+++ b/src/server/nfs/nfs4_access.h
@@ -68,8 +68,14 @@ chimera_nfs4_access4_to_mask(uint32_t access)
     if (access & ACCESS4_EXTEND) {
         mask |= CHIMERA_ACE_APPEND_DATA;
     }
+    /* ACCESS4_DELETE is "delete an existing directory entry" and is meaningful
+     * only on a directory, so it asks about the entries *in* the queried
+     * directory -- POSIX write+execute on it, i.e. DELETE_CHILD.  Plain
+     * CHIMERA_ACE_DELETE would instead ask whether the directory itself may be
+     * unlinked from its parent, which ACCESS cannot see.  Same mapping as the
+     * NFSv3 handler. */
     if (access & ACCESS4_DELETE) {
-        mask |= CHIMERA_ACE_DELETE;
+        mask |= CHIMERA_ACE_DELETE_CHILD;
     }
     if (access & ACCESS4_EXECUTE) {
         mask |= CHIMERA_ACE_EXECUTE;
@@ -109,7 +115,7 @@ chimera_nfs4_access_from_granted(
     if ((requested & ACCESS4_EXTEND) && (granted & CHIMERA_ACE_APPEND_DATA)) {
         access |= ACCESS4_EXTEND;
     }
-    if ((requested & ACCESS4_DELETE) && (granted & CHIMERA_ACE_DELETE)) {
+    if ((requested & ACCESS4_DELETE) && (granted & CHIMERA_ACE_DELETE_CHILD)) {
         access |= ACCESS4_DELETE;
     }
     if ((requested & ACCESS4_EXECUTE) && (granted & CHIMERA_ACE_EXECUTE)) {

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -176,6 +176,7 @@ chimera_nfs4_attr2mask(
                         attr_mask |= CHIMERA_VFS_ATTR_SPACE_TOTAL;
                         break;
                     case FATTR4_UNIQUE_HANDLES:
+                    case FATTR4_MOUNTED_ON_FILEID:
                         attr_mask |= CHIMERA_VFS_ATTR_INUM;
                         break;
                     case FATTR4_LEASE_TIME:
@@ -485,6 +486,7 @@ chimera_nfs4_marshall_attrs(
                                             (1UL << (FATTR4_TIME_MODIFY - 32)) |
                                             (1UL << (FATTR4_TIME_MODIFY_SET - 32)) |
                                             (1UL << (FATTR4_TIME_METADATA - 32)) |
+                                            (1UL << (FATTR4_MOUNTED_ON_FILEID - 32)) |
                                             (1UL << (FATTR4_SPACE_AVAIL - 32)) |
                                             (1UL << (FATTR4_SPACE_FREE - 32)) |
                                             (1UL << (FATTR4_SPACE_TOTAL - 32)) |
@@ -883,6 +885,22 @@ chimera_nfs4_marshall_attrs(
 
             chimera_nfs4_attr_append_uint64(&attrs, attr->va_mtime.tv_sec);
             chimera_nfs4_attr_append_uint32(&attrs, attr->va_mtime.tv_nsec);
+        }
+
+        /* mounted_on_fileid (RFC 7530 5.8.2) is the fileid the parent
+        * directory's READDIR reports for this object.  Chimera grafts each
+        * export directly into the pseudo-fs root, and nfs4_root_readdir
+        * reports the export root's own fileid for that entry -- there is no
+        * separate junction inode -- so the mounted-on fileid IS the object's
+        * fileid at every boundary, and trivially so away from one.  Clients
+        * (notably Linux, which requests this on every crossing) need it to
+        * fill in d_ino for a mount point without a second GETATTR. */
+        if ((req_mask[1] & (1 << (FATTR4_MOUNTED_ON_FILEID - 32))) &&
+            (attr->va_set_mask & CHIMERA_VFS_ATTR_INUM)) {
+            rsp_mask[1]  |= (1 << (FATTR4_MOUNTED_ON_FILEID - 32));
+            *num_rsp_mask = 2;
+
+            chimera_nfs4_attr_append_uint64(&attrs, attr->va_ino);
         }
 
         /* fs_layout_types is server-static (no backing VFS attribute); emit it
@@ -1295,7 +1313,8 @@ chimera_nfs4_validate_createattrs(
         (1 << (FATTR4_TIME_ACCESS_SET - 32)) |
         (1 << (FATTR4_TIME_METADATA - 32)) |
         (1 << (FATTR4_TIME_MODIFY - 32)) |
-        (1 << (FATTR4_TIME_MODIFY_SET - 32));
+        (1 << (FATTR4_TIME_MODIFY_SET - 32)) |
+        (1 << (FATTR4_MOUNTED_ON_FILEID - 32));
 
     static const uint32_t writable_word0 =
         (1 << FATTR4_SIZE) |

--- a/src/server/nfs/nfs4_callback.c
+++ b/src/server/nfs/nfs4_callback.c
@@ -779,6 +779,7 @@ nfs4_cb_layoutrecall(
     const uint8_t                    *fh,
     uint32_t                          fh_len,
     uint16_t                          export_id,
+    uint32_t                          layout_type,
     const struct stateid4            *layout_stateid,
     void (                           *done )(
         int   cb_status,
@@ -816,8 +817,15 @@ nfs4_cb_layoutrecall(
         nops++;
     }
 
+    /* clora_type must echo the layouttype4 that was granted: the client matches
+     * a recall by {type, fh, iomode, range} and answers NFS4ERR_NOMATCHING_LAYOUT
+     * for a block/SCSI layout recalled as flex-files (RFC 8881 20.3). */
+    if (!layout_type) {
+        layout_type = NFS4_LAYOUT4_FLEX_FILES;
+    }
+
     ops[nops].argop                                        = OP_CB_LAYOUTRECALL;
-    ops[nops].opcblayoutrecall.clora_type                  = NFS4_LAYOUT4_FLEX_FILES;
+    ops[nops].opcblayoutrecall.clora_type                  = layout_type;
     ops[nops].opcblayoutrecall.clora_iomode                = LAYOUTIOMODE4_ANY;
     ops[nops].opcblayoutrecall.clora_changed               = 0;
     ops[nops].opcblayoutrecall.clora_recall.lor_recalltype = LAYOUTRECALL4_FILE;

--- a/src/server/nfs/nfs4_callback.h
+++ b/src/server/nfs/nfs4_callback.h
@@ -208,7 +208,9 @@ nfs4_find_conflicting_write_deleg(
  * use.  `done(cb_status, arg)` runs on completion: cb_status is the callback
  * compound status (NFS4_OK => the client will LAYOUTRETURN), or a negative
  * value on transport failure.  Returns false WITHOUT calling done if the client
- * has no usable callback channel (the caller should then revoke locally). */
+ * has no usable callback channel (the caller should then revoke locally).
+ * `layout_type` is the layouttype4 that was granted; the client matches the
+ * recall against its held layouts by type, so it must be the granted one. */
 bool
 nfs4_cb_layoutrecall(
     struct chimera_server_nfs_thread *thread,
@@ -216,6 +218,7 @@ nfs4_cb_layoutrecall(
     const uint8_t                    *fh,
     uint32_t                          fh_len,
     uint16_t                          export_id,
+    uint32_t                          layout_type,
     const struct stateid4            *layout_stateid,
     void (                           *done )(
         int   cb_status,

--- a/src/server/nfs/nfs4_cb.c
+++ b/src/server/nfs/nfs4_cb.c
@@ -149,7 +149,7 @@ nfs4_cb_recall_holder(
     ctx->fhlen = holder->fh_len;
 
     if (!nfs4_cb_layoutrecall(thread, client, holder->fh, holder->fh_len,
-                              holder->export_id,
+                              holder->export_id, holder->layout_type,
                               &recall_stateid, nfs4_cb_recall_done, ctx)) {
         chimera_nfs_error("CB: holder has no callback channel; revoking layout");
         free(ctx);

--- a/src/server/nfs/nfs4_layout_table.c
+++ b/src/server/nfs/nfs4_layout_table.c
@@ -167,3 +167,25 @@ nfs_layout_table_recall_prepare(
     pthread_mutex_unlock(&shard->lock);
     return n;
 } /* nfs_layout_table_recall_prepare */
+
+bool
+nfs_layout_table_recall_active(
+    struct nfs_layout_table *table,
+    const uint8_t           *fh,
+    uint16_t                 fh_len)
+{
+    struct nfs_layout_shard *shard = &table->shards[layout_shard_index(fh, fh_len)];
+    struct nfs_layout_entry *e;
+    bool                     active;
+
+    pthread_mutex_lock(&shard->lock);
+
+    /* The entry carries waiters only between recall_prepare and the last
+     * holder's deregistration, which frees the entry -- so a non-empty waiter
+     * list is exactly "a recall is outstanding on this file". */
+    HASH_FIND(hh, shard->by_fh, fh, fh_len, e);
+    active = (e && e->waiters);
+
+    pthread_mutex_unlock(&shard->lock);
+    return active;
+} /* nfs_layout_table_recall_active */

--- a/src/server/nfs/nfs4_layout_table.h
+++ b/src/server/nfs/nfs4_layout_table.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <uthash.h>
 
@@ -88,3 +89,15 @@ int nfs_layout_table_recall_prepare(
     struct nfs_layout_recall_waiter *waiter,
     struct nfs_layout_state        **out_holders,
     int                              max_holders);
+
+/*
+ * True while a recall started by nfs_layout_table_recall_prepare is still
+ * outstanding for fh (i.e. the file has deferred operations waiting for every
+ * holder to return).  LAYOUTGET consults this so it does not hand out a layout
+ * the in-progress recall has already snapshotted past
+ * (RFC 8881 §12.5.5.2 / §18.43.3: NFS4ERR_RECALLCONFLICT).
+ */
+bool nfs_layout_table_recall_active(
+    struct nfs_layout_table *table,
+    const uint8_t           *fh,
+    uint16_t                 fh_len);

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -538,6 +538,20 @@ ff_lg_fail(
     chimera_nfs4_compound_complete(req, status);
 } /* ff_lg_fail */
 
+/*
+ * XDR size of one layout4 carrying a loc_body of body_len bytes: lo_offset (8)
+ * + lo_length (8) + lo_iomode (4) + loc_type (4) + the loc_body opaque length
+ * prefix (4) plus the body padded to a 4-byte boundary.  loga_maxcount bounds
+ * this (RFC 8881 18.43.3: "the maximum layout size (in bytes) that the client
+ * can handle"); the array's own count word is left out so a client that sized
+ * its buffer for the layouts alone is not refused.
+ */
+static inline uint32_t
+lg_layout4_xdr_len(uint32_t body_len)
+{
+    return 28 + ((body_len + 3) & ~3u);
+} /* lg_layout4_xdr_len */
+
 static void
 ff_lg_emit(struct ff_layoutget_ctx *ctx)
 {
@@ -596,6 +610,19 @@ ff_lg_emit(struct ff_layoutget_ctx *ctx)
         native_fh_len = backing_fh_len - FF_BLOB_FH_SKIP;
     }
 
+    body = xdr_dbuf_alloc_space(256, req->encoding->dbuf);
+    chimera_nfs_abort_if(body == NULL, "Failed to allocate space");
+    body_len = chimera_nfs4_encode_ff_layout(body, deviceid, native_fh, native_fh_len,
+                                             args->loga_iomode);
+
+    /* Enforce loga_maxcount before taking any layout state: a LAYOUTGET that
+     * fails must leave nothing registered, or the server would hold a layout
+     * whose stateid the client never saw. */
+    if (lg_layout4_xdr_len(body_len) > args->loga_maxcount) {
+        ff_lg_fail(ctx, NFS4ERR_TOOSMALL);
+        return;
+    }
+
     client_short_id = (uint32_t) client->client_id;
 
     layout = nfs_layout_state_find(client, req->fh, req->fhlen);
@@ -621,11 +648,6 @@ ff_lg_emit(struct ff_layoutget_ctx *ctx)
     /* Open the client's callback channel so a later conflicting op can recall
      * this layout; CB_LAYOUTRECALL rides the shared delegation channel. */
     nfs4_cb_ensure_probe(req->thread, client, req);
-
-    body = xdr_dbuf_alloc_space(256, req->encoding->dbuf);
-    chimera_nfs_abort_if(body == NULL, "Failed to allocate space");
-    body_len = chimera_nfs4_encode_ff_layout(body, deviceid, native_fh, native_fh_len,
-                                             args->loga_iomode);
 
     lo = xdr_dbuf_alloc_space(sizeof(*lo), req->encoding->dbuf);
     chimera_nfs_abort_if(lo == NULL, "Failed to allocate space");
@@ -807,6 +829,7 @@ lg_sourced_cb(
     struct nfs_client       *client = req->session ? req->session->client_unified : NULL;
     struct nfs_layout_state *layout;
     uint32_t                 client_short_id, i, loc_type;
+    uint32_t                 layouts_len = 0;
 
     if (error_code != CHIMERA_VFS_OK) {
         ff_lg_fail(ctx, chimera_nfs4_errno_to_nfsstat4(error_code));
@@ -839,29 +862,6 @@ lg_sourced_cb(
         nfs_pnfs_devcache_put(&req->thread->shared->nfs4_pnfs_devcache, &devices[i]);
     }
 
-    client_short_id = (uint32_t) client->client_id;
-    layout          = nfs_layout_state_find(client, req->fh, req->fhlen);
-    if (layout) {
-        /* See ff_lg_emit(): widen an existing READ layout to RW. */
-        if (args->loga_iomode == LAYOUTIOMODE4_RW) {
-            layout->iomode = LAYOUTIOMODE4_RW;
-        }
-        nfs_layout_state_bump(layout, client_short_id, &res->logr_resok4.logr_stateid);
-    } else {
-        layout = nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
-                                         client_short_id, table,
-                                         &req->thread->shared->nfs4_layout_table,
-                                         &res->logr_resok4.logr_stateid);
-    }
-
-    /* Remember the backend-sourced type: a block/SCSI holder must be recalled
-     * as block/SCSI or the client finds no matching layout to return. */
-    layout->layout_type = loc_type;
-
-    /* Open the client's callback channel so a later conflicting op can recall
-     * this layout; CB_LAYOUTRECALL rides the shared delegation channel. */
-    nfs4_cb_ensure_probe(req->thread, client, req);
-
     if (loc_type == LAYOUT4_BLOCK_VOLUME || loc_type == LAYOUT4_SCSI) {
         uint8_t        *body = xdr_dbuf_alloc_space(1024, req->encoding->dbuf);
         struct layout4 *lo   = xdr_dbuf_alloc_space(sizeof(*lo), req->encoding->dbuf);
@@ -891,6 +891,7 @@ lg_sourced_cb(
                                                        body_len, req->encoding->dbuf);
         chimera_nfs_abort_if(rc, "Failed to copy layout body");
 
+        layouts_len                      = lg_layout4_xdr_len(body_len);
         res->logr_resok4.num_logr_layout = 1;
         res->logr_resok4.logr_layout     = lo;
     } else {
@@ -916,11 +917,43 @@ lg_sourced_cb(
             rc                         = xdr_dbuf_opaque_copy(&los[i].lo_content.loc_body, body,
                                                               body_len, req->encoding->dbuf);
             chimera_nfs_abort_if(rc, "Failed to copy layout body");
+
+            layouts_len += lg_layout4_xdr_len(body_len);
         }
 
         res->logr_resok4.num_logr_layout = num_segments;
         res->logr_resok4.logr_layout     = los;
     }
+
+    /* Enforce loga_maxcount before taking any layout state, so a rejected
+     * LAYOUTGET leaves nothing registered (see ff_lg_emit). */
+    if (layouts_len > args->loga_maxcount) {
+        ff_lg_fail(ctx, NFS4ERR_TOOSMALL);
+        return;
+    }
+
+    client_short_id = (uint32_t) client->client_id;
+    layout          = nfs_layout_state_find(client, req->fh, req->fhlen);
+    if (layout) {
+        /* See ff_lg_emit(): widen an existing READ layout to RW. */
+        if (args->loga_iomode == LAYOUTIOMODE4_RW) {
+            layout->iomode = LAYOUTIOMODE4_RW;
+        }
+        nfs_layout_state_bump(layout, client_short_id, &res->logr_resok4.logr_stateid);
+    } else {
+        layout = nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
+                                         client_short_id, table,
+                                         &req->thread->shared->nfs4_layout_table,
+                                         &res->logr_resok4.logr_stateid);
+    }
+
+    /* Remember the backend-sourced type: a block/SCSI holder must be recalled
+     * as block/SCSI or the client finds no matching layout to return. */
+    layout->layout_type = loc_type;
+
+    /* Open the client's callback channel so a later conflicting op can recall
+     * this layout; CB_LAYOUTRECALL rides the shared delegation channel. */
+    nfs4_cb_ensure_probe(req->thread, client, req);
 
     res->logr_resok4.logr_return_on_close = 0;
 

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -998,6 +998,7 @@ chimera_nfs4_layoutget(
     struct LAYOUTGET4args   *args = &argop->oplayoutget;
     struct LAYOUTGET4res    *res  = &resop->oplayoutget;
     struct ff_layoutget_ctx *ctx;
+    struct nfs_client       *client;
 
     req->handle = NULL;
 
@@ -1022,6 +1023,44 @@ chimera_nfs4_layoutget(
         res->logr_status = NFS4ERR_NOFILEHANDLE;
         chimera_nfs4_compound_complete(req, res->logr_status);
         return;
+    }
+
+    /* RFC 8881 §18.43.3: once the client holds a layout on this file,
+     * loga_stateid MUST be that layout's stateid, and §12.5.3 makes its seqid
+     * the server's to advance -- so a superseded seqid is NFS4ERR_OLD_STATEID
+     * and one never issued is NFS4ERR_BAD_STATEID (both listed in §18.43.4).
+     * A zero seqid means "the current stateid" (§8.2.2).  Only a layout-typed
+     * stateid is judged here: before the first layout is granted the client
+     * legitimately presents an open, lock, or delegation stateid, about which
+     * the layout state has nothing to say -- and the all-ones READ-bypass
+     * stateid decodes as the layout type without being one. */
+    client = req->session ? req->session->client_unified : NULL;
+
+    if (client && !nfs4_stateid_is_special(&args->loga_stateid)) {
+        struct nfs4_stateid_view view;
+
+        nfs4_stateid_decode(&view, &args->loga_stateid);
+
+        if (view.type == NFS4_STATEID_TYPE_LAYOUT) {
+            struct nfs_layout_state *layout =
+                nfs_layout_state_find(client, req->fh, req->fhlen);
+            uint32_t                 in_seqid = args->loga_stateid.seqid;
+
+            if (!layout) {
+                res->logr_status = NFS4ERR_BAD_STATEID;
+            } else if (in_seqid != 0 && in_seqid < layout->seqid) {
+                res->logr_status = NFS4ERR_OLD_STATEID;
+            } else if (in_seqid > layout->seqid) {
+                res->logr_status = NFS4ERR_BAD_STATEID;
+            } else {
+                res->logr_status = NFS4_OK;
+            }
+
+            if (res->logr_status != NFS4_OK) {
+                chimera_nfs4_compound_complete(req, res->logr_status);
+                return;
+            }
+        }
     }
 
     ctx = xdr_dbuf_alloc_space(sizeof(*ctx), req->encoding->dbuf);
@@ -1084,9 +1123,8 @@ chimera_nfs4_layoutreturn(
 
             /* RFC 8881 §12.5.3: the layout stateid carried by LAYOUTRETURN must
              * match the server's current seqid for this layout.  A stale seqid
-             * is OLD_STATEID, a future one BAD_STATEID.  (LAYOUTGET, by
-             * contrast, tolerates an old seqid -- the client may race two
-             * LAYOUTGETs.) */
+             * is OLD_STATEID, a future one BAD_STATEID.  (LAYOUTGET applies the
+             * same rule, except that it also accepts a zero seqid.) */
             if (in_seqid < layout->seqid) {
                 res->lorr_status = NFS4ERR_OLD_STATEID;
                 chimera_nfs4_compound_complete(req, res->lorr_status);

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -1100,8 +1100,24 @@ chimera_nfs4_layoutreturn(
 
     client = req->session ? req->session->client_unified : NULL;
 
+    /* RFC 8881 §18.44.3: a LAYOUTRETURN4_ALL makes the client believe every
+     * layout it held is gone, so the server has to forget them all.  Keeping
+     * them registered left the server-wide recall barrier standing for files
+     * the client had already given up, and a later conflicting op then parked
+     * behind a CB_LAYOUTRECALL to a client that was usually on its way out
+     * (RETURN ALL is what an unmount sends) until the recall deadline or the
+     * lease expired.  FSID stays a no-op: the fsid is a backend attribute the
+     * layout record does not carry, so selecting by it needs a getattr per
+     * record that this synchronous path cannot make. */
+    if (client &&
+        args->lora_layoutreturn.lr_returntype == LAYOUTRETURN4_ALL) {
+        nfs_layout_state_destroy_all(client,
+                                     &thread->shared->nfs4_state_table,
+                                     thread->vfs_thread);
+    }
+
     /* v1 tracks a single whole-file layout per file, so a FILE return drops
-     * the record entirely.  FSID/ALL returns are accepted as no-ops. */
+     * the record entirely. */
     if (client &&
         args->lora_layoutreturn.lr_returntype == LAYOUTRETURN4_FILE) {
         struct nfs_layout_state *layout =

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -609,11 +609,14 @@ ff_lg_emit(struct ff_layoutget_ctx *ctx)
         }
         nfs_layout_state_bump(layout, client_short_id, &res->logr_resok4.logr_stateid);
     } else {
-        nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
-                                client_short_id, table,
-                                &req->thread->shared->nfs4_layout_table,
-                                &res->logr_resok4.logr_stateid);
+        layout = nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
+                                         client_short_id, table,
+                                         &req->thread->shared->nfs4_layout_table,
+                                         &res->logr_resok4.logr_stateid);
     }
+
+    /* Remember what we handed out so CB_LAYOUTRECALL can name the same type. */
+    layout->layout_type = LAYOUT4_FLEX_FILES;
 
     /* Open the client's callback channel so a later conflicting op can recall
      * this layout; CB_LAYOUTRECALL rides the shared delegation channel. */
@@ -845,11 +848,15 @@ lg_sourced_cb(
         }
         nfs_layout_state_bump(layout, client_short_id, &res->logr_resok4.logr_stateid);
     } else {
-        nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
-                                client_short_id, table,
-                                &req->thread->shared->nfs4_layout_table,
-                                &res->logr_resok4.logr_stateid);
+        layout = nfs_layout_state_create(client, req->fh, req->fhlen, req->export_id, args->loga_iomode,
+                                         client_short_id, table,
+                                         &req->thread->shared->nfs4_layout_table,
+                                         &res->logr_resok4.logr_stateid);
     }
+
+    /* Remember the backend-sourced type: a block/SCSI holder must be recalled
+     * as block/SCSI or the client finds no matching layout to return. */
+    layout->layout_type = loc_type;
 
     /* Open the client's callback channel so a later conflicting op can recall
      * this layout; CB_LAYOUTRECALL rides the shared delegation channel. */

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -1059,6 +1059,18 @@ chimera_nfs4_layoutget(
         return;
     }
 
+    /* LAYOUTIOMODE4_ANY is legal only for LAYOUTRETURN and CB_LAYOUTRECALL
+     * (RFC 8881 §3.3.20), and the returned lo_iomode MUST be READ or RW
+     * (§18.43.3).  Reject anything else here rather than echo an illegal
+     * iomode back -- it would also mis-derive the per-iomode ff_layout
+     * principal, handing a write layout the read principal. */
+    if (args->loga_iomode != LAYOUTIOMODE4_READ &&
+        args->loga_iomode != LAYOUTIOMODE4_RW) {
+        res->logr_status = NFS4ERR_BADIOMODE;
+        chimera_nfs4_compound_complete(req, res->logr_status);
+        return;
+    }
+
     if (req->fhlen == 0) {
         res->logr_status = NFS4ERR_NOFILEHANDLE;
         chimera_nfs4_compound_complete(req, res->logr_status);

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -1115,6 +1115,21 @@ chimera_nfs4_layoutget(
         }
     }
 
+    /* RFC 8881 §18.43.3 / §12.5.5.2: a LAYOUTGET that overlaps a recall in
+     * progress MUST be rejected with NFS4ERR_RECALLCONFLICT.  The recall
+     * snapshots the holders it will call back at recall_prepare time, so a
+     * layout granted after that point would never be recalled: the client
+     * would keep writing through a range the deferred operation (e.g. a
+     * SETATTR truncate) is about to change, and that operation would stall
+     * until the new layout's lease lapsed.  The client retries once the
+     * recall completes. */
+    if (nfs_layout_table_recall_active(&thread->shared->nfs4_layout_table,
+                                       req->fh, (uint16_t) req->fhlen)) {
+        res->logr_status = NFS4ERR_RECALLCONFLICT;
+        chimera_nfs4_compound_complete(req, res->logr_status);
+        return;
+    }
+
     ctx = xdr_dbuf_alloc_space(sizeof(*ctx), req->encoding->dbuf);
     chimera_nfs_abort_if(ctx == NULL, "Failed to allocate space");
     memset(ctx, 0, sizeof(*ctx));

--- a/src/server/nfs/nfs4_proc_allocate.c
+++ b/src/server/nfs/nfs4_proc_allocate.c
@@ -86,7 +86,7 @@ chimera_nfs4_allocate_typecheck_complete(
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
         !S_ISREG(attr->va_mode)) {
-        res->ar_status = chimera_nfs4_data_nonreg_status(attr->va_mode);
+        res->ar_status = chimera_nfs4_sparse_nonreg_status(attr->va_mode);
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
         req->handle = NULL;
         chimera_nfs4_compound_complete(req, res->ar_status);

--- a/src/server/nfs/nfs4_proc_deallocate.c
+++ b/src/server/nfs/nfs4_proc_deallocate.c
@@ -88,7 +88,7 @@ chimera_nfs4_deallocate_typecheck_complete(
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
         !S_ISREG(attr->va_mode)) {
-        res->dr_status = chimera_nfs4_data_nonreg_status(attr->va_mode);
+        res->dr_status = chimera_nfs4_sparse_nonreg_status(attr->va_mode);
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
         req->handle = NULL;
         chimera_nfs4_compound_complete(req, res->dr_status);

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -46,11 +46,11 @@
  */
 static uint32_t
 nfs4_set_state_protect(
-    const struct state_protect4_a *req_sp,
-    struct state_protect4_r       *res_sp,
-    xdr_dbuf                      *dbuf)
+    uint32_t                 spa_how,
+    struct state_protect4_r *res_sp,
+    xdr_dbuf                *dbuf)
 {
-    if (req_sp->spa_how == SP4_MACH_CRED) {
+    if (spa_how == SP4_MACH_CRED) {
         static const uint32_t      enforce[2] = { 0, NFS4_MACH_ENFORCE_WORD1 };
         struct state_protect_ops4 *ops        = &res_sp->spr_mach_ops;
 
@@ -68,7 +68,7 @@ nfs4_set_state_protect(
     /* SP4_SSV is declined: chimera cannot enforce SSV-derived credentials, so
      * it falls through to the SP4_NONE result below rather than advertising a
      * capability it does not back.  See the function comment above. */
-    if (req_sp->spa_how == SP4_SSV) {
+    if (spa_how == SP4_SSV) {
         chimera_nfs_debug(
             "EXCHANGE_ID: client requested SP4_SSV; declining (not enforced), "
             "negotiating SP4_NONE instead");
@@ -181,24 +181,50 @@ chimera_nfs4_exchange_id(
     }
 
     /* Negotiate state protection (RFC 8881 §18.35.3) and record the chosen mode
-     * on the client so per-op enforcement (SP4_MACH_CRED) can consult it. */
-    uint32_t sp_how = nfs4_set_state_protect(&args->eia_state_protect,
-                                             &res->eir_resok4.eir_state_protect,
-                                             req->encoding->dbuf);
-
-    /* Phase 5: 4.1+ EXCHANGE_ID is the moment of identity establishment;
+     * on the client so per-op enforcement (SP4_MACH_CRED) can consult it.
+     *
+     * The mode is a property of the client ID, and §18.35.3 states that "once
+     * the client ID is confirmed, this property cannot be updated by subsequent
+     * EXCHANGE_ID operations".  So whenever the record this call resolved to is
+     * already confirmed -- the case-2 trunking match and the case-6 update --
+     * the negotiation replays the mode stored at creation instead of this
+     * call's spa_how, and the store below is skipped.  Re-deriving it would let
+     * a later EXCHANGE_ID downgrade a confirmed SP4_MACH_CRED client to
+     * SP4_NONE and silently disable the WRONG_CRED enforcement that client
+     * asked for on CREATE_SESSION / BIND_CONN_TO_SESSION / DESTROY_*.
+     *
+     * The negotiation runs under the client-table lock because the stored mode
+     * it may replay must be read there; EXCHANGE_ID is a per-client-lifetime
+     * operation, not a hot path.
+     *
+     * Phase 5: 4.1+ EXCHANGE_ID is the moment of identity establishment;
      * stub-persist the unified client so a future stable-storage backend
      * can pick it up after a restart. */
     {
-        struct nfs4_client *c  = NULL;
-        struct nfs_client  *uc = NULL;
+        struct nfs4_client *c       = NULL;
+        struct nfs_client  *uc      = NULL;
+        uint32_t            spa_how = args->eia_state_protect.spa_how;
+        uint32_t            sp_how;
+        int                 immutable = 0;
+
         pthread_mutex_lock(&thread->shared->nfs4_shared_clients.nfs4_ct_lock);
         HASH_FIND(nfs4_client_hh_by_id,
                   thread->shared->nfs4_shared_clients.nfs4_ct_clients_by_id,
                   &eid.clientid, sizeof(eid.clientid), c);
+        if (c && eid.confirmed) {
+            spa_how   = c->nfs4_client_sp_how;
+            immutable = 1;
+        }
+
+        sp_how = nfs4_set_state_protect(spa_how,
+                                        &res->eir_resok4.eir_state_protect,
+                                        req->encoding->dbuf);
+
         if (c) {
-            c->nfs4_client_sp_how = sp_how;
-            uc                    = c->unified;
+            if (!immutable) {
+                c->nfs4_client_sp_how = sp_how;
+            }
+            uc = c->unified;
             /* EXCHANGE_ID is client liveness: renew the lease so a client
              * mid-handshake (EXCHANGE_ID -> CREATE_SESSION -> first SEQUENCE)
              * is not expired by the lease sweep before it establishes a

--- a/src/server/nfs/nfs4_proc_getattr.c
+++ b/src/server/nfs/nfs4_proc_getattr.c
@@ -243,13 +243,16 @@ chimera_nfs4_getattr_complete(
         return;
     }
 
-    /* RFC 8881 §10.4.3 / §20.1: if another client holds a write delegation on
-     * this file it may have uncommitted size/change locally, so query it via
-     * CB_GETATTR and merge the result.  Only meaningful on 4.1+ with a known
-     * requesting client and delegations enabled. */
+    /* RFC 7530 §10.4.3 / RFC 8881 §10.4.3: if another client holds a write
+     * delegation on this file it may have uncommitted size/change locally, so
+     * query it via CB_GETATTR and merge the result.  CB_GETATTR is an NFSv4.0
+     * mechanism (RFC 7530 §18.1) that 4.1 inherited, and the send path serves
+     * both (nfs4_callback.c prepends CB_SEQUENCE only for 4.1+), so the query
+     * runs for any minor version -- gating it on 4.1+ left 4.0 peers reading
+     * pre-modification size/change. */
     client = req->session ? req->session->client_unified : NULL;
 
-    if (req->minorversion >= 1 && client &&
+    if (client &&
         chimera_server_config_get_nfs4_delegations(req->thread->shared->config) &&
         (wdeleg = nfs4_find_conflicting_write_deleg(req->thread, req->fh,
                                                     req->fhlen,

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -318,6 +318,22 @@ chimera_nfs4_lock(
         open_state = state_void;
         client     = open_state->owner->client;
 
+        /* RFC 8881 §8.2.2: a stateid presented on a session designates state
+         * owned by that session's client, so an open stateid belonging to a
+         * different client cannot anchor a lock here.  The 4.0 clientid test
+         * below covers only the wire clientid; this is the same check the
+         * I/O operations already make. */
+        status = nfs_state_check_client(open_state, NFS4_SLOT_TYPE_OPEN,
+                                        req->session ?
+                                        req->session->client_unified : NULL);
+        if (status != NFS4_OK) {
+            nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
+                                    thread->vfs_thread);
+            res->status = status;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
+
         /* RFC 7530 §9.1.4: the new lock-owner's clientid must be the client
          * that holds the open being locked.  A mismatched (e.g. stale)
          * clientid is a bad stateid. */
@@ -572,6 +588,20 @@ chimera_nfs4_lock(
             chimera_nfs4_lock_finish(req, res->status);
             return;
         }
+        /* RFC 8881 §8.2.2: the lock stateid must designate state owned by the
+         * client issuing the request; another client's lock stateid designates
+         * no state for this one. */
+        status = nfs_state_check_client(state_void, NFS4_SLOT_TYPE_LOCK,
+                                        req->session ?
+                                        req->session->client_unified : NULL);
+        if (status != NFS4_OK) {
+            nfs_state_table_release(table, state_void, NFS4_SLOT_TYPE_LOCK,
+                                    thread->vfs_thread);
+            res->status = status;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
+
         lock_state          = state_void;
         handle              = lock_state->handle;
         req->nfs_state_ref  = lock_state;

--- a/src/server/nfs/nfs4_proc_lock.c
+++ b/src/server/nfs/nfs4_proc_lock.c
@@ -288,6 +288,28 @@ chimera_nfs4_lock(
         return;
     }
 
+    /* RFC 7530 §9.6.2/§9.6.3 (RFC 8881 §8.4.2): LOCK carries its own reclaim
+     * flag and takes part in the reboot-recovery state machine exactly as OPEN
+     * does.  Inside the grace window only reclaims are admitted (non-reclaim ->
+     * NFS4ERR_GRACE); outside it a reclaim has nothing left to reclaim
+     * (-> NFS4ERR_NO_GRACE), and a reclaim from a client with no persisted
+     * pre-restart record is NFS4ERR_RECLAIM_BAD.  Without this the byte-range
+     * half of recovery was unsound: stale reclaims were granted as fresh locks
+     * and ordinary locks taken during grace could conflict with a lock another
+     * client had not reclaimed yet. */
+    {
+        nfsstat4 g_status = nfs_recovery_open_check(
+            &thread->shared->nfs4_recovery,
+            req->session ? req->session->client_unified : NULL,
+            args->reclaim != 0);
+
+        if (g_status != NFS4_OK) {
+            res->status = g_status;
+            chimera_nfs4_lock_finish(req, res->status);
+            return;
+        }
+    }
+
     if (args->locktype == READ_LT || args->locktype == READW_LT) {
         lock_type = CHIMERA_VFS_LOCK_READ;
     } else {

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -66,10 +66,20 @@ chimera_nfs4_lockt_probe(
     }
 
     memset(&owner, 0, sizeof(owner));
-    owner.proto      = CHIMERA_CLAIM_PROTO_NFSV4;
-    owner.client_key = args->owner.clientid;
-    owner.owner_lo   = XXH3_64bits(args->owner.owner.data,
-                                   args->owner.owner.len);
+    owner.proto = CHIMERA_CLAIM_PROTO_NFSV4;
+    /* RFC 8881 §2.4: in 4.1+ the client is identified by the session, not by
+     * the clientid embedded in lock_owner4 -- clients routinely leave that
+     * field zero or stale.  LOCK registers its claims under the server-assigned
+     * client id (nfs4_proc_lock.c), so keying the probe on the wire field would
+     * make the caller's own locks look foreign and defeat the SHOULD-exclude-
+     * self rule of RFC 7530 §16.11.5. */
+    if (req->minorversion > 0 && req->session && req->session->client_unified) {
+        owner.client_key = req->session->client_unified->client_id;
+    } else {
+        owner.client_key = args->owner.clientid;
+    }
+    owner.owner_lo = XXH3_64bits(args->owner.owner.data,
+                                 args->owner.owner.len);
     owner.owner_hi = 0;
 
     chimera_vfs_claim_init_range(&probe,

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -110,6 +110,52 @@ chimera_nfs4_open_acquire_share(
 } /* chimera_nfs4_open_acquire_share */
 
 /*
+ * Report a declined delegation.  RFC 8881 §18.16: a server that supports the
+ * OPEN4_SHARE_ACCESS_WANT_* flags (chimera advertises WANT_ANY_DELEG and
+ * WANT_NO_DELEG in supported_attrs' open_arguments) MUST answer an OPEN that
+ * carried one of them with OPEN_DELEGATE_NONE_EXT and a reason, so the client
+ * can tell contention from resource exhaustion.  A 4.0 client, or a 4.1 client
+ * that expressed no preference, keeps the bare OPEN_DELEGATE_NONE.
+ *
+ * Always returns false, so decline sites can `return
+ * chimera_nfs4_open_deleg_none(...)` in place of a bare `return false`.
+ */
+static bool
+chimera_nfs4_open_deleg_none(
+    struct nfs_request *req,
+    struct OPEN4res    *res,
+    uint32_t            why)
+{
+    struct OPEN4args *args = &req->args_compound->argarray[req->index].opopen;
+    uint32_t          want = args->share_access & OPEN4_SHARE_ACCESS_WANT_DELEG_MASK;
+
+    res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
+
+    if (req->minorversion < 1 || want == OPEN4_SHARE_ACCESS_WANT_NO_PREFERENCE) {
+        return false;
+    }
+
+    /* A want that only asked to cancel an outstanding registration is not a
+     * failure to delegate; report it as such. */
+    if (want == OPEN4_SHARE_ACCESS_WANT_CANCEL) {
+        why = WND4_CANCELLED;
+    }
+
+    res->resok4.delegation.delegation_type    = OPEN_DELEGATE_NONE_EXT;
+    res->resok4.delegation.od_whynone.ond_why = why;
+
+    /* The union arm is selected by ond_why; chimera never registers a want, so
+     * it promises neither a push nor a signal. */
+    if (why == WND4_CONTENTION) {
+        res->resok4.delegation.od_whynone.ond_server_will_push_deleg = 0;
+    } else if (why == WND4_RESOURCE) {
+        res->resok4.delegation.od_whynone.ond_server_will_signal_avail = 0;
+    }
+
+    return false;
+} /* chimera_nfs4_open_deleg_none */
+
+/*
  * Decide whether to grant an OPEN delegation and, if so, mint it and populate
  * the OPEN response.  A read open is offered an OPEN_DELEGATE_READ; an open
  * that requests write access is offered an OPEN_DELEGATE_WRITE.  A delegation
@@ -120,7 +166,8 @@ chimera_nfs4_open_acquire_share(
  *   - no conflicting access is present on the file (a write delegation also
  *     requires no other reader/writer; conflicts are surfaced by the CACHING
  *     lease conflict matrix).
- * Otherwise the response carries OPEN_DELEGATE_NONE.  Must be called on the
+ * Otherwise the response carries a decline built by
+ * chimera_nfs4_open_deleg_none().  Must be called on the
  * client's connection thread (it may kick a CB_NULL probe).
  *
  * Returns true when the OPEN's response has been parked on the cb_path's
@@ -150,31 +197,30 @@ chimera_nfs4_open_grant_delegation(
     uint64_t                          fh_hash;
     bool                              exists = false;
     uint8_t                           deleg_type;
+    uint32_t                          want;
     struct nfsace4                   *perms;
     static const char                 everyone[] = "EVERYONE@";
 
     res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
 
     if (!chimera_server_config_get_nfs4_delegations(thread->shared->config)) {
-        return false;
+        return chimera_nfs4_open_deleg_none(req, res, WND4_RESOURCE);
     }
     if (!client) {
-        return false;
+        return chimera_nfs4_open_deleg_none(req, res, WND4_RESOURCE);
     }
     if (args->claim.claim != CLAIM_NULL && args->claim.claim != CLAIM_FH) {
-        return false;
+        return chimera_nfs4_open_deleg_none(req, res, WND4_RESOURCE);
     }
 
-    /* RFC 8881 §18.16: honor an explicit "no delegation wanted" request.  On
-    * 4.1+ this is reported as OPEN_DELEGATE_NONE_EXT with WND4_NOT_WANTED;
-    * 4.0 has no such extension, so the default OPEN_DELEGATE_NONE stands. */
-    if (args->share_access & OPEN4_SHARE_ACCESS_WANT_NO_DELEG) {
-        if (req->minorversion >= 1) {
-            res->resok4.delegation.delegation_type                       = OPEN_DELEGATE_NONE_EXT;
-            res->resok4.delegation.od_whynone.ond_why                    = WND4_NOT_WANTED;
-            res->resok4.delegation.od_whynone.ond_server_will_push_deleg = 0;
-        }
-        return false;
+    /* RFC 8881 §18.16: honor an explicit "no delegation wanted" request.  The
+     * WANT_ values are a field in share_access, not independent bits, so they
+     * have to be compared under the mask; WANT_CANCEL also means "no
+     * delegation" (and reports WND4_CANCELLED instead). */
+    want = args->share_access & OPEN4_SHARE_ACCESS_WANT_DELEG_MASK;
+    if (want == OPEN4_SHARE_ACCESS_WANT_NO_DELEG ||
+        want == OPEN4_SHARE_ACCESS_WANT_CANCEL) {
+        return chimera_nfs4_open_deleg_none(req, res, WND4_NOT_WANTED);
     }
 
     /* A write open earns a write delegation; otherwise a pure-read open earns
@@ -184,7 +230,7 @@ chimera_nfs4_open_grant_delegation(
     } else if (args->share_access & OPEN4_SHARE_ACCESS_READ) {
         deleg_type = OPEN_DELEGATE_READ;
     } else {
-        return false;
+        return chimera_nfs4_open_deleg_none(req, res, WND4_RESOURCE);
     }
 
     /* Tri-state probe gate.  PATH_UP grants below; NO_PATH is the historical
@@ -200,7 +246,7 @@ chimera_nfs4_open_grant_delegation(
         case NFS4_CB_GRANT_PATH_UP:
             break;
         case NFS4_CB_GRANT_NO_PATH:
-            return false;
+            return chimera_nfs4_open_deleg_none(req, res, WND4_RESOURCE);
         case NFS4_CB_GRANT_DEFER:
             nfs4_cb_probe_park(client, req);
             return true;
@@ -236,7 +282,7 @@ chimera_nfs4_open_grant_delegation(
     }
     pthread_mutex_unlock(&client->lock);
     if (exists) {
-        return false;
+        return chimera_nfs4_open_deleg_none(req, res, WND4_RESOURCE);
     }
 
     deleg = nfs_delegation_create(client, deleg_type,
@@ -267,7 +313,7 @@ chimera_nfs4_open_grant_delegation(
     if (!file_state) {
         nfs_delegation_destroy(deleg, &thread->shared->nfs4_state_table,
                                thread->vfs_thread);
-        return false;
+        return chimera_nfs4_open_deleg_none(req, res, WND4_RESOURCE);
     }
     deleg->file_state = file_state;
 
@@ -279,7 +325,7 @@ chimera_nfs4_open_grant_delegation(
         deleg->file_state = NULL;
         nfs_delegation_destroy(deleg, &thread->shared->nfs4_state_table,
                                thread->vfs_thread);
-        return false;
+        return chimera_nfs4_open_deleg_none(req, res, WND4_CONTENTION);
     }
     deleg->lease_held = true;
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -1585,7 +1585,10 @@ chimera_nfs4_open(
      *   2. Per-client reclaim completion (RFC 8881 §18.51.3): once a 4.1+
      *      client establishes a new client ID it MUST send RECLAIM_COMPLETE
      *      before performing any non-reclaim locking operation.  Until it does,
-     *      a non-reclaim OPEN is refused with NFS4ERR_GRACE.  This is a
+     *      a non-reclaim OPEN is refused with NFS4ERR_GRACE.  Symmetrically,
+     *      once it has sent RECLAIM_COMPLETE the client may no longer reclaim:
+     *      a further CLAIM_PREVIOUS is NFS4ERR_NO_GRACE even while the
+     *      server-wide window is still open for other clients.  This is a
      *      per-client obligation independent of the server-wide grace window,
      *      so it is enforced whether or not in_grace is set. */
     {
@@ -1601,12 +1604,22 @@ chimera_nfs4_open(
             return;
         }
 
-        if (req->minorversion > 0 && !is_reclaim && req->session &&
-            !nfs4_client_reclaim_complete(&thread->shared->nfs4_shared_clients,
-                                          req->session->nfs4_session_clientid)) {
-            res->status = NFS4ERR_GRACE;
-            chimera_nfs4_open_complete(req, res->status);
-            return;
+        if (req->minorversion > 0 && req->session) {
+            bool done = nfs4_client_reclaim_complete(
+                &thread->shared->nfs4_shared_clients,
+                req->session->nfs4_session_clientid);
+
+            if (is_reclaim && done) {
+                res->status = NFS4ERR_NO_GRACE;
+                chimera_nfs4_open_complete(req, res->status);
+                return;
+            }
+
+            if (!is_reclaim && !done) {
+                res->status = NFS4ERR_GRACE;
+                chimera_nfs4_open_complete(req, res->status);
+                return;
+            }
         }
     }
 

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -206,6 +206,21 @@ chimera_nfs4_open_grant_delegation(
             return true;
     } /* switch */
 
+    /* RFC 7530 §9.1.11: "The server must not bestow a delegation for any open
+     * that would require confirmation", and §16.18.5: "Servers MUST NOT
+     * require confirmation on OPENs that grant delegations."  The two
+     * decisions are made in different places -- install_state has already
+     * committed OPEN4_RESULT_CONFIRM into the reply for a 4.0 OPEN on an
+     * unconfirmed open_owner -- so read that decision back and decline rather
+     * than hand out a delegation stateid on open state that is still subject
+     * to cancellation if OPEN_CONFIRM never arrives.  The client gets one on
+     * its next OPEN.  Deliberately after the probe gate above so the first
+     * OPEN of a new owner still kicks the CB_NULL probe, leaving the path
+     * validated by the time that next OPEN arrives. */
+    if (res->resok4.rflags & OPEN4_RESULT_CONFIRM) {
+        return false;
+    }
+
     /* fh_hash must match the open-cache / SHARE-lease hashing so the
      * delegation and conflicting opens land on the same file_state. */
     fh_hash = XXH3_64bits(req->fh, req->fhlen) & INT64_MAX;

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -560,6 +560,12 @@ chimera_nfs4_open_finish(
         owner->seqid = args->seqid;
         nfs4_replay_record(&owner->replay, args->seqid, OP_OPEN, status,
                            status == NFS4_OK ? &res->resok4.stateid : NULL);
+        /* RFC 7530 §9.1.7 wants the stored last response replayed verbatim.
+         * rflags carries OPEN4_RESULT_CONFIRM (§16.18.5), which a client may
+         * act on, so keep it alongside the stateid. */
+        if (status == NFS4_OK) {
+            owner->replay.rflags = res->resok4.rflags;
+        }
         pthread_mutex_unlock(&owner->lock);
     }
 
@@ -1522,23 +1528,26 @@ chimera_nfs4_open(
                                                                args->seqid);
 
         if (cls == NFS4_SEQID_REPLAY) {
-            /* Return the cached reply.  Simplified replay (status +
-             * stateid only); cinfo/attrset/rflags/delegation are
-             * reconstructed as zero/none.  Linux clients tolerate this
-             * since they re-fetch attrs via GETATTR after OPEN.
+            /* Return the cached reply.  Simplified replay (status, stateid
+             * and rflags); cinfo/attrset/delegation are reconstructed as
+             * zero/none.  Linux clients tolerate that since they re-fetch
+             * attrs via GETATTR after OPEN.
+             *
+             * rflags is replayed rather than zeroed: RFC 7530 §9.1.7 requires
+             * the stored last response, and dropping OPEN4_RESULT_CONFIRM
+             * (§16.18.5) tells a retransmitting client the opposite of what
+             * the original reply said about its OPEN_CONFIRM obligation.
              *
              * A retransmit on the SAME connection is normally answered
              * byte-exact by the v4.0 reply cache before the compound is
              * even decoded (nfs4_v40_drc.c), so this branch is reached
-             * only when the retransmit arrives on a new connection --
-             * where losing rflags matters least, since a reconnecting
-             * client re-establishes its state anyway. */
+             * only when the retransmit arrives on a new connection. */
             res->status                            = owner->replay.status;
             res->resok4.stateid                    = owner->replay.stateid;
             res->resok4.cinfo.atomic               = 0;
             res->resok4.cinfo.before               = 0;
             res->resok4.cinfo.after                = 0;
-            res->resok4.rflags                     = 0;
+            res->resok4.rflags                     = owner->replay.rflags;
             res->resok4.num_attrset                = 0;
             res->resok4.delegation.delegation_type = OPEN_DELEGATE_NONE;
             pthread_mutex_unlock(&owner->lock);

--- a/src/server/nfs/nfs4_proc_open_downgrade.c
+++ b/src/server/nfs/nfs4_proc_open_downgrade.c
@@ -150,6 +150,33 @@ chimera_nfs4_open_downgrade(
 
     pthread_mutex_unlock(&owner->lock);
 
+    /* RFC 7530 §16.19: the downgrade changes the *effective* share
+     * reservation, so the cross-protocol claim that arbitrates against SMB
+     * and NLM has to narrow with it -- otherwise the old, broader deny keeps
+     * blocking opens this state no longer denies.  The new bits are a subset
+     * of the standing ones (checked above), which is what shrink requires.
+     * Done outside owner->lock: shrink pumps the claim waiters, whose
+     * completions take that lock. */
+    if (open_state->share_claim_held) {
+        uint8_t granted = 0, denied = 0;
+
+        if (args->share_access & OPEN4_SHARE_ACCESS_READ) {
+            granted |= CHIMERA_CLAIM_R;
+        }
+        if (args->share_access & OPEN4_SHARE_ACCESS_WRITE) {
+            granted |= CHIMERA_CLAIM_W;
+        }
+        if (args->share_deny & OPEN4_SHARE_DENY_READ) {
+            denied |= CHIMERA_CLAIM_R;
+        }
+        if (args->share_deny & OPEN4_SHARE_DENY_WRITE) {
+            denied |= CHIMERA_CLAIM_W;
+        }
+
+        chimera_vfs_claim_shrink(open_state->share_file_state,
+                                 &open_state->share_claim, granted, denied);
+    }
+
     nfs_state_table_release(table, open_state, NFS4_SLOT_TYPE_OPEN,
                             thread->vfs_thread);
 

--- a/src/server/nfs/nfs4_proc_secinfo.c
+++ b/src/server/nfs/nfs4_proc_secinfo.c
@@ -41,7 +41,8 @@ chimera_nfs4_secinfo_complete(
     chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
 
     res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
-                                               export ? export->sec_allowed : 0);
+                                               export ? export->sec_allowed : 0,
+                                               req->thread->shared->gss_enabled);
     /* RFC 7530 §16.31.3 / RFC 8881 §18.29.3: SECINFO consumes the current
      * filehandle on success, so a following op relying on it fails with
      * NFS4ERR_NOFILEHANDLE. */
@@ -103,7 +104,8 @@ chimera_nfs4_secinfo_resume(
                                            req->encoding->dbuf);
         chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
         res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
-                                                   sibling.sec_allowed);
+                                                   sibling.sec_allowed,
+                                                   thread->shared->gss_enabled);
         /* Consume the current filehandle on success (see above). */
         req->fhlen  = 0;
         res->status = NFS4_OK;
@@ -165,7 +167,8 @@ chimera_nfs4_secinfo(
                                            req->encoding->dbuf);
         chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
         res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
-                                                   export ? export->sec_allowed : 0);
+                                                   export ? export->sec_allowed : 0,
+                                                   req->thread->shared->gss_enabled);
         /* Consume the current filehandle on success (see above). */
         req->fhlen  = 0;
         res->status = NFS4_OK;

--- a/src/server/nfs/nfs4_proc_secinfo_no_name.c
+++ b/src/server/nfs/nfs4_proc_secinfo_no_name.c
@@ -30,7 +30,8 @@ chimera_nfs4_secinfo_no_name(
     chimera_nfs_abort_if(res->resok4 == NULL, "Failed to allocate space");
 
     res->num_resok4 = chimera_nfs_fill_secinfo(res->resok4,
-                                               export ? export->sec_allowed : 0);
+                                               export ? export->sec_allowed : 0,
+                                               thread->shared->gss_enabled);
     /* RFC 8881 §18.45.3: SECINFO_NO_NAME consumes the current filehandle on
      * success, so a following op relying on it fails with NFS4ERR_NOFILEHANDLE. */
     req->fhlen  = 0;

--- a/src/server/nfs/nfs4_proc_secinfo_no_name.c
+++ b/src/server/nfs/nfs4_proc_secinfo_no_name.c
@@ -9,9 +9,14 @@
 
 /*
  * SECINFO_NO_NAME (RFC 8881 §18.45) reports the security flavors the server
- * accepts for the current filehandle.  We advertise the owning export's
- * configured flavors (or everything chimera supports if the export has no
- * explicit policy), as RPCSEC_GSS triples for krb5/krb5i/krb5p.
+ * accepts for the current filehandle (SECINFO_STYLE4_CURRENT_FH) or for its
+ * parent (SECINFO_STYLE4_PARENT).  We advertise the owning export's configured
+ * flavors (or everything chimera supports if the export has no explicit
+ * policy), as RPCSEC_GSS triples for krb5/krb5i/krb5p.
+ *
+ * The flavors are a property of the export, so a parent inside the same export
+ * has the same answer as the current filehandle and needs no ".." resolution;
+ * only the namespace root, which has no parent at all, is special-cased below.
  */
 void
 chimera_nfs4_secinfo_no_name(
@@ -20,8 +25,35 @@ chimera_nfs4_secinfo_no_name(
     struct nfs_argop4                *argop,
     struct nfs_resop4                *resop)
 {
-    struct SECINFO4res              *res = &resop->opsecinfo_no_name;
+    struct SECINFO4res              *res   = &resop->opsecinfo_no_name;
+    uint32_t                         style = argop->opsecinfo_no_name;
     const struct chimera_nfs_export *export;
+
+    /* RFC 8881 §18.45.3: the operation reports on the current filehandle, so
+     * it needs one. */
+    if (req->fhlen == 0) {
+        res->status = NFS4ERR_NOFILEHANDLE;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* secinfo_style4 names exactly two values (RFC 8881 §18.45.1).  The XDR
+     * decoder is built with relaxed enum checking, so an undeclared style
+     * reaches here and has to be rejected rather than silently treated as
+     * CURRENT_FH. */
+    if (style != SECINFO_STYLE4_CURRENT_FH && style != SECINFO_STYLE4_PARENT) {
+        res->status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
+
+    /* SECINFO_STYLE4_PARENT asks about "..", which the NFSv4 namespace root
+     * does not have -- the same reason LOOKUPP answers NFS4ERR_NOENT there. */
+    if (style == SECINFO_STYLE4_PARENT && fh_is_nfs4_root(req->fh, req->fhlen)) {
+        res->status = NFS4ERR_NOENT;
+        chimera_nfs4_compound_complete(req, res->status);
+        return;
+    }
 
     export = chimera_nfs_get_export_by_id(thread->shared, req->export_id);
 

--- a/src/server/nfs/nfs4_proc_seek.c
+++ b/src/server/nfs/nfs4_proc_seek.c
@@ -86,7 +86,7 @@ chimera_nfs4_seek_typecheck_complete(
 
     if ((attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
         !S_ISREG(attr->va_mode)) {
-        res->sa_status = chimera_nfs4_data_nonreg_status(attr->va_mode);
+        res->sa_status = chimera_nfs4_sparse_nonreg_status(attr->va_mode);
         chimera_vfs_release(req->thread->vfs_thread, req->handle);
         req->handle = NULL;
         chimera_nfs4_compound_complete(req, res->sa_status);

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -43,6 +43,20 @@ nfs4_sequence_fill_resok(
                              memory_order_acquire) > 0) {
         res->sr_resok4.sr_status_flags |= SEQ4_STATUS_RECALLABLE_STATE_REVOKED;
     }
+
+    /* RFC 8881 §18.46.3: SEQ4_STATUS_CB_PATH_DOWN tells the client the server
+     * has no usable callback path to it, so it re-establishes one (in 4.1 via
+     * BIND_CONN_TO_SESSION on a fresh connection).  4.0 signals the same
+     * condition with NFS4ERR_CB_PATH_DOWN from RENEW (nfs4_proc_renew.c); 4.1
+     * has no RENEW, so without this bit a client whose backchannel died was
+     * never told, and delegation recall stayed broken silently.  cb_state
+     * returns to UNINIT when the backchannel is rebound, which clears the bit
+     * on the next SEQUENCE. */
+    if (session->client_unified &&
+        atomic_load_explicit(&session->client_unified->cb_path.cb_state,
+                             memory_order_acquire) == NFS4_CB_DOWN) {
+        res->sr_resok4.sr_status_flags |= SEQ4_STATUS_CB_PATH_DOWN;
+    }
 } /* nfs4_sequence_fill_resok */
 
 void

--- a/src/server/nfs/nfs4_proc_sequence.c
+++ b/src/server/nfs/nfs4_proc_sequence.c
@@ -12,8 +12,9 @@
  *
  * RFC 8881 Section 2.10.6.1.1 requires this reply to be cached, and permits a
  * replier to recompute the slot-usage fields rather than store them; that is
- * what this does, which is also why the uncached-retry path can call it to
- * reconstruct the reply the client should have received.
+ * what this does, which is also why the uncached-retry path can be answered
+ * from it: the reply the client should have received is reconstructible from
+ * the session and the args alone.
  */
 static void
 nfs4_sequence_fill_resok(
@@ -83,6 +84,51 @@ chimera_nfs4_sequence(
 
     req->session = session;
 
+    /*
+     * The COMPOUND-shape limits are checked before the slot is touched.
+     *
+     * RFC 8881 §2.10.6.1.2 and §18.46.3: when SEQUENCE returns an error "the
+     * sequence ID of the slot MUST NOT change" and the replier "MUST NOT
+     * modify the reply cache entry for the slot".  Checking these after
+     * nfs4_replay_slot_acquire left the slot CAS-advanced to the new seqid and
+     * finalized as COMPLETED with no cached bytes, so the client's retry at the
+     * old seqid was answered NFS4ERR_RETRY_UNCACHED_REP forever -- one
+     * over-large COMPOUND permanently wedged the slot.  None of these limits
+     * depend on slot state, so they can simply be evaluated first.
+     */
+    if (session->nfs4_session_fore_attrs.ca_maxrequestsize &&
+        marshall_length_COMPOUND4args(req->args_compound) >
+        (int) session->nfs4_session_fore_attrs.ca_maxrequestsize) {
+        res->sr_status = NFS4ERR_REQ_TOO_BIG;
+        chimera_nfs4_compound_complete(req, NFS4ERR_REQ_TOO_BIG);
+        return;
+    }
+
+    /* RFC 8881 §2.10.6.4: a COMPOUND with more operations than the session's
+     * negotiated fore-channel ca_maxoperations (SEQUENCE counts as one) is
+     * rejected with NFS4ERR_TOO_MANY_OPS. */
+    if (session->nfs4_session_fore_attrs.ca_maxoperations &&
+        req->args_compound->num_argarray >
+        session->nfs4_session_fore_attrs.ca_maxoperations) {
+        res->sr_status = NFS4ERR_TOO_MANY_OPS;
+        chimera_nfs4_compound_complete(req, NFS4ERR_TOO_MANY_OPS);
+        return;
+    }
+
+    /* The reply is reconstructible from the session and the args alone, so it
+     * can be built before the slot is claimed; that is what lets the
+     * cacheability check below also run without disturbing the slot. */
+    nfs4_sequence_fill_resok(res, session, args);
+
+    if (args->sa_cachethis &&
+        session->nfs4_session_fore_attrs.ca_maxresponsesize_cached &&
+        marshall_length_nfs_resop4(resop) >
+        (int) session->nfs4_session_fore_attrs.ca_maxresponsesize_cached) {
+        res->sr_status = NFS4ERR_REP_TOO_BIG_TO_CACHE;
+        chimera_nfs4_compound_complete(req, NFS4ERR_REP_TOO_BIG_TO_CACHE);
+        return;
+    }
+
     status = nfs4_replay_slot_acquire(session,
                                       args->sa_slotid,
                                       args->sa_sequenceid,
@@ -109,8 +155,7 @@ chimera_nfs4_sequence(
      * to cache, so the cached success is the whole answer.
      */
     if (status == NFS4ERR_RETRY_UNCACHED_REP) {
-        nfs4_sequence_fill_resok(res, session, args);
-
+        /* res already carries the reconstructed SEQUENCE reply. */
         if (req->args_compound->num_argarray > 1) {
             req->index = 1;
             nfs4_fail_undispatched_op(thread,
@@ -137,36 +182,6 @@ chimera_nfs4_sequence(
          * returns NFS4ERR_RETRY_UNCACHED_REP instead. */
         nfs_client_touch(session->client_unified);
         chimera_nfs4_compound_complete(req, NFS4_OK);
-        return;
-    }
-
-    if (session->nfs4_session_fore_attrs.ca_maxrequestsize &&
-        marshall_length_COMPOUND4args(req->args_compound) >
-        (int) session->nfs4_session_fore_attrs.ca_maxrequestsize) {
-        res->sr_status = NFS4ERR_REQ_TOO_BIG;
-        chimera_nfs4_compound_complete(req, NFS4ERR_REQ_TOO_BIG);
-        return;
-    }
-
-    /* RFC 8881 §2.10.6.4: a COMPOUND with more operations than the session's
-     * negotiated fore-channel ca_maxoperations (SEQUENCE counts as one) is
-     * rejected with NFS4ERR_TOO_MANY_OPS. */
-    if (session->nfs4_session_fore_attrs.ca_maxoperations &&
-        req->args_compound->num_argarray >
-        session->nfs4_session_fore_attrs.ca_maxoperations) {
-        res->sr_status = NFS4ERR_TOO_MANY_OPS;
-        chimera_nfs4_compound_complete(req, NFS4ERR_TOO_MANY_OPS);
-        return;
-    }
-
-    nfs4_sequence_fill_resok(res, session, args);
-
-    if (args->sa_cachethis &&
-        session->nfs4_session_fore_attrs.ca_maxresponsesize_cached &&
-        marshall_length_nfs_resop4(resop) >
-        (int) session->nfs4_session_fore_attrs.ca_maxresponsesize_cached) {
-        res->sr_status = NFS4ERR_REP_TOO_BIG_TO_CACHE;
-        chimera_nfs4_compound_complete(req, NFS4ERR_REP_TOO_BIG_TO_CACHE);
         return;
     }
 

--- a/src/server/nfs/nfs4_proc_setclientid.c
+++ b/src/server/nfs/nfs4_proc_setclientid.c
@@ -61,17 +61,21 @@ chimera_nfs4_setclientid(
     }
 
     /* RFC 7530 §16.33: capture the callback path (cb_client4) so the server
-     * can deliver CB_RECALL once it grants a delegation.  Only meaningful when
-     * delegations are enabled; harmless to record otherwise. */
-    nfs4_client_set_cb_path(&shared->nfs4_shared_clients,
-                            scid.clientid,
-                            args->callback.cb_program,
-                            args->callback_ident,
-                            0,
-                            args->callback.cb_location.na_r_netid.str,
-                            args->callback.cb_location.na_r_netid.len,
-                            args->callback.cb_location.na_r_addr.str,
-                            args->callback.cb_location.na_r_addr.len);
+     * can deliver CB_RECALL once it grants a delegation.  Staged, not applied:
+     * §16.33.5 says the update "is only confirmed if followed up by a
+     * SETCLIENTID_CONFIRM", which is why the RFC can call a stray SETCLIENTID
+     * carrying stale callback info harmless.  Applying it here let an
+     * unconfirmed (or replayed) request retarget a confirmed client's callback
+     * path and tear down its working back-channel; the confirm handler commits
+     * it instead. */
+    nfs4_client_stage_cb_path(&shared->nfs4_shared_clients,
+                              scid.clientid,
+                              args->callback.cb_program,
+                              args->callback_ident,
+                              args->callback.cb_location.na_r_netid.str,
+                              args->callback.cb_location.na_r_netid.len,
+                              args->callback.cb_location.na_r_addr.str,
+                              args->callback.cb_location.na_r_addr.len);
 
     res->status          = NFS4_OK;
     res->resok4.clientid = scid.clientid;

--- a/src/server/nfs/nfs4_proc_setclientid_confirm.c
+++ b/src/server/nfs/nfs4_proc_setclientid_confirm.c
@@ -64,6 +64,12 @@ chimera_nfs4_setclientid_confirm(
         return;
     }
 
+    /* RFC 7530 §16.34.5: this is the step that modifies the recorded and
+     * confirmed callback information, so apply the path the matching
+     * SETCLIENTID staged.  One-shot -- a retransmitted confirm finds nothing
+     * staged and leaves the path (and any channel built on it) alone. */
+    nfs4_client_commit_cb_path(&shared->nfs4_shared_clients, args->clientid);
+
     /* The clientid is now confirmed and usable.  Ensure it has an implicit
      * (NFS4.0) session and bind it to this connection so subsequent
      * non-SEQUENCE operations resolve the client. */
@@ -87,10 +93,11 @@ chimera_nfs4_setclientid_confirm(
                                  &thread->shared->nfs4_recovery, uc);
 
             /* If the client re-registered a new callback address while holding
-             * delegations (RFC 7530 §16.33), its stale channel was torn down in
-             * nfs4_client_set_cb_path.  Rebuild a channel to the new address now,
-             * on this (the client's) thread, so a subsequent recall reaches the
-             * new callback server rather than being revoked for want of a path. */
+             * delegations (RFC 7530 §16.33), its stale channel was torn down
+             * by nfs4_client_commit_cb_path above.  Rebuild a channel to the
+             * new address now, on this (the client's) thread, so a subsequent
+             * recall reaches the new callback server rather than being revoked
+             * for want of a path. */
             if (uc->delegations) {
                 nfs4_cb_ensure_probe(thread, uc, req);
             }

--- a/src/server/nfs/nfs4_proc_setclientid_confirm.c
+++ b/src/server/nfs/nfs4_proc_setclientid_confirm.c
@@ -32,11 +32,21 @@ chimera_nfs4_setclientid_confirm(
     struct chimera_server_nfs_shared *shared          = thread->shared;
     struct nfs_client                *destroy_unified = NULL;
     struct nfs4_session              *session;
+    struct nfs4_client_principal      principal;
     nfsstat4                          status;
+
+    /* RFC 7530 §16.34.5 binds the confirm to the principal that issued the
+     * SETCLIENTID, so it travels into the record match. */
+    principal.flavor          = req->principal_flavor;
+    principal.uid             = req->principal_uid;
+    principal.gid             = req->principal_gid;
+    principal.machinename     = req->principal_machinename;
+    principal.machinename_len = req->principal_machinename_len;
 
     status = nfs4_client_setclientid_confirm(&shared->nfs4_shared_clients,
                                              args->clientid,
                                              args->setclientid_confirm,
+                                             &principal,
                                              &destroy_unified);
 
     /* A superseded (rebooted) client's state hierarchy is torn down outside

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -176,7 +176,8 @@ verify_validate_mask(
         (1U << (FATTR4_SPACE_AVAIL - 32))  | (1U << (FATTR4_SPACE_FREE - 32)) |
         (1U << (FATTR4_SPACE_TOTAL - 32))  | (1U << (FATTR4_SPACE_USED - 32)) |
         (1U << (FATTR4_TIME_ACCESS - 32))  | (1U << (FATTR4_TIME_METADATA - 32)) |
-        (1U << (FATTR4_TIME_MODIFY - 32));
+        (1U << (FATTR4_TIME_MODIFY - 32))  |
+        (1U << (FATTR4_MOUNTED_ON_FILEID - 32));
     static const uint32_t writeonly_word1 =
         (1U << (FATTR4_TIME_ACCESS_SET - 32)) |
         (1U << (FATTR4_TIME_MODIFY_SET - 32));

--- a/src/server/nfs/nfs4_recovery.c
+++ b/src/server/nfs/nfs4_recovery.c
@@ -567,14 +567,25 @@ nfs_recovery_open_check(
      * this leg is unreachable on the default memkv backend. */
     if (in_grace && is_reclaim && load_ready && client) {
         struct nfs_recovery_record *r;
+        bool                        reclaimed;
 
         pthread_mutex_lock(&rec->lock);
         HASH_FIND(hh, rec->to_reclaim, client->owner_string,
                   client->owner_len, r);
+        reclaimed = r && r->reclaimed;
         pthread_mutex_unlock(&rec->lock);
 
         if (!r) {
             return NFS4ERR_RECLAIM_BAD;
+        }
+
+        /* RFC 8881 §18.51.3: once this client has declared reclaim complete
+         * the server MUST NOT let it reclaim any more state, even though the
+         * server-wide grace window is still open because some *other* client
+         * has not finished.  Grace is a per-client obligation that this client
+         * has already retired. */
+        if (reclaimed) {
+            return NFS4ERR_NO_GRACE;
         }
     }
 

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -1963,44 +1963,26 @@ nfs4_replay_slot_replay_done(struct nfs_request *req)
 } /* nfs4_replay_slot_replay_done */
 
 /*
- * Record the delegation callback path for a client onto its unified state
- * record.  Called from the SETCLIENTID handler (4.0, with a cb_client4) and
- * from CREATE_SESSION (4.1, program only -- the backchannel rides the fore
- * conn).  Re-setting the path (e.g. a fresh SETCLIENTID) resets the probe
- * state so the callback channel is re-validated before any new delegation.
+ * Commit callback addressing onto a client's unified state record.  Re-setting
+ * the path resets the probe state so the callback channel is re-validated
+ * before any new delegation.  The caller holds the client table lock.
  *
  * The actual outbound channel (cb_path.cb_client) is established lazily by
  * the callback subsystem; here we only capture the addressing the client
  * supplied.
  */
-void
-nfs4_client_set_cb_path(
-    struct nfs4_client_table *table,
-    uint64_t                  client_id,
-    uint32_t                  cb_program,
-    uint32_t                  cb_ident,
-    uint8_t                   minorversion,
-    const char               *netid,
-    int                       netid_len,
-    const char               *addr,
-    int                       addr_len)
+static void
+nfs4_cb_path_store(
+    struct nfs_client *u,
+    uint32_t           cb_program,
+    uint32_t           cb_ident,
+    uint8_t            minorversion,
+    const char        *netid,
+    int                netid_len,
+    const char        *addr,
+    int                addr_len)
 {
-    struct nfs4_client  *c;
-    struct nfs_client   *u;
-    struct nfs4_cb_path *cb;
-
-    pthread_mutex_lock(&table->nfs4_ct_lock);
-
-    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
-              &client_id, sizeof(client_id), c);
-
-    if (!c || !c->unified) {
-        pthread_mutex_unlock(&table->nfs4_ct_lock);
-        return;
-    }
-
-    u  = c->unified;
-    cb = &u->cb_path;
+    struct nfs4_cb_path *cb = &u->cb_path;
 
     if (addr_len >= (int) sizeof(cb->cb_addr)) {
         addr_len = sizeof(cb->cb_addr) - 1;
@@ -2047,8 +2029,128 @@ nfs4_client_set_cb_path(
     }
 
     pthread_mutex_unlock(&u->lock);
+} /* nfs4_cb_path_store */
+
+/*
+ * Apply a callback path immediately.  Used by CREATE_SESSION (4.1, program
+ * only -- the backchannel rides the fore conn), where the operation that
+ * carries the addressing is itself the one that confirms the client.  The 4.0
+ * SETCLIENTID path stages instead; see nfs4_client_stage_cb_path.
+ */
+void
+nfs4_client_set_cb_path(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id,
+    uint32_t                  cb_program,
+    uint32_t                  cb_ident,
+    uint8_t                   minorversion,
+    const char               *netid,
+    int                       netid_len,
+    const char               *addr,
+    int                       addr_len)
+{
+    struct nfs4_client *c;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (c && c->unified) {
+        nfs4_cb_path_store(c->unified, cb_program, cb_ident, minorversion,
+                           netid, netid_len, addr, addr_len);
+    }
+
     pthread_mutex_unlock(&table->nfs4_ct_lock);
 } /* nfs4_client_set_cb_path */
+
+/*
+ * Stage the callback path a 4.0 SETCLIENTID supplied.
+ *
+ * RFC 7530 §16.33.5: a callback/callback_ident update "is only confirmed if
+ * followed up by a SETCLIENTID_CONFIRM", and §16.34.5 makes the confirm the
+ * step that modifies "recorded and confirmed callback and callback_ident
+ * information".  The RFC tolerates a stray SETCLIENTID carrying stale
+ * callback info precisely because of that deferral, so the addressing is
+ * parked on the client record here and only reaches the live unified record
+ * in nfs4_client_commit_cb_path.
+ */
+void
+nfs4_client_stage_cb_path(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id,
+    uint32_t                  cb_program,
+    uint32_t                  cb_ident,
+    const char               *netid,
+    int                       netid_len,
+    const char               *addr,
+    int                       addr_len)
+{
+    struct nfs4_client *c;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (c) {
+        if (netid_len < 0) {
+            netid_len = 0;
+        }
+        if (netid_len > (int) sizeof(c->nfs4_client_scid_cb_netid)) {
+            netid_len = sizeof(c->nfs4_client_scid_cb_netid);
+        }
+        if (addr_len < 0) {
+            addr_len = 0;
+        }
+        if (addr_len > (int) sizeof(c->nfs4_client_scid_cb_addr)) {
+            addr_len = sizeof(c->nfs4_client_scid_cb_addr);
+        }
+
+        c->nfs4_client_scid_cb_program   = cb_program;
+        c->nfs4_client_scid_cb_ident     = cb_ident;
+        c->nfs4_client_scid_cb_netid_len = (uint32_t) netid_len;
+        c->nfs4_client_scid_cb_addr_len  = (uint32_t) addr_len;
+        if (netid_len) {
+            memcpy(c->nfs4_client_scid_cb_netid, netid, netid_len);
+        }
+        if (addr_len) {
+            memcpy(c->nfs4_client_scid_cb_addr, addr, addr_len);
+        }
+        c->nfs4_client_scid_cb_valid = 1;
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+} /* nfs4_client_stage_cb_path */
+
+void
+nfs4_client_commit_cb_path(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id)
+{
+    struct nfs4_client *c;
+
+    pthread_mutex_lock(&table->nfs4_ct_lock);
+
+    HASH_FIND(nfs4_client_hh_by_id, table->nfs4_ct_clients_by_id,
+              &client_id, sizeof(client_id), c);
+
+    if (c && c->unified && c->nfs4_client_scid_cb_valid) {
+        /* One-shot: a retransmitted SETCLIENTID_CONFIRM must not tear the
+         * channel this one just authorised back down. */
+        c->nfs4_client_scid_cb_valid = 0;
+        nfs4_cb_path_store(c->unified,
+                           c->nfs4_client_scid_cb_program,
+                           c->nfs4_client_scid_cb_ident,
+                           0,
+                           c->nfs4_client_scid_cb_netid,
+                           (int) c->nfs4_client_scid_cb_netid_len,
+                           c->nfs4_client_scid_cb_addr,
+                           (int) c->nfs4_client_scid_cb_addr_len);
+    }
+
+    pthread_mutex_unlock(&table->nfs4_ct_lock);
+} /* nfs4_client_commit_cb_path */
 
 /*
  * Record the RPC auth flavor/credentials the client wants the server to use on

--- a/src/server/nfs/nfs4_session.c
+++ b/src/server/nfs/nfs4_session.c
@@ -648,10 +648,11 @@ nfs4_client_setclientid(
 
 nfsstat4
 nfs4_client_setclientid_confirm(
-    struct nfs4_client_table *table,
-    uint64_t                  clientid,
-    const uint8_t            *confirm,
-    struct nfs_client       **destroy_unified)
+    struct nfs4_client_table           *table,
+    uint64_t                            clientid,
+    const uint8_t                      *confirm,
+    const struct nfs4_client_principal *principal,
+    struct nfs_client                 **destroy_unified)
 {
     struct nfs4_client *r, *old;
     nfsstat4            status;
@@ -675,6 +676,17 @@ nfs4_client_setclientid_confirm(
          * specifies NFS4ERR_STALE_CLIENTID here; NFS4ERR_STALE_STATEID is only
          * valid for stateid operations. */
         status = NFS4ERR_STALE_CLIENTID;
+        goto out_unlock;
+    }
+
+    /* RFC 7530 §16.34.5: in every case where the confirm names an existing
+     * record, "if the principals of the records do not match that of the
+     * SETCLIENTID_CONFIRM, the server returns NFS4ERR_CLID_INUSE".  Without
+     * it a principal that learns the {clientid, confirm verifier} pair --
+     * the confirm verifiers being a monotonic counter -- can confirm, and on
+     * a reboot record supersede, a client it did not create. */
+    if (!nfs4_principal_matches(r, principal)) {
+        status = NFS4ERR_CLID_INUSE;
         goto out_unlock;
     }
 

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -357,14 +357,17 @@ nfs4_client_setclientid(
  * named by `clientid`/`confirm`.  On a client reboot this promotes the
  * superseding record and tears the old one down, returning its unified state
  * hierarchy via *destroy_unified for teardown outside the table lock.
- * Returns NFS4ERR_STALE_CLIENTID (no such clientid) or NFS4ERR_CLID_INUSE
- * (confirm verifier mismatch) on failure. */
+ * `principal` is the confirming request's principal, which §16.34.5 requires
+ * to be the one that created the record.  Returns NFS4ERR_STALE_CLIENTID (no
+ * such clientid, or no record awaiting this confirm verifier) or
+ * NFS4ERR_CLID_INUSE (principal mismatch) on failure. */
 nfsstat4
 nfs4_client_setclientid_confirm(
-    struct nfs4_client_table *table,
-    uint64_t                  clientid,
-    const uint8_t            *confirm,
-    struct nfs_client       **destroy_unified);
+    struct nfs4_client_table           *table,
+    uint64_t                            clientid,
+    const uint8_t                      *confirm,
+    const struct nfs4_client_principal *principal,
+    struct nfs_client                 **destroy_unified);
 
 /* RFC 8881 §18.35.4 EXCHANGE_ID client-record matching state machine.  Runs
  * entirely under the table lock and fills *out (see nfs4_exchange_id_result).

--- a/src/server/nfs/nfs4_session.h
+++ b/src/server/nfs/nfs4_session.h
@@ -209,6 +209,20 @@ struct nfs4_client {
     uint8_t               nfs4_client_scid_confirm[NFS4_VERIFIER_SIZE];
     uint8_t               nfs4_client_scid_confirm_valid;
     uint64_t              nfs4_client_scid_pending_id;
+    /* Callback path (cb_client4) carried by a SETCLIENTID that has not been
+     * confirmed yet.  RFC 7530 §16.33.5: the update "is only confirmed if
+     * followed up by a SETCLIENTID_CONFIRM", so it is staged here instead of
+     * being applied to the live unified record -- a stray or never-confirmed
+     * SETCLIENTID must not disturb a confirmed client's working back-channel.
+     * Committed and cleared by nfs4_client_commit_cb_path.  The two buffers
+     * are sized to match nfs4_cb_path's cb_netid/cb_addr. */
+    uint8_t               nfs4_client_scid_cb_valid;
+    uint32_t              nfs4_client_scid_cb_program;
+    uint32_t              nfs4_client_scid_cb_ident;
+    uint32_t              nfs4_client_scid_cb_netid_len;
+    uint32_t              nfs4_client_scid_cb_addr_len;
+    char                  nfs4_client_scid_cb_netid[8];
+    char                  nfs4_client_scid_cb_addr[64];
     /* Unified state hierarchy.  Created when this nfs4_client is first
      * registered; freed when the nfs4_client is unregistered or the table
      * is torn down.  See nfs4_state.h. */
@@ -590,6 +604,27 @@ nfs4_client_set_cb_path(
     int                       netid_len,
     const char               *addr,
     int                       addr_len);
+
+/* Stage a 4.0 SETCLIENTID's callback path on the client record without
+ * touching the live one, and commit a staged path once the matching
+ * SETCLIENTID_CONFIRM lands (RFC 7530 §16.33.5/§16.34.5).  Committing is a
+ * one-shot: a retransmitted SETCLIENTID_CONFIRM finds nothing staged and
+ * leaves the path (and any channel already built on it) alone. */
+void
+nfs4_client_stage_cb_path(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id,
+    uint32_t                  cb_program,
+    uint32_t                  cb_ident,
+    const char               *netid,
+    int                       netid_len,
+    const char               *addr,
+    int                       addr_len);
+
+void
+nfs4_client_commit_cb_path(
+    struct nfs4_client_table *table,
+    uint64_t                  client_id);
 
 /* Record the callback-channel RPC auth (CREATE_SESSION csa_sec_parms /
  * BACKCHANNEL_CTL).  flavor is an ONC RPC flavor (AUTH_NONE=0, AUTH_SYS=1);

--- a/src/server/nfs/nfs4_state.c
+++ b/src/server/nfs/nfs4_state.c
@@ -1482,6 +1482,29 @@ nfs_layout_state_destroy(
     pthread_mutex_unlock(&client->lock);
 } /* nfs_layout_state_destroy */
 
+void
+nfs_layout_state_destroy_all(
+    struct nfs_client         *client,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread)
+{
+    pthread_mutex_lock(&client->lock);
+
+    /* The uthash delete-during-iteration idiom trips scan-build's
+     * use-after-free checker; guard it the way the client teardown above
+     * guards the identical loop. */
+#ifndef __clang_analyzer__
+    struct nfs_layout_state *ly, *ly_tmp;
+
+    HASH_ITER(hh, client->layouts_by_fh, ly, ly_tmp)
+    {
+        layout_state_destroy_locked(client, ly, table, vfs_thread);
+    }
+#endif /* ifndef __clang_analyzer__ */
+
+    pthread_mutex_unlock(&client->lock);
+} /* nfs_layout_state_destroy_all */
+
 struct nfs_lock_owner *
 nfs_lock_owner_find_or_create(
     struct nfs_client *client,

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -140,6 +140,10 @@ struct nfs4_replay_cache {
     uint32_t        op;        /* nfs_opnum4 of the cached op  */
     nfsstat4        status;
     struct stateid4 stateid;   /* for OPEN/CLOSE/LOCK/LOCKU/etc. responses */
+    /* OPEN4_RESULT_* of a cached OPEN reply.  OPEN4_RESULT_CONFIRM is the one
+     * bit a client may act on, so replaying it verbatim matters; zeroed by
+     * nfs4_replay_record and filled in by the OPEN completion path. */
+    uint32_t        rflags;
     uint8_t         valid;
 };
 
@@ -191,6 +195,7 @@ nfs4_replay_record(
     replay->seqid  = seqid;
     replay->op     = op;
     replay->status = status;
+    replay->rflags = 0;
     if (stateid) {
         replay->stateid = *stateid;
     } else {

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -1129,6 +1129,13 @@ nfs_layout_state_destroy(
     struct nfs_state_table    *table,
     struct chimera_vfs_thread *vfs_thread);
 
+/* Tear down every layout_state a client holds (LAYOUTRETURN4_ALL). */
+SYMBOL_EXPORT void
+nfs_layout_state_destroy_all(
+    struct nfs_client         *client,
+    struct nfs_state_table    *table,
+    struct chimera_vfs_thread *vfs_thread);
+
 /* Touch a client's lease.  Cheap relaxed store; called from any op that
  * counts as renewal evidence (state acquire, SEQUENCE, RENEW).  Phase 3. */
 static inline void

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -512,6 +512,12 @@ struct nfs_layout_state {
     uint32_t                 seqid;     /* server-incremented layout stateid seqid */
     uint32_t                 iomode;    /* current LAYOUTIOMODE4 */
 
+    /* layouttype4 granted for this file (RFC 8881 3.3.13): flex-files, block
+     * or SCSI.  CB_LAYOUTRECALL must echo it -- the client matches a recall by
+     * {layout type, fh, iomode, range} and answers NFS4ERR_NOMATCHING_LAYOUT
+     * otherwise.  Set by LAYOUTGET; 0 means "not yet granted". */
+    uint32_t                 layout_type;
+
     uint8_t                  shard;
     uint32_t                 slot_idx;
     uint32_t                 generation;

--- a/src/server/nfs/nfs4_status.h
+++ b/src/server/nfs/nfs4_status.h
@@ -99,3 +99,26 @@ chimera_nfs4_data_nonreg_status(mode_t mode)
     }
     return NFS4ERR_INVAL;
 } /* chimera_nfs4_data_nonreg_status */
+
+/*
+ * Status for an RFC 7862 sparse op -- ALLOCATE, DEALLOCATE, SEEK -- whose
+ * current filehandle is not a regular file.
+ *
+ * These are NFSv4.2-only, so there is no 4.0 minor version to be bug-compatible
+ * with, and RFC 7862 §15.1.3/§15.4.3 make a non-regular CURRENT_FH
+ * NFS4ERR_WRONG_TYPE.  A directory still answers NFS4ERR_ISDIR and a symlink
+ * NFS4ERR_SYMLINK, the more specific errors both the RFC error tables and the
+ * quint model predict; WRONG_TYPE covers the fifos, sockets and devices where
+ * chimera_nfs4_data_nonreg_status has to keep saying INVAL for pynfs's sake.
+ */
+static inline nfsstat4
+chimera_nfs4_sparse_nonreg_status(mode_t mode)
+{
+    if (S_ISDIR(mode)) {
+        return NFS4ERR_ISDIR;
+    }
+    if (S_ISLNK(mode)) {
+        return NFS4ERR_SYMLINK;
+    }
+    return NFS4ERR_WRONG_TYPE;
+} /* chimera_nfs4_sparse_nonreg_status */

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -390,6 +390,11 @@ struct chimera_server_nfs_shared {
     int                                 fh_sign;
     uint8_t                             fh_key[16];
 
+    /* True once the RPCSEC_GSS (Kerberos) acceptor is installed, snapshotted
+     * from server.nfs_kerberos_enabled at init.  Security-flavor advertisement
+     * consults it so we never offer a flavor the RPC layer cannot accept. */
+    int                                 gss_enabled;
+
     struct chimera_nfs_mount_entry     *mount_entries;
     pthread_mutex_t                     mount_entries_lock;
     int                                 num_mount_entries;
@@ -796,13 +801,15 @@ chimera_nfs_fh_encode(
 /*
  * Populate `out` (capacity >= 4) with the secinfo4 entries advertising an
  * export's allowed security flavors.  An export with no explicit policy
- * (sec_allowed == 0) advertises everything chimera supports.  Returns the
+ * (sec_allowed == 0) advertises everything chimera supports.  `gss_enabled` is
+ * the server's live RPCSEC_GSS state (shared->gss_enabled).  Returns the
  * number of entries written, in the server's preference order.
  */
 static inline int
 chimera_nfs_fill_secinfo(
     struct secinfo4 *out,
-    uint32_t         sec_allowed)
+    uint32_t         sec_allowed,
+    int              gss_enabled)
 {
     /* Kerberos v5 mechanism OID 1.2.840.113554.1.2.2 (RFC 1964). */
     static const uint8_t krb5_oid[9] = {
@@ -825,6 +832,17 @@ chimera_nfs_fill_secinfo(
     };
     /* *INDENT-ON* */
     unsigned i;
+
+    /* RFC 7530 §3.2.1.1 / §16.31: SECINFO must report flavors the server will
+     * actually accept.  Without the Kerberos acceptor installed (default:
+     * server.nfs_kerberos_enabled is off) an RPCSEC_GSS client would be
+     * rejected at the RPC layer, so suppress the krb5 triples -- but only when
+     * AUTH_SYS survives, since an export explicitly configured for GSS alone
+     * must not be silently downgraded to an empty (or AUTH_SYS) list. */
+    if (!gss_enabled && (mask & CHIMERA_NFS_SEC_SYS)) {
+        mask &= ~(CHIMERA_NFS_SEC_KRB5 | CHIMERA_NFS_SEC_KRB5I |
+                  CHIMERA_NFS_SEC_KRB5P);
+    }
 
     if (mask & CHIMERA_NFS_SEC_SYS) {
         out[n++].flavor = AUTH_SYS;

--- a/src/server/nfs/nfs_nlm.c
+++ b/src/server/nfs/nfs_nlm.c
@@ -1229,16 +1229,24 @@ chimera_nfs_nlm4_do_cancel(
             break;
         }
     }
-    pthread_mutex_unlock(&shared->nlm_state.mutex);
 
     if (match && match->file_state) {
         /* The entry is queued inside the claim core waiting on a break.  Try
          * to dequeue it; if we win the race against the in-flight cb,
          * synthesize a DENIED completion so the original LOCK reply is
-         * still sent (the protocol layer's cb tears down the entry). */
+         * still sent (the protocol layer's cb tears down the entry).
+         *
+         * This must happen while we still hold nlm_state.mutex: the moment it
+         * is dropped a concurrent client reap (FREE_ALL, SM_NOTIFY, or the
+         * client's last connection dropping) can detach and free `match`, so
+         * touching it afterwards is a use-after-free.  claim_cancel is
+         * documented as never blocking and never re-entering the caller, so
+         * it is safe under our own lock -- nlm_client_release_all_locks
+         * calls it from exactly the same position. */
         cancelled       = chimera_vfs_claim_cancel(vfs_state, &match->ticket);
         ctx_for_lock_cb = match->ticket.private_data;
     }
+    pthread_mutex_unlock(&shared->nlm_state.mutex);
 
     nlm4_send_res(shared, evpl, conn, encoding, &args->cookie, NLM4_GRANTED,
                   proc);

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -1030,7 +1030,8 @@ cairn_inherit_acl(
      * always set ATTR_ACL (e.g., NFS3 creates). */
     if (new_acl && new_acl->num_aces) {
         cairn_put_acl(thread, child->inum, new_acl);
-        child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(new_acl);
+        child->mode = (child->mode & CHIMERA_MODE_ACL_PRESERVE) |
+            chimera_acl_to_mode(new_acl);
         return;
     }
 
@@ -1052,7 +1053,8 @@ cairn_inherit_acl(
 
             if (n > 0) {
                 cairn_put_acl(thread, child->inum, tmp);
-                child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(tmp);
+                child->mode = (child->mode & CHIMERA_MODE_ACL_PRESERVE) |
+                    chimera_acl_to_mode(tmp);
                 free(tmp);
                 return;
             }
@@ -2192,7 +2194,7 @@ cairn_setattr(
         if (orig_set_mask & CHIMERA_VFS_ATTR_ACL) {
             if (sa->va_acl && sa->va_acl->num_aces) {
                 cairn_put_acl(thread, inode->inum, sa->va_acl);
-                inode->mode = (inode->mode & S_IFMT) |
+                inode->mode = (inode->mode & CHIMERA_MODE_ACL_PRESERVE) |
                     chimera_acl_to_mode(sa->va_acl);
             } else {
                 cairn_remove_acl(thread, inode->inum);

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -445,7 +445,8 @@ diskfs_inherit_acl_async(
 
         if (len >= 0) {
             if (derive_mode) {
-                child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(store);
+                child->mode = (child->mode & CHIMERA_MODE_ACL_PRESERVE) |
+                    chimera_acl_to_mode(store);
             }
             diskfs_acl_serial_install(child, sbuf, len);
             /* The child is brand new, so there is no existing record to
@@ -982,7 +983,8 @@ diskfs_setattr_inode_cb(
         int                       slen = -1;
 
         if (acl && acl->num_aces) {
-            inode->mode = (inode->mode & S_IFMT) | chimera_acl_to_mode(acl);
+            inode->mode = (inode->mode & CHIMERA_MODE_ACL_PRESERVE) |
+                chimera_acl_to_mode(acl);
         }
         if (acl && acl->num_aces && acl->num_aces <= DISKFS_ACL_REC_MAX_ACES) {
             slen = chimera_acl_serialize(acl, sbuf, sizeof(sbuf));

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1894,7 +1894,8 @@ memfs_apply_attrs(
     if (set_mask & CHIMERA_VFS_ATTR_ACL) {
         memfs_inode_set_acl(inode, attr->va_acl);
         if (inode->acl) {
-            inode->mode = (inode->mode & S_IFMT) | chimera_acl_to_mode(inode->acl);
+            inode->mode = (inode->mode & CHIMERA_MODE_ACL_PRESERVE) |
+                chimera_acl_to_mode(inode->acl);
         }
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ACL;
     } else if ((set_mask & CHIMERA_VFS_ATTR_MODE) && inode->acl) {
@@ -2007,7 +2008,8 @@ memfs_inherit_acl(
 
         if (n > 0) {
             memfs_inode_set_acl(child, tmp);
-            child->mode = (child->mode & S_IFMT) | chimera_acl_to_mode(child->acl);
+            child->mode = (child->mode & CHIMERA_MODE_ACL_PRESERVE) |
+                chimera_acl_to_mode(child->acl);
         }
         free(tmp);
 

--- a/src/vfs/sdk/vfs_acl.h
+++ b/src/vfs/sdk/vfs_acl.h
@@ -21,8 +21,22 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <sys/stat.h>
 
 struct chimera_vfs_cred;
+
+/*
+ * Mode bits that survive a re-derivation of the mode from an ACL.
+ *
+ * chimera_acl_to_mode projects only the nine rwx bits, so a backend that
+ * recomputes an object's mode after a SETATTR(acl) or a create-time inherit
+ * must carry the rest over from the stored mode: the file type, and the three
+ * high-order bits.  RFC 7530 6.4.1.2 -- "the three high-order bits of the mode
+ * (MODE4_SUID, MODE4_SGID, MODE4_SVTX) SHOULD remain unchanged" -- setuid,
+ * setgid and sticky are not expressible in an ACL, so setting or inheriting one
+ * must leave them alone rather than project them away.
+ */
+#define CHIMERA_MODE_ACL_PRESERVE          (S_IFMT | S_ISUID | S_ISGID | S_ISVTX)
 
 /* ---- ACE types (match nfsace4 type and the NT ACE type family) ---------- */
 #define CHIMERA_ACE_ALLOWED                0

--- a/src/vfs/sdk/vfs_cred.h
+++ b/src/vfs/sdk/vfs_cred.h
@@ -138,8 +138,9 @@ chimera_vfs_cred_init_unix(
  * @param cred   The credential to initialize
  * @param uid    User ID to assign to created files
  * @param gid    Group ID to assign to created files
- * @param ngids  Unused; reserved for future use
- * @param gids   Unused; reserved for future use
+ * @param ngids  Number of supplementary group IDs (capped at
+ *               CHIMERA_VFS_CRED_MAX_GIDS)
+ * @param gids   Array of supplementary group IDs (may be NULL if ngids == 0)
  */
 void
 chimera_vfs_cred_init_attr(

--- a/src/vfs/vfs_cred.c
+++ b/src/vfs/vfs_cred.c
@@ -112,15 +112,29 @@ chimera_vfs_cred_init_attr(
     uint32_t                 ngids,
     const uint32_t          *gids)
 {
-    (void) ngids;
-    (void) gids;
-
     cred->flavor = CHIMERA_VFS_AUTH_ATTR;
     cred->uid    = uid;
     cred->gid    = gid;
-    cred->ngids  = 0;
     cred->origin = NULL;
     cred->flags  = 0;
+
+    /* The caller's whole group set matters to the access decision, not just
+     * its primary group: MS-DTYP 2.5.2 evaluates every group SID in the token,
+     * and cred_in_group() (the ACL engine's GROUP@/named-group test, and the
+     * POSIX group class behind it) can only see what is carried here.  Dropping
+     * them denied an SMB caller whose membership is supplementary -- the normal
+     * AD case -- access that the same identity is granted over NFS, where
+     * cred_init_unix keeps the list. */
+    if (ngids > CHIMERA_VFS_CRED_MAX_GIDS) {
+        ngids = CHIMERA_VFS_CRED_MAX_GIDS;
+    }
+
+    cred->ngids = ngids;
+    if (ngids > 0 && gids) {
+        memcpy(cred->gids, gids, ngids * sizeof(uint32_t));
+    } else {
+        cred->ngids = 0;
+    }
 } /* chimera_vfs_cred_init_attr */
 
 SYMBOL_EXPORT int


### PR DESCRIPTION
The `effort:medium` / `severity:medium` NFS band: 49 issues investigated, **29 closed** and 3 partially addressed, one commit each.

These are larger than the one-liners in #1640 but still contained — a missing ownership check, a state machine that ignores a flag it was handed, an attribute that exists one layer down and is never plumbed through.

### Authorization and identity
| | |
|---|---|
| #967 | LOCK never checked that the open/lock stateid belonged to the calling client |
| #964 | SETCLIENTID_CONFIRM was not bound to the principal that issued SETCLIENTID |
| #1085 | state-protection mode was recomputed on every EXCHANGE_ID, so a confirmed SP4_MACH_CRED client could be flipped to SP4_NONE |
| #383 | the ACCESS DELETE bit asked about the object rather than the directory entry |
| #386 | SECINFO advertised krb5 on exports the GSS acceptor would reject |
| #1079 | re-deriving a mode from an ACL dropped SUID/SGID/SVTX |
| #1398 | the SMB session credential dropped supplementary groups |

### State machines
| | |
|---|---|
| #1088 | grace/reclaim was global-only; a client that finished RECLAIM_COMPLETE could still reclaim |
| #1075 | LOCK ignored the reclaim flag entirely |
| #1076 | LOCKT keyed its conflict probe on the wire clientid, not the session's |
| #1077 | SETCLIENTID applied and tore down the callback path before confirmation |
| #1073 | a delegation could be granted on the same OPEN that demanded OPEN_CONFIRM |
| #998 | a 4.0 OPEN replay dropped OPEN4_RESULT_CONFIRM from rflags |
| #1381 | SEQUENCE errors advanced the slot before the compound limits were checked |
| #402 | SEQUENCE never reported CB_PATH_DOWN |
| #1083 | CB_GETATTR was gated to 4.1+ although it is a 4.0 mechanism |

### pNFS
#970 (LAYOUTGET never validated its layout stateid), #1378 (no RECALLCONFLICT), #1092 (illegal `loga_iomode` accepted), #1089/#1094 (CB_LAYOUTRECALL hardcoded FLEX_FILES — one defect, one commit, both trailers), #1082 (declined delegation reported without the WND4 reason).

### Wire and attributes
#392 (mounted_on_fileid), #960 (wcc_data `after` suppressed unless the backend flagged ATOMIC), #958 (READDIR never returned TOOSMALL), #399 (SECINFO_NO_NAME ignored style and current FH), #1095 (WRONG_TYPE for a special-file cfh), #1373 (**NLM CANCEL use-after-free** — the ticket read now happens under `nlm_state.mutex`).

## Not fixed

19 issues were investigated and deliberately left alone. The two recurring reasons are worth stating, because they are the same reasons in most cases:

- **The quint model pins the current behaviour.** #1009, #1096, #1097, #969 each have an `ext/specs/quint/` rule asserting what the code does today (`NLM_SHARE_ENFORCED = false`, `NLM_UPGRADE_IS_NOOP = true`, `dropWithin` containment-only, the `opLock` newOwner arm). Changing chimera alone turns the merge-gating tier red; each needs a paired `ext/specs` commit that cannot ride here.
- **The issue is wrong.** #966 attributes to RFC 7530 §16.10.4 a sentence that is not there; the actual text (§16.10.5, RFC 8881 §18.10.4) says the opposite — lock-vs-open-mode is explicitly server-dependent — and `nfs4.qnt:1306` says so too. Adopting POSIX semantics is defensible but is a policy decision, not a bug fix.

The rest (#67 already implemented, #394, #944 upgrade half, #1003 minlength, #1004 FSID, #1005, #1080, #1084, #1098, #1109, #1375, #1377, #1380, #1399) needed a new subsystem, a schema decision, or a policy call. #944, #1003 and #1004 are committed as `Refs`, not `Fixes`, so they stay open for their remaining half.

#1010 (NLM TEST denied-holder identity) was fixed and then **dropped**: the server names a different conflicting owner than the model expects when several locks conflict, so it needs the same paired `ext/specs` change as the other NLM items.

## Testing

Quick tier green (97/97 on macOS), Debug and Release build clean, every commit uncrustify-clean, each written against current `main` and cherry-picked onto it.

Note that the macOS quick tier does not cover the `linux` and `io_uring` passthrough backends — CI runs 128 tests where macOS runs 97. #960 in particular changes nfs3 `wcc_data` behaviour that is only observable on those backends, so the devcontainer leg is the one that matters for this PR.