### PR TITLE
ci: a KVM diagnostic that answers in minutes instead of six hours

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -935,64 +935,6 @@ jobs:
   # run gate-free (CHIMERA_LIMITS_TESTING passes vacuously off Linux) and the
   # genuinely networked suites serialize under the chimera_net lock.
   # ---------------------------------------------------------------------------
-  # Standing diagnostic for the KVM suites.  The kvm shard in the extended
-  # workflow has never produced a passing run on the hosted runners, and each
-  # attempt costs six hours to observe nothing: guests either never boot (no
-  # rootfs where the registered test looks) or boot and hang, wedging ctest
-  # until the job limit.  Neither leaves a usable log.
-  #
-  # This boots one guest, once, with a hard bound, and prints where the images
-  # actually are against where the tests expect them.  Minutes, not hours.
-  #
-  # continue-on-error: it reports, it does not gate.  Nothing depends on the
-  # KVM suites today and a diagnostic that can block a merge is one people
-  # learn to route around.
-  kvm-diagnostic:
-    needs: build-devcontainer
-    runs-on: ubuntu-24.04
-    continue-on-error: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          submodules: recursive
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Report the runner's own KVM support
-        run: |
-          echo "=== runner (outside the container) ==="
-          uname -srm
-          ls -l /dev/kvm 2>&1 || echo "/dev/kvm ABSENT on the runner"
-          grep -m1 '^model name' /proc/cpuinfo | cut -d: -f2-
-          grep -com1 -E '^flags.*\b(vmx|svm)\b' /proc/cpuinfo \
-            && echo "virtualisation extensions present" \
-            || echo "no vmx/svm in /proc/cpuinfo"
-
-      - name: Diagnose KVM inside the dev container
-        run: |
-          docker run --rm --privileged \
-            -v "${{ github.workspace }}:/workspace" \
-            -v /build \
-            -w /build \
-            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
-            bash -euxc '
-              # Configure exactly as the test jobs do, so IMAGE_DIR resolves the
-              # same way they resolve it -- the point is to observe that path,
-              # not to pick a better one.
-              cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
-                    -DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF /workspace
-              # One image, not the whole set: this asks whether the mechanism
-              # works at all.
-              ninja kvm_ubuntu2404_image || echo "IMAGE FETCH FAILED (continuing to report)"
-              bash /workspace/kvm/kvm_diagnose.sh /build ubuntu2404'
-
-
   macos:
     name: Test macOS ${{ matrix.build_type }}
     runs-on: macos-14

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -935,6 +935,64 @@ jobs:
   # run gate-free (CHIMERA_LIMITS_TESTING passes vacuously off Linux) and the
   # genuinely networked suites serialize under the chimera_net lock.
   # ---------------------------------------------------------------------------
