### PR TITLE
pynfs: fix the SEC7 and FFLOOS regressions

### DIFF
--- a/pynfs/CMakeLists.txt
+++ b/pynfs/CMakeLists.txt
@@ -90,6 +90,17 @@ set(PYNFS_SKIP_BACKENDS_SATT15 linux io_uring)
 # already excluded from the combined suite; this drops the per-code entries.)
 set(PYNFS_SKIP_BACKENDS_EID50  ${PYNFS_BACKENDS})
 
+# SEC7 (st_secinfo.testRPCSEC_GSS) requires SECINFO to list an RPCSEC_GSS
+# triple.  Chimera advertises krb5 only when the Kerberos acceptor is actually
+# installed (server.nfs_kerberos_enabled, off by default and off in this
+# harness): RFC 7530 3.2.1.1 / 16.31 require SECINFO to report flavors the
+# server will accept, and an RPCSEC_GSS client would otherwise be refused at the
+# RPC layer.  The test asserts the advertisement unconditionally, so it cannot
+# pass against a server with GSS disabled -- the same shape as EID50 above, a
+# test of a feature this configuration does not offer.  Scoped to 4.0, which is
+# where it runs; an unknown no<CODE> token aborts the 4.1/4.2 testserver.
+set(PYNFS_SKIP_BACKENDS_SEC7   ${PYNFS_BACKENDS})
+
 # Per-code NFSv4 lease-time override (seconds).  Delegation recall-handshake
 # tests open a file as one client, then drive a *second* client's conflicting
 # OPEN to force a CB_RECALL.  Establishing that second client (SETCLIENTID /
@@ -308,6 +319,9 @@ function(pynfs_add_combined_suite backend minor)
         endif()
         if("${backend}" IN_LIST PYNFS_SKIP_BACKENDS_SATT15)
             list(APPEND excludes noSATT15)
+        endif()
+        if("${backend}" IN_LIST PYNFS_SKIP_BACKENDS_SEC7)
+            list(APPEND excludes noSEC7)
         endif()
     endif()
 

