### PR TITLE
tests/fio: make the intermittent SIGILL diagnosable

### DIFF
--- a/scripts/netns_test_wrapper.sh
+++ b/scripts/netns_test_wrapper.sh
@@ -52,9 +52,57 @@ ulimit -l unlimited
 echo 16777216 > /proc/sys/fs/aio-max-nr
 
 # Run the test command inside the namespace, restoring LD_PRELOAD only for
-# the test process (not for the ip binary itself, which ASAN would break)
+# the test process (not for the ip binary itself, which ASAN would break).
+#
+# set -e is lifted around the run so a signal death reaches the report below
+# rather than killing the shell with the status unexamined.
+set +e
 if [ -n "${SAVED_LD_PRELOAD}" ]; then
     ip netns exec "${NETNS_NAME}" env LD_PRELOAD="${SAVED_LD_PRELOAD}" "$@"
 else
     ip netns exec "${NETNS_NAME}" "$@"
 fi
+STATUS=$?
+set -e
+
+# A command killed by a signal leaves only bash's own one-line "Illegal
+# instruction" on stderr, which says nothing about which binary died or why.
+# That is exactly how the fio SIGILL has stayed unexplained: the tests run with
+# chimera logging off, so the process produces no output at all before it dies.
+# Report what is knowable here, while the namespace and the environment that
+# produced it are still the ones the command saw.
+if [ "${STATUS}" -gt 128 ]; then
+    SIG=$((STATUS - 128))
+    echo "=== netns test died on signal ${SIG} ($(kill -l "${SIG}" 2>/dev/null || echo unknown)) ===" >&2
+    echo "  command: $*" >&2
+    echo "  uname:   $(uname -m) $(uname -r)" >&2
+
+    # SIGILL is the one that needs hardware context: an instruction the build
+    # emitted that this particular runner cannot execute looks exactly like a
+    # crash in the loaded plugin.  Name the CPU and the ISA levels it claims.
+    if [ "${SIG}" -eq 4 ]; then
+        echo "  cpu:     $(grep -m1 '^model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ *//')" >&2
+        for f in avx2 bmi2 fma avx512f sse4_2; do
+            if grep -qm1 "^flags.*\b${f}\b" /proc/cpuinfo 2>/dev/null; then
+                printf '  isa:     %s present\n' "${f}" >&2
+            else
+                printf '  isa:     %s ABSENT\n' "${f}" >&2
+            fi
+        done
+        # The plugin is dlopened, so a mismatch there is invisible to ldd on the
+        # host binary; name it explicitly when the job file points at one.
+        for arg in "$@"; do
+            case "${arg}" in
+                *.fio)
+                    plugin=$(sed -n 's/^ioengine=external://p' "${arg}" 2>/dev/null | head -1)
+                    if [ -n "${plugin}" ]; then
+                        echo "  plugin:  ${plugin}" >&2
+                        ls -l "${plugin}" >&2 2>/dev/null || echo "  plugin:  MISSING" >&2
+                    fi
+                    ;;
+            esac
+        done
+    fi
+fi
+
+exit "${STATUS}"

--- a/src/fio/tests/diskfs_aio_basic.fio
+++ b/src/fio/tests/diskfs_aio_basic.fio
@@ -2,10 +2,16 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# chimera_log below sends chimera's own log to stderr.  Without it the engine
+# disables logging entirely, so a failure inside chimera produces no output at
+# all -- which is why the intermittent SIGILL here has only ever been visible as
+# bash's one-line "Illegal instruction" and nothing else.
+
 [global]
 thread=1
 ioengine=external:${PLUGIN_PATH}
 chimera_config=${FIO_TEST_BINARY}/diskfs_aio_basic.json
+chimera_log=/dev/stderr
 group_reporting
 numjobs=1
 create_on_open=1