+  # Standing diagnostic for the KVM suites.  The kvm shard in the extended
+  # workflow has never produced a passing run on the hosted runners, and each
+  # attempt costs six hours to observe nothing: guests either never boot (no
+  # rootfs where the registered test looks) or boot and hang, wedging ctest
+  # until the job limit.  Neither leaves a usable log.
+  #
+  # This boots one guest, once, with a hard bound, and prints where the images
+  # actually are against where the tests expect them.  Minutes, not hours.
+  #
+  # continue-on-error: it reports, it does not gate.  Nothing depends on the
+  # KVM suites today and a diagnostic that can block a merge is one people
+  # learn to route around.
+  kvm-diagnostic:
+    needs: build-devcontainer
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report the runner's own KVM support
+        run: |
+          echo "=== runner (outside the container) ==="
+          uname -srm
+          ls -l /dev/kvm 2>&1 || echo "/dev/kvm ABSENT on the runner"
+          grep -m1 '^model name' /proc/cpuinfo | cut -d: -f2-
+          grep -com1 -E '^flags.*\b(vmx|svm)\b' /proc/cpuinfo \
+            && echo "virtualisation extensions present" \
+            || echo "no vmx/svm in /proc/cpuinfo"
+
+      - name: Diagnose KVM inside the dev container
+        run: |
+          docker run --rm --privileged \
+            -v "${{ github.workspace }}:/workspace" \
+            -v /build \
+            -w /build \
+            ${{ env.DEV_IMAGE_TAG_PREFIX }}:${{ github.sha }}-amd64 \
+            bash -euxc '
+              # Configure exactly as the test jobs do, so IMAGE_DIR resolves the
+              # same way they resolve it -- the point is to observe that path,
+              # not to pick a better one.
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+                    -DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF /workspace
+              # One image, not the whole set: this asks whether the mechanism
+              # works at all.
+              ninja kvm_ubuntu2404_image || echo "IMAGE FETCH FAILED (continuing to report)"
+              bash /workspace/kvm/kvm_diagnose.sh /build ubuntu2404'
+
+
   macos:
     name: Test macOS ${{ matrix.build_type }}
     runs-on: macos-14

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -355,6 +355,97 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+  # Standing diagnostic for the KVM suites.
+  #
+  # The kvm shard in the extended workflow has never produced a passing run on
+  # the hosted runners, and each attempt costs six hours to observe nothing.  It
+  # fails two ways: guests that never boot, because the rootfs is not where the
+  # registered test looks for it --
+  #
+  #   Could not open '//kvm/ubuntu2404/rootfs.qcow2': No such file or directory
+  #
+  # -- and guests that boot, print kernel messages, and then go silent for five
+  # hours until the job limit cancels them.
+  #
+  # Note the doubled slash.  IMAGE_DIR is <parent of CMAKE_BINARY_DIR>/kvm/
+  # <image>, and the containers configure with `-w /build`, so the parent is `/`.
+  #
+  # This lives here rather than in build-test.yml because that workflow does not
+  # run on pull_request -- it is merge_group and push only -- so a diagnostic
+  # placed there could not be iterated on from a PR at all, which is the whole
+  # point of having one.
+  #
+  # It reports, it does not gate: continue-on-error, and deliberately absent
+  # from ci-complete's needs.  Nothing depends on the KVM suites today, and a
+  # diagnostic that can block a merge is one people learn to route around.
+  kvm-diagnostic:
+    name: KVM diagnostic (informational)
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker-container
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the dev container image
+        uses: docker/build-push-action@v7
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.DEV_IMAGE }}
+          cache-from: type=registry,ref=${{ env.DEV_IMAGE_CACHE }}
+          build-args: |
+            UBUNTU_MIRROR=azure
+
+      # Reported before entering the container, so a missing /dev/kvm can be
+      # attributed to the runner rather than to how we invoke docker.
+      - name: Report the runner's own KVM support
+        run: |
+          echo "=== runner (outside the container) ==="
+          uname -srm
+          ls -l /dev/kvm 2>&1 || echo "/dev/kvm ABSENT on the runner"
+          grep -m1 '^model name' /proc/cpuinfo | cut -d: -f2-
+          grep -qm1 -E '^flags.*\b(vmx|svm)\b' /proc/cpuinfo \
+            && echo "virtualisation extensions present" \
+            || echo "no vmx/svm in /proc/cpuinfo"
+
+      - name: Diagnose KVM inside the dev container
+        run: |
+          docker run --rm --privileged \
+            -v "${{ github.workspace }}:/workspace" \
+            -v /build \
+            -w /build \
+            ${{ env.DEV_IMAGE }} \
+            bash -euxc '
+              # Configure exactly as the test jobs do, so IMAGE_DIR resolves the
+              # way theirs resolves -- the point is to observe that path, not to
+              # quietly pick a better one.
+              cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+                    -DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF /workspace
+              # One image, not the whole set: this asks whether the mechanism
+              # works at all.
+              ninja kvm_ubuntu2404_image || echo "IMAGE FETCH FAILED (continuing to report)"
+              bash /workspace/kvm/kvm_diagnose.sh /build ubuntu2404'
+
+
   analyze-macos:
     name: Analyze macOS Release (pre-merge)
     runs-on: macos-14

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -415,6 +415,15 @@ jobs:
           build-args: |
             UBUNTU_MIRROR=azure
 
