### PR TITLE
config: expose the io_uring ring depth, and size CI's rings to a test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -524,13 +524,14 @@ jobs:
 
       - name: Configure, build, and test inside the container
         run: |
+          # EVPL_IO_URING_ENTRIES below sizes the io_uring rings to a test
+          # rather than to a server.  The 8192-entry default costs ~1.5 MB of
+          # kernel-accounted memory per ring (SQE128/CQE32 double both entry
+          # sizes) and SQPOLL adds a kernel thread each; ctest -j nproc stacks
+          # enough of them to be refused with ENOMEM, which is fatal to the
+          # process and takes an unrelated test with it.
           docker run --rm --privileged \
             -e CCACHE_DIR=/ccache \
-            # Ring depth for the io_uring event core.  The 8192-entry default
-            # costs ~1.5 MB of kernel-accounted memory per ring and SQPOLL adds a
-            # kernel thread each; ctest -j nproc stacks enough of them to be
-            # refused with ENOMEM, which is fatal to the process.  Size the ring
-            # to a test rather than to a server.
             -e EVPL_IO_URING_ENTRIES=1024 \
             -e CCACHE_MAXSIZE \
             -v "${{ runner.temp }}/ccache:/ccache" \
@@ -872,13 +873,14 @@ jobs:
 
       - name: Configure, build, and test inside the container
         run: |
+          # EVPL_IO_URING_ENTRIES below sizes the io_uring rings to a test
+          # rather than to a server.  The 8192-entry default costs ~1.5 MB of
+          # kernel-accounted memory per ring (SQE128/CQE32 double both entry
+          # sizes) and SQPOLL adds a kernel thread each; ctest -j nproc stacks
+          # enough of them to be refused with ENOMEM, which is fatal to the
+          # process and takes an unrelated test with it.
           docker run --rm --privileged \
             -e CCACHE_DIR=/ccache \
-            # Ring depth for the io_uring event core.  The 8192-entry default
-            # costs ~1.5 MB of kernel-accounted memory per ring and SQPOLL adds a
-            # kernel thread each; ctest -j nproc stacks enough of them to be
-            # refused with ENOMEM, which is fatal to the process.  Size the ring
-            # to a test rather than to a server.
             -e EVPL_IO_URING_ENTRIES=1024 \
             -e CCACHE_MAXSIZE \
             -v "${{ runner.temp }}/ccache:/ccache" \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -526,6 +526,12 @@ jobs:
         run: |
           docker run --rm --privileged \
             -e CCACHE_DIR=/ccache \
+            # Ring depth for the io_uring event core.  The 8192-entry default
+            # costs ~1.5 MB of kernel-accounted memory per ring and SQPOLL adds a
+            # kernel thread each; ctest -j nproc stacks enough of them to be
+            # refused with ENOMEM, which is fatal to the process.  Size the ring
+            # to a test rather than to a server.
+            -e EVPL_IO_URING_ENTRIES=1024 \
             -e CCACHE_MAXSIZE \
             -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
@@ -868,6 +874,12 @@ jobs:
         run: |
           docker run --rm --privileged \
             -e CCACHE_DIR=/ccache \
+            # Ring depth for the io_uring event core.  The 8192-entry default
+            # costs ~1.5 MB of kernel-accounted memory per ring and SQPOLL adds a
+            # kernel thread each; ctest -j nproc stacks enough of them to be
+            # refused with ENOMEM, which is fatal to the process.  Size the ring
+            # to a test rather than to a server.
+            -e EVPL_IO_URING_ENTRIES=1024 \
             -e CCACHE_MAXSIZE \
             -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -560,6 +560,10 @@ jobs:
           docker run --rm --privileged \
             -e CCACHE_DIR=/ccache \
             -e CCACHE_MAXSIZE \
+            # Ring depth for the io_uring event core -- see the same setting in
+            # test-dev below.  This job runs the whole suite under ctest -j nproc,
+            # so it stacks rings the same way.
+            -e EVPL_IO_URING_ENTRIES=1024 \
             -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
@@ -726,6 +730,14 @@ jobs:
         run: |
           docker run --rm --privileged \
             -e CATEGORY=${{ matrix.category }} \
+            # Ring depth for the io_uring event core.  The default 8192
+            # entries cost ~1.5 MB of kernel-accounted memory per ring
+            # (SQE128/CQE32 double both entry sizes) and SQPOLL adds a kernel
+            # thread each; ctest -j nproc runs many multi-threaded chimera
+            # processes at once, which is enough to be refused with ENOMEM and
+            # lose unrelated tests to a fatal ring allocation.  Ask for a ring
+            # sized to a test rather than to a server.
+            -e EVPL_IO_URING_ENTRIES=1024 \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
@@ -1127,6 +1139,14 @@ jobs:
           echo "smbtorture concurrency: ${SMBTORTURE_PARALLEL} cells ($(nproc) vCPU)"
           docker run --rm --privileged \
             -e SMBTORTURE_BACKENDS \