--- a/src/fio/tests/diskfs_io_uring_basic.fio
+++ b/src/fio/tests/diskfs_io_uring_basic.fio
@@ -2,10 +2,16 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# chimera_log below sends chimera's own log to stderr.  Without it the engine
+# disables logging entirely, so a failure inside chimera produces no output at
+# all -- which is why the intermittent SIGILL here has only ever been visible as
+# bash's one-line "Illegal instruction" and nothing else.
+
 [global]
 thread=1
 ioengine=external:${PLUGIN_PATH}
 chimera_config=${FIO_TEST_BINARY}/diskfs_io_uring_basic.json
+chimera_log=/dev/stderr
 group_reporting
 numjobs=1
 create_on_open=1

--- a/src/fio/tests/memfs_basic.fio
+++ b/src/fio/tests/memfs_basic.fio
@@ -1,11 +1,17 @@
-# SPDX-FileCopyrightText: 2025 Chimera-NAS Project Contributors
+# SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
 #
 # SPDX-License-Identifier: Unlicense
+
+# chimera_log below sends chimera's own log to stderr.  Without it the engine
+# disables logging entirely, so a failure inside chimera produces no output at
+# all -- which is why the intermittent SIGILL here has only ever been visible as
+# bash's one-line "Illegal instruction" and nothing else.
 
 [global]
 thread=1
 ioengine=external:${PLUGIN_PATH}
 chimera_config=${FIO_TEST_BINARY}/memfs_basic.json
+chimera_log=/dev/stderr
 group_reporting
 numjobs=1
 create_on_open=1


### PR DESCRIPTION
The three fio tests die intermittently with nothing but bash's own report:

```
netns_test_wrapper.sh: line 60: 34532 Illegal instruction  (core dumped)
```

0.13 s, **no output at all**, all three together.

## What I established from the logs

| observation | what it rules out |
|---|---|
| `elbencho` uses the **same** netns wrapper and dlopens its own chimera plugin — and **passes in the very cell where fio dies** | the wrapper, the namespace, plugin loading, and chimera code on that runner |
| The same build artifacts pass in other cells of the same run | a bad artifact |
| Fails in Debug *and* Release, amd64 *and* arm64, across runs | ASAN preload; build type; architecture |
| Failing cells vary run to run (4/4, 2/4, 1/4, 0/4, 1/4) | anything deterministic — it tracks the runner instance |
| No `__builtin_trap` anywhere in chimera or libevpl | a chimera trap instruction |

So it is fio-specific, instantaneous, and runner-dependent. What the logs *cannot* say is which binary died or why — and there are two distinct reasons for that, both fixed here.

## 1. The tests run blind

The engine disables chimera logging entirely unless `chimera_log` names a file, and the job files never set it. A failure inside chimera therefore produces **no output whatsoever**. Pointing it at `/dev/stderr` — which the engine `fopen()`s like any other path — stops that.

## 2. A signal death is reported as one uninformative line

The wrapper now reports it where the namespace and environment are still in scope: the signal, the command, and for SIGILL the CPU model, the ISA levels the runner claims (`avx2`, `bmi2`, `fma`, `avx512f`, `sse4_2`), and the dlopened plugin's path and presence.

That last part is the point. chimera builds amd64 with `-march=x86-64-v3` and `XXH_AVX2`, so "an instruction this runner cannot execute" is a live hypothesis — but so is a plugin problem, and today's logs distinguish neither. The elbencho observation argues *against* hardware, which is exactly why the ISA dump is worth having rather than guessing.

## Verification

The reporting block was exercised directly with simulated deaths:

```
SIGILL (132)  -> signal name, command, uname, cpu, five ISA lines, plugin path + presence
SIGSEGV (139) -> signal, command, uname; no ISA dump
exit 1        -> silent
```

It also correctly parsed the dlopened plugin out of the `.fio` job file and reported it missing when it was. `bash -n` clean, `cmake` configures.

The explanatory comment sits **above** `[global]` rather than inside it: the existing files only demonstrate `#` comments at file scope, and if fio rejected an in-section comment this "diagnostic" would turn an intermittent failure into a permanent one. Zero cost to avoid that.

**Diagnostic only — this does not fix the crash.** No behaviour change on a passing run. `set -e` is lifted around the run so the status is examined rather than killing the shell, and the original exit status is preserved.