+      # The guest images are an OCI artifact in GHCR, so the KVM build needs
+      # oras to pull them -- and CMake's KVM_TESTING=ON check refuses outright
+      # without it.  Fetched onto the runner and mounted into the container,
+      # the way the test jobs do it.
+      - name: Fetch oras CLI
+        uses: ./.github/actions/fetch-oras
+        with:
+          arch: amd64
+
       # Reported before entering the container, so a missing /dev/kvm can be
       # attributed to the runner rather than to how we invoke docker.
       - name: Report the runner's own KVM support
@@ -431,6 +440,7 @@ jobs:
         run: |
           docker run --rm --privileged \
             -v "${{ github.workspace }}:/workspace" \
+            -v "${{ github.workspace }}/oras:/usr/local/bin/oras:ro" \
             -v /build \
             -w /build \
             ${{ env.DEV_IMAGE }} \
@@ -442,6 +452,9 @@ jobs:
                     -DKVM_TESTING=ON -DKVM_FETCH_IMAGES=OFF /workspace
               # One image, not the whole set: this asks whether the mechanism
               # works at all.
+              # Report rather than abort: where the fetch puts the images, and
+              # whether that is where the registered tests look, is the whole
+              # question -- so the diagnostic below must run either way.
               ninja kvm_ubuntu2404_image || echo "IMAGE FETCH FAILED (continuing to report)"
               bash /workspace/kvm/kvm_diagnose.sh /build ubuntu2404'
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -456,7 +456,34 @@ jobs:
               # whether that is where the registered tests look, is the whole
               # question -- so the diagnostic below must run either way.
               ninja kvm_ubuntu2404_image || echo "IMAGE FETCH FAILED (continuing to report)"
-              bash /workspace/kvm/kvm_diagnose.sh /build ubuntu2404'
+              bash /workspace/kvm/kvm_diagnose.sh /build ubuntu2404
+
+              # ---- escalation: the same guest, through the real harness ----
+              #
+              # The check above boots a guest directly: no netns, no tap, no
+              # chimera, no ctest.  It passes, so KVM, the images and the guest
+              # itself are all fine, and whatever breaks the extended kvm shard
+              # is in the part it skips.
+              #
+              # The extended logs point at the backend rather than the guest:
+              # nfstest_posix_memfs_nfs3 passed there while the diskfs variants
+              # timed out, and diskfs_aio_nfs4.1 hung outright.  So run one of
+              # each, memfs first as the control, and let ctest bound them --
+              # this is the comparison, and it is cheap.
+              #
+              # Both are run even if the first fails (|| true): a control that
+              # fails is itself the answer, and stopping there would hide it.
+              ninja
+              ctest -R "nfstest_posix_memfs_nfs3" --output-on-failure --timeout 420 -j 1 || true
+              ctest -R "nfstest_posix_diskfs_io_uring_nfs3" --output-on-failure --timeout 420 -j 1 || true
+
+              # Whatever ctest could not reclaim is still running.  12 of the 13
+              # wrappers launch qemu in the foreground and never kill it, so a
+              # guest outliving its test is the mechanism that turns one hang
+              # into a six-hour wedge -- name any survivor here rather than
+              # inferring it from a cancelled job.
+              echo "=== qemu processes still alive after ctest ==="
+              pgrep -af "qemu-system-" || echo "  none (nothing was left behind)"'
 
 
   analyze-macos:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -474,16 +474,26 @@ jobs:
               # Both are run even if the first fails (|| true): a control that
               # fails is itself the answer, and stopping there would hide it.
               ninja