+            # Ring depth for the io_uring event core.  The default 8192
+            # entries cost ~1.5 MB of kernel-accounted memory per ring
+            # (SQE128/CQE32 double both entry sizes) and SQPOLL adds a kernel
+            # thread each; ctest -j nproc runs many multi-threaded chimera
+            # processes at once, which is enough to be refused with ENOMEM and
+            # lose unrelated tests to a fatal ring allocation.  Ask for a ring
+            # sized to a test rather than to a server.
+            -e EVPL_IO_URING_ENTRIES=1024 \
             -e SMBTORTURE_FILTER \
             -e SMBTORTURE_PARALLEL \
             -v "${{ github.workspace }}:/workspace" \

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -557,12 +557,15 @@ jobs:
 
       - name: Configure, build, and test inside the container
         run: |
+          # EVPL_IO_URING_ENTRIES below sizes the io_uring rings to a test
+          # rather than to a server.  The 8192-entry default costs ~1.5 MB of
+          # kernel-accounted memory per ring (SQE128/CQE32 double both entry
+          # sizes) and SQPOLL adds a kernel thread each; ctest -j nproc stacks
+          # enough of them to be refused with ENOMEM, which is fatal to the
+          # process and takes an unrelated test with it.
           docker run --rm --privileged \
             -e CCACHE_DIR=/ccache \
             -e CCACHE_MAXSIZE \
-            # Ring depth for the io_uring event core -- see the same setting in
-            # test-dev below.  This job runs the whole suite under ctest -j nproc,
-            # so it stacks rings the same way.
             -e EVPL_IO_URING_ENTRIES=1024 \
             -v "${{ runner.temp }}/ccache:/ccache" \
             -v "${{ github.workspace }}:/workspace" \
@@ -728,15 +731,14 @@ jobs:
 
       - name: Unpack and run the category
         run: |
+          # EVPL_IO_URING_ENTRIES below sizes the io_uring rings to a test
+          # rather than to a server.  The 8192-entry default costs ~1.5 MB of
+          # kernel-accounted memory per ring (SQE128/CQE32 double both entry
+          # sizes) and SQPOLL adds a kernel thread each; ctest -j nproc stacks
+          # enough of them to be refused with ENOMEM, which is fatal to the
+          # process and takes an unrelated test with it.
           docker run --rm --privileged \
             -e CATEGORY=${{ matrix.category }} \
-            # Ring depth for the io_uring event core.  The default 8192
-            # entries cost ~1.5 MB of kernel-accounted memory per ring
-            # (SQE128/CQE32 double both entry sizes) and SQPOLL adds a kernel
-            # thread each; ctest -j nproc runs many multi-threaded chimera
-            # processes at once, which is enough to be refused with ENOMEM and
-            # lose unrelated tests to a fatal ring allocation.  Ask for a ring
-            # sized to a test rather than to a server.
             -e EVPL_IO_URING_ENTRIES=1024 \
             -v "${{ github.workspace }}:/workspace" \
             -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
@@ -1137,15 +1139,14 @@ jobs:
           fi
           export SMBTORTURE_PARALLEL
           echo "smbtorture concurrency: ${SMBTORTURE_PARALLEL} cells ($(nproc) vCPU)"
+          # EVPL_IO_URING_ENTRIES below sizes the io_uring rings to a test
+          # rather than to a server.  The 8192-entry default costs ~1.5 MB of
+          # kernel-accounted memory per ring (SQE128/CQE32 double both entry
+          # sizes) and SQPOLL adds a kernel thread each; ctest -j nproc stacks
+          # enough of them to be refused with ENOMEM, which is fatal to the
+          # process and takes an unrelated test with it.
           docker run --rm --privileged \
             -e SMBTORTURE_BACKENDS \
-            # Ring depth for the io_uring event core.  The default 8192
-            # entries cost ~1.5 MB of kernel-accounted memory per ring
-            # (SQE128/CQE32 double both entry sizes) and SQPOLL adds a kernel
-            # thread each; ctest -j nproc runs many multi-threaded chimera
-            # processes at once, which is enough to be refused with ENOMEM and
-            # lose unrelated tests to a fatal ring allocation.  Ask for a ring
-            # sized to a test rather than to a server.
             -e EVPL_IO_URING_ENTRIES=1024 \
             -e SMBTORTURE_FILTER \
             -e SMBTORTURE_PARALLEL \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,7 @@ the canonical place to set them.
 | `slab_size` | size | libevpl default | libevpl memory slab size. |
 | `preallocate_slabs` | int | libevpl default | Number of memory slabs to preallocate at startup. |
 | `preallocate_threads` | int | libevpl default | Threads used to preallocate slabs in parallel. |