--- a/src/server/nfs/nfs4_pnfs.c
+++ b/src/server/nfs/nfs4_pnfs.c
@@ -1082,14 +1082,25 @@ chimera_nfs4_layoutget(
     }
 
     /* RFC 8881 §18.43.3: once the client holds a layout on this file,
-     * loga_stateid MUST be that layout's stateid, and §12.5.3 makes its seqid
-     * the server's to advance -- so a superseded seqid is NFS4ERR_OLD_STATEID
-     * and one never issued is NFS4ERR_BAD_STATEID (both listed in §18.43.4).
-     * A zero seqid means "the current stateid" (§8.2.2).  Only a layout-typed
-     * stateid is judged here: before the first layout is granted the client
-     * legitimately presents an open, lock, or delegation stateid, about which
-     * the layout state has nothing to say -- and the all-ones READ-bypass
-     * stateid decodes as the layout type without being one. */
+     * loga_stateid MUST be that layout's stateid, so one naming no layout this
+     * client holds is NFS4ERR_BAD_STATEID, as is a seqid the server never
+     * issued.  A zero seqid means "the current stateid" (§8.2.2).  Only a
+     * layout-typed stateid is judged here: before the first layout is granted
+     * the client legitimately presents an open, lock, or delegation stateid,
+     * about which the layout state has nothing to say -- and the all-ones
+     * READ-bypass stateid decodes as the layout type without being one.
+     *
+     * A *lagging* seqid is accepted, unlike LAYOUTRETURN below.  The server
+     * advances the seqid on every LAYOUTGET (§12.5.3), so a client with more
+     * than one LAYOUTGET in flight cannot know the current value -- it can only
+     * echo the last one it was given, and the second of two pipelined
+     * LAYOUTGETs therefore arrives carrying a seqid the server has already
+     * superseded.  Rejecting that breaks a legitimate client, which is what
+     * pynfs FFLOOS (st_flex.testFlexLayoutOldSeqid) checks.  A stale seqid is
+     * still a value this server issued for this layout, so honoring it forges
+     * nothing; NFS4ERR_OLD_STATEID is merely listed as permitted for the op
+     * (§18.43.4), not required for this case.  LAYOUTRETURN is a single ordered
+     * operation with no such ambiguity and keeps the strict check. */
     client = req->session ? req->session->client_unified : NULL;
 
     if (client && !nfs4_stateid_is_special(&args->loga_stateid)) {
@@ -1104,8 +1115,6 @@ chimera_nfs4_layoutget(
 
             if (!layout) {
                 res->logr_status = NFS4ERR_BAD_STATEID;
-            } else if (in_seqid != 0 && in_seqid < layout->seqid) {
-                res->logr_status = NFS4ERR_OLD_STATEID;
             } else if (in_seqid > layout->seqid) {
                 res->logr_status = NFS4ERR_BAD_STATEID;
             } else {


### PR DESCRIPTION
pynfs passed 4/4 in extended run 33987639268 and fails 4/4 in 33991552198. Two independent causes, from the 51 commits between those runs.

## SEC7 — `st_secinfo.testRPCSEC_GSS` (12 occurrences, 6 backends × 2)

```
SECINFO returned mechanism list without RPCSEC_GSS
```

From `79d00d0d`, which stopped advertising krb5 when the Kerberos acceptor is not installed. **That change is right** — RFC 7530 §3.2.1.1 / §16.31 require SECINFO to report flavors the server will actually accept, and an RPCSEC_GSS client would otherwise be refused at the RPC layer. The test asserts the advertisement unconditionally, so it cannot pass against a server with GSS disabled (the default, and this harness's setting).

Excluded with pynfs's `no<CODE>` token, mirroring WRT18/SATT15, and scoped to 4.0 where it runs — an unknown token aborts the 4.1/4.2 testserver. This is the same shape as the existing EID50 exclusion directly above it: a test of a feature this configuration does not offer.

## FFLOOS — `st_flex.testFlexLayoutOldSeqid`

```
OP_LAYOUTGET should return NFS4_OK, instead got NFS4ERR_OLD_STATEID
```

From `679196e5`, which began validating `loga_stateid`. **Here I think the server is wrong**, and this is the judgement call in the PR.

The server advances the layout seqid on *every* LAYOUTGET (§12.5.3), so a client can only ever echo the last seqid it was given. A client with more than one LAYOUTGET in flight therefore sends the second carrying a seqid the server has already superseded — through no fault of its own. pynfs FFLOOS checks exactly that: that two LAYOUTGETs sent in a row without bumping the seqid are both honored.

So the fix accepts a lagging seqid. A stale seqid is still a value **this server issued for this layout**, so honoring it forges nothing, and `NFS4ERR_OLD_STATEID` is *listed as permitted* for the operation (§18.43.4) rather than required for this case — which is what the original commit's citation actually supports.

Everything `679196e5` was for is kept: a layout-typed stateid naming no layout this client holds is still `NFS4ERR_BAD_STATEID`, as is a seqid the server never issued. LAYOUTRETURN is a single ordered operation with no such ambiguity and keeps the strict check.

**Stated plainly:** I could not retrieve RFC 8881 §12.5.3's exact normative sentence — the section is inside a document too large for the fetchers I have, and searches surfaced the surrounding text but not the rule itself. This rests on pynfs's stated intent for FFLOOS plus the pipelining argument above. If §12.5.3 does mandate OLD_STATEID here, the right answer is to skip FFLOOS the way SEC7 is skipped, and I'd revert this commit in favour of that.

## Verification

Debug build clean, `ctest -R "pnfs|nfs4_mbt"` 0 failures, uncrustify clean, `cmake` configures. pynfs itself is gated on `/opt/pynfs`, absent here, so the CMake branch could not execute locally — I validated its list logic in an isolated CMake project instead, and confirmed `PYNFS_BACKENDS` is fully populated (diskfs_aio, cairn appended at lines 12/16) before the skip list is set at line 102, so all six backends are covered.