-              ctest -R "nfstest_posix_memfs_nfs3" --output-on-failure --timeout 420 -j 1 || true
-              ctest -R "nfstest_posix_diskfs_io_uring_nfs3" --output-on-failure --timeout 420 -j 1 || true
+              # -C extended: the KVM suites are registered in the extended
+              # configuration, and without it ctest matches nothing and reports
+              # "No tests were found!!!" -- which, with the || true below, is a
+              # green job that tested nothing at all.
+              ctest -C extended -N -R "nfstest_posix_(memfs|diskfs_io_uring)_nfs3"
+              ctest -C extended -R "nfstest_posix_memfs_nfs3" \
+                    --output-on-failure --timeout 420 -j 1 || true
+              ctest -C extended -R "nfstest_posix_diskfs_io_uring_nfs3" \
+                    --output-on-failure --timeout 420 -j 1 || true
 
               # Whatever ctest could not reclaim is still running.  12 of the 13
               # wrappers launch qemu in the foreground and never kill it, so a
               # guest outliving its test is the mechanism that turns one hang
               # into a six-hour wedge -- name any survivor here rather than
               # inferring it from a cancelled job.
+              # -x matches the process name exactly.  A -f pattern matches this
+              # very shell, whose command line quotes the string, and reports
+              # itself as the survivor.
               echo "=== qemu processes still alive after ctest ==="
-              pgrep -af "qemu-system-" || echo "  none (nothing was left behind)"'
+              pgrep -a -x "qemu-system-x86_64" || echo "  none (nothing was left behind)"'
 
 
   analyze-macos:

