### PR TITLE
tests/quint: line-buffer the MBT drivers so a crash keeps its output

### DIFF
--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -3746,6 +3746,16 @@ main(
     int         ntraces = 0;
     int         i, ran = 0, failures = 0, bad = 0;
 
+    /* Line-buffer stdout so a crash cannot swallow the progress output.
+     * These drivers print one line per trace, and both that and chimera's log
+     * (which defaults to stdout) are block-buffered when stdout is a pipe --
+     * which it always is under ctest.  glibc's abort() does not flush stdio,
+     * so on Linux an aborting run loses everything since the last 4 KB
+     * boundary, including the line naming the trace that was executing and
+     * the fatal log message itself.  That is exactly what made a CI abort
+     * here undiagnosable from its artifacts. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     for (i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--backend") == 0 && i + 1 < argc) {
             backend = argv[++i];

--- a/src/server/nfs/tests/quint/nfs3_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_replay.c
@@ -1732,6 +1732,16 @@ main(
     /* Neutralize the host umask so passthrough backends (linux/io_uring) apply
      * client-sent modes verbatim and the export root keeps its 0777.  The mkfs
      * backends store modes directly and are unaffected. */
+    /* Line-buffer stdout so a crash cannot swallow the progress output.
+     * These drivers print one line per trace, and both that and chimera's log
+     * (which defaults to stdout) are block-buffered when stdout is a pipe --
+     * which it always is under ctest.  glibc's abort() does not flush stdio,
+     * so on Linux an aborting run loses everything since the last 4 KB
+     * boundary, including the line naming the trace that was executing and
+     * the fatal log message itself.  That is exactly what made a CI abort
+     * here undiagnosable from its artifacts. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     umask(0);
 
     /* --trace/--trace-dir/--exclude-prefix are gathered from the raw argv by

--- a/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
@@ -1726,6 +1726,16 @@ main(
     struct mbt_env       env;
     struct mbt_env_opts  opts;
 
+    /* Line-buffer stdout so a crash cannot swallow the progress output.
+     * These drivers print one line per trace, and both that and chimera's log
+     * (which defaults to stdout) are block-buffered when stdout is a pipe --
+     * which it always is under ctest.  glibc's abort() does not flush stdio,
+     * so on Linux an aborting run loses everything since the last 4 KB
+     * boundary, including the line naming the trace that was executing and
+     * the fatal log message itself.  That is exactly what made a CI abort
+     * here undiagnosable from its artifacts. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     traces = mbt_collect_traces(argc, argv, &ntraces);
 
     while ((c = getopt_long(argc, argv, "t:D:X:nvpB:R", long_options,

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
@@ -885,6 +885,16 @@ main(
     struct mbt_env      env;
     struct mbt_env_opts opts;
 
+    /* Line-buffer stdout so a crash cannot swallow the progress output.
+     * These drivers print one line per trace, and both that and chimera's log
+     * (which defaults to stdout) are block-buffered when stdout is a pipe --
+     * which it always is under ctest.  glibc's abort() does not flush stdio,
+     * so on Linux an aborting run loses everything since the last 4 KB
+     * boundary, including the line naming the trace that was executing and
+     * the fatal log message itself.  That is exactly what made a CI abort
+     * here undiagnosable from its artifacts. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     umask(0);
 
     traces = mbt_collect_traces(argc, argv, &ntraces);

--- a/src/server/rest/tests/quint/ctl_mbt_replay.c
+++ b/src/server/rest/tests/quint/ctl_mbt_replay.c
@@ -1199,6 +1199,16 @@ main(
     struct mbt_env      env;
     struct mbt_env_opts opts;
 
+    /* Line-buffer stdout so a crash cannot swallow the progress output.
+     * These drivers print one line per trace, and both that and chimera's log
+     * (which defaults to stdout) are block-buffered when stdout is a pipe --
+     * which it always is under ctest.  glibc's abort() does not flush stdio,
+     * so on Linux an aborting run loses everything since the last 4 KB
+     * boundary, including the line naming the trace that was executing and
+     * the fatal log message itself.  That is exactly what made a CI abort
+     * here undiagnosable from its artifacts. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     umask(0);
 
     traces = mbt_collect_traces(argc, argv, &ntraces);


### PR DESCRIPTION
`posix/mbt/batch_nfs3_linux` aborted in the extended run and **the artifacts could not say why**. The captured output stopped mid-line at a 4 KB boundary, naming neither the trace that was executing nor the fatal message.

## Why the output vanished

The MBT drivers print one line per trace, and chimera's log defaults to stdout (`ChimeraLogFile == NULL`), so both go through the same stdio buffer. Under ctest stdout is always a pipe — `scripts/cap_ctest_output.sh` pipes it — which makes that buffer **block**-buffered rather than line-buffered. glibc's `abort()` does not flush stdio, so on Linux everything written since the last 4 KB flush is discarded: precisely the tail that says what went wrong.

**This is not a truncation limit**, which is where I first looked. Verified locally with a deliberately noisy aborting test under the same ctest flags — the JUnit came back **complete at 12 KB with its stderr intact**. macOS hides the bug because its `abort()` *does* flush stdio, which is why this only ever bit in CI.

There is a second, subtler effect. With block buffering an unbuffered stderr write lands *ahead* of the stdout progress output it actually followed:

```
block-buffered:   line 1 = "ABORT REASON: ..."   <- written first, buffer still unflushed
line-buffered:    line 301 = "ABORT REASON: ..." <- correct chronological position
```

So even a message that survives reads as though it happened before the run started.

## The fix

`setvbuf(stdout, NULL, _IOLBF, 0)` at the top of the five MBT replay drivers (posix, nfs3, nfs_drc, nfs_aux, ctl) — matching what `fsx.c` and the fuse tests already do.

## Scope

Diagnostic only; no behaviour change on a passing run. **It does not fix the `batch_nfs3_linux` abort** — it makes the next occurrence legible, which it currently is not. That abort remains unattributed: it appeared on amd64 Debug only, with arm64 Debug and both Release configurations passing, and there are only three sharded extended runs of history to compare against.

Debug build clean; all MBT tests pass (`ctest -R mbt`, 0 failures).
