### PR TITLE
s3/tests: bind the test access keys to a user

### DIFF
--- a/src/server/s3/tests/ceph/run_ceph_s3tests.sh
+++ b/src/server/s3/tests/ceph/run_ceph_s3tests.sh
@@ -70,13 +70,20 @@ case "$BACKEND" in
         ;;
 esac
 
+# All three keys bind to one user, which is what they effectively were before
+# keys carried an identity: an unbound key now acts as nobody and cannot write
+# to the backing store.  Giving them three distinct uids would be a behaviour
+# change rather than a fix -- the suite has always run them as one identity.
 cat > "$WORK/chimera.conf" <<EOF
 {
   "server": { "s3_enabled": true, "s3_port": $PORT },
+  "users": [
+    { "username": "s3test", "uid": $(id -u), "gid": $(id -g) }
+  ],
   "s3_access_keys": [
-    { "access_key": "mainaccesskey0001", "secret_key": "mainsecretkey0001" },
-    { "access_key": "altaccesskey0002",  "secret_key": "altsecretkey0002" },
-    { "access_key": "tenantaccesskey03", "secret_key": "tenantsecretkey03" }
+    { "access_key": "mainaccesskey0001", "secret_key": "mainsecretkey0001", "username": "s3test" },
+    { "access_key": "altaccesskey0002",  "secret_key": "altsecretkey0002",  "username": "s3test" },
+    { "access_key": "tenantaccesskey03", "secret_key": "tenantsecretkey03", "username": "s3test" }
   ],
   $FS_SECTION
   "mounts": { "share": { "module": "$BACKEND", "path": "$MOUNT_PATH" } },

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -69,10 +69,24 @@ class ChimeraServer:
                 "s3_enabled": True,
                 "s3_port": 5000,
             },
+            # Bind the key to the identity that owns the backing store.  An
+            # S3 key naming no user is unbound and acts as the anonymous
+            # identity (nobody), which cannot write into the temp directory the
+            # passthrough backends serve -- every mutating operation comes back
+            # AccessDenied.  memfs and cairn do not enforce ownership the same
+            # way, which is why only the linux/io_uring variants noticed.
+            "users": [
+                {
+                    "username": "s3test",
+                    "uid": os.getuid(),
+                    "gid": os.getgid()
+                }
+            ],
             "s3_access_keys": [
                 {
                     "access_key": "myaccessid",
-                    "secret_key": "mysecretkey"
+                    "secret_key": "mysecretkey",
+                    "username": "s3test"
                 }
             ],
             "mounts": {},


### PR DESCRIPTION
Giving each access key a POSIX identity (a8e6833, 02681e8) left the two S3 test harnesses behind. Their keys name no user, so they are **unbound** and act as the anonymous identity — nobody, uid 65534 — which cannot write into the directory the passthrough backends serve.

Every mutating operation comes back `AccessDenied`:

```
boto3_v4_linux_{put,get,head,delete,delete_objects,list,copy,multipart}
streaming PUT -> HTTP 403
```

All nine, on **rocky9 and rocky10, each arch and build type** — 8 jobs in extended run 33991552198.

## Why it looked distro-specific

It isn't. `memfs` and `cairn` do not enforce ownership against a real filesystem, so only the `linux` variants noticed — and the ubuntu images skip these tests entirely for want of boto3 (`boto3 not found`). The blast radius is any S3 deployment over a passthrough backend, not one distro.

## The server was right, and says so

Reproduced locally by starting the daemon with each config:

| config | startup |
|---|---|
| unbound (current) | `S3 access key myaccessid is not bound to a user; it will act as uid=65534 gid=65534 ... Set "username" on the key to bind it` — **level=error** |
| bound (this PR) | `Adding S3 access key myaccessid (user s3test)` — no error |

So this is a test-configuration gap, not a product defect. The commit that introduced the identity noted the *model* harness was updated to bind its key; these two were missed.

## The change

Both harnesses get a `users` entry carrying the invoking uid/gid, and their keys name it — which is what they implicitly were before.

The ceph harness binds **all three** of its keys to one user deliberately. Those keys have always run as a single identity, so giving them three distinct uids would be a behaviour change rather than a fix, and on a passthrough backend only one of the three could own the store. (That suite is gated on `S3TESTS_DIR`, so it never ran and never reported this — it was latently broken the same way.)

Generated config validated as JSON with the shell's own expansion; `bash -n` clean.