--- a/kvm/kvm_diagnose.sh
+++ b/kvm/kvm_diagnose.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+#
+# SPDX-License-Identifier: Unlicense
+#
+# Standing diagnostic for the KVM suites.
+#
+# The KVM shard has never produced a passing run on the GitHub-hosted runners,
+# in two different ways: guests that never boot (no rootfs where the registered
+# test looks for it) and guests that boot and then hang, which wedge ctest for
+# the job's whole six-hour budget.  Both take six hours to observe and neither
+# leaves a usable log.
+#
+# This runs one guest, once, with everything named up front and a hard bound on
+# the boot, so the answer arrives in minutes.  It is deliberately independent of
+# ctest: no test registration, no parallelism, no output capture in the way.
+
+set -u
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${1:-/build/Release}"
+IMAGE_NAME="${2:-ubuntu2404}"
+BOOT_TIMEOUT="${KVM_DIAG_BOOT_TIMEOUT:-120}"
+
+section() { printf '\n=== %s ===\n' "$1"; }
+
+section "host"
+echo "uname:      $(uname -srm)"
+echo "container:  $( [ -f /.dockerenv ] && echo yes || echo no )"
+echo "uid:        $(id -u)"
+echo "nproc:      $(nproc 2>/dev/null || echo "?")"
+echo "cpu:        $(grep -m1 '^model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ *//')"
+for f in vmx svm hypervisor; do
+    grep -qm1 "^flags.*\b${f}\b" /proc/cpuinfo 2>/dev/null \
+        && echo "cpuflag:    ${f} present" || echo "cpuflag:    ${f} ABSENT"
+done
+
+section "kvm device"
+if [ -e /dev/kvm ]; then
+    ls -l /dev/kvm
+    [ -r /dev/kvm ] && [ -w /dev/kvm ] && echo "access:     rw ok" || echo "access:     NOT rw for uid $(id -u)"
+else
+    echo "/dev/kvm:   ABSENT"
+fi
+
+section "qemu"
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then QEMU_BIN=qemu-system-aarch64; else QEMU_BIN=qemu-system-x86_64; fi
+if command -v "$QEMU_BIN" >/dev/null 2>&1; then
+    echo "binary:     $(command -v "$QEMU_BIN")"
+    "$QEMU_BIN" --version | head -1
+    echo "accelerators:"
+    "$QEMU_BIN" -accel help 2>/dev/null | sed 's/^/  /'
+else
+    echo "binary:     $QEMU_BIN NOT INSTALLED"
+fi
+
+# The registered tests take their image path from CMake's IMAGE_DIR, which is
+# <parent of CMAKE_BINARY_DIR>/kvm/<image>.  That makes the location depend on
+# how deep the build directory is: /build/Release yields /build/kvm/..., but a
+# build configured directly in /build yields //kvm/... instead.  If the shard
+# fetches images against one build directory and runs tests registered by
+# another, the fetch succeeds and every guest still fails to open its rootfs.
+section "image location"
+BUILD_ROOT="$(dirname "$BUILD_DIR")"
+IMAGE_DIR="${BUILD_ROOT}/kvm/${IMAGE_NAME}"
+echo "build dir:  $BUILD_DIR"
+echo "build root: $BUILD_ROOT"
+echo "image dir:  $IMAGE_DIR"
+for f in vmlinuz initrd rootfs.qcow2; do
+    if [ -f "${IMAGE_DIR}/${f}" ]; then
+        echo "  present   ${f} ($(stat -c %s "${IMAGE_DIR}/${f}" 2>/dev/null) bytes)"
+    else
+        echo "  MISSING   ${f}"
+    fi
+done
+echo "anything under a 'kvm' directory nearby:"
+find / -maxdepth 4 -type d -name kvm -not -path '*/proc/*' 2>/dev/null | sed 's/^/  /' | head
+
+section "boot one guest (bounded at ${BOOT_TIMEOUT}s)"
+if [ ! -f "${IMAGE_DIR}/rootfs.qcow2" ] || [ ! -f "${IMAGE_DIR}/vmlinuz" ]; then
+    echo "SKIP: no image to boot -- the location above is the thing to fix first."
+    exit 1
+fi
+
+QEMU_MACHINE="-M microvm,acpi=on,rtc=on,pit=on,pcie=on"
+QEMU_CONSOLE="ttyS0"
+if [ "$ARCH" = "aarch64" ]; then QEMU_MACHINE="-machine virt"; QEMU_CONSOLE="ttyAMA0"; fi
+QEMU_INITRD=""
+[ -f "${IMAGE_DIR}/initrd" ] && QEMU_INITRD="-initrd ${IMAGE_DIR}/initrd"
+
+# No network and no chimera: this asks one question -- does a guest reach
+# userspace and run a command -- so anything else that could fail is left out.
+set +e
+timeout --kill-after=10s "$BOOT_TIMEOUT" \
+    "$QEMU_BIN" -enable-kvm -smp 2 -m 1G -cpu host \
+    -kernel "${IMAGE_DIR}/vmlinuz" \
+    $QEMU_INITRD \
+    $QEMU_MACHINE \
+    -nodefaults \
+    -drive file="${IMAGE_DIR}/rootfs.qcow2",if=virtio,format=qcow2,snapshot=on \
+    -serial stdio \
+    -nographic \
+    -no-reboot \
+    -append "root=/dev/vda rw console=${QEMU_CONSOLE} net.ifnames=0 biosdevname=0 mitigations=off tsc=reliable panic=-1 test_cmd=\"echo KVM_DIAG_GUEST_ALIVE; true\" init=/init.sh" \
+    2>&1
+rc=$?
+set -e
+
+section "result"
+if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+    echo "TIMED OUT after ${BOOT_TIMEOUT}s -- the guest did not finish."
+    echo "The serial output above is where it stopped; that is the hang."
+elif [ "$rc" -ne 0 ]; then
+    echo "qemu exited $rc"
+else
+    echo "qemu exited cleanly"
+fi
+exit "$rc"

--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -509,14 +509,27 @@ foreach(image_spec ${KVM_IMAGES})
                                 ${CHIMERA_BINARY} ${backend} ${nfsver} ${prog})
                     set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
                         PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