+| `io_uring_entries` | int | `8192` | io_uring submission/completion ring depth, per event-loop thread. Each ring costs roughly 1.5 MB of kernel-accounted memory at the default (`SQE128`/`CQE32` double both entry sizes) and SQPOLL adds a kernel thread per ring, so a host running many threads or many Chimera processes can be refused with `ENOMEM`. The value is honoured or the ring fails; it is never reduced silently. Can also be set with `EVPL_IO_URING_ENTRIES`. |
 | `rdmacm_tos` | int | `0` | RoCEv2 traffic class stamped on every RDMA QP. ToS = DSCP x 4 (e.g. `104` for DSCP 26) so the fabric's lossless/PFC class carries Chimera traffic. |
 | `metrics_file` | string | - | On shutdown, write a final Prometheus scrape to this file (so short runs keep their metrics). |
 | `umount_timeout_ms` | int | `1000` | How long an unmount waits for the mount's open handles to be closed and released before giving up and returning `EBUSY`. Raise it for backends whose closes are slow; it exists so that unmounting a genuinely busy mount fails rather than hanging. |

--- a/src/common/common_config.h
+++ b/src/common/common_config.h
@@ -171,6 +171,20 @@ chimera_apply_common_config(
         evpl_global_config_set_buffer_size(cfg, size);
     }
 
+    /* io_uring ring depth.  Each ring costs roughly 1.5 MB of kernel-accounted
+     * memory at the default 8192 entries -- IORING_SETUP_SQE128 and
+     * IORING_SETUP_CQE32 double both entry sizes -- and SQPOLL adds a kernel
+     * thread per ring.  A host running many event-loop threads, or many chimera
+     * processes at once, can be refused with ENOMEM while otherwise healthy, so
+     * a constrained deployment needs to be able to ask for less.  libevpl
+     * honours the value or fails the ring; it never reduces it silently, since
+     * a ring that quietly shrank would make throughput depend on how loaded the
+     * machine was at startup. */
+    val = json_object_get(common, "io_uring_entries");
+    if (json_is_integer(val)) {
+        evpl_global_config_set_io_uring_entries(cfg, json_integer_value(val));
+    }
+
     val = json_object_get(common, "preallocate_slabs");
     if (json_is_integer(val)) {
         evpl_global_config_set_preallocate_slabs(cfg, json_integer_value(val));


### PR DESCRIPTION
Companion to chimera-nas/libevpl#163, which replaces the automatic ring reduction I first proposed (libevpl#160, now closed). The stack should do what the configuration says, or fail — not quietly shrink, which would make throughput depend on how loaded the machine happened to be at startup and would hide the resource problem instead of reporting it.

## The failure being addressed

Each io_uring ring costs roughly **1.5 MB** of kernel-accounted memory at libevpl's default 8192 entries (`IORING_SETUP_SQE128` and `IORING_SETUP_CQE32` double both entry sizes), and SQPOLL adds a kernel thread per ring. Every test container runs `ctest -j nproc`, and each chimera process under it has several event-loop threads, so rings stack until the kernel refuses one:

```
io_uring_queue_init_params() failed: Cannot allocate memory (-12)
level=fatal module=io_uring
```

That is fatal, so the process dies where it stands and takes an unrelated test with it — `posix/fsstress_diskfs_io_uring` and several smbtorture cases, in cells that vary run to run because it depends on what else the runner is carrying.

## Two commits

**1. `common.io_uring_entries`** — a config key for deployments, alongside the other libevpl knobs (`slab_size`, `preallocate_slabs`, …), documented in `docs/configuration.md`. A constrained deployment can now ask for a smaller ring rather than discovering the limit as a crash.

**2. CI states its intent** — `EVPL_IO_URING_ENTRIES=1024` on the containers that actually run `ctest`: the distro `test` job and the sharded devcontainer shards, in both `extended.yml` and `build-test.yml`. Not on the build or static-analysis containers, which start no rings.

1024 entries is ample for a test's queue depth and cuts the per-ring cost about eightfold.

## Why the environment variable rather than the config key for CI

The config key only reaches processes that parse a config file — the daemon and the fio engine. chimera's **test harnesses build their server state programmatically and never see one**, and those are exactly the processes that hit this. The env override in libevpl#163 is the only lever that reaches them.

## The pin

Now carried here as a third commit, advancing `ext/libevpl` to `33d920b`:

```
c3ec46c io_uring: do not let a completion arrive with nothing to wake the loop  (libevpl#162)
33d920b config: let the environment state the io_uring ring size               (libevpl#163)
```

Neither changes an interface this tree uses. Without it `EVPL_IO_URING_ENTRIES` is unread and the CI change does nothing, so it belongs with the setting that depends on it.

It originally rode in on the krb5p branch and did not survive #912's merge — main landed at the commit before it, so the pin there is still `dd9a07a`. Carrying it here makes the change self-contained and removes the ordering caveat entirely.

`c3ec46c` is also the fix for the diskfs intent-log stall behind `smb2.maxfid`, so this pin is what makes that land.

Debug build clean; uncrustify clean; both workflow files re-parsed as YAML after editing.
