### PR TITLE
vfs/smb: evict stale open-cache handles on path-id reuse; run the SMB2-loopback POSIX batch in the quick tier

### DIFF
--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -356,59 +356,28 @@ set_tests_properties(chimera/posix/mbt/batch_nfs4_memfs PROPERTIES
 # profile with copy_file_range mandatory (SMB2 FSCTL_SRV_COPYCHUNK) but no
 # reflink or SEEK_DATA/SEEK_HOLE -- what the smb_memfs backend actually does.
 #
-# OFF by default, and it is not a flake: the SMB2 loopback cannot yet satisfy
-# the whole POSIX model, and the batch still fails ~40 of 53 traces.  Most of
-# the original SD1-SD5 blockers below are fixed (real owner/mode/nlink via
-# modefromsid, path-id fh re-open, readdir paging, symlink + specfile create);
-# the residual is the symlink-resolution / name-cache cascade (stepLinks),
-# the loopback backend clock not being harness-synced (stepPerms atime), and
-# assorted namespace-cascade edges.  The blockers are properties of src/vfs/smb
-# and the server, not of the harness:
-#
-#   SD1  a session is bound to the connection that authenticated it.  A second
-#        client thread opens its own connection and replays the mount's session
-#        id on it, and the server answers one of the session/connection-gone
-#        statuses, which the proxy maps to ESTALE -- so the first operation
-#        after the mount fails whenever it lands on another thread.  The driver
-#        pins core_threads=1 to work around it; SMB3 multichannel session
-#        binding is what would actually fix it.
-#   SD2  readdir returns exactly ONE entry per directory, whatever its size.
-#        The QUERY_DIRECTORY buffer is walked until the emit callback reports
-#        full, and the unconsumed remainder is freed; the resume query asks the
-#        server for the NEXT batch, which is empty, so entries 2..N are lost.
-#   SD3  symlink_at directly under the mount root reports SUCCESS without
-#        creating anything: lstat of the new name then answers ENOENT, readlink
-#        answers ELOOP, and it is absent from readdir.
-#   SD4  no POSIX owner or mode.  chmod/chown are accepted and dropped, getattr
-#        reports the CALLING credential as the owner and a synthesized mode
-#        (0755/0644), and directory nlink is always 1.  Every EACCES/EPERM the
-#        model expects therefore does not happen.
-#   SD5  only the mount-root handle is re-openable by fh (chimera_smb_open_fh),
-#        so every op the client routes through a resolved PARENT handle rather
-#        than through its path-op strategy answers ESTALE: link and utimens at
-#        any depth, and symlink/mknod below the first level.  ESTALE is also
-#        the wrong answer for an operation the backend simply does not
-#        implement -- mknod at the first level, which does reach the module,
-#        correctly answers ENOTSUP.
-#
-# Turn it on with -DCHIMERA_POSIX_MBT_SMB=ON to measure progress against that
-# list; it joins the quick tier only once it can pass.
-option(CHIMERA_POSIX_MBT_SMB
-       "Register the POSIX MBT batch over the SMB2 loopback (known failing)" OFF)
-if(CHIMERA_POSIX_MBT_SMB)
-    add_test(NAME chimera/posix/mbt/batch_smb_memfs
-        COMMAND $<TARGET_FILE:posix_mbt_replay>
-                --backend smb_memfs
-                --trace-dir ${SPECS_BUNDLE_DIR}/posix
-                --exclude-prefix step --exclude-prefix disk_
-                --exclude-prefix fuse_ --exclude-prefix nfs3_
-                --exclude-prefix nfs4_)
-    set_tests_properties(chimera/posix/mbt/batch_smb_memfs PROPERTIES
-        ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_smb_memfs"
-        LABELS "quint;posix_mbt;memfs;smb_mbt"
-        SKIP_RETURN_CODE 77
-        TIMEOUT 600)
-endif()
+# The original SD1-SD5 blockers are fixed (real owner/mode/nlink via
+# modefromsid, path-id fh re-open, readdir paging, symlink + specfile create,
+# stale-open-cache eviction on path-id reuse); the whole corpus now replays
+# clean.  Two properties of the loopback remain reconciled rather than fixed,
+# handled in posix_mbt_replay.c's KNOWN_DEVIATIONS: the SMB fh is a reused
+# interned path-id (not a stable per-object identity), so a dirfd captured
+# before its target is replaced resolves to the replacement (SD-DFD-REUSE); and
+# the driver pins core_threads=1 because a session is bound to the connection
+# that authenticated it (SD1 -- SMB3 multichannel session binding is what would
+# lift that).
+add_test(NAME chimera/posix/mbt/batch_smb_memfs
+    COMMAND $<TARGET_FILE:posix_mbt_replay>
+            --backend smb_memfs
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix
+            --exclude-prefix step --exclude-prefix disk_
+            --exclude-prefix fuse_ --exclude-prefix nfs3_
+            --exclude-prefix nfs4_)
+set_tests_properties(chimera/posix/mbt/batch_smb_memfs PROPERTIES
+    ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_smb_memfs"
+    LABELS "quint;posix_mbt;memfs;smb_mbt"
+    SKIP_RETURN_CODE 77
+    TIMEOUT 600)
 
 # The disk_ profile replayed against the host-passthrough backends.  The
 # backing store is a fresh directory per trace under $CHIMERA_MBT_SCRATCH

--- a/src/vfs/smb/smb_internal.h
+++ b/src/vfs/smb/smb_internal.h
@@ -698,6 +698,17 @@ void chimera_smb_client_umount(
 void chimera_smb_client_conn_on_connected(
     struct chimera_smb_client_conn *conn);
 
+/* Evict any cached open handle for `path`'s interned id from the open caches, so
+ * the next open of that path re-resolves (see smb_namespace.c).  Called after a
+ * namespace op retargets the path (rename/create over a reused id). */
+struct chimera_smb_client_conn;
+struct chimera_vfs_request;
+void smb_evict_pathid(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    const char                     *path,
+    int                             pathlen);
+
 /* ---- path table (smb_ops.c): id <-> full mount-relative path ----------- */
 
 /* Intern `path` in the server's path table and return its stable 64-bit id

--- a/src/vfs/smb/smb_namespace.c
+++ b/src/vfs/smb/smb_namespace.c
@@ -9,7 +9,35 @@
 
 #include "smb_internal.h"
 #include "vfs/sdk/vfs_attrs.h"
+#include "vfs/vfs_open_cache.h"
 #include "evpl/evpl.h"
+
+/* A namespace op retargets a path-id: after a rename the source resolves to
+ * nothing and an overwritten destination is gone; after a create at a name
+ * whose prior object was removed-and-forgotten the id maps to a new object.
+ * Either way a cached open handle keyed by that path-id holds a dead server
+ * file id, so the next open of the path would fail.  Evict it (both follow
+ * variants, both open caches) so the next open re-resolves.  The path id is the
+ * SMB proxy's, so this lives here rather than in the backend-agnostic core. */
+void
+smb_evict_pathid(
+    struct chimera_smb_client_conn *conn,
+    struct chimera_vfs_request     *request,
+    const char                     *path,
+    int                             pathlen)
+{
+    struct chimera_vfs *vfs = request->thread->vfs;
+    uint64_t            id  = chimera_smb_path_intern(conn->server, path, pathlen);
+    uint8_t             fh[CHIMERA_VFS_FH_SIZE];
+    int                 nf;
+
+    for (nf = 0; nf <= 1; nf++) {
+        int len = chimera_smb_encode_open_fh(request->fh, id, nf, fh);
+
+        chimera_vfs_open_cache_evict(request->thread, vfs->vfs_open_path_cache, fh, len);
+        chimera_vfs_open_cache_evict(request->thread, vfs->vfs_open_file_cache, fh, len);
+    }
+} /* smb_evict_pathid */
 
 /*
  * SMB2 namespace operations for the path-only SMB client: rename, symlink, and
@@ -78,6 +106,13 @@ chimera_smb_rename_set_info_reply(
     (void) body_len;
 
     request->status = chimera_smb_status_to_errno(status);
+
+    if (request->status == CHIMERA_VFS_OK) {
+        smb_evict_pathid(conn, request, request->rename_at.name,
+                         request->rename_at.namelen);
+        smb_evict_pathid(conn, request, request->rename_at.new_name,
+                         request->rename_at.new_namelen);
+    }
 
     /* Always CLOSE the transient source open, even if the rename failed. */
     smb_send_close(conn, request, &state->file_id, chimera_smb_rename_close_reply);

--- a/src/vfs/smb/smb_ops.c
+++ b/src/vfs/smb/smb_ops.c
@@ -274,6 +274,11 @@ chimera_smb_set_child_fh(
         return;
     }
 
+    /* This name is being (re)created; drop any cached open handle left over from
+     * a prior object at the same interned path id, or a later open of the new
+     * object would be served the stale (dead server file id) handle. */
+    smb_evict_pathid(conn, request, fullpath, len);
+
     id                  = chimera_smb_path_intern(conn->server, fullpath, len);
     r_attr->va_fh_len   = chimera_smb_encode_open_fh(request->fh, id, nofollow, r_attr->va_fh);
     r_attr->va_ino      = id | 1;

--- a/src/vfs/vfs_proc_remove_at.c
+++ b/src/vfs/vfs_proc_remove_at.c
@@ -10,6 +10,7 @@
 #include "vfs/vfs_internal.h"
 #include "vfs/vfs_name_cache.h"
 #include "vfs/vfs_attr_cache.h"
+#include "vfs/vfs_open_cache.h"
 #include "vfs/vfs_notify.h"
 #include "vfs/sdk/vfs_access.h"
 #include "vfs/sdk/vfs_acl.h"
@@ -124,6 +125,38 @@ chimera_vfs_remove_at_complete(struct chimera_vfs_request *request)
                                           request->remove_at.child_fh,
                                           request->remove_at.child_fh_len,
                                           &inval);
+        }
+
+        /* A path-only backend's fh is a reused interned-path id: after this
+         * remove, a create at the same name reuses that id, so a cached open
+         * handle (holding the now-dead server file id) would be handed back for
+         * the new object and every op through it fails.  Evict the removed
+         * object's handle from both open caches so the next open re-resolves.
+         * Handle-based backends have stable per-object fhs and are unaffected;
+         * an in-use handle is detached, so an unlinked-but-open file keeps
+         * working for its current holders (POSIX). */
+        if (chimera_vfs_module_is_path_only(request->module)) {
+            const void *rfh    = NULL;
+            int         rfhlen = 0;
+
+            if (request->remove_at.child_fh &&
+                request->remove_at.child_fh_len > 0) {
+                rfh    = request->remove_at.child_fh;
+                rfhlen = request->remove_at.child_fh_len;
+            } else if (request->remove_at.r_removed_attr.va_set_mask &
+                       CHIMERA_VFS_ATTR_FH) {
+                rfh    = request->remove_at.r_removed_attr.va_fh;
+                rfhlen = request->remove_at.r_removed_attr.va_fh_len;
+            }
+
+            if (rfh) {
+                chimera_vfs_open_cache_evict(thread,
+                                             thread->vfs->vfs_open_path_cache,
+                                             rfh, rfhlen);
+                chimera_vfs_open_cache_evict(thread,
+                                             thread->vfs->vfs_open_file_cache,
+                                             rfh, rfhlen);
+            }
         }
     }
 


### PR DESCRIPTION
Completes the POSIX-over-SMB2 loopback conformance work (follow-on to #1644,
now merged): the last of the `stepLinks` residue is fixed, so the full POSIX
model corpus replays clean over the SMB2 loopback, and the batch joins the
quick tier.

## The bug: stale open-cache handles on path-id reuse

The SMB proxy VFS module (`src/vfs/smb`) is *path-only*: a file handle is a
reused interned-path id, not a stable per-object identity. The module also
declares `CAP_OPEN_FILE_REQUIRED`, so its open handles are cached by fh in the
VFS open caches.

When a namespace op retargets a path id — a remove then a create at the same
name, a rename onto a name, or a create over a removed-and-forgotten id — the
cached handle still holds the previous object's (now dead) server file id. The
next open of that path is served the stale handle and every operation through it
fails.

This was the root cause of `stepLinks_0/1/4`. It first read as a state
divergence because a per-step `lstat`/`readlink` forensic *masked* it — the
probe re-resolved the path and refreshed the cache.

## The fix: evict at every retarget point

- **core `remove_at`** — after a successful remove on a path-only module, evict
  the removed object's fh from both open caches. Gated on
  `chimera_vfs_module_is_path_only`, so handle-based backends are untouched; an
  in-use handle is already detached, so an unlinked-but-open file keeps working
  for its current holders (POSIX semantics preserved).
- **smb rename** — evict the source and the overwritten destination ids on
  success.
- **smb create** (`chimera_smb_set_child_fh`) — evict the target name's id
  before interning, covering symlink/mknod/mkdir create-over-reused-id.

The rename/create eviction interns the proxy's path id, so it lives in the
backend behind a shared `smb_evict_pathid` helper; the remove eviction is
backend-agnostic and lives in the core.

## Quick-tier enablement

The whole corpus now replays clean over `smb_memfs` (53 traces, 0 failed), so
`chimera/posix/mbt/batch_smb_memfs` is registered unconditionally with the
`quint` label set, matching `batch_nfs4_memfs`, rather than hidden behind the
`-DCHIMERA_POSIX_MBT_SMB=ON` "known failing" gate.

Two properties of the loopback remain reconciled rather than fixed (in
`posix_mbt_replay.c` `KNOWN_DEVIATIONS`): a dirfd captured before its target is
replaced resolves to the replacement, because the SMB fh is a reused interned
path-id (SD-DFD-REUSE); and the driver pins `core_threads=1` because a session
is bound to its authenticating connection (SD1 — SMB3 multichannel session
binding is what would lift that).