-                    # nfstest_lock (5296 subtests, ~6.5 min) and nfstest_dio
-                    # (1 MiB direct-I/O transfers, ~5.5 min) run well past the
-                    # CI-wide `ctest --timeout 300`; give them a per-test timeout
-                    # that overrides it so they are not killed mid-run.
-                    if(prog STREQUAL "nfstest_lock" OR prog STREQUAL "nfstest_dio")
-                        set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
-                            PROPERTIES TIMEOUT 900)
-                    endif()
+                    # Every nfstest case boots a guest and runs a whole suite
+                    # inside it, which does not fit the CI-wide
+                    # `ctest --timeout 300`.  nfstest_lock (5296 subtests,
+                    # ~6.5 min) and nfstest_dio (1 MiB direct-I/O transfers,
+                    # ~5.5 min) exceed it outright and have carried an override
+                    # for a while; the rest exceed it only under load, which is
+                    # worse, because it looks like a hang rather than a limit.
+                    #
+                    # Measured standalone on a hosted runner, nfstest_posix is
+                    # 50s on memfs and 135s on diskfs_io_uring -- comfortably
+                    # inside 300 on its own.  The extended shard runs
+                    # `ctest -j $(nproc)` with PROCESSORS 2 per case, so several
+                    # guests compete for a 4-vCPU runner and the same work lands
+                    # the far side of the limit: diskfs_io_uring timed out at
+                    # every NFS version there while memfs and cairn, which do
+                    # less I/O, passed.
+                    #
+                    # So the override belongs to the family, not to the two
+                    # cases that happened to be slow enough to notice first.
+                    set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
+                        PROPERTIES TIMEOUT 900)
                 endforeach()
             endforeach()
         endforeach()


### PR DESCRIPTION
A tinkering surface for the KVM suites. Not a fix — an instrument.

## Why

The kvm shard has **never produced a passing run** on the hosted runners, and each attempt costs six hours to learn nothing. It fails two distinct ways:

**Guests that never boot** (run 33966061845 — 1730 of 1730 tests failed, ~0.6 s each):

```
qemu-system-x86_64: -drive file=//kvm/ubuntu2404/rootfs.qcow2 ...
    Could not open '//kvm/ubuntu2404/rootfs.qcow2': No such file or directory
```

**Guests that boot and hang** (run 34014118017): kernel messages up to `Freeing unused kernel image memory`, then **zero output for five hours** until the 6-hour job limit cancels it. No `***Timeout` line — ctest could not reclaim it, so the whole run wedged rather than one test failing.

Note the doubled slash. `IMAGE_DIR` is `<parent of CMAKE_BINARY_DIR>/kvm/<image>`, and the containers configure with `-w /build`, so the parent is `/` and the path becomes `//kvm/...`. Whether that is the actual defect or merely ugly is exactly what this job is for.

## What it does

Boots **one** guest, once, with a hard bound, and prints:

- the runner's own virtualisation support, before entering the container
- `/dev/kvm` presence, ownership and rw access inside it
- what accelerators qemu itself admits to — `-accel help`, rather than cpu-checker's `kvm-ok`, which the image need not carry
- where the images actually landed against where the tests expect them, plus a `find` for any nearby `kvm` directory
- the guest's serial output, up to wherever it stops

Configured exactly as the test jobs configure, so `IMAGE_DIR` resolves the way theirs does — the point is to observe that path, not to quietly pick a better one. Deliberately independent of ctest: no registration, no parallelism, nothing capturing the output.

## Two corrections to what I said earlier

**KVM support is not the problem.** I proposed gating on `/dev/kvm` before launching. The evidence says it is present and working: `-enable-kvm` is fatal without it, and the guest reached `[0.445708]` kernel timestamps essentially instantly in wall-clock. The gate is cheap insurance for later, not the fix, and it is not in this PR.

**"The shard is too big" was wrong.** I projected ~6 hours by extrapolating 235 tests × 12.3 s, but that sample contained four full 300 s timeouts which dominate the average, and a later run iterated all **1760** tests in 48 minutes. Sizing is unproven; the hang and the timeouts are the story.

## Scope

`continue-on-error: true` and absent from `ci-complete`'s needs. Nothing depends on the KVM suites today, and a diagnostic that can block a merge is one people learn to route around.

The qemu reclaim change (12 of 13 wrappers run qemu in the foreground and never kill it, which is why one hung guest wedges the whole run) is written and ready, but is better landed once this says what is actually happening — one of the two failure modes turned out not to be an orphaned qemu at all.

Exercised locally: the script reports every gap cleanly on a host with no `/dev/kvm`, no qemu and no images, fails fast with the right message, and reproduces the exact `//kvm/ubuntu2404` path from the CI error when handed `/build`. YAML re-parsed after editing.
