### PR TITLE
nfs: twenty-seven NFS conformance and hardening fixes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -129,7 +129,7 @@ POST /api/v1/users
 | Field       | Type           | Required | Description                                              |
 |-------------|----------------|----------|----------------------------------------------------------|
 | `username`  | string         | yes      | User login name                                          |
-| `password`  | string         | no       | User password                                            |
+| `password`  | string         | no       | crypt(3) password hash for REST login, e.g. `$6$salt$hash` (stored verbatim and verified with crypt(3), so a plaintext value here can never authenticate) |
 | `smbpasswd` | string         | no       | SMB/NTLM password hash                                   |
 | `uid`       | integer        | no       | User ID (defaults to `0` if omitted)                     |
 | `gid`       | integer        | no       | Primary group ID (defaults to `0` if omitted)            |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -957,7 +957,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password (optional)"
+            "description": "crypt(3) password hash for REST login, e.g. \"$6$salt$hash\" (optional). The value is stored verbatim and verified with crypt(3), so a plaintext password here can never authenticate."
           },
           "smbpasswd": {
             "type": "string",

--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -773,6 +773,10 @@ nfs_server_destroy(void *data)
     free(shared->nlm_v4.rpc2.metrics);
     free(shared->nsm_v1.rpc2.metrics);
 
+    /* Drain any export removed at runtime whose free is still queued behind a
+     * grace period (see chimera_nfs_remove_export). */
+    rcu_barrier();
+
     while (shared->exports) {
         export = shared->exports;
         LL_DELETE(shared->exports, export);
@@ -1229,6 +1233,12 @@ chimera_nfs_get_export_by_id(
 } /* chimera_nfs_get_export_by_id */
 
 
+static void
+chimera_nfs_export_free_rcu(struct rcu_head *head)
+{
+    free(container_of(head, struct chimera_nfs_export, rcu));
+} /* chimera_nfs_export_free_rcu */
+
 SYMBOL_EXPORT int
 chimera_nfs_remove_export(
     void       *nfs_shared,
@@ -1252,7 +1262,13 @@ chimera_nfs_remove_export(
             LL_DELETE(shared->exports, export);
             shared->num_exports--;
             chimera_nfs_abort_if(shared->num_exports < 0, "num_exports went negative");
-            free(export);
+            /* Request threads resolve exports_by_id[] locklessly and then read
+             * the export's sec/squash policy, so freeing here (this runs on the
+             * REST thread) would let an in-flight request touch freed memory,
+             * or a recycled id hand it another export's policy.  Defer the free
+             * to a grace period: the evpl loops report their quiescent state
+             * between requests, never inside one. */
+            call_rcu(&export->rcu, chimera_nfs_export_free_rcu);
             found = 1;
             break;
         }

--- a/src/server/nfs/nfs3_proc_fsstat.c
+++ b/src/server/nfs/nfs3_proc_fsstat.c
@@ -20,28 +20,28 @@ chimera_nfs3_fsstat_complete(
     struct chimera_server_nfs_shared *shared = thread->shared;
     struct evpl                      *evpl   = thread->evpl;
     struct FSSTAT3res                 res;
+    uint64_t                          mask;
     int                               rc;
 
     res.status = chimera_vfs_error_to_nfsstat3(error_code);
 
-    /* Only treat missing statfs attributes as NOTSUPP when the getattr itself
-     * succeeded -- otherwise a real error (e.g. NFS3ERR_NOENT from a stale
-     * handle, whose failed getattr leaves va_set_mask empty) would be
-     * clobbered into a misleading NFS3ERR_NOTSUPP. */
-    if (res.status == NFS3_OK &&
-        (attr->va_set_mask & CHIMERA_NFS3_FSSTAT_MASK) != CHIMERA_NFS3_FSSTAT_MASK) {
-        res.status = NFS3ERR_NOTSUPP;
-    }
-
     if (res.status == NFS3_OK) {
         chimera_nfs3_set_post_op_attr(&res.resok.obj_attributes, attr);
 
-        res.resok.tbytes   = attr->va_fs_space_total;
-        res.resok.fbytes   = attr->va_fs_space_free;
-        res.resok.abytes   = attr->va_fs_space_avail;
-        res.resok.tfiles   = attr->va_fs_files_total;
-        res.resok.ffiles   = attr->va_fs_files_free;
-        res.resok.afiles   = attr->va_fs_files_avail;
+        mask = attr->va_set_mask;
+
+        /* FSSTAT is mandatory and RFC 1813 3.3.18 does not list NFS3ERR_NOTSUPP
+         * among its errors, so a backend that supplies only part of the statfs
+         * set must still get an answer: report every field it did supply and
+         * leave the rest at 0, which the spec already treats as "unknown".
+         * Failing the whole call made df (and mount-time usage reporting) error
+         * out on any backend short of the complete set. */
+        res.resok.tbytes   = (mask & CHIMERA_VFS_ATTR_SPACE_TOTAL) ? attr->va_fs_space_total : 0;
+        res.resok.fbytes   = (mask & CHIMERA_VFS_ATTR_SPACE_FREE) ? attr->va_fs_space_free : 0;
+        res.resok.abytes   = (mask & CHIMERA_VFS_ATTR_SPACE_AVAIL) ? attr->va_fs_space_avail : 0;
+        res.resok.tfiles   = (mask & CHIMERA_VFS_ATTR_FILES_TOTAL) ? attr->va_fs_files_total : 0;
+        res.resok.ffiles   = (mask & CHIMERA_VFS_ATTR_FILES_FREE) ? attr->va_fs_files_free : 0;
+        res.resok.afiles   = (mask & CHIMERA_VFS_ATTR_FILES_AVAIL) ? attr->va_fs_files_avail : 0;
         res.resok.invarsec = 0;
     } else {
         chimera_nfs3_set_post_op_attr(&res.resfail.obj_attributes, attr);

--- a/src/server/nfs/nfs3_proc_link.c
+++ b/src/server/nfs/nfs3_proc_link.c
@@ -63,15 +63,14 @@ chimera_nfs3_link(
     nfs3_trace_link(req, args);
 
     /* Decode the existing-file handle (sets the request export + squash) and
-     * the target-directory handle (authenticated into req->saved_fh).  The
-     * target handle must outlive this (async) call, so it lives in the request
-     * rather than on the stack (saved_fh is unused by NFSv3). */
+     * the target-directory handle (authenticated into req->saved_fh, layering
+     * its own export's sec= and squash policy on top).  The target handle must
+     * outlive this (async) call, so it lives in the request rather than on the
+     * stack (saved_fh is unused by NFSv3). */
     res.status = chimera_nfs3_decode_fh(req, args->file.data.data, args->file.data.len);
-    if (res.status == NFS3_OK &&
-        chimera_nfs_fh_unwrap(args->link.dir.data.data, args->link.dir.data.len,
-                              &linkdir_export_id, req->saved_fh, &req->saved_fhlen,
-                              shared->fh_key, shared->fh_sign) != CHIMERA_NFS_FH_OK) {
-        res.status = NFS3ERR_BADHANDLE;
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_decode_fh2(req, args->link.dir.data.data,
+                                             args->link.dir.data.len, &linkdir_export_id);
     }
     /* The link directory gains an entry and the file's nlink changes, so
      * both exports must be writable. */

--- a/src/server/nfs/nfs3_proc_pathconf.c
+++ b/src/server/nfs/nfs3_proc_pathconf.c
@@ -13,13 +13,13 @@
 #include "nfs3_dump.h"
 #include "nfs3_trace.h"
 
-/* PATHCONF's reply is entirely synthetic -- the limits are server constants,
- * independent of the object -- but the handle is still validated the way every
- * other file-handle-bearing procedure validates it: decoded (a bogus handle is
- * NFS3ERR_BADHANDLE) then resolved with a GETATTR (a stale handle is
- * NFS3ERR_NOENT).  memfs's open_fh is lazy and does not resolve the inode, so
- * the GETATTR is what actually catches a freed object; its returned attributes
- * are discarded and the constants are returned. */
+/* PATHCONF's limits are server constants, independent of the object, but the
+ * handle is still validated the way every other file-handle-bearing procedure
+ * validates it: decoded (a bogus handle is NFS3ERR_BADHANDLE) then resolved
+ * with a GETATTR (a stale handle is NFS3ERR_NOENT).  memfs's open_fh is lazy
+ * and does not resolve the inode, so the GETATTR is what actually catches a
+ * freed object; its attributes fill obj_attributes, which RFC 1813 3.3.20
+ * defines as the post-operation attributes of the argument object. */
 static void
 chimera_nfs3_pathconf_complete(
     enum chimera_vfs_error    error_code,
@@ -36,15 +36,16 @@ chimera_nfs3_pathconf_complete(
     res.status = chimera_vfs_error_to_nfsstat3(error_code);
 
     if (res.status == NFS3_OK) {
-        res.resok.obj_attributes.attributes_follow = 0;
-        res.resok.case_insensitive                 = 0;
-        res.resok.case_preserving                  = 1;
-        res.resok.no_trunc                         = 1;
-        res.resok.linkmax                          = UINT32_MAX;
-        res.resok.name_max                         = 255;
-        res.resok.chown_restricted                 = 1;   /* POSIX: chown is superuser-only */
+        chimera_nfs3_set_post_op_attr(&res.resok.obj_attributes, attr);
+
+        res.resok.case_insensitive = 0;
+        res.resok.case_preserving  = 1;
+        res.resok.no_trunc         = 1;
+        res.resok.linkmax          = UINT32_MAX;
+        res.resok.name_max         = 255;
+        res.resok.chown_restricted = 1;   /* POSIX: chown is superuser-only */
     } else {
-        res.resfail.obj_attributes.attributes_follow = 0;
+        chimera_nfs3_set_post_op_attr(&res.resfail.obj_attributes, attr);
     }
 
     chimera_vfs_release(thread->vfs_thread, req->handle);

--- a/src/server/nfs/nfs3_proc_readdir.c
+++ b/src/server/nfs/nfs3_proc_readdir.c
@@ -24,7 +24,7 @@ chimera_nfs3_readdir_callback(
     struct READDIR3args            *args = req->args_readdir;
     struct entry3                  *entry;
     struct nfs_nfs3_readdir_cursor *cursor;
-    int                             dbuf_before = req->encoding->dbuf->used, dbuf_cur;
+    uint32_t                        entry_cur;
     int                             rc;
 
     cursor = &req->readdir3_cursor;
@@ -39,13 +39,20 @@ chimera_nfs3_readdir_callback(
     rc = xdr_dbuf_alloc_string(&entry->name, name, namelen, req->encoding->dbuf);
     chimera_nfs_abort_if(rc, "Failed to allocate string");
 
-    dbuf_cur = req->encoding->dbuf->used - dbuf_before;
+    /* RFC 1813 3.3.16: count bounds the XDR-encoded READDIR3resok, so the
+     * budget has to be charged in wire bytes.  The bytes this entry consumed in
+     * the dbuf are the in-memory struct entry3 (nextentry pointer, xdr_string
+     * descriptor, padding) and over-charge by a fixed per-entry delta, which
+     * made the server return fewer entries than count allowed.  On the wire an
+     * entry3 is value_follows (4) + fileid3 (8) + filename3 (4 + padded len) +
+     * cookie3 (8). */
+    entry_cur = 24 + ((namelen + 3) & ~3);
 
-    if (cursor->count + dbuf_cur > args->count) {
+    if (cursor->count + entry_cur > args->count) {
         return -1;
     }
 
-    cursor->count += dbuf_cur;
+    cursor->count += entry_cur;
 
     if (cursor->entries) {
         cursor->last->nextentry = entry;

--- a/src/server/nfs/nfs3_proc_readdirplus.c
+++ b/src/server/nfs/nfs3_proc_readdirplus.c
@@ -23,7 +23,7 @@ chimera_nfs3_readdirplus_callback(
     struct READDIRPLUS3args            *args = req->args_readdirplus;
     struct entryplus3                  *entry;
     struct nfs_nfs3_readdirplus_cursor *cursor;
-    int                                 dbuf_before = req->encoding->dbuf->used, dbuf_cur;
+    uint32_t                            entry_cur, dirinfo_cur, fh_cur = 0;
     int                                 rc;
 
     cursor = &req->readdirplus3_cursor;
@@ -54,25 +54,34 @@ chimera_nfs3_readdirplus_callback(
                                   req->encoding->dbuf);
         chimera_nfs_abort_if(rc, "Failed to copy opaque");
 
+        fh_cur = 4 + ((wirelen + 3) & ~3);
     } else {
         entry->name_handle.handle_follows = 0;
     }
 
-    dbuf_cur = req->encoding->dbuf->used - dbuf_before;
-
     /* XDR wire size of directory info (fileid + name + cookie) per RFC 1813:
      * value_follows (4) + fileid3 (8) + filename3 (4 + padded len) + cookie3 (8) */
-    uint32_t dirinfo_cur = 24 + ((namelen + 3) & ~3);
+    dirinfo_cur = 24 + ((namelen + 3) & ~3);
 
-    if (cursor->count + dbuf_cur > args->maxcount ||
+    /* RFC 1813 3.3.17: maxcount bounds the XDR-encoded READDIRPLUS3resok, so
+    * the budget has to be charged in wire bytes.  The dbuf bytes this entry
+    * consumed are the in-memory entryplus3 (pointers, xdr_string descriptors,
+    * padding) and over-charge by a fixed per-entry delta, which made the
+    * server return fewer entries than maxcount allowed.  On the wire an
+    * entryplus3 adds a post_op_attr (4, plus fattr3's 84 when present) and a
+    * post_op_fh3 (4, plus the padded handle when present) to the dirinfo. */
+    entry_cur = dirinfo_cur + 4 +
+        (entry->name_attributes.attributes_follow ? 84 : 0) + 4 + fh_cur;
+
+    if (cursor->count + entry_cur > args->maxcount ||
         cursor->dircount + dirinfo_cur > args->dircount) {
         chimera_nfs_debug("readdirplus: exceeded limits (count %d+%d vs max %d, dircount %d+%d vs max %d)",
-                          (int) cursor->count, dbuf_cur, args->maxcount,
+                          (int) cursor->count, entry_cur, args->maxcount,
                           (int) cursor->dircount, dirinfo_cur, args->dircount);
         return -1;
     }
 
-    cursor->count    += dbuf_cur;
+    cursor->count    += entry_cur;
     cursor->dircount += dirinfo_cur;
 
     if (cursor->entries) {

--- a/src/server/nfs/nfs3_proc_rename.c
+++ b/src/server/nfs/nfs3_proc_rename.c
@@ -98,14 +98,13 @@ chimera_nfs3_rename(
     nfs3_trace_rename(req, args);
 
     /* Decode both directory handles: the source sets the request export (and
-     * squash); the destination is authenticated into req->saved_fh.  Both must
-     * outlive this (async) call, so they go in the request, not on the stack. */
+     * squash); the destination is authenticated into req->saved_fh and layers
+     * its own export's sec= and squash policy on top.  Both must outlive this
+     * (async) call, so they go in the request, not on the stack. */
     res.status = chimera_nfs3_decode_fh(req, args->from.dir.data.data, args->from.dir.data.len);
-    if (res.status == NFS3_OK &&
-        chimera_nfs_fh_unwrap(args->to.dir.data.data, args->to.dir.data.len,
-                              &todir_export_id, req->saved_fh, &req->saved_fhlen,
-                              shared->fh_key, shared->fh_sign) != CHIMERA_NFS_FH_OK) {
-        res.status = NFS3ERR_BADHANDLE;
+    if (res.status == NFS3_OK) {
+        res.status = chimera_nfs3_decode_fh2(req, args->to.dir.data.data,
+                                             args->to.dir.data.len, &todir_export_id);
     }
     /* Both directories are mutated, so both exports must be writable. */
     if (res.status == NFS3_OK) {

--- a/src/server/nfs/nfs3_procs.h
+++ b/src/server/nfs/nfs3_procs.h
@@ -40,6 +40,52 @@ chimera_nfs3_decode_fh(
 } /* chimera_nfs3_decode_fh */
 
 /*
+ * Decode the second (destination) wire handle of RENAME / LINK into
+ * req->saved_fh and report its export id.
+ *
+ * The first handle went through chimera_nfs3_decode_fh, which stamped
+ * req->export_id and squashed req->cred under that export.  Two exports may
+ * name sub-paths of one VFS share, so the destination directory can belong to
+ * a different export whose policy the VFS-level cross-mount check will not
+ * catch: its sec= list must permit the request's auth flavor, and its squash
+ * must apply to the credential the new entry is created under.  Unwrapping
+ * alone enforces neither.
+ *
+ * Squashing only ever maps toward the anonymous identity, so layering the
+ * destination export's policy on top of the source's yields the more
+ * restrictive of the two and is a no-op when both handles name the same
+ * export.  A sec= rejection maps to NFS3ERR_ACCES for the same reason as in
+ * chimera_nfs3_decode_fh.
+ */
+static inline nfsstat3
+chimera_nfs3_decode_fh2(
+    struct nfs_request *req,
+    const void         *fhdata,
+    uint32_t            fhlen,
+    uint16_t           *export_id)
+{
+    struct chimera_server_nfs_shared *shared = req->thread->shared;
+
+    if (chimera_nfs_fh_unwrap(fhdata, fhlen, export_id,
+                              req->saved_fh, &req->saved_fhlen,
+                              shared->fh_key, shared->fh_sign) !=
+        CHIMERA_NFS_FH_OK) {
+        return NFS3ERR_BADHANDLE;
+    }
+
+    const struct chimera_nfs_export *export =
+        chimera_nfs_get_export_by_id(shared, *export_id);
+
+    if (!chimera_nfs_export_sec_ok(export, req->sec_bit)) {
+        return NFS3ERR_ACCES;
+    }
+
+    chimera_nfs_squash_cred(&req->cred, export);
+
+    return NFS3_OK;
+} /* chimera_nfs3_decode_fh2 */
+
+/*
  * Per-export read-only gate for mutating NFSv3 procedures.  Call after a
  * successful chimera_nfs3_decode_fh with the export id the mutation targets.
  * RENAME and LINK mutate through two handles and use chimera_nfs3_check_rofs2

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -1147,6 +1147,20 @@ chimera_nfs4_unmarshall_attrs(
                     return NFS4ERR_ATTRNOTSUPP;
                 }
 
+                /* RFC 7530 §6.2.1.4.1: ACE4_INHERIT_ONLY_ACE with neither
+                 * ACE4_FILE_INHERIT_ACE nor ACE4_DIRECTORY_INHERIT_ACE set
+                 * describes an ACE that is never enforced and never inherited,
+                 * so setting it SHOULD fail with NFS4ERR_ATTRNOTSUPP rather
+                 * than store an entry that silently does nothing.  The ACEs the
+                 * server itself materialises always carry an inherit bit
+                 * alongside INHERIT_ONLY (vfs_acl.c), so a GETATTR/SETATTR
+                 * round trip is unaffected. */
+                if ((flag & CHIMERA_ACE_FLAG_INHERIT_ONLY) &&
+                    !(flag & (CHIMERA_ACE_FLAG_FILE_INHERIT |
+                              CHIMERA_ACE_FLAG_DIR_INHERIT))) {
+                    return NFS4ERR_ATTRNOTSUPP;
+                }
+
                 is_group = !!(flag & CHIMERA_ACE_FLAG_IDENTIFIER_GROUP);
 
                 acl_buf->aces[i].type        = (uint16_t) type;

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -53,6 +53,22 @@ chimera_nfs4_change_from_attrs(const struct chimera_vfs_attrs *attr)
 #define OPEN_ARGS_OPEN_CLAIM_PREVIOUS                1
 #define OPEN_ARGS_OPEN_CLAIM_DELEGATE_CUR            2
 #define OPEN_ARGS_OPEN_CLAIM_FH                      4
+
+/*
+ * suppattr_exclcreat (RFC 8881 5.8.1.14): the attributes this server can
+ * honour in an EXCLUSIVE4_1 cva_attrs.  time_access_set/time_modify_set are
+ * deliberately absent because the create verifier is stored in atime/mtime
+ * (the Linux nfsd strategy), so a client value for them could not survive the
+ * create.  Defined here so the advertisement (chimera_nfs4_marshall_attrs) and
+ * the cva_attrs check (chimera_nfs4_validate_exclcreat_attrs) cannot drift
+ * apart -- RFC 8881 18.16.3 requires the second to be exactly the first.
+ */
+#define CHIMERA_NFS4_SUPPATTR_EXCLCREAT_WORD0        (1U << FATTR4_SIZE)
+#define CHIMERA_NFS4_SUPPATTR_EXCLCREAT_WORD1        ( \
+            (1U << (FATTR4_MODE - 32)) | \
+            (1U << (FATTR4_OWNER - 32)) | \
+            (1U << (FATTR4_OWNER_GROUP - 32)))
+
 /*
  * The single pNFS layouttype4 this file's backend supports, for FATTR4
  * advertisement: LAYOUT4_FLEX_FILES (0x4) for an orchestrated backend
@@ -1041,11 +1057,9 @@ chimera_nfs4_marshall_attrs(
             * encodes the verifier into atime/mtime (same as Linux nfsd). */
             chimera_nfs4_attr_append_uint32(&attrs, 2);
             chimera_nfs4_attr_append_uint32(&attrs,
-                                            (1 << FATTR4_SIZE));
+                                            CHIMERA_NFS4_SUPPATTR_EXCLCREAT_WORD0);
             chimera_nfs4_attr_append_uint32(&attrs,
-                                            (1UL << (FATTR4_MODE - 32)) |
-                                            (1UL << (FATTR4_OWNER - 32)) |
-                                            (1UL << (FATTR4_OWNER_GROUP - 32)));
+                                            CHIMERA_NFS4_SUPPATTR_EXCLCREAT_WORD1);
         }
 
         if ((req_mask[2] & (1 << (FATTR4_CHANGE_ATTR_TYPE - 64))) &&
@@ -1463,6 +1477,35 @@ chimera_nfs4_validate_createattrs(
 
     return NFS4_OK;
 } /* chimera_nfs4_validate_createattrs */
+
+/*
+ * EXCLUSIVE4_1 create attributes.  RFC 8881 §18.16.3: "If the client attempts
+ * to set in cva_attrs an attribute that is not in suppattr_exclcreat, the
+ * server MUST return NFS4ERR_INVAL."  Run in addition to (after)
+ * chimera_nfs4_validate_createattrs, which keeps reporting NFS4ERR_ATTRNOTSUPP
+ * for attributes the server does not implement at all.
+ */
+static inline nfsstat4
+chimera_nfs4_validate_exclcreat_attrs(
+    uint32_t        num_attrmask,
+    const uint32_t *attrmask)
+{
+    if (num_attrmask >= 1 &&
+        (attrmask[0] & ~CHIMERA_NFS4_SUPPATTR_EXCLCREAT_WORD0)) {
+        return NFS4ERR_INVAL;
+    }
+
+    if (num_attrmask >= 2 &&
+        (attrmask[1] & ~CHIMERA_NFS4_SUPPATTR_EXCLCREAT_WORD1)) {
+        return NFS4ERR_INVAL;
+    }
+
+    if (num_attrmask >= 3 && attrmask[2] != 0) {
+        return NFS4ERR_INVAL;
+    }
+
+    return NFS4_OK;
+} /* chimera_nfs4_validate_exclcreat_attrs */
 
 /* GETATTR: requested attrs must be supported and readable. The "*_set"
  * attributes (FATTR4_TIME_ACCESS_SET, FATTR4_TIME_MODIFY_SET) are write-only

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -506,9 +506,9 @@ chimera_nfs4_marshall_attrs(
                                             (1 << FATTR4_FILES_TOTAL) |
                                             /* fs_locations */
                                             /* hidden */
-                                            /* homogeneous */
-                                            /* maxfilesize */
-                                            /* maxlink */
+                                            (1 << FATTR4_HOMOGENEOUS) |
+                                            (1 << FATTR4_MAXFILESIZE) |
+                                            (1 << FATTR4_MAXLINK) |
                                             (1 << FATTR4_MAXNAME) |
                                             (1 << FATTR4_MAXREAD) |
                                             (1 << FATTR4_MAXWRITE));
@@ -805,6 +805,32 @@ chimera_nfs4_marshall_attrs(
             *num_rsp_mask = 1;
 
             chimera_nfs4_attr_append_uint64(&attrs, attr->va_fs_files_total);
+        }
+
+        /* The three fs-wide limits below carry the same answers the NFSv3 side
+         * of this server already gives for the same filesystem: FSF3_HOMOGENEOUS
+         * and maxfilesize UINT64_MAX from FSINFO, linkmax UINT32_MAX from
+         * PATHCONF.  Values are packed in ascending attribute order, so they
+         * precede maxname (29). */
+        if (req_mask[0] & (1 << FATTR4_HOMOGENEOUS)) {
+            rsp_mask[0]  |= (1 << FATTR4_HOMOGENEOUS);
+            *num_rsp_mask = 1;
+
+            chimera_nfs4_attr_append_uint32(&attrs, 1);
+        }
+
+        if (req_mask[0] & (1 << FATTR4_MAXFILESIZE)) {
+            rsp_mask[0]  |= (1 << FATTR4_MAXFILESIZE);
+            *num_rsp_mask = 1;
+
+            chimera_nfs4_attr_append_uint64(&attrs, UINT64_MAX);
+        }
+
+        if (req_mask[0] & (1 << FATTR4_MAXLINK)) {
+            rsp_mask[0]  |= (1 << FATTR4_MAXLINK);
+            *num_rsp_mask = 1;
+
+            chimera_nfs4_attr_append_uint32(&attrs, UINT32_MAX);
         }
 
         if (req_mask[0] & (1 << FATTR4_MAXNAME)) {
@@ -1369,7 +1395,10 @@ chimera_nfs4_validate_createattrs(
         (1 << FATTR4_FILES_AVAIL) |
         (1 << FATTR4_FILES_FREE) |
         (1 << FATTR4_FILES_TOTAL) |
-        /* no fs_locations=24, hidden=25, homogeneous=26, maxfilesize=27, maxlink=28 */
+        /* no fs_locations=24, hidden=25 */
+        (1 << FATTR4_HOMOGENEOUS) |
+        (1 << FATTR4_MAXFILESIZE) |
+        (1 << FATTR4_MAXLINK) |
         (1 << FATTR4_MAXNAME) |
         (1 << FATTR4_MAXREAD) |
         (1U << FATTR4_MAXWRITE);

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -596,7 +596,14 @@ chimera_nfs4_marshall_attrs(
             chimera_nfs4_attr_append_uint32(&attrs, FH4_PERSISTENT);
         }
 
-        if (req_mask[0] & (1 << FATTR4_CHANGE)) {
+        /* change is REQUIRED, but so are type and size, and both are dropped
+         * from the reply when the backend did not supply their source.  Doing
+         * the same here matters more, not less: with neither a native counter
+         * nor a ctime to derive from, the fallback below would read unset
+         * fields and hand every object the same change value, which defeats
+         * the cache validation the attribute exists for (RFC 7530 §5.8.1.4). */
+        if (req_mask[0] & (1 << FATTR4_CHANGE) &&
+            (attr->va_set_mask & (CHIMERA_VFS_ATTR_CHANGE | CHIMERA_VFS_ATTR_CTIME))) {
             rsp_mask[0]  |= (1 << FATTR4_CHANGE);
             *num_rsp_mask = 1;
 

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -393,7 +393,9 @@ chimera_nfs4_attr_append_acl(
     const struct chimera_acl *acl,
     const char               *domain)
 {
-    uint32_t num = acl ? acl->num_aces : 0;
+    uint32_t num     = acl ? acl->num_aces : 0;
+    void    *countp  = *attrs;
+    uint32_t emitted = 0;
 
     chimera_nfs4_attr_append_uint32(attrs, num);
 
@@ -418,14 +420,23 @@ chimera_nfs4_attr_append_acl(
         wholen = chimera_idmap_principal_to_who(&ace->who, domain,
                                                 who, sizeof(who));
         if (wholen < 0) {
-            /* Should not happen; emit EVERYONE@ as a safe fallback. */
-            wholen = snprintf(who, sizeof(who), "EVERYONE@");
+            /* Nameless principals are dropped, not renamed: substituting a
+             * real who (EVERYONE@, as this used to) presents an ACL granting
+             * access the server never enforces, and a client read-modify-write
+             * then turns that fiction into a genuine grant.  RFC 7530 §6.2.1
+             * forbids reporting more access than is enforced. */
+            continue;
         }
 
         chimera_nfs4_attr_append_uint32(attrs, ace->type);
         chimera_nfs4_attr_append_uint32(attrs, flag);
         chimera_nfs4_attr_append_uint32(attrs, ace->access_mask);
         chimera_nfs4_attr_append_utf8str(attrs, who, wholen);
+        emitted++;
+    }
+
+    if (emitted != num) {
+        *(uint32_t *) countp = chimera_nfs_hton32(emitted);
     }
 } /* chimera_nfs4_attr_append_acl */
 

--- a/src/server/nfs/nfs4_proc_allocate.c
+++ b/src/server/nfs/nfs4_proc_allocate.c
@@ -162,6 +162,18 @@ chimera_nfs4_allocate(
         return;
     }
 
+    /* RFC 7862 §15.1 describes the reservation as the byte range
+     * [aa_offset, aa_offset + aa_length); a range whose end does not fit in a
+     * uint64 names no such interval.  Reject it here rather than handing a
+     * wrapped end to the backends, where it becomes a tiny (or absurd) block
+     * range in memfs and an out-of-range fallocate() elsewhere. */
+    if (args->aa_length &&
+        args->aa_offset > UINT64_MAX - args->aa_length) {
+        res->ar_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->ar_status);
+        return;
+    }
+
     /*
      * RFC 8881 §8.2.3 requires ALLOCATE to honor the special stateids.  These
      * carry no state-table entry, so open the current FH on the fly instead of

--- a/src/server/nfs/nfs4_proc_copy.c
+++ b/src/server/nfs/nfs4_proc_copy.c
@@ -575,6 +575,18 @@ chimera_nfs4_copy(
             chimera_nfs4_copy_fail(refs, status);
             return;
         }
+
+        /* The source stateid must name a read-capable open of the saved
+         * filehandle (RFC 7862 §15.2.3; the open-mode rule is RFC 8881
+         * §9.1.2, the same one READ enforces).  Without it a read-denied
+         * open -- or an open of some altogether different object -- could
+         * source the copy. */
+        status = nfs_state_check_read_for_fh(refs->src_state, refs->src_type,
+                                             req->saved_fh, req->saved_fhlen);
+        if (status != NFS4_OK) {
+            chimera_nfs4_copy_fail(refs, status);
+            return;
+        }
     }
 
     if (!refs->dst_special) {

--- a/src/server/nfs/nfs4_proc_deallocate.c
+++ b/src/server/nfs/nfs4_proc_deallocate.c
@@ -164,6 +164,16 @@ chimera_nfs4_deallocate(
         return;
     }
 
+    /* RFC 7862 §15.2 punches [da_offset, da_offset + da_length); a range whose
+     * end does not fit in a uint64 names no such interval, so reject it rather
+     * than letting the wrapped end reach a backend. */
+    if (args->da_length &&
+        args->da_offset > UINT64_MAX - args->da_length) {
+        res->dr_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->dr_status);
+        return;
+    }
+
     /*
      * RFC 8881 §8.2.3 requires DEALLOCATE to honor the special stateids.  These
      * carry no state-table entry, so open the current FH on the fly instead of

--- a/src/server/nfs/nfs4_proc_delegreturn.c
+++ b/src/server/nfs/nfs4_proc_delegreturn.c
@@ -98,6 +98,29 @@ chimera_nfs4_delegpurge(
     (void) thread;
     (void) argop;
 
+    /* DELEGPURGE is in the spo_must_enforce set EXCHANGE_ID advertises, so a
+     * client that negotiated SP4_MACH_CRED must send it with the machine
+     * credential (RFC 8881 §2.10.8.3; NFS4ERR_WRONG_CRED is a listed
+     * DELEGPURGE error).  §18.5.3 requires the client be derived from the
+     * preceding SEQUENCE's session and the clientid argument ignored; state
+     * protection exists only in 4.1+, so a sessionless (4.0) request has none
+     * to enforce. */
+    if (req->session) {
+        const struct nfs4_client_principal p = {
+            .flavor          = req->principal_flavor,
+            .uid             = req->principal_uid,
+            .gid             = req->principal_gid,
+            .machinename     = req->principal_machinename,
+            .machinename_len = req->principal_machinename_len,
+        };
+
+        if (!nfs4_client_mach_cred_ok(req->session->nfs4_session_client, &p)) {
+            res->status = NFS4ERR_WRONG_CRED;
+            chimera_nfs4_compound_complete(req, NFS4ERR_WRONG_CRED);
+            return;
+        }
+    }
+
     res->status = NFS4_OK;
     chimera_nfs4_compound_complete(req, NFS4_OK);
 } /* chimera_nfs4_delegpurge */

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -19,9 +19,18 @@
          EXCHGID4_FLAG_UPD_CONFIRMED_REC_A)
 
 /* State-management operations chimera enforces under SP4_MACH_CRED, as a
- * bitmap4 (RFC 8881 §2.10.8.3): BIND_CONN_TO_SESSION(41), EXCHANGE_ID(42),
- * CREATE_SESSION(43), DESTROY_SESSION(44), DESTROY_CLIENTID(57).  Bit op N is
- * word[N/32] bit (N%32); ops 41-57 all fall in word 1. */
+ * bitmap4 (RFC 8881 §2.10.8.3): DELEGPURGE(7) in word 0, and
+ * BIND_CONN_TO_SESSION(41), EXCHANGE_ID(42), CREATE_SESSION(43),
+ * DESTROY_SESSION(44), DESTROY_CLIENTID(57) in word 1.  Bit op N is
+ * word[N/32] bit (N%32).
+ *
+ * This is exactly the set §18.35.3 names as the one a client typically
+ * requests, and the set whose members the result spo_must_enforce MUST include
+ * whenever the client asked for them.  Advertising the whole set unconditionally
+ * -- which §18.35.3 permits, "the result MAY be different" -- satisfies that
+ * MUST for every client without having to remember each client's requested
+ * bitmap across the confirmed-record replay below. */
+#define NFS4_MACH_ENFORCE_WORD0 (1u << 7)
 #define NFS4_MACH_ENFORCE_WORD1                                                 \
         ((1u << (41 - 32)) | (1u << (42 - 32)) | (1u << (43 - 32)) |            \
          (1u << (44 - 32)) | (1u << (57 - 32)))
@@ -51,7 +60,7 @@ nfs4_set_state_protect(
     xdr_dbuf                *dbuf)
 {
     if (spa_how == SP4_MACH_CRED) {
-        static const uint32_t      enforce[2] = { 0, NFS4_MACH_ENFORCE_WORD1 };
+        static const uint32_t      enforce[2] = { NFS4_MACH_ENFORCE_WORD0, NFS4_MACH_ENFORCE_WORD1 };
         struct state_protect_ops4 *ops        = &res_sp->spr_mach_ops;
 
         chimera_nfs_debug("EXCHANGE_ID: negotiated SP4_MACH_CRED state protection");

--- a/src/server/nfs/nfs4_proc_exchange_id.c
+++ b/src/server/nfs/nfs4_proc_exchange_id.c
@@ -150,6 +150,23 @@ chimera_nfs4_exchange_id(
         return;
     }
 
+    /* RFC 8881 §18.35.3 makes three of the SP4_SSV protection parameters
+     * unconditionally invalid: "If ssp_hash_algs is empty, the server MUST
+     * return NFS4ERR_INVAL", likewise for ssp_encr_algs, and "If ssp_window is
+     * zero, the server MUST return NFS4ERR_INVAL".  These are argument
+     * checks, independent of whether the server goes on to accept SP4_SSV
+     * (chimera declines it -- see nfs4_set_state_protect), so they run on the
+     * spa_how the client actually sent rather than the mode the negotiation
+     * below may replay from a confirmed record. */
+    if (args->eia_state_protect.spa_how == SP4_SSV &&
+        (args->eia_state_protect.spa_ssv_parms.num_ssp_hash_algs == 0 ||
+         args->eia_state_protect.spa_ssv_parms.num_ssp_encr_algs == 0 ||
+         args->eia_state_protect.spa_ssv_parms.ssp_window == 0)) {
+        res->eir_status = NFS4ERR_INVAL;
+        chimera_nfs4_compound_complete(req, res->eir_status);
+        return;
+    }
+
     update = (args->eia_flags & EXCHGID4_FLAG_UPD_CONFIRMED_REC_A) != 0;
 
     principal.flavor          = req->principal_flavor;

--- a/src/server/nfs/nfs4_proc_free_stateid.c
+++ b/src/server/nfs/nfs4_proc_free_stateid.c
@@ -88,6 +88,19 @@ chimera_nfs4_free_stateid(
         return;
     }
 
+    /* A layout stateid names a struct nfs_layout_state, not a lock state, and
+     * a layout still held is returned via LAYOUTRETURN.  Anything else the
+     * table can hand back is likewise not a lock state; treating it as one
+     * would type-pun the slot's object. */
+    if (state_type != NFS4_SLOT_TYPE_LOCK) {
+        nfs_state_table_release(table, state_void, state_type,
+                                thread->vfs_thread);
+        res->fsr_status = (state_type == NFS4_SLOT_TYPE_LAYOUT)
+                          ? NFS4ERR_LOCKS_HELD : NFS4ERR_BAD_STATEID;
+        chimera_nfs4_compound_complete(req, res->fsr_status);
+        return;
+    }
+
     lock_state = state_void;
 
     /* A lock stateid that still owns byte-range locks cannot be freed. */

--- a/src/server/nfs/nfs4_proc_lockt.c
+++ b/src/server/nfs/nfs4_proc_lockt.c
@@ -169,6 +169,22 @@ chimera_nfs4_lockt(
         return;
     }
 
+    /* RFC 7530 §9.6.2: inside the server-reboot grace window the byte-range
+     * locks held before the restart have not all been reclaimed, so LOCKT
+     * would report a range as available that another client is about to
+     * reclaim.  Refuse it with NFS4ERR_GRACE rather than answer from
+     * half-rebuilt state. */
+    {
+        nfsstat4 g_status = nfs_recovery_io_check(
+            &thread->shared->nfs4_recovery);
+
+        if (g_status != NFS4_OK) {
+            res->status = g_status;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+    }
+
     /* RFC 7530 §9.1.4: the lock-owner names a clientid; reject one the server
      * has no record of.  4.1+ identifies the client via the session instead. */
     if (req->minorversion == 0) {

--- a/src/server/nfs/nfs4_proc_open.c
+++ b/src/server/nfs/nfs4_proc_open.c
@@ -1315,6 +1315,16 @@ chimera_nfs4_open_parent_complete(
                 status = chimera_nfs4_validate_createattrs(
                     args->openhow.how.ch_createboth.cva_attrs.num_attrmask,
                     args->openhow.how.ch_createboth.cva_attrs.attrmask);
+                if (status == NFS4_OK) {
+                    /* RFC 8881 18.16.3: an attribute in cva_attrs that is not
+                     * in suppattr_exclcreat MUST be rejected with
+                     * NFS4ERR_INVAL.  Without this the server unmarshalled
+                     * time_access_set/time_modify_set and then silently
+                     * clobbered them with the verifier below. */
+                    status = chimera_nfs4_validate_exclcreat_attrs(
+                        args->openhow.how.ch_createboth.cva_attrs.num_attrmask,
+                        args->openhow.how.ch_createboth.cva_attrs.attrmask);
+                }
                 if (status != NFS4_OK) {
                     struct OPEN4res *res = &req->res_compound.resarray[req->index].opopen;
                     chimera_vfs_release(req->thread->vfs_thread, parent_handle);

--- a/src/server/nfs/nfs4_proc_read.c
+++ b/src/server/nfs/nfs4_proc_read.c
@@ -194,6 +194,16 @@ chimera_nfs4_read(
     req->handle              = NULL;
     req->io_owner_from_deleg = false;
 
+    /* RFC 7530 §9.6.2: READ is refused with NFS4ERR_GRACE while the
+     * server-reboot grace window is open, because a byte-range lock that
+     * would conflict with it may not have been reclaimed yet. */
+    status = nfs_recovery_io_check(&thread->shared->nfs4_recovery);
+    if (status != NFS4_OK) {
+        res->status = status;
+        chimera_nfs4_compound_complete(req, status);
+        return;
+    }
+
     /*
      * NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2).
      */

--- a/src/server/nfs/nfs4_proc_setattr.c
+++ b/src/server/nfs/nfs4_proc_setattr.c
@@ -196,6 +196,23 @@ chimera_nfs4_setattr(
     /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
     chimera_nfs4_resolve_current_stateid(req, &args->stateid);
 
+    /* RFC 7530 §9.6.2: a size-changing SETATTR is a write (§9.1.4.3), so it
+     * is refused with NFS4ERR_GRACE while the server-reboot grace window is
+     * open -- the byte-range lock it would truncate through may not have been
+     * reclaimed yet.  Attribute-only SETATTRs conflict with no reclaim and
+     * are left alone. */
+    if (args->obj_attributes.num_attrmask >= 1 &&
+        (args->obj_attributes.attrmask[0] & (1 << FATTR4_SIZE))) {
+        nfsstat4 g_status = nfs_recovery_io_check(
+            &thread->shared->nfs4_recovery);
+
+        if (g_status != NFS4_OK) {
+            res->status = g_status;
+            chimera_nfs4_compound_complete(req, res->status);
+            return;
+        }
+    }
+
     /* RFC 7530 §16.32.3: when SETATTR carries FATTR4_SIZE the supplied
      * stateid must identify an open with write access.  Special stateids
      * (all-zero / all-ones) are exempt -- treated as anonymous, like the

--- a/src/server/nfs/nfs4_proc_verify.c
+++ b/src/server/nfs/nfs4_proc_verify.c
@@ -168,8 +168,10 @@ verify_validate_mask(
         (1 << FATTR4_CASE_PRESERVING) | (1 << FATTR4_CHOWN_RESTRICTED) |
         (1 << FATTR4_FILEHANDLE)      | (1 << FATTR4_FILEID) |
         (1 << FATTR4_FILES_AVAIL)     | (1 << FATTR4_FILES_FREE) |
-        (1 << FATTR4_FILES_TOTAL)     | (1 << FATTR4_MAXNAME) |
-        (1 << FATTR4_MAXREAD)         | (1U << FATTR4_MAXWRITE);
+        (1 << FATTR4_FILES_TOTAL)     | (1 << FATTR4_HOMOGENEOUS) |
+        (1 << FATTR4_MAXFILESIZE)     | (1 << FATTR4_MAXLINK) |
+        (1 << FATTR4_MAXNAME)         | (1 << FATTR4_MAXREAD) |
+        (1U << FATTR4_MAXWRITE);
     static const uint32_t supported_word1 =
         (1U << (FATTR4_MODE - 32))         | (1U << (FATTR4_NUMLINKS - 32)) |
         (1U << (FATTR4_OWNER - 32))        | (1U << (FATTR4_OWNER_GROUP - 32)) |

--- a/src/server/nfs/nfs4_proc_write.c
+++ b/src/server/nfs/nfs4_proc_write.c
@@ -221,6 +221,18 @@ chimera_nfs4_write(
     req->handle              = NULL;
     req->io_owner_from_deleg = false;
 
+    /* RFC 7530 §9.6.2: WRITE is refused with NFS4ERR_GRACE while the
+     * server-reboot grace window is open, because a byte-range lock that
+     * would conflict with it may not have been reclaimed yet.  Checked
+     * before the read chunk is taken below, so the RPC layer still owns the
+     * payload iovecs on this path. */
+    status = nfs_recovery_io_check(&thread->shared->nfs4_recovery);
+    if (status != NFS4_OK) {
+        res->status = status;
+        chimera_nfs4_compound_complete(req, status);
+        return;
+    }
+
     /* NFS4.1 current-stateid substitution (RFC 8881 §16.2.3.1.2). */
     chimera_nfs4_resolve_current_stateid(req, &args->stateid);
 

--- a/src/server/nfs/nfs4_recovery.c
+++ b/src/server/nfs/nfs4_recovery.c
@@ -592,6 +592,21 @@ nfs_recovery_open_check(
     return NFS4_OK;
 } /* nfs_recovery_open_check */
 
+nfsstat4
+nfs_recovery_io_check(struct nfs_recovery *rec)
+{
+    /* RFC 7530 §9.6.2: during the grace period the server must reject READ
+     * and WRITE operations and non-reclaim locking requests with
+     * NFS4ERR_GRACE, and may only service them if it can guarantee that no
+     * conflict with an impending reclaim could arise.  The locks that would
+     * conflict are precisely the ones the window exists to rebuild, so no
+     * such guarantee is available here.  Same window (and same
+     * load-still-in-flight treatment) as the OPEN gate; these operations
+     * carry no reclaim flag, so is_reclaim is always false and the client is
+     * irrelevant. */
+    return nfs_recovery_open_check(rec, NULL, false);
+} /* nfs_recovery_io_check */
+
 void
 nfs_recovery_reclaim_complete(
     struct nfs_recovery     *rec,

--- a/src/server/nfs/nfs4_recovery.h
+++ b/src/server/nfs/nfs4_recovery.h
@@ -175,6 +175,16 @@ nfs_recovery_open_check(
     bool                     is_reclaim);
 
 /*
+ * Gate for the operations the grace window protects that carry no reclaim
+ * flag of their own: READ, WRITE, a size-changing SETATTR and LOCKT.
+ * NFS4ERR_GRACE while the window is open (or the cold-start load is still in
+ * flight), NFS4_OK otherwise.
+ */
+nfsstat4
+nfs_recovery_io_check(
+    struct nfs_recovery *rec);
+
+/*
  * Mark `client` as having completed reclaim.  When the pending_reclaim
  * count drops to zero the grace window ends early.
  */

--- a/src/server/nfs/nfs4_state.h
+++ b/src/server/nfs/nfs4_state.h
@@ -668,18 +668,18 @@ nfs_open_state_check_principal(
 } /* nfs_open_state_check_principal */
 
 /*
- * Validate a stateid that authorizes a mutation of the current filehandle.
+ * Validate a stateid that authorizes I/O against a given filehandle.
  *
  * Returns NFS4ERR_BAD_STATEID unless `state` names an open (directly, or the
- * open a lock state is anchored to) of the object that is the current
- * filehandle -- required by RFC 7530 sec 9.1.4.3 / RFC 8881 sec 8.2.4 -- and
- * NFS4ERR_OPENMODE if that open does not carry write access.
+ * open a lock state is anchored to) of the object `fh` names -- required by
+ * RFC 7530 sec 9.1.4.3 / RFC 8881 sec 8.2.4 -- and NFS4ERR_OPENMODE if that
+ * open does not carry `want_access` (an OPEN4_SHARE_ACCESS_* bit).
  *
- * The current-filehandle half matters beyond conformance: any access check the
- * server makes against the current filehandle is only meaningful if the
- * operation actually acts on that filehandle.  An op that instead mutated some
- * other handle carried by its stateid would slip past such a check entirely.
- * The per-export read-only gate (nfs4_rofs_gate) is exactly such a check, and
+ * The filehandle half matters beyond conformance: any access check the server
+ * makes against the current filehandle is only meaningful if the operation
+ * actually acts on that filehandle.  An op that instead mutated some other
+ * handle carried by its stateid would slip past such a check entirely.  The
+ * per-export read-only gate (nfs4_rofs_gate) is exactly such a check, and
  * relies on this one to stay a dispatch-time decision.
  *
  * Delegation and layout stateids are rejected rather than misinterpreted:
@@ -687,11 +687,12 @@ nfs_open_state_check_principal(
  * must handle them before calling this.
  */
 static inline nfsstat4
-nfs_state_check_write_for_fh(
+nfs_state_check_access_for_fh(
     void          *state,
     uint8_t        type,
     const uint8_t *fh,
-    uint32_t       fh_len)
+    uint32_t       fh_len,
+    uint32_t       want_access)
 {
     const struct nfs_open_state *open_state;
 
@@ -712,12 +713,37 @@ nfs_state_check_write_for_fh(
         return NFS4ERR_BAD_STATEID;
     }
 
-    if ((open_state->share_access & OPEN4_SHARE_ACCESS_WRITE) == 0) {
+    if ((open_state->share_access & want_access) == 0) {
         return NFS4ERR_OPENMODE;
     }
 
     return NFS4_OK;
+} /* nfs_state_check_access_for_fh */
+
+/* A stateid that authorizes a mutation of the current filehandle. */
+static inline nfsstat4
+nfs_state_check_write_for_fh(
+    void          *state,
+    uint8_t        type,
+    const uint8_t *fh,
+    uint32_t       fh_len)
+{
+    return nfs_state_check_access_for_fh(state, type, fh, fh_len,
+                                         OPEN4_SHARE_ACCESS_WRITE);
 } /* nfs_state_check_write_for_fh */
+
+/* A stateid that authorizes reading a given filehandle -- COPY's source, which
+ * is the SAVED filehandle rather than the current one. */
+static inline nfsstat4
+nfs_state_check_read_for_fh(
+    void          *state,
+    uint8_t        type,
+    const uint8_t *fh,
+    uint32_t       fh_len)
+{
+    return nfs_state_check_access_for_fh(state, type, fh, fh_len,
+                                         OPEN4_SHARE_ACCESS_READ);
+} /* nfs_state_check_read_for_fh */
 
 /*
  * Public API.

--- a/src/server/nfs/nfs_common.h
+++ b/src/server/nfs/nfs_common.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <utlist.h>
+#include <urcu/urcu-qsbr.h>
 
 #include "nfs.h"
 #include "nfs_fh_wrap.h"
@@ -281,6 +282,10 @@ struct chimera_nfs_export {
     uint32_t                   anonuid;
     uint32_t                   anongid;
     uint32_t                   sec_allowed;  /* CHIMERA_NFS_SEC_* mask; 0 = any */
+    /* Deferred-reclaim head: request threads reach an export locklessly via
+     * exports_by_id[], so a removal must wait out a grace period before the
+     * struct is freed. */
+    struct rcu_head            rcu;
     struct chimera_nfs_export *prev;
     struct chimera_nfs_export *next;
 };

--- a/src/server/nfs/nfs_mount.c
+++ b/src/server/nfs/nfs_mount.c
@@ -280,6 +280,23 @@ chimera_nfs_mount_mnt(
     }
 
     /*
+     * RFC 2623 §2.3.2: a MNT that does not satisfy the export's security
+     * policy is refused rather than handed the export root handle.  The
+     * per-op path already rejects such a handle (chimera_nfs_fh_decode
+     * returns WRONGSEC), so this only stops MOUNT itself from being the one
+     * place the policy is not applied.
+     */
+    if (!chimera_nfs_export_sec_ok(export, req->sec_bit)) {
+        chimera_nfs_debug("NFS mount of export '%s' refused: caller flavor "
+                          "not in the export's sec= policy", export->name);
+        if (full_path) {
+            free(full_path);
+        }
+        chimera_nfs_mount_lookup_complete(CHIMERA_VFS_EACCES, NULL, req);
+        return;
+    }
+
+    /*
      * Record the mount in the rmtab keyed by the client-requested path (which
      * is what UMNT will present and what showmount displays).  The export
      * resolved, so the subsequent VFS lookup of its root is expected to

--- a/src/server/nfs/nfs_nsm.c
+++ b/src/server/nfs/nfs_nsm.c
@@ -699,6 +699,33 @@ nsm_conn_peer_addr(
     }
 } /* nsm_conn_peer_addr */
 
+/* True unless `host` is monitored at an address other than `src`.
+ *
+ * SM_NOTIFY carries no authentication, so the only correlation available is
+ * the one a real statd makes: the notify has to come from the peer it claims
+ * restarted.  A monitored host's reach-address was recorded from its own NLM
+ * connection (nfs_nlm.c), so a notify naming it from anywhere else is a
+ * spoof and is ignored.  A host with no monitor entry -- one whose locks are
+ * already gone, so the release is a no-op -- has no address to compare
+ * against and is left to the caller's exact-match path. */
+static int
+nsm_notify_src_ok(
+    struct chimera_server_nfs_thread *thread,
+    const char                       *host,
+    const char                       *src)
+{
+    struct nsm_state   *nsm = &thread->shared->nsm_state;
+    struct nsm_monitor *mon;
+    int                 ok;
+
+    pthread_mutex_lock(&nsm->mutex);
+    HASH_FIND_STR(nsm->monitors, host, mon);
+    ok = (mon == NULL) || (strcmp(mon->addr, src) == 0);
+    pthread_mutex_unlock(&nsm->mutex);
+
+    return ok;
+} /* nsm_notify_src_ok */
+
 /* Release every NLM lock held by `host` (the NLMPROC4_FREE_ALL sequence).
  * Returns 1 if a matching client was found.  Takes nlm_state.mutex internally
  * and no other lock, so it is safe to call after dropping nsm_state.mutex. */
@@ -744,6 +771,7 @@ chimera_nfs_sm_notify(
     struct chimera_server_nfs_thread *thread = private_data;
     struct chimera_server_nfs_shared *shared = thread->shared;
     char                              host[SM_MAXSTRLEN + 1];
+    char                              src[80];
     size_t                            hn_len;
     int                               rc;
 
@@ -753,6 +781,18 @@ chimera_nfs_sm_notify(
     hn_len = args->mon_name.len < SM_MAXSTRLEN ? args->mon_name.len : SM_MAXSTRLEN;
     memcpy(host, args->mon_name.str, hn_len);
     host[hn_len] = '\0';
+
+    nsm_conn_peer_addr(conn, src, sizeof(src));
+
+    /* A notify naming a host we monitor at a different address did not come
+     * from that host: dropping its locks on an arbitrary peer's say-so is a
+     * lock-release spoof, so ignore it (the reply is still sent -- SM_NOTIFY
+     * has no error status). */
+    if (!nsm_notify_src_ok(thread, host, src)) {
+        chimera_nfs_info("NSM SM_NOTIFY for '%s' from %s ignored: not the "
+                         "address that host is monitored at", host, src);
+        goto reply;
+    }
 
     chimera_nfs_info("NSM SM_NOTIFY: host '%s' restarted (state %d); releasing its locks",
                      host, args->state);
@@ -764,12 +804,9 @@ chimera_nfs_sm_notify(
          * the caller_name it used for NLM.  Match monitored hosts by the
          * notify's source IP instead.  Collect matches under nsm_state.mutex,
          * then release outside it (nsm before nlm lock ordering). */
-        char                src[80];
         char                matched[NSM_NOTIFY_FALLBACK_MAX][SM_MAXSTRLEN + 1];
         struct nsm_monitor *mon, *tmp;
         int                 n = 0, truncated = 0, i;
-
-        nsm_conn_peer_addr(conn, src, sizeof(src));
 
         pthread_mutex_lock(&shared->nsm_state.mutex);
         HASH_ITER(hh, shared->nsm_state.monitors, mon, tmp)
@@ -797,6 +834,8 @@ chimera_nfs_sm_notify(
             nsm_unmonitor(thread, matched[i]);
         }
     }
+
+ reply:
 
     /* SM_NOTIFY is a void procedure (no reply body), but the RPC layer still
      * expects an accepted-reply ack. */

--- a/src/server/rest/rest.c
+++ b/src/server/rest/rest.c
@@ -819,7 +819,8 @@ chimera_rest_init(
     rest->debug_fsops  = chimera_server_config_get_rest_debug_fsops(config);
     rest->auth_enabled = chimera_server_config_get_rest_auth_enabled(config);
 
-    chimera_rest_auth_init_secret(rest);
+    chimera_rest_auth_init_secret(rest,
+                                  chimera_server_config_get_state_dir(config));
 
     rest->winbind_enabled = chimera_server_config_get_smb_winbind_enabled(
         config);

--- a/src/server/rest/rest_auth.c
+++ b/src/server/rest/rest_auth.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #if defined(__linux__) || defined(CHIMERA_HAVE_XCRYPT)
 #include <crypt.h>
@@ -344,6 +345,11 @@ chimera_rest_jwt_create(
 
 /* ========== JWT verify ========== */
 
+/* Leeway applied to the time-based claims.  RFC 7519 Section 4.1.5 permits
+ * "some small leeway, normally no more than a few minutes, to account for
+ * clock skew" between the issuer and the verifier. */
+#define CHIMERA_REST_JWT_CLOCK_SKEW 60
+
 int
 chimera_rest_jwt_verify(
     struct chimera_rest_server     *rest,
@@ -356,11 +362,15 @@ chimera_rest_jwt_verify(
     size_t        expected_sig_len = 32;
     unsigned char actual_sig[32];
     int           actual_sig_len;
+    unsigned char header_raw[256];
+    int           header_raw_len;
     unsigned char payload_raw[512];
     int           payload_raw_len;
-    json_t       *root;
+    json_t       *header, *root;
     json_error_t  error;
-    const char   *sub;
+    const char   *alg, *typ, *sub;
+    json_t       *nbf_json;
+    time_t        nbf;
     time_t        now;
 
     /* Find the two dots */
@@ -378,6 +388,38 @@ chimera_rest_jwt_verify(
     if (strchr(second_dot + 1, '.')) {
         return -1;
     }
+
+    /* Validate the JOSE header before verifying the signature (RFC 7519
+     * Section 7.2 step 8, RFC 8725 Section 3.1): the verifier must decide the
+     * algorithm from its own configuration rather than trusting the token, so
+     * an "alg":"none" or algorithm-substituted token is rejected outright
+     * instead of relying on the HMAC comparison to fail.  HS256 is the only
+     * algorithm chimera_rest_jwt_create issues and the only one implemented
+     * here. */
+    header_raw_len = base64url_decode(token, first_dot - token,
+                                      header_raw, sizeof(header_raw) - 1);
+    if (header_raw_len < 0) {
+        return -1;
+    }
+    header_raw[header_raw_len] = '\0';
+
+    header = json_loadb((const char *) header_raw, header_raw_len, 0, &error);
+    if (!header) {
+        return -1;
+    }
+
+    alg = json_string_value(json_object_get(header, "alg"));
+    typ = json_string_value(json_object_get(header, "typ"));
+
+    /* "typ" is optional (RFC 7519 Section 5.1); when present it names a media
+     * type, whose comparison is case-insensitive (RFC 8725 Section 3.11). */
+    if (!alg || strcmp(alg, "HS256") != 0 ||
+        (typ && strcasecmp(typ, "JWT") != 0)) {
+        json_decref(header);
+        return -1;
+    }
+
+    json_decref(header);
 
     /* signing_input = header.payload (everything before second dot) */
     si_len = second_dot - token;
@@ -426,11 +468,28 @@ chimera_rest_jwt_verify(
     claims->iat                          = json_integer_value(json_object_get(root, "iat"));
     claims->exp                          = json_integer_value(json_object_get(root, "exp"));
 
+    /* "nbf" is optional and not issued by chimera_rest_jwt_create, but a token
+     * that carries one must still be honored; read it before the payload is
+     * released. */
+    nbf_json = json_object_get(root, "nbf");
+    nbf      = nbf_json ? (time_t) json_integer_value(nbf_json) : 0;
+
     json_decref(root);
 
     /* Check expiration */
     now = time(NULL);
     if (now >= claims->exp) {
+        return -1;
+    }
+
+    /* RFC 7519 Section 4.1.5: the token must not be accepted before "nbf".
+     * Section 4.1.6's "iat" is the issue time, so a token claiming to have
+     * been issued in the future is not yet usable either. */
+    if (nbf && now + CHIMERA_REST_JWT_CLOCK_SKEW < nbf) {
+        return -1;
+    }
+
+    if (claims->iat && now + CHIMERA_REST_JWT_CLOCK_SKEW < claims->iat) {
         return -1;
     }
 

--- a/src/server/rest/rest_auth.c
+++ b/src/server/rest/rest_auth.c
@@ -7,6 +7,9 @@
 #include <string.h>
 #include <strings.h>
 #include <time.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
 #if defined(__linux__) || defined(CHIMERA_HAVE_XCRYPT)
 #include <crypt.h>
 #else  /* __linux__ || CHIMERA_HAVE_XCRYPT */
@@ -185,8 +188,33 @@ hmac_sha256(
 /* ========== Secret init ========== */
 
 void
-chimera_rest_auth_init_secret(struct chimera_rest_server *rest)
+chimera_rest_auth_init_secret(
+    struct chimera_rest_server *rest,
+    const char                 *state_dir)
 {
+    char    path[512];
+    ssize_t n;
+    int     fd;
+
+    /* A freshly random per-process secret invalidates every bearer token the
+     * moment the daemon restarts, and no two processes can verify each other's
+     * tokens.  RFC 8725 wants an HS256 signing key that is long-lived and
+     * shared by every verifier, so resolve it the way the NFS file-handle key
+     * already is: reuse the copy persisted under state_dir if there is one,
+     * otherwise mint one and persist it 0600 for the next start. */
+    snprintf(path, sizeof(path), "%s/rest_jwt.key", state_dir);
+
+    fd = open(path, O_RDONLY);
+    if (fd >= 0) {
+        n = read(fd, rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN);
+        close(fd);
+        if (n == (ssize_t) CHIMERA_REST_JWT_SECRET_LEN) {
+            chimera_rest_info("Loaded JWT signing secret from %s", path);
+            return;
+        }
+        chimera_rest_error("Short read of JWT secret %s; regenerating", path);
+    }
+
     /* RAND_bytes returns 1 on success; on 0/-1 it may not write the buffer at
      * all (CWE-252).  A zero/unseeded jwt_secret would let anyone forge a valid
      * JWT for any user -- a full control-plane authentication bypass -- so a
@@ -195,6 +223,21 @@ chimera_rest_auth_init_secret(struct chimera_rest_server *rest)
     if (RAND_bytes(rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN) != 1) {
         chimera_rest_abort("Failed to seed JWT signing secret from CSPRNG");
     }
+
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd >= 0) {
+        if (write(fd, rest->jwt_secret, CHIMERA_REST_JWT_SECRET_LEN) !=
+            (ssize_t) CHIMERA_REST_JWT_SECRET_LEN) {
+            chimera_rest_error("Failed to persist JWT secret to %s; issued "
+                               "tokens will not survive restart", path);
+        }
+        close(fd);
+    } else {
+        chimera_rest_error("Could not persist JWT secret to %s (%s); issued "
+                           "tokens will not survive restart", path,
+                           strerror(errno));
+    }
+
     chimera_rest_info("JWT authentication secret initialized");
 } /* chimera_rest_auth_init_secret */
 

--- a/src/server/rest/rest_auth.h
+++ b/src/server/rest/rest_auth.h
@@ -23,7 +23,8 @@ struct chimera_rest_jwt_claims {
 
 void
 chimera_rest_auth_init_secret(
-    struct chimera_rest_server *rest);
+    struct chimera_rest_server *rest,
+    const char                 *state_dir);
 
 int
 chimera_rest_auth_validate_credentials(

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -2899,7 +2899,15 @@ diskfs_get_layout_process(struct chimera_vfs_request *request)
             ext->file_offset : end;
 
         if (!rw) {
-            /* Read of a hole: skip it (the client reads zeros). */
+            /* RFC 5663 2.3.1: the extents of a block/SCSI layout describe its
+             * whole range, so a hole is reported as a NONE_DATA extent (which
+             * the client reads as zeroes).  Skipping it left a sub-range with
+             * no extent at all inside the lo_length the server then advertised
+             * from the last segment's end.  vol_id and storage_offset are not
+             * meaningful for NONE_DATA; device 0 always exists. */
+            diskfs_layout_emit(request, shared, p->loop_off,
+                               gap_end - p->loop_off, 0, 0,
+                               CHIMERA_VFS_BLOCK_NONE_DATA);
             p->loop_off = gap_end;
             diskfs_get_layout_process(request);
             return;

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -2209,7 +2209,14 @@ chimera_io_uring_write(
 
     fd = (int) request->write.handle->vfs_private;
 
-    if (request->write.sync) {
+    /* RFC 1813 3.3.7: DATA_SYNC needs the data (and only the metadata needed
+     * to retrieve it) durable, FILE_SYNC needs all metadata durable too.
+     * RWF_DSYNC/RWF_SYNC are exactly that distinction, so honor the level the
+     * client asked for instead of promoting DATA_SYNC to a full fsync -- the
+     * reply already reports the requested level back in r_sync. */
+    if (request->write.sync == CHIMERA_VFS_WRITE_DATASYNC) {
+        flags = RWF_DSYNC;
+    } else if (request->write.sync == CHIMERA_VFS_WRITE_FILESYNC) {
         flags = RWF_SYNC;
     }
 

--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -80,7 +80,7 @@ chimera_io_uring_dispatch(
 #define chimera_io_uring_abort_if(cond, ...) \
         chimera_abort_if(cond, "io_uring", __FILE__, __LINE__, __VA_ARGS__)
 
-#define CHIMERA_IO_URING_STATX_MASK STATX_BASIC_STATS
+#define CHIMERA_IO_URING_STATX_MASK CHIMERA_LINUX_STATX_MASK
 
 /*
  * CHIMERA_VFS_CAP_CLAIM_RANGE registry, mirroring the linux backend's.
@@ -3293,7 +3293,7 @@ chimera_io_uring_set_xattr(
     char                           *scratch = (char *) request->plugin_data;
     int                             flags   = 0;
     int                             rc;
-    struct stat                     st;
+    struct statx                    stx;
 
     --thread->inflight;
 
@@ -3303,12 +3303,13 @@ chimera_io_uring_set_xattr(
         flags = XATTR_REPLACE;
     }
 
-    if (fstat(fd, &st) < 0) {
+    if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+              CHIMERA_IO_URING_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;
     }
-    chimera_linux_stat_to_attr(&request->set_xattr.r_pre_attr, &st);
+    chimera_linux_statx_to_attr(&request->set_xattr.r_pre_attr, &stx);
 
     TERM_STR(name, request->set_xattr.name, request->set_xattr.namelen, scratch);
 
@@ -3317,10 +3318,11 @@ chimera_io_uring_set_xattr(
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
-    } else if (fstat(fd, &st) < 0) {
+    } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                     CHIMERA_IO_URING_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
     } else {
-        chimera_linux_stat_to_attr(&request->set_xattr.r_post_attr, &st);
+        chimera_linux_statx_to_attr(&request->set_xattr.r_post_attr, &stx);
         request->status = CHIMERA_VFS_OK;
     }
 
@@ -3376,16 +3378,17 @@ chimera_io_uring_remove_xattr(
     int                             fd      = (int) request->remove_xattr.handle->vfs_private;
     char                           *scratch = (char *) request->plugin_data;
     int                             rc;
-    struct stat                     st;
+    struct statx                    stx;
 
     --thread->inflight;
 
-    if (fstat(fd, &st) < 0) {
+    if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+              CHIMERA_IO_URING_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;
     }
-    chimera_linux_stat_to_attr(&request->remove_xattr.r_pre_attr, &st);
+    chimera_linux_statx_to_attr(&request->remove_xattr.r_pre_attr, &stx);
 
     TERM_STR(name, request->remove_xattr.name, request->remove_xattr.namelen, scratch);
 
@@ -3393,10 +3396,11 @@ chimera_io_uring_remove_xattr(
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
-    } else if (fstat(fd, &st) < 0) {
+    } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                     CHIMERA_IO_URING_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
     } else {
-        chimera_linux_stat_to_attr(&request->remove_xattr.r_post_attr, &st);
+        chimera_linux_statx_to_attr(&request->remove_xattr.r_post_attr, &stx);
         request->status = CHIMERA_VFS_OK;
     }
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -1275,7 +1275,7 @@ chimera_linux_read(
     int                          fd, i;
     ssize_t                      len, left = request->read.length;
     struct iovec                *iov;
-    struct stat                  st;
+    struct statx                 stx;
 
     (void) thread;
 
@@ -1334,9 +1334,11 @@ chimera_linux_read(
          * because the offset exceeds the directory's nominal size.  The VFS
          * core owns request->read.iov and releases it on completion (r_length
          * stays 0 here). */
-        if (errno == EINVAL && fstat(fd, &st) == 0) {
-            if (S_ISREG(st.st_mode) &&
-                request->read.offset >= (uint64_t) st.st_size) {
+        if (errno == EINVAL &&
+            statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                  CHIMERA_LINUX_STATX_MASK, &stx) == 0) {
+            if (S_ISREG(stx.stx_mode) &&
+                request->read.offset >= stx.stx_size) {
                 chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX,
                                         &request->read.r_attr, fd);
 
@@ -1349,7 +1351,7 @@ chimera_linux_read(
             /* POSIX read(2): a directory descriptor answers EISDIR whatever
              * else is also wrong with the request (the kernel checks offset
              * validity first and can answer EINVAL for a huge offset). */
-            if (S_ISDIR(st.st_mode)) {
+            if (S_ISDIR(stx.stx_mode)) {
                 errno = EISDIR;
             }
         }
@@ -1361,16 +1363,17 @@ chimera_linux_read(
         return;
     }
 
-    if (fstat(fd, &st) == 0) {
+    if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+              CHIMERA_LINUX_STATX_MASK, &stx) == 0) {
         if (request->read.r_attr.va_req_mask & CHIMERA_VFS_ATTR_MASK_STAT) {
-            chimera_linux_stat_to_attr(&request->read.r_attr, &st);
+            chimera_linux_statx_to_attr(&request->read.r_attr, &stx);
         }
 
-        request->read.r_eof = (request->read.offset + len >= (uint64_t) st.st_size);
+        request->read.r_eof = (request->read.offset + len >= stx.stx_size);
     } else {
         chimera_linux_map_attrs(CHIMERA_VFS_FH_MAGIC_LINUX, &request->read.r_attr, fd);
 
-        /* fstat() failed: we cannot compare against the file size, so report
+        /* statx() failed: we cannot compare against the file size, so report
          * EOF only when the read returned nothing for a non-zero request -- a
          * short read is NOT end-of-file (RFC 1813 §3.3.6). */
         request->read.r_eof = (len == 0 && request->read.length > 0);
@@ -2598,11 +2601,11 @@ chimera_linux_set_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    int         fd      = (int) request->set_xattr.handle->vfs_private;
-    char       *scratch = (char *) request->plugin_data;
-    int         flags   = 0;
-    int         rc;
-    struct stat st;
+    int          fd      = (int) request->set_xattr.handle->vfs_private;
+    char        *scratch = (char *) request->plugin_data;
+    int          flags   = 0;
+    int          rc;
+    struct statx stx;
 
     (void) private_data;
 
@@ -2612,12 +2615,13 @@ chimera_linux_set_xattr(
         flags = XATTR_REPLACE;
     }
 
-    if (fstat(fd, &st) < 0) {
+    if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+              CHIMERA_LINUX_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;
     }
-    chimera_linux_stat_to_attr(&request->set_xattr.r_pre_attr, &st);
+    chimera_linux_statx_to_attr(&request->set_xattr.r_pre_attr, &stx);
 
     TERM_STR(name, request->set_xattr.name, request->set_xattr.namelen, scratch);
 
@@ -2626,10 +2630,11 @@ chimera_linux_set_xattr(
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
-    } else if (fstat(fd, &st) < 0) {
+    } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                     CHIMERA_LINUX_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
     } else {
-        chimera_linux_stat_to_attr(&request->set_xattr.r_post_attr, &st);
+        chimera_linux_statx_to_attr(&request->set_xattr.r_post_attr, &stx);
         request->status = CHIMERA_VFS_OK;
     }
 
@@ -2680,19 +2685,20 @@ chimera_linux_remove_xattr(
     struct chimera_vfs_request *request,
     void                       *private_data)
 {
-    int         fd      = (int) request->remove_xattr.handle->vfs_private;
-    char       *scratch = (char *) request->plugin_data;
-    int         rc;
-    struct stat st;
+    int          fd      = (int) request->remove_xattr.handle->vfs_private;
+    char        *scratch = (char *) request->plugin_data;
+    int          rc;
+    struct statx stx;
 
     (void) private_data;
 
-    if (fstat(fd, &st) < 0) {
+    if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+              CHIMERA_LINUX_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;
     }
-    chimera_linux_stat_to_attr(&request->remove_xattr.r_pre_attr, &st);
+    chimera_linux_statx_to_attr(&request->remove_xattr.r_pre_attr, &stx);
 
     TERM_STR(name, request->remove_xattr.name, request->remove_xattr.namelen, scratch);
 
@@ -2700,10 +2706,11 @@ chimera_linux_remove_xattr(
 
     if (rc < 0) {
         request->status = chimera_linux_errno_to_status(errno);
-    } else if (fstat(fd, &st) < 0) {
+    } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                     CHIMERA_LINUX_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
     } else {
-        chimera_linux_stat_to_attr(&request->remove_xattr.r_post_attr, &st);
+        chimera_linux_statx_to_attr(&request->remove_xattr.r_post_attr, &stx);
         request->status = CHIMERA_VFS_OK;
     }
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -1412,7 +1412,14 @@ chimera_linux_write(
 
     fd = (int) request->write.handle->vfs_private;
 
-    if (request->write.sync) {
+    /* RFC 1813 3.3.7: DATA_SYNC needs the data (and only the metadata needed
+     * to retrieve it) durable, FILE_SYNC needs all metadata durable too.
+     * RWF_DSYNC/RWF_SYNC are exactly that distinction, so honor the level the
+     * client asked for instead of promoting DATA_SYNC to a full fsync -- the
+     * reply already reports the requested level back in r_sync. */
+    if (request->write.sync == CHIMERA_VFS_WRITE_DATASYNC) {
+        flags = RWF_DSYNC;
+    } else if (request->write.sync == CHIMERA_VFS_WRITE_FILESYNC) {
         flags = RWF_SYNC;
     }
 

--- a/src/vfs/linux/linux_common.h
+++ b/src/vfs/linux/linux_common.h
@@ -40,6 +40,14 @@
 
 #define chimera_linux_abort_if(cond, ...) \
         chimera_abort_if(cond, "linux", __FILE__, __LINE__, __VA_ARGS__)
+
+/* The statx(2) request mask both passthrough backends use for attributes.
+ * STATX_BTIME rides along with the basic set: ext4/xfs/btrfs track a birth
+ * time and the mapper needs it to fill va_btime (SMB CreationTime, NFSv4
+ * time_create).  Asking for it costs nothing on filesystems that do not have
+ * one -- the kernel simply leaves the bit clear in stx_mask. */
+#define CHIMERA_LINUX_STATX_MASK (STATX_BASIC_STATS | STATX_BTIME)
+
 #define TERM_STR(name, str, len, scratch) \
         char *(name) = scratch; \
         scratch     += (len) + 1; \
@@ -206,6 +214,17 @@ chimera_linux_statx_to_attr(
     attr->va_mtime.tv_nsec = stx->stx_mtime.tv_nsec;
     attr->va_ctime.tv_sec  = stx->stx_ctime.tv_sec;
     attr->va_ctime.tv_nsec = stx->stx_ctime.tv_nsec;
+
+    /* Birth time is optional in the VFS and optional in statx: only claim the
+     * bit when the kernel actually returned one (ext4/xfs/btrfs do, tmpfs and
+     * older kernels do not), so consumers keep their "not tracked" fallback
+     * rather than reporting a zero creation time. */
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_BTIME) &&
+        (stx->stx_mask & STATX_BTIME)) {
+        attr->va_set_mask     |= CHIMERA_VFS_ATTR_BTIME;
+        attr->va_btime.tv_sec  = stx->stx_btime.tv_sec;
+        attr->va_btime.tv_nsec = stx->stx_btime.tv_nsec;
+    }
 
     /* See chimera_linux_stat_to_attr: map the device id to a stable
      * per-filesystem fsid (vfs_fsid.h) rather than exposing the raw device
@@ -518,18 +537,20 @@ chimera_linux_map_attrs(
     int                       fd)
 {
     int            rc;
-    struct stat    st;
+    struct statx   stx;
     struct statvfs stvfs;
 
+    /* statx() rather than fstat(): same stats, one syscall, plus a birth time. */
     if (attr->va_req_mask & (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_FSID)) {
 
-        rc = fstat(fd, &st);
+        rc = statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
+                   CHIMERA_LINUX_STATX_MASK, &stx);
 
         if (rc) {
             return;
         }
 
-        chimera_linux_stat_to_attr(attr, &st);
+        chimera_linux_statx_to_attr(attr, &stx);
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {
@@ -587,7 +608,7 @@ chimera_linux_map_child_attrs(
     const char                 *name)
 {
     int            rc;
-    struct stat    st;
+    struct statx   stx;
     struct statvfs stvfs;
     int            stat_valid = 0;
 
@@ -597,13 +618,16 @@ chimera_linux_map_child_attrs(
 
     if (attr->va_req_mask & (CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_FSID)) {
 
-        rc = fstatat(dirfd, name, &st, AT_SYMLINK_NOFOLLOW);
+        /* statx() rather than fstatat(): same basic stats in one syscall, plus
+         * the birth time that fstatat(2) cannot report. */
+        rc = statx(dirfd, name, AT_SYMLINK_NOFOLLOW | AT_STATX_SYNC_AS_STAT,
+                   CHIMERA_LINUX_STATX_MASK, &stx);
 
         if (rc) {
             return chimera_linux_errno_to_status(errno);
         }
 
-        chimera_linux_stat_to_attr(attr, &st);
+        chimera_linux_statx_to_attr(attr, &stx);
         stat_valid = 1;
     }
 
@@ -628,7 +652,7 @@ chimera_linux_map_child_attrs(
     }
 
     if ((attr->va_req_mask & CHIMERA_VFS_ATTR_EA_SIZE) && stat_valid &&
-        (S_ISREG(st.st_mode) || S_ISDIR(st.st_mode))) {
+        (S_ISREG(stx.stx_mode) || S_ISDIR(stx.stx_mode))) {
         attr->va_ea_size   = chimera_linux_ea_size_at(dirfd, name);
         attr->va_set_mask |= CHIMERA_VFS_ATTR_EA_SIZE;
     }

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -4348,6 +4348,15 @@ memfs_allocate(
                                                EVPL_IOVEC_FLAG_SHARED, block->iov);
                 memset(block->iov[0].data, 0, block_size);
                 fork->blocks[bi] = block;
+
+                /* RFC 7862 §15.1.3: ALLOCATE increases space_used by the bytes
+                 * reserved, "unless they were previously reserved or written
+                 * and not shared" -- so charge only the blocks this call
+                 * materialized, which is exactly the ones the skip above let
+                 * through.  Without it a GETATTR after ALLOCATE still reported
+                 * the pre-ALLOCATE value even though the blocks (and the
+                 * filesystem-wide charge) were real. */
+                *p_space_used += block_size;
             }
         }
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -3846,11 +3846,19 @@ memfs_read(
         return;
     }
 
-    /* read() of a directory is EISDIR (the previous behavior fabricated
-     * zero-filled bytes from the empty data fork). */
-    if (unlikely(!stream && S_ISDIR(inode->mode))) {
+    /* A read of a named stream (stream != NULL) targets the stream's own data
+     * fork and is valid on any base object, including a directory's ADS.  A
+     * plain read only makes sense for a regular file: inode->file shares a
+     * union with the dirent tree and the symlink target, so any other type
+     * would have its union member reinterpreted as fork blocks/num_blocks and
+     * indexed far out of bounds (inodes are recycled, so num_blocks is not
+     * even reliably zero).  A directory is EISDIR (the previous behavior
+     * fabricated zero-filled bytes from the empty data fork); RFC 1813 3.3.6
+     * asks for INVAL on every other non-NF3REG handle. */
+    if (unlikely(!stream && !S_ISREG(inode->mode))) {
         pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EISDIR;
+        request->status = S_ISDIR(inode->mode) ?
+            CHIMERA_VFS_EISDIR : CHIMERA_VFS_EINVAL;
         request->complete(request);
         return;
     }

--- a/src/vfs/smb/smb_ops.c
+++ b/src/vfs/smb/smb_ops.c
@@ -841,11 +841,26 @@ chimera_smb_client_remove_at(
     struct chimera_smb_client_conn *conn,
     struct chimera_vfs_request     *request)
 {
+    /* Project the caller's rmdir-vs-unlink assertion onto the CREATE options
+     * so the peer enforces it: without one, an SMB server happily deletes
+     * whatever the name resolves to and RMDIR of a file (or REMOVE of a
+     * directory) would succeed instead of failing NFS3ERR_NOTDIR /
+     * NFS3ERR_ISDIR (RFC 1813 3.3.12, 3.3.13).  The peer answers
+     * STATUS_NOT_A_DIRECTORY / STATUS_FILE_IS_A_DIRECTORY, which the status
+     * map turns back into ENOTDIR / EISDIR. */
+    uint32_t options = SMB2_FILE_DELETE_ON_CLOSE;
+
+    if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISDIR) {
+        options |= SMB2_FILE_DIRECTORY_FILE;
+    } else if (request->remove_at.flags & CHIMERA_VFS_REMOVE_ISNOTDIR) {
+        options |= SMB2_FILE_NON_DIRECTORY_FILE;
+    }
+
     smb_send_create(conn, request,
                     request->remove_at.name, request->remove_at.namelen,
                     SMB2_DELETE | SMB2_FILE_READ_ATTRIBUTES,
                     SMB2_FILE_SHARE_READ | SMB2_FILE_SHARE_WRITE | SMB2_FILE_SHARE_DELETE,
-                    SMB2_FILE_OPEN, SMB2_FILE_DELETE_ON_CLOSE,
+                    SMB2_FILE_OPEN, options,
                     chimera_smb_remove_create_reply);
 } /* chimera_smb_client_remove_at */
 

--- a/src/vfs/vfs_idmap.c
+++ b/src/vfs/vfs_idmap.c
@@ -90,7 +90,14 @@ chimera_idmap_principal_to_who(
         const char *s = special_to_who_string(p->special);
 
         if (!s) {
-            return -1;
+            /* SYSTEM, CREATOR_OWNER, CREATOR_GROUP and OWNER_RIGHTS have no
+             * NFSv4 special identifier (RFC 8881 section 6.2.1.5 Table 5), so
+             * emit their well-known SID as the who string.  Naming them by SID
+             * keeps the ACE distinct and round-trips through the decoder;
+             * folding them onto any real principal would present an ACL that
+             * grants access the server does not enforce, which section 6.2.1
+             * forbids. */
+            return chimera_idmap_principal_to_sid(p, buf, buflen);
         }
         len = (int) strlen(s);
         if (len + 1 > buflen) {
@@ -177,6 +184,22 @@ chimera_idmap_who_to_principal(
         p->special = (uint8_t) special;
         p->id      = 0;
         return 0;
+    }
+
+    /* A SID string, as principal_to_who emits for the specials that have no
+     * NFSv4 identifier; decoding it back keeps a client read-modify-write of
+     * such an ACL lossless. */
+    if (len > 4 && memcmp(who, "S-1-", 4) == 0 &&
+        memchr(who, '@', len) == NULL) {
+        char sid[CHIMERA_IDMAP_SID_MAX];
+
+        if (len >= (int) sizeof(sid)) {
+            return -1;
+        }
+        memcpy(sid, who, len);
+        sid[len] = '\0';
+
+        return chimera_idmap_sid_to_principal(sid, p);
     }
 
     /* Pure numeric id. */


### PR DESCRIPTION
Third sweep over the NFS backlog, selected purely on **fix effort** rather than severity: 50 issues investigated, **18 closed** and 9 partially addressed, one commit each.

Because effort and severity are only loosely correlated here, the selection happened to include most of the remaining high-severity items.

### Security and access control
| | |
|---|---|
| #991 | MOUNT MNT handed out the root FH with no auth-flavor check; now enforces the export `sec=` policy |
| #1048 | RENAME and LINK never enforced the **destination** export's `sec=` or squash |
| #1012 | SM_NOTIFY released another host's locks with no source authentication |
| #1369 | unmapped special-who principals (SYSTEM/CREATOR_*) encoded as `EVERYONE@`, silently widening an ACL |
| #1162 | DELEGPURGE missing from the SP4_MACH_CRED enforce set, and unenforced |
| #1215 | REST JWT verifier never validated the JOSE header (`alg`/`typ`) or `nbf`/`iat` |
| #1314 | REST JWT signing secret re-randomized every start; now persisted under `state_dir` |

### Crashes and memory safety
| | |
|---|---|
| #1370 | FREE_STATEID treated a pNFS layout stateid as a lock state — type confusion |
| #1060 | a removed export was freed under `exports_lock` while NFS threads still dereferenced it; now reclaimed after an RCU grace period |
| #1046 | memfs READ on a non-regular handle aliased the inode union |
| #1173 | ALLOCATE/DEALLOCATE `offset + length` overflow (partial — the ceiling half is a policy call) |

### State machine and protocol
#1051 (reboot grace gated only OPEN; now covers READ/WRITE/LOCKT and truncating SETATTR), #1001 (EXCLUSIVE4_1 accepted `cva_attrs` outside `suppattr_exclcreat`), #1152, #393, #1161.

### Wire format, attributes, backends
#994 (FSSTAT failed outright rather than reporting what the backend gave), #1141 (READDIR budget charged in-memory rather than XDR wire bytes), #1428 (block/SCSI READ layout skipped holes), #1481 (btime never populated on the passthroughs — now via `statx`), #1174, #74, #380, #959.

## Notes for review

**One commit was written, tested and dropped.** A fix for #1146 made `OPEN` with `CLAIM_FH` return `NFS4ERR_ISDIR` for directories — correct on a plain reading of the RFC, and the quint model's `OCFh` arm predicts exactly that. But chimera's **own** NFSv4 client opens directories by filehandle to implement `opendir`, so it broke POSIX-over-NFSv4 on 16 of 53 traces with `errno 21`. Confirmed by reverting that commit alone and watching the suite go green. #1146 stays open; the type gate cannot be applied uniformly to the by-FH claims without breaking the in-tree client.

**Nine issues are committed as `Refs`, not `Fixes`** — #380, #947, #959, #1046, #1153, #1161, #1173, #1214, #1314 — each closing a named half and leaving the rest, rather than overclaiming.

**Four issues turned out already fixed** and want closing without a commit: #1007 and #1368 (landed in the session-reply-cache and RDMA DRC work), #1175 (`47033e71`), #1483 (`234e4d02`).

**Model-pinned, deliberately not fixed:** #385 (`MBT_FSINFO_*` constants pin every FSINFO field), #992 (`aux_mount.qnt` documents the early rmtab record as intended), #945 (implemented, then reverted — `opRemove` never calls `revokeLayoutsOn`, and the pNFS corpus is merge-gating). Each needs a paired `ext/specs` change.

## Testing

Quick tier green (97/97). Debug and Release build clean on macOS, and **the `linux` and `io_uring` backends were compile-checked on Linux in a container** — macOS does not build them, and #1481 and #74 both touch them. `make syntax-check` passes against the pinned uncrustify 0.78.1, not the newer local one.