### PR TITLE
nfs: map Kerberos principals to identities, and call as more than one

### DIFF
--- a/src/server/nfs/nfs.c
+++ b/src/server/nfs/nfs.c
@@ -215,6 +215,7 @@ nfs_server_init(
     shared->gss_enabled = chimera_server_config_get_nfs_kerberos_enabled(config);
     if (shared->gss_enabled) {
         chimera_nfs_gss_init(chimera_server_config_get_nfs_kerberos_keytab(config));
+        chimera_nfs_gss_set_principal_map(config);
         chimera_nfs_info("RPCSEC_GSS: Kerberos authentication enabled");
     }
 

--- a/src/server/nfs/nfs_gss.c
+++ b/src/server/nfs/nfs_gss.c
@@ -19,6 +19,7 @@
 
 #include "evpl/evpl.h"          /* struct evpl_iovec, for verify_mic_iov */
 #include "nfs_gss.h"
+#include "server/server.h"
 #include "nfs_internal.h"
 #include "vfs/sdk/vfs_cred.h"
 
@@ -317,6 +318,81 @@ const struct evpl_rpc2_gss_provider chimera_nfs_gss_provider = {
     .destroy = chimera_nfs_gss_destroy,
 };
 
+/*
+ * The static principal map (see chimera_server_config_add_nfs_principal_map).
+ *
+ * Process-global for the same reason the acceptor identity above is: a
+ * principal means one local identity to this process, and the acceptor keytab
+ * is already registered process-wide by gsskrb5_register_acceptor_identity.
+ */
+struct chimera_nfs_gss_map_entry {
+    char     principal[256];
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t num_gids;
+    uint32_t gids[CHIMERA_VFS_CRED_MAX_GIDS];
+};
+
+static struct chimera_nfs_gss_map_entry chimera_nfs_gss_map[64];
+static int                              chimera_nfs_gss_map_count;
+
+void
+chimera_nfs_gss_set_principal_map(const struct chimera_server_config *config)
+{
+    int         i, n;
+    const char *principal;
+
+    chimera_nfs_gss_map_count = 0;
+
+    if (!config) {
+        return;
+    }
+
+    n = chimera_server_config_get_nfs_principal_map_count(config);
+
+    for (i = 0; i < n && i < (int) (sizeof(chimera_nfs_gss_map) /
+                                    sizeof(chimera_nfs_gss_map[0])); i++) {
+        struct chimera_nfs_gss_map_entry *e = &chimera_nfs_gss_map[i];
+        const uint32_t                   *gids;
+        uint32_t                          j;
+
+        principal = chimera_server_config_get_nfs_principal_map_entry(
+            config, i, &e->uid, &e->gid, &e->num_gids, &gids);
+
+        if (!principal) {
+            break;
+        }
+
+        snprintf(e->principal, sizeof(e->principal), "%s", principal);
+
+        for (j = 0; j < e->num_gids; j++) {
+            e->gids[j] = gids[j];
+        }
+
+        chimera_nfs_gss_map_count++;
+    }
+
+    if (chimera_nfs_gss_map_count) {
+        chimera_nfs_info("rpcsec_gss: %d principal mapping(s) configured",
+                         chimera_nfs_gss_map_count);
+    }
+} /* chimera_nfs_gss_set_principal_map */
+
+/* The mapping for `name` (realm already stripped), or NULL. */
+static const struct chimera_nfs_gss_map_entry *
+chimera_nfs_gss_map_lookup(const char *name)
+{
+    int i;
+
+    for (i = 0; i < chimera_nfs_gss_map_count; i++) {
+        if (!strcmp(chimera_nfs_gss_map[i].principal, name)) {
+            return &chimera_nfs_gss_map[i];
+        }
+    }
+
+    return NULL;
+} /* chimera_nfs_gss_map_lookup */
+
 int
 chimera_nfs_gss_init(const char *keytab)
 {
@@ -363,6 +439,30 @@ chimera_nfs_gss_map_principal(
     }
     memcpy(user, principal, ulen);
     user[ulen] = '\0';
+
+    /*
+     * An explicit mapping wins over everything below it: it is the operator
+     * saying what this principal means, which is not a question nsswitch can
+     * answer for a Kerberos principal with no local account.  Matched on the
+     * full name for a service principal and on the primary component for a
+     * user one, which is why it is consulted before the '/' split below.
+     */
+    {
+        const struct chimera_nfs_gss_map_entry *e;
+
+        e = chimera_nfs_gss_map_lookup(user);
+
+        if (!e && at) {
+            /* Also allow an entry written with its realm. */
+            e = chimera_nfs_gss_map_lookup(principal);
+        }
+
+        if (e) {
+            chimera_vfs_cred_init_unix(cred, e->uid, e->gid, e->num_gids,
+                                       e->num_gids ? e->gids : NULL);
+            return;
+        }
+    }
 
     /*
      * A machine/service principal ("host/h", "nfs/h", "root/h") is the

--- a/src/server/nfs/nfs_gss.h
+++ b/src/server/nfs/nfs_gss.h
@@ -25,6 +25,18 @@ int
 chimera_nfs_gss_init(
     const char *keytab);
 
+struct chimera_server_config;
+
+/*
+ * Install the configured principal -> UNIX identity map.  Consulted by
+ * chimera_nfs_gss_map_principal ahead of nsswitch, which stays the fallback.
+ * Process-global, like the acceptor identity above; call once per server
+ * start, before any context is accepted.
+ */
+void
+chimera_nfs_gss_set_principal_map(
+    const struct chimera_server_config *config);
+
 /* The GSSAPI-backed RPCSEC_GSS provider vtable. */
 extern const struct evpl_rpc2_gss_provider chimera_nfs_gss_provider;
 

--- a/src/server/nfs/tests/quint/nfs3_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs3_mbt_common.h
@@ -102,12 +102,35 @@ enum mbt_sec {
 /* The MEMORY: keytab krb5_local populates.  MIT krb5 keys these by name
  * within a process, so naming the same one here is what lets the server's own
  * acceptor resolve the key the test's realm minted. */
-#define MBT_KRB5_KEYTAB    "MEMORY:evpl_krb5_local"
+#define MBT_KRB5_KEYTAB      "MEMORY:evpl_krb5_local"
 
 /* A two-component principal, which chimera's NFS server maps to root -- the
  * identity every trace's default credential already assumes.  A one-component
  * name would squash to anonymous and no trace would pass. */
-#define MBT_KRB5_PRINCIPAL "nfs/localhost"
+#define MBT_KRB5_PRINCIPAL   "nfs/localhost"
+
+/*
+ * User principals are named for the uid they stand for, and the server is
+ * configured to map them back (see mbt_gss_configure_principals).  A real
+ * deployment would name them for people and map through nsswitch or an
+ * explicit table; naming them for the uid is what lets a trace that says
+ * "as uid 1000" be replayed without inventing a directory of users.
+ */
+#define MBT_KRB5_USER_PREFIX "u"
+
+/* Distinct uids one replay can call as. */
+#define MBT_MAX_IDENTITIES   32
+
+/* The server reads its principal map once, at start-up, so every uid a replay
+ * will call as has to be declared before the first trace runs.  A caller that
+ * knows its corpus passes them in (mbt_env_opts.principal_uids); this is the
+ * bound on how many. */
+#define MBT_MAX_MAPPED_UIDS  32
+
+struct mbt_identity {
+    uint32_t                    uid;
+    struct krb5_local_identity *id;
+};
 
 static inline const char *
 mbt_sec_name(enum mbt_sec sec)
@@ -188,6 +211,7 @@ mbt_sec_service(enum mbt_sec sec)
 
 struct mbt_conn_cred {
     struct evpl_rpc2_conn       *conn;
+    uint32_t                     uid;
     struct evpl_rpc2_gss_client *gss;
     struct evpl_rpc2_cred        cred;
 };
@@ -256,19 +280,19 @@ struct mbt_result {
 /* Optional server shaping for a suite (the NFS4 MBT suite needs all
  * three; the NFS3 defaults need none). */
 struct mbt_env_opts {
-    int         nfs4_delegations; /* delegations are off by default */
-    int         smb_named_streams; /* NFSv4 OPENATTR / named attributes: off by
-                                    * default (the shared knob gates OPENATTR) */
-    int         disable_caches;   /* VFS attr+name caches: exact attr
-                                   * comparison cannot tolerate staleness */
-    const char *memfs_config;     /* module config JSON, e.g. block_size */
-    const char *module;           /* VFS backend: NULL/"memfs", "diskfs",
+    int             nfs4_delegations; /* delegations are off by default */
+    int             smb_named_streams; /* NFSv4 OPENATTR / named attributes: off by
+                                        * default (the shared knob gates OPENATTR) */
+    int             disable_caches; /* VFS attr+name caches: exact attr
+                                     * comparison cannot tolerate staleness */
+    const char     *memfs_config; /* module config JSON, e.g. block_size */
+    const char     *module;       /* VFS backend: NULL/"memfs", "diskfs",
                                    * "cairn".  diskfs/cairn self-provision
                                    * scratch under the env's session_dir. */
     /* Auxiliary NFS services (portmap/rpcbind, NLM, NSM).  Off by default:
      * the NFS3/NFS4 suites never touch them, and connecting three more
      * inproc services per replay process is pure overhead there. */
-    int         aux;
+    int             aux;
     /* Carry NFS over RPC-over-RDMA instead of plain RPC record marking.
      *
      * The inproc transport has two protocols: STREAM_INPROC, and
@@ -278,43 +302,48 @@ struct mbt_env_opts {
      * so pointing the client at the server's RDMA endpoint exercises the read
      * and write chunk paths -- the RDMA framing is genuinely under test here,
      * not emulated away. */
-    int         rdma;
+    int             rdma;
     /* server.portmap_hostname: when set, portmap universal addresses are
      * built from this host instead of the connection's local address.  The
      * aux suite uses it to make the uaddr predictable (the inproc local
      * address is not an IP). */
-    const char *portmap_hostname;
-    int         pnfs_num_ds;      /* >0: run as a pNFS metadata server with
+    const char     *portmap_hostname;
+    int             pnfs_num_ds;  /* >0: run as a pNFS metadata server with
                                    * this many in-process data servers */
-    const char *pnfs_ds_module;   /* DS backend (default "memfs") */
+    const char     *pnfs_ds_module; /* DS backend (default "memfs") */
     /* REST API and Prometheus scrape endpoint, for the control-plane suite:
      * both follow the server's transport flavor, so under inproc these are
      * endpoint names rather than bound ports, reachable from this process by
      * an http agent on env->evpl (see server/rest/tests/quint/ctl_http.h).
      * 0 leaves the endpoint off, which is what every other suite wants. */
-    int         rest_port;
-    int         metrics_port;
+    int             rest_port;
+    int             metrics_port;
     /* REST bearer/basic authentication.  Only meaningful with rest_port. */
-    int         rest_auth;
+    int             rest_auth;
     /* The other two protocol servers.  Off by default (the NFS suites want
      * nothing else listening); the control-plane suite turns them on because
      * shares and buckets cannot be created on a server whose SMB or S3
      * protocol was never initialized. */
-    int         smb_enabled;
-    int         s3_enabled;
+    int             smb_enabled;
+    int             s3_enabled;
     /* common.umount_timeout_ms: how long umount waits for a mount's open
      * handles to drain before reporting EBUSY.  0 keeps the server default
      * (1s).  A suite that unmounts often wants this short, because the wait
      * is per attempt and the handles are dropped by an asynchronous sweep. */
-    int         umount_timeout_ms;
+    int             umount_timeout_ms;
+    /* The uids this replay will call as, declared to the server's principal
+     * map before it starts.  Empty means root only, which is what every probe
+     * wants; a replayer scans its corpus (mbt_collect_cred_uids). */
+    const uint32_t *principal_uids;
+    int             num_principal_uids;
     /* The client's security flavor (see enum mbt_sec).  AUTH_SYS by default;
      * anything else stands a Kerberos realm up in this process and runs every
      * call under a context established against the server's own acceptor. */
-    int         sec;
+    int             sec;
     /* server.nfs3_drc: the NFSv3 duplicate-request cache.  Off by default in
      * the server and here; the DRC suite is the only caller that turns it on.
      * The NFSv4.0 cache needs no flag -- it is always installed. */
-    int         nfs3_drc;
+    int             nfs3_drc;
 };
 
 struct mbt_env {
@@ -349,6 +378,11 @@ struct mbt_env {
      * flavor covers here and stay on AUTH_SYS. */
     struct evpl_rpc2_cred        mount_cred;
     struct evpl_rpc2_cred        aux_cred;
+    /* The NFS connection's machine-principal credential, kept pristine.
+     * env->cred is working storage -- a replayer rewrites it per operation to
+     * whichever identity that operation is made as -- so the credential for
+     * root has to live somewhere that rewriting cannot reach. */
+    struct evpl_rpc2_cred        root_cred;
 
     /* Credentials for connections the suites open themselves.  Under AUTH_SYS
      * one credential serves every connection; a GSS context belongs to the
@@ -362,6 +396,15 @@ struct mbt_env {
      * server's acceptor registers that identity at start-up. */
     int                          sec;
     struct krb5_local           *krb5;
+    /* One per distinct uid the replay has called as; uid 0 uses the realm's
+     * own machine principal and needs no entry. */
+    struct mbt_identity          identities[MBT_MAX_IDENTITIES];
+    int                          num_identities;
+    /* Contexts established minus contexts retired.  LeakSanitizer would catch
+     * an imbalance, but only where there is one -- macOS has no LSan, so a
+     * context leaked here passes locally and fails in CI.  Counting them is
+     * cheap and fails the same way everywhere. */
+    int                          gss_outstanding;
     struct evpl_rpc2_gss_client *nfs_gss;
     struct evpl_rpc2_gss_client *mount_gss;
 
@@ -497,11 +540,59 @@ mbt_gss_ready(
     w->done   = 1;
 } /* mbt_gss_ready */
 
+/*
+ * The initiator identity for `uid`.
+ *
+ * uid 0 is the machine principal, which is what a real client presents for the
+ * mount and for root's I/O; every other uid gets a user principal of its own.
+ * Identities are kept on the env because minting one is not free and a trace
+ * returns to the same uid many times.
+ */
+static inline void *
+mbt_gss_identity(
+    struct mbt_env *env,
+    uint32_t        uid)
+{
+    char name[64];
+    int  i;
+
+    if (uid == 0) {
+        return krb5_local_initiator_arg(env->krb5);
+    }
+
+    for (i = 0; i < env->num_identities; i++) {
+        if (env->identities[i].uid == uid) {
+            return krb5_local_identity_arg(env->identities[i].id);
+        }
+    }
+
+    if (env->num_identities == MBT_MAX_IDENTITIES) {
+        fprintf(stderr, "%s: more than %d identities wanted\n",
+                mbt_sec_name(env->sec), MBT_MAX_IDENTITIES);
+        exit(1);
+    }
+
+    snprintf(name, sizeof(name), MBT_KRB5_USER_PREFIX "%u", uid);
+
+    env->identities[env->num_identities].uid = uid;
+    env->identities[env->num_identities].id  =
+        krb5_local_identity_create(env->krb5, name);
+
+    if (!env->identities[env->num_identities].id) {
+        fprintf(stderr, "%s: could not build an identity for uid %u\n",
+                mbt_sec_name(env->sec), uid);
+        exit(1);
+    }
+
+    return krb5_local_identity_arg(env->identities[env->num_identities++].id);
+} /* mbt_gss_identity */
+
 static inline struct evpl_rpc2_gss_client *
-mbt_gss_establish(
+mbt_gss_establish_as(
     struct mbt_env           *env,
     struct evpl_rpc2_program *program,
     struct evpl_rpc2_conn    *conn,
+    uint32_t                  uid,
     const char               *what)
 {
     struct mbt_gss_wait w = { 0 };
@@ -509,7 +600,7 @@ mbt_gss_establish(
 
     evpl_rpc2_gss_client_create(env->evpl, program, conn,
                                 krb5_local_initiator_provider(),
-                                krb5_local_arg(env->krb5),
+                                mbt_gss_identity(env, uid),
                                 mbt_sec_service(env->sec),
                                 MBT_KRB5_PRINCIPAL, mbt_gss_ready, &w);
 
@@ -525,7 +616,35 @@ mbt_gss_establish(
         exit(1);
     }
 
+    env->gss_outstanding++;
+
     return w.client;
+} /* mbt_gss_establish_as */
+
+/* Retire a context this harness established.  Every destroy goes through here
+ * so the balance above stays honest. */
+static inline void
+mbt_gss_retire(
+    struct mbt_env              *env,
+    struct evpl_rpc2_gss_client *client)
+{
+    if (!client) {
+        return;
+    }
+
+    evpl_rpc2_gss_client_destroy(env->evpl, client);
+    env->gss_outstanding--;
+} /* mbt_gss_retire */
+
+/* The machine principal, which is who every connection-level context is. */
+static inline struct evpl_rpc2_gss_client *
+mbt_gss_establish(
+    struct mbt_env           *env,
+    struct evpl_rpc2_program *program,
+    struct evpl_rpc2_conn    *conn,
+    const char               *what)
+{
+    return mbt_gss_establish_as(env, program, conn, 0, what);
 } /* mbt_gss_establish */
 
 /*
@@ -548,11 +667,11 @@ mbt_cred_for(
     int                   i;
 
     if (env->sec == MBT_SEC_SYS || conn == env->nfs_conn) {
-        return &env->cred;
+        return &env->root_cred;
     }
 
     for (i = 0; i < env->num_conn_creds; i++) {
-        if (env->conn_creds[i].conn == conn) {
+        if (env->conn_creds[i].conn == conn && env->conn_creds[i].uid == 0) {
             return &env->conn_creds[i].cred;
         }
     }
@@ -565,6 +684,7 @@ mbt_cred_for(
 
     cc       = &env->conn_creds[env->num_conn_creds++];
     cc->conn = conn;
+    cc->uid  = 0;
     cc->gss  = mbt_gss_establish(env, program, conn, "connection");
 
     cc->cred.flavor      = EVPL_RPC2_AUTH_RPCSEC_GSS;
@@ -573,6 +693,59 @@ mbt_cred_for(
 
     return &cc->cred;
 } /* mbt_cred_for */
+
+/*
+ * The credential for a call on `conn` made as `uid`.
+ *
+ * Under AUTH_SYS the caller sets uid in the credential and one credential
+ * serves everyone.  Under RPCSEC_GSS there is no uid on the wire: the caller
+ * is whoever the context authenticated, so calling as a second user means a
+ * second context, established under that user's own principal.  That is what
+ * rpc.gssd does per user, and it is what this builds -- lazily, and kept,
+ * because a trace returns to the same uid many times.
+ */
+static inline struct evpl_rpc2_cred *
+mbt_cred_for_uid(
+    struct mbt_env           *env,
+    struct evpl_rpc2_conn    *conn,
+    struct evpl_rpc2_program *program,
+    uint32_t                  uid)
+{
+    struct mbt_conn_cred *cc;
+    int                   i;
+
+    if (env->sec == MBT_SEC_SYS) {
+        return &env->cred;
+    }
+
+    if (uid == 0 && conn == env->nfs_conn) {
+        return &env->root_cred;
+    }
+
+    for (i = 0; i < env->num_conn_creds; i++) {
+        if (env->conn_creds[i].conn == conn &&
+            env->conn_creds[i].uid == uid) {
+            return &env->conn_creds[i].cred;
+        }
+    }
+
+    if (env->num_conn_creds == MBT_MAX_CONN_CREDS) {
+        fprintf(stderr, "%s: more than %d contexts wanted\n",
+                mbt_sec_name(env->sec), MBT_MAX_CONN_CREDS);
+        exit(1);
+    }
+
+    cc       = &env->conn_creds[env->num_conn_creds++];
+    cc->conn = conn;
+    cc->uid  = uid;
+    cc->gss  = mbt_gss_establish_as(env, program, conn, uid, "identity");
+
+    cc->cred.flavor      = EVPL_RPC2_AUTH_RPCSEC_GSS;
+    cc->cred.gss.service = mbt_sec_service(env->sec);
+    cc->cred.gss.client  = cc->gss;
+
+    return &cc->cred;
+} /* mbt_cred_for_uid */
 
 /*
  * Retire whatever context a suite's own connection carried, before the
@@ -591,9 +764,7 @@ mbt_conn_release(
             continue;
         }
 
-        if (env->conn_creds[i].gss) {
-            evpl_rpc2_gss_client_destroy(env->evpl, env->conn_creds[i].gss);
-        }
+        mbt_gss_retire(env, env->conn_creds[i].gss);
 
         env->conn_creds[i] = env->conn_creds[--env->num_conn_creds];
         return;
@@ -731,9 +902,33 @@ mbt_env_open_opts(
     chimera_server_config_set_nfs_enabled(config, 1);
 
     if (env->sec != MBT_SEC_SYS) {
+        uint32_t uid;
+
         chimera_server_config_set_nfs_kerberos_enabled(config, 1);
         chimera_server_config_set_nfs_kerberos_keytab(config,
                                                       MBT_KRB5_KEYTAB);
+
+        /*
+         * Teach the server what the harness's principals mean.  Without this
+         * every user principal would resolve through nsswitch, find no local
+         * account, and squash to anonymous -- so a trace's "as uid 1000" would
+         * silently become "as nobody" and its expected access outcomes would
+         * all be wrong.  The map is the same mechanism a Kerberos-only
+         * deployment uses for the same reason.
+         */
+        for (i = 0; opts && i < opts->num_principal_uids; i++) {
+            char name[64];
+
+            uid = opts->principal_uids[i];
+
+            if (uid == 0) {
+                continue;   /* the machine principal already maps to root */
+            }
+
+            snprintf(name, sizeof(name), MBT_KRB5_USER_PREFIX "%u", uid);
+            chimera_server_config_add_nfs_principal_map(config, name, uid, uid,
+                                                        0, NULL);
+        }
     }
 
     /* The RDMA listener is additional, not instead: the server keeps its
@@ -1050,6 +1245,8 @@ mbt_env_open_opts(
         env->mount_cred.gss.client  = env->mount_gss;
     }
 
+    env->root_cred = env->cred;
+
     env->data_buf = malloc(MBT_MAX_DATA);
 } /* mbt_env_open_opts */
 
@@ -1266,15 +1463,22 @@ mbt_env_stop(struct mbt_env *env)
     }
     /* Before the connections they were established on: destroy sends a
      * DESTROY down each one so the server drops its half now rather than at
-     * expiry. */
-    if (env->nfs_gss) {
-        evpl_rpc2_gss_client_destroy(env->evpl, env->nfs_gss);
-        env->nfs_gss = NULL;
+     * expiry.
+     *
+     * The per-identity contexts first.  A suite that opened its own
+     * connections releases those through mbt_conn_release, but the ones
+     * mbt_cred_for_uid raised for a second user live on the env's own
+     * connection and have nothing else to retire them. */
+    for (i = 0; i < env->num_conn_creds; i++) {
+        mbt_gss_retire(env, env->conn_creds[i].gss);
+        env->conn_creds[i].gss = NULL;
     }
-    if (env->mount_gss) {
-        evpl_rpc2_gss_client_destroy(env->evpl, env->mount_gss);
-        env->mount_gss = NULL;
-    }
+    env->num_conn_creds = 0;
+
+    mbt_gss_retire(env, env->nfs_gss);
+    env->nfs_gss = NULL;
+    mbt_gss_retire(env, env->mount_gss);
+    env->mount_gss = NULL;
 
     evpl_rpc2_client_disconnect(env->rpc2_thread, env->nfs_conn);
     evpl_rpc2_client_disconnect(env->rpc2_thread, env->mount_conn);
@@ -1298,6 +1502,17 @@ mbt_env_stop(struct mbt_env *env)
         chimera_server_destroy(env->ds_server[i]);
         prometheus_metrics_destroy(env->ds_metrics[i]);
     }
+
+    if (env->gss_outstanding) {
+        fprintf(stderr, "%s: %d GSS context(s) never retired\n",
+                mbt_sec_name(env->sec), env->gss_outstanding);
+        exit(1);
+    }
+
+    for (i = 0; i < env->num_identities; i++) {
+        krb5_local_identity_destroy(env->identities[i].id);
+    }
+    env->num_identities = 0;
 
     if (env->krb5) {
         krb5_local_destroy(env->krb5);

--- a/src/server/nfs/tests/quint/nfs3_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs3_mbt_replay.c
@@ -1454,12 +1454,18 @@ static int      g_traces_skipped;
  * Returns 0 when the operation can be replayed under the harness's security
  * flavor, and -1 when it cannot.
  *
- * Under RPCSEC_GSS the caller's identity is the authenticated principal, not
- * a field of the credential, so an operation that asks to be made as some
- * other uid has no expression: there is one context and it is root's.  Rather
- * than replay it as root and compare against an oracle that expected a
- * different identity -- which would turn a DAC trace into a false pass -- the
- * trace is abandoned and counted as not applicable to this flavor.
+ * Under RPCSEC_GSS there is no uid on the wire: the caller is whoever the
+ * context authenticated.  Calling as a second user therefore means a second
+ * context under that user's own principal -- which is what a real client's
+ * rpc.gssd builds, one per user, from each user's credential cache -- so that
+ * is what this asks for, and the server maps the principal back to the uid
+ * through its configured principal map.
+ *
+ * What the map cannot express is a gid unrelated to the uid, or supplementary
+ * groups: those come from the server's idea of the user, not from the call.
+ * An operation asking for one is abandoned rather than replayed under an
+ * identity that only resembles it, which would turn a DAC trace into a false
+ * pass.
  */
 static int
 mbt_set_cred(
@@ -1471,10 +1477,22 @@ mbt_set_cred(
     size_t  n, i, cap = sizeof(mbt_cred_gids) / sizeof(mbt_cred_gids[0]);
 
     if (env->sec != MBT_SEC_SYS) {
-        /* The default credential is root's, which is who the principal maps
-         * to, so a trace that never names one replays unchanged. */
-        return (!cred || (op_i64(cred, "uid") == 0 && op_i64(cred, "gid") == 0))
-               ? 0 : -1;
+        uint32_t uid = 0, gid = 0;
+
+        if (cred) {
+            uid  = (uint32_t) op_i64(cred, "uid");
+            gid  = (uint32_t) op_i64(cred, "gid");
+            gids = json_object_get(cred, "gids");
+
+            if (gid != uid ||
+                (gids && json_array_size(itf_seq(gids)) > 0)) {
+                return -1;
+            }
+        }
+
+        env->cred = *mbt_cred_for_uid(env, env->nfs_conn, &env->nfs_v3.rpc2,
+                                      uid);
+        return 0;
     }
 
     env->cred.flavor = EVPL_RPC2_AUTH_SYS;
@@ -1506,6 +1524,68 @@ mbt_set_cred(
     env->cred.authsys.gids     = n ? mbt_cred_gids : NULL;
     return 0;
 } /* mbt_set_cred */
+
+/*
+ * The distinct uids a corpus calls as.
+ *
+ * The server reads its principal map once, at start-up, so the identities a
+ * replay will need have to be known before the first trace runs.  Reading the
+ * traces twice is cheaper than the alternative -- a map wide enough for any
+ * uid a corpus might one day use -- and it stays right when the corpus
+ * changes.
+ */
+static int
+mbt_collect_cred_uids(
+    char    **traces,
+    int       ntraces,
+    uint32_t *out,
+    int       cap)
+{
+    int n = 0, i;
+
+    for (i = 0; i < ntraces; i++) {
+        json_error_t jerr;
+        json_t      *root = json_load_file(traces[i], 0, &jerr);
+        json_t      *states, *st;
+        size_t       k;
+
+        if (!root) {
+            continue;   /* run_trace reports the parse error properly */
+        }
+
+        states = json_object_get(root, "states");
+
+        json_array_foreach(states, k, st)
+        {
+            json_t  *last_op = json_object_get(st, "lastOp");
+            json_t  *op      = last_op ? json_object_get(last_op, "value") : NULL;
+            json_t  *cred    = op ? json_object_get(op, "cred") : NULL;
+            uint32_t uid;
+            int      seen = 0, j;
+
+            if (!cred) {
+                continue;
+            }
+
+            uid = (uint32_t) op_i64(cred, "uid");
+
+            for (j = 0; j < n; j++) {
+                if (out[j] == uid) {
+                    seen = 1;
+                    break;
+                }
+            }
+
+            if (!seen && n < cap) {
+                out[n++] = uid;
+            }
+        }
+
+        json_decref(root);
+    }
+
+    return n;
+} /* mbt_collect_cred_uids */
 
 /* ---- replay driver -------------------------------------------------------- */
 
@@ -1848,8 +1928,13 @@ main(
      * isolation.  A single-fs backend (linux/io_uring) would instead clear the
      * backing directory between traces. */
     if (!dry_run) {
+        uint32_t            uids[MBT_MAX_MAPPED_UIDS];
         struct mbt_env_opts opts = { .module = backend, .rdma = rdma,
                                      .sec    = sec };
+
+        opts.num_principal_uids = mbt_collect_cred_uids(traces, ntraces, uids,
+                                                        MBT_MAX_MAPPED_UIDS);
+        opts.principal_uids = uids;
         mbt_env_open_opts(&env, &opts);
     }
 

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_common.h
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_common.h
@@ -108,9 +108,31 @@ struct drc_ctx {
 
 static inline void
 drc_cred_init(
+    struct mbt_env        *env,
     struct evpl_rpc2_cred *cred,
     uint32_t               uid)
 {
+    /*
+     * Whose call this is, said the way the flavor in force says it.
+     *
+     * The distinction this suite turns on -- that a retransmit from a
+     * different requester is not a replay of somebody else's answer -- is
+     * asserted differently by each flavor: AUTH_SYS names a uid and a machine,
+     * RPCSEC_GSS names an authenticated principal and nothing else.  Chimera
+     * folds whichever of those the call carried into the identity it caches
+     * against, so a suite that only ever sent AUTH_SYS would leave the GSS arm
+     * of that untested no matter which security flavor the cells claimed to
+     * run under.
+     */
+    if (env->sec != MBT_SEC_SYS) {
+        /* One context per user, established on the env's own connection and
+         * used on whichever the suite is testing.  A context handle is
+         * server-global, and a real client keeps one per (user, server) rather
+         * than per connection, so this is both simpler and closer to life. */
+        *cred = *mbt_cred_for_uid(env, env->nfs_conn, &env->nfs_v3.rpc2, uid);
+        return;
+    }
+
     memset(cred, 0, sizeof(*cred));
     cred->flavor                  = EVPL_RPC2_AUTH_SYS;
     cred->authsys.uid             = uid;

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
@@ -253,7 +253,7 @@ issue_v3(
     const struct mbt_fh  *fh;
     uint32_t              st;
 
-    drc_cred_init(&cred, uid);
+    drc_cred_init(o->c.env, &cred, uid);
     drc_v3_begin(&o->c, conn, &cred, xid);
 
     if (strcmp(tag, "ACreate") == 0) {
@@ -409,7 +409,7 @@ issue_v4(
         return 0;
     }
 
-    drc_cred_init(&cred, uid);
+    drc_cred_init(o->c.env, &cred, uid);
     drc_v4_call(&o->c, conn, &cred, xid, a, nops, 0, &res);
     return res.status;
 } /* issue_v4 */
@@ -444,7 +444,7 @@ learn_handles(
         return;
     }
 
-    drc_cred_init(&cred, 1000);
+    drc_cred_init(o->c.env, &cred, 1000);
 
     for (i = 0; i < json_array_size(entries); i++) {
         json_t     *pair = json_array_get(entries, i);
@@ -807,7 +807,7 @@ run_trace(
         } else if (strcmp(tag, "ONull") == 0) {
             struct evpl_rpc2_cred cred;
 
-            drc_cred_init(&cred, 1000);
+            drc_cred_init(o->c.env, &cred, 1000);
             drc_v3_begin(&o->c, (int) op_i64(op, "conn"), &cred,
                          DRC_HOUSEKEEPING_XID);
             mbt_null(o->env);

--- a/src/server/nfs/tests/quint/nfs_drc_probe.c
+++ b/src/server/nfs/tests/quint/nfs_drc_probe.c
@@ -504,8 +504,8 @@ main(
     c.env = &env;
     snprintf(c.mntpath, sizeof(c.mntpath), "/fs0");
 
-    drc_cred_init(&u1, 1000);
-    drc_cred_init(&u2, 1001);
+    drc_cred_init(&env, &u1, 1000);
+    drc_cred_init(&env, &u2, 1001);
 
     /* The shared wrappers used by trace setup run as root, which is what
      * creates the 0777 working directory the two users then share. */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -50,9 +50,34 @@ struct chimera_server_config_smb_auth {
     char kerberos_realm[256];
 };
 
+/*
+ * One entry of the static principal map: an authenticated Kerberos principal
+ * and the UNIX identity it stands for.
+ *
+ * RPCSEC_GSS puts no uid on the wire -- the caller is whoever the context
+ * authenticated -- so the server has to decide for itself what local identity
+ * a principal means.  Resolving the name through nsswitch is the usual answer
+ * and remains the fallback, but it requires every Kerberos user to also be a
+ * local account, which is not true of every deployment and is awkward to
+ * arrange in a test.  An explicit map is what nfsidmap's static method and
+ * Ganesha both offer for the same reason.
+ */
+struct chimera_server_config_principal_map_entry {
+    char     principal[256];
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t num_gids;
+    uint32_t gids[CHIMERA_VFS_CRED_MAX_GIDS];
+};
+
+#define CHIMERA_NFS_MAX_PRINCIPAL_MAP 64
+
 struct chimera_server_config_nfs_auth {
-    int  kerberos_enabled;       /* enable RPCSEC_GSS (sec=krb5) on the NFS server */
-    char kerberos_keytab[256];   /* keytab path; empty => KRB5_KTNAME default */
+    int                                              kerberos_enabled; /* enable RPCSEC_GSS (sec=krb5) on the NFS server */
+    char                                             kerberos_keytab[256]; /* keytab path; empty => KRB5_KTNAME default */
+    /* Consulted before nsswitch; empty means nsswitch alone, as before. */
+    struct chimera_server_config_principal_map_entry principal_map[CHIMERA_NFS_MAX_PRINCIPAL_MAP];
+    int                                              num_principal_map;
 };
 
 struct chimera_server_config {
@@ -308,6 +333,7 @@ chimera_server_config_init(void)
     config->smb_auth.kerberos_realm[0]  = '\0';
     config->nfs_auth.kerberos_enabled   = 0;
     config->nfs_auth.kerberos_keytab[0] = '\0';
+    config->nfs_auth.num_principal_map  = 0;
 
     config->anonuid = 65534;
     config->anongid = 65534;
@@ -3389,6 +3415,82 @@ chimera_server_config_get_nfs_kerberos_keytab(const struct chimera_server_config
 {
     return config->nfs_auth.kerberos_keytab;
 } /* chimera_server_config_get_nfs_kerberos_keytab */
+
+/*
+ * Add a principal -> UNIX identity mapping.
+ *
+ * `principal` is matched against the authenticated name with its realm
+ * stripped, so "u1000" matches "u1000@EXAMPLE.COM"; a two-component service
+ * name is written in full ("nfs/host").  Supplementary groups are carried
+ * because that is the part nsswitch resolution most often gets wrong for a
+ * Kerberos-only user: there is no local account to read them from.
+ */
+SYMBOL_EXPORT int
+chimera_server_config_add_nfs_principal_map(
+    struct chimera_server_config *config,
+    const char                   *principal,
+    uint32_t                      uid,
+    uint32_t                      gid,
+    uint32_t                      num_gids,
+    const uint32_t               *gids)
+{
+    struct chimera_server_config_principal_map_entry *e;
+    uint32_t                                          i;
+
+    if (!principal || !*principal ||
+        strlen(principal) >= sizeof(e->principal) ||
+        config->nfs_auth.num_principal_map >= CHIMERA_NFS_MAX_PRINCIPAL_MAP) {
+        return -1;
+    }
+
+    if (num_gids > CHIMERA_VFS_CRED_MAX_GIDS) {
+        num_gids = CHIMERA_VFS_CRED_MAX_GIDS;
+    }
+
+    e = &config->nfs_auth.principal_map[config->nfs_auth.num_principal_map++];
+
+    snprintf(e->principal, sizeof(e->principal), "%s", principal);
+    e->uid      = uid;
+    e->gid      = gid;
+    e->num_gids = num_gids;
+
+    for (i = 0; i < num_gids; i++) {
+        e->gids[i] = gids[i];
+    }
+
+    return 0;
+} /* chimera_server_config_add_nfs_principal_map */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_nfs_principal_map_count(const struct chimera_server_config *config)
+{
+    return config->nfs_auth.num_principal_map;
+} /* chimera_server_config_get_nfs_principal_map_count */
+
+SYMBOL_EXPORT const char *
+chimera_server_config_get_nfs_principal_map_entry(
+    const struct chimera_server_config *config,
+    int                                 index,
+    uint32_t                           *uid,
+    uint32_t                           *gid,
+    uint32_t                           *num_gids,
+    const uint32_t                    **gids)
+{
+    const struct chimera_server_config_principal_map_entry *e;
+
+    if (index < 0 || index >= config->nfs_auth.num_principal_map) {
+        return NULL;
+    }
+
+    e = &config->nfs_auth.principal_map[index];
+
+    *uid      = e->uid;
+    *gid      = e->gid;
+    *num_gids = e->num_gids;
+    *gids     = e->gids;
+
+    return e->principal;
+} /* chimera_server_config_get_nfs_principal_map_entry */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_smb_kerberos_realm(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -1087,6 +1087,35 @@ const char *
 chimera_server_config_get_nfs_kerberos_keytab(
     const struct chimera_server_config *config);
 
+/*
+ * The static principal map: an authenticated Kerberos principal and the UNIX
+ * identity it stands for.  Consulted before nsswitch, which stays the
+ * fallback.  See the struct comment in server.c for why an explicit map
+ * exists at all.
+ */
+int
+chimera_server_config_add_nfs_principal_map(
+    struct chimera_server_config *config,
+    const char                   *principal,
+    uint32_t                      uid,
+    uint32_t                      gid,
+    uint32_t                      num_gids,
+    const uint32_t               *gids);
+
+int
+chimera_server_config_get_nfs_principal_map_count(
+    const struct chimera_server_config *config);
+
+/* Returns the principal, or NULL when index is out of range. */
+const char *
+chimera_server_config_get_nfs_principal_map_entry(
+    const struct chimera_server_config *config,
+    int                                 index,
+    uint32_t                           *uid,
+    uint32_t                           *gid,
+    uint32_t                           *num_gids,
+    const uint32_t                    **gids);
+
 void
 chimera_server_config_set_smb_kerberos_realm(
     struct chimera_server_config *config,


### PR DESCRIPTION
The NFS model-based harness held one GSS context, as the machine principal, so a trace operation asking to be made as some other uid could not be replayed at all — 24 of the NFS3 corpus's 28 traces were set aside for it.

That was a limit of the harness, not of the protocol. RPCSEC_GSS carries no uid: the caller is whoever the context authenticated. A client calling as several users holds a **context per user**, which is what `rpc.gssd` builds from each user's own credential cache.

Three things were missing.

**Multiple identities** — libevpl#164, already merged: a realm keeps one service key and one acceptor credential, as a server does, and gains per-user identities alongside.

**A principal map on the server.** `chimera_nfs_gss_map_principal` resolved through `getpwnam`, which requires every Kerberos user to also be a local account. A Kerberos-only user need not be, which is why `nfsidmap`'s static method and Ganesha both offer an explicit map. This adds one, consulted ahead of nsswitch (which stays the fallback), carrying uid, gid **and supplementary groups** — the part nsswitch most often cannot answer, there being no local account to read them from.

**A context per uid in the harness**, named `u<uid>` and translated back by that map. Contexts are keyed by user and established once, then used on whichever connection is being tested: a context handle is server-global and a real client keeps one per (user, server) rather than per connection.

## Results, and what they actually prove

The NFS3 corpus now runs whole under krb5, krb5i and krb5p — 28 of 28, zero divergences, zero leaked buffers, with `u1000@` and `u1001@` genuinely authenticated. Quick tier 108/108.

Two honest qualifications:

- **The NFS3 corpus distinguishes root from a user, but not one user from another.** Mapping `u1000` to uid 1001 changes nothing; mapping either to root breaks 21 traces. So identity demonstrably drives behaviour, but telling two non-root users apart is a case the model does not currently make.
- **NFS4 and the auxiliary corpus carry no per-operation credentials at all**, so they gain nothing here — they were already faithful as machine-principal runs. Both gaps are in the model, not the harness.

## The duplicate-request suites

These are where identity matters most, and they were worst served. `drc_cred_init` built an AUTH_SYS credential whatever flavor the cell asked for, so the krb5p cells ran their calls unprotected — and the `EVPL_RPC2_AUTH_RPCSEC_GSS` arm of chimera's requester-identity hash, which folds in the service and the principal, had never once been executed by any test.

It is now. Collapsing the suite's two callers onto one principal fails the probe, which is the check that says the coverage is real rather than merely green.
