### PR TITLE
posix/quint: replay one unified POSIX corpus instead of one per backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ venv/
 .pytest_cache/
 .plan
 .claude/scheduled_tasks.lock
+
+# MBT harness artifacts: every quint replayer writes <suite>.debug.log and
+# <suite>.metrics.prom into the working directory it is run from.
+*.debug.log
+*.metrics.prom

--- a/src/posix/posix_lockf.c
+++ b/src/posix/posix_lockf.c
@@ -9,11 +9,21 @@
 #include "posix.h"
 #include "posix_internal.h"
 
-/* lockf() takes exclusive locks only, so POSIX requires the descriptor be
- * open for writing ("the file shall be opened with write-only permission or
- * with read/write permission") and names EBADF for it.  fcntl() cannot make
- * this check on our behalf: F_ULOCK reaches it as F_UNLCK and F_TEST as
- * F_GETLK, and neither of those is access-constrained there. */
+/* lockf() takes exclusive locks, so a descriptor that cannot be written
+ * cannot take one -- but only for the two commands that DO take one.  XSH
+ * lockf's EBADF condition is "The fildes argument is not a valid open file
+ * descriptor; or function is F_LOCK or F_TLOCK and fildes is not a valid
+ * file descriptor open for writing": F_ULOCK and F_TEST are deliberately
+ * absent from that list, and Linux (where lockf is a glibc wrapper over
+ * fcntl) accepts both on a read-only descriptor.  fcntl() cannot make the
+ * check on our behalf, since F_ULOCK reaches it as F_UNLCK and F_TEST as
+ * F_GETLK and neither is access-constrained there. */
+static int
+chimera_posix_lockf_takes_lock(int cmd)
+{
+    return cmd == F_LOCK || cmd == F_TLOCK;
+} /* chimera_posix_lockf_takes_lock */
+
 static int
 chimera_posix_lockf_writable(int fd)
 {
@@ -45,18 +55,9 @@ chimera_posix_lockf(
     int                            fcntl_cmd;
     int                            rc;
 
-    /* lockf(3): "The fildes argument is an open file descriptor ... open for
-     * writing"; every command -- F_ULOCK and F_TEST included -- fails EBADF
-     * on a descriptor without write access.  fcntl below cannot enforce this
-     * (its rules differ: read locks want readability, F_GETLK/F_UNLCK are
-     * ungated), so gate here. */
+    /* The descriptor must be open at all, whatever the command. */
     entry = chimera_posix_fd_acquire(posix, fd, 0);
     if (!entry) {
-        errno = EBADF;
-        return -1;
-    }
-    if (!chimera_posix_fd_may_write(entry)) {
-        chimera_posix_fd_release(entry, 0);
         errno = EBADF;
         return -1;
     }
@@ -88,7 +89,9 @@ chimera_posix_lockf(
             return -1;
     } /* switch */
 
-    if (!chimera_posix_lockf_writable(fd)) {
+    /* ... and open for WRITING only when the command takes a lock. */
+    if (chimera_posix_lockf_takes_lock(cmd) &&
+        !chimera_posix_lockf_writable(fd)) {
         errno = EBADF;
         return -1;
     }

--- a/src/posix/posix_mkdir.c
+++ b/src/posix/posix_mkdir.c
@@ -71,60 +71,19 @@ chimera_posix_mkdir(
     chimera_posix_completion_destroy(&comp);
 
     if (err) {
-        if ((err == EEXIST || err == EACCES) &&
-            path_len > 1 && path[path_len - 1] == '/') {
-            /* The backend judged the slash-stripped name.  XBD 4.16: a
-             * trailing slash makes the pathname resolve through the final
-             * component -- a non-directory there is ENOTDIR and a symlink
-             * loop is ELOOP, and resolution errors precede the operation's
-             * own existence/permission errors.  stat() with the slash
-             * preserved applies exactly those rules; any other stat
-             * outcome (a directory, a dangling link) keeps the backend's
-             * errno. */
-            struct stat st;
-
-            if (chimera_posix_stat(path, &st) < 0) {
-                if (errno == ENOTDIR || errno == ELOOP) {
-                    return -1;
-                }
-                if (errno == ENOENT) {
-                    /* The final component is a symbolic link whose target does
-                     * not exist.  The trailing slash resolves through the link
-                     * (XBD 4.16), so mkdir(2) must create the link's *target*,
-                     * not fail EEXIST on the link itself.  Read the link and
-                     * retry the create on the resolved path. */
-                    char    link[CHIMERA_VFS_PATH_MAX];
-                    char    tgt[CHIMERA_VFS_PATH_MAX];
-                    char    full[CHIMERA_VFS_PATH_MAX];
-                    ssize_t n;
-                    int     llen = path_len;
-
-                    while (llen > 1 && path[llen - 1] == '/') {
-                        llen--;
-                    }
-                    memcpy(link, path, llen);
-                    link[llen] = '\0';
-
-                    n = chimera_posix_readlink(link, tgt, sizeof(tgt) - 1);
-                    if (n > 0) {
-                        tgt[n] = '\0';
-                        if (tgt[0] == '/') {
-                            return chimera_posix_mkdir(tgt, mode);
-                        } else {
-                            const char *ls   = rindex(link, '/');
-                            int         dlen = ls ? (int) (ls - link) : 0;
-
-                            if (snprintf(full, sizeof(full), "%.*s/%s", dlen,
-                                         link, tgt) >= (int) sizeof(full)) {
-                                errno = ENAMETOOLONG;
-                                return -1;
-                            }
-                            return chimera_posix_mkdir(full, mode);
-                        }
-                    }
-                }
-            }
-        }
+        /* The backend's answer stands, trailing slash and all.  This used to
+         * re-judge a slash-terminated path with stat() and turn EEXIST into
+         * ENOTDIR or ELOOP -- and, for a dangling symlink, follow the link
+         * and create its target -- on the reading that XBD 4.16 makes a
+         * trailing slash resolve THROUGH the final component.  It does not,
+         * on the create path: XSH mkdir lists EEXIST as "the named file
+         * exists" with no qualification, and Linux answers EEXIST for
+         * mkdir("f/"), mkdir("dir/"), mkdir("lnk2dir/") and
+         * mkdir("dangling/") alike, creating nothing in any of them.  The
+         * old reading was shared with the quint model, which is why the MBT
+         * suite passed: the two agreed on something POSIX never said, and it
+         * took replaying the corpus at ext4 to break the tie.
+         */
         errno = err;
         return -1;
     }

--- a/src/posix/tests/quint/CMakeLists.txt
+++ b/src/posix/tests/quint/CMakeLists.txt
@@ -19,7 +19,11 @@ set(CHIMERA_TEST_TIER quick)
 # into SPECS_BUNDLE_DIR.  The specs `posix` suite generates every backend
 # profile into one directory, distinguished by filename prefix (memfs has none;
 # nfs3_/nfs4_/disk_ for the loopback and diskfs/cairn profiles); the replay
-# selects a profile with --trace-dir plus --exclude-prefix.
+# points at with --trace-dir.  There is ONE posix corpus now: the model no
+# longer pins a per-backend profile, so every batch replays the same traces
+# and a backend that lacks an optional interface (reflink, copy_file_range)
+# reports the traces needing it as SKIPs instead of getting a corpus of its
+# own.
 
 add_executable(posix_quint_driver posix_driver.c)
 target_link_libraries(posix_quint_driver
@@ -247,17 +251,17 @@ endif()
 # does not match the backend skip individually; the batch reports SKIP (77) only
 # if every trace skips.
 #
-# The specs `posix` corpus carries per-backend profiles distinguished by
-# filename prefix: memfs (no prefix, and also what diskfs replays), the NFS
-# loopbacks (nfs3_/nfs4_), the no-clone profile (disk_, shared by cairn and
-# the linux/io_uring passthroughs) and FUSE (fuse_).  Each registered batch
-# selects its profile with --exclude-prefix.
+# One corpus, replayed by every batch.  It used to carry a profile per
+# backend, distinguished by filename prefix, because the model pinned
+# sixteen capability and policy knobs; those are gone (the errno acceptance
+# sets are stated in the trace and honoured by the replayer, the rest
+# resolved to the POSIX reading or the cross-implementation consensus), and
+# what is left -- whether the optional interfaces exist -- is handled by
+# skipping the traces that need a missing one.
 add_test(NAME chimera/posix/mbt/batch_memfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend memfs
-            --trace-dir ${SPECS_BUNDLE_DIR}/posix
-            --exclude-prefix nfs3_ --exclude-prefix nfs4_ --exclude-prefix disk_
-            --exclude-prefix fuse_ --exclude-prefix smb_)
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix)
 set_tests_properties(chimera/posix/mbt/batch_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_memfs"
     LABELS "quint;posix_mbt;memfs"
@@ -277,9 +281,7 @@ set_tests_properties(chimera/posix/mbt/batch_memfs PROPERTIES
 add_test(NAME chimera/posix/mbt/batch_diskfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend diskfs
-            --trace-dir ${SPECS_BUNDLE_DIR}/posix
-            --exclude-prefix nfs3_ --exclude-prefix nfs4_ --exclude-prefix disk_
-            --exclude-prefix fuse_ --exclude-prefix smb_)
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix)
 set_tests_properties(chimera/posix/mbt/batch_diskfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_diskfs"
     LABELS "quint;posix_mbt;diskfs"
@@ -303,9 +305,7 @@ set_tests_properties(chimera/posix/mbt/batch_diskfs PROPERTIES
 add_test(NAME chimera/posix/mbt/batch_cairn
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend cairn
-            --trace-dir ${SPECS_BUNDLE_DIR}/posix
-            --exclude-prefix step --exclude-prefix nfs3_
-            --exclude-prefix nfs4_ --exclude-prefix fuse_ --exclude-prefix smb_)
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix)
 set_tests_properties(chimera/posix/mbt/batch_cairn PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_cairn"
     LABELS "quint;posix_mbt;cairn"
@@ -325,9 +325,7 @@ set_tests_properties(chimera/posix/mbt/batch_cairn PROPERTIES
 add_test(NAME chimera/posix/mbt/batch_nfs3_memfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend nfs3_memfs
-            --trace-dir ${SPECS_BUNDLE_DIR}/posix
-            --exclude-prefix step --exclude-prefix disk_
-            --exclude-prefix fuse_ --exclude-prefix nfs4_ --exclude-prefix smb_)
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix)
 set_tests_properties(chimera/posix/mbt/batch_nfs3_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs3_memfs"
     LABELS "quint;posix_mbt;memfs;nfs3_mbt"
@@ -341,9 +339,7 @@ set_tests_properties(chimera/posix/mbt/batch_nfs3_memfs PROPERTIES
 add_test(NAME chimera/posix/mbt/batch_nfs4_memfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend nfs4_memfs
-            --trace-dir ${SPECS_BUNDLE_DIR}/posix
-            --exclude-prefix step --exclude-prefix disk_
-            --exclude-prefix fuse_ --exclude-prefix nfs3_ --exclude-prefix smb_)
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix)
 set_tests_properties(chimera/posix/mbt/batch_nfs4_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs4_memfs"
     LABELS "quint;posix_mbt;memfs;nfs4_mbt"
@@ -369,10 +365,7 @@ set_tests_properties(chimera/posix/mbt/batch_nfs4_memfs PROPERTIES
 add_test(NAME chimera/posix/mbt/batch_smb_memfs
     COMMAND $<TARGET_FILE:posix_mbt_replay>
             --backend smb_memfs
-            --trace-dir ${SPECS_BUNDLE_DIR}/posix
-            --exclude-prefix step --exclude-prefix disk_
-            --exclude-prefix fuse_ --exclude-prefix nfs3_
-            --exclude-prefix nfs4_)
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix)
 set_tests_properties(chimera/posix/mbt/batch_smb_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_smb_memfs"
     LABELS "quint;posix_mbt;memfs;smb_mbt"
@@ -389,9 +382,7 @@ if(CHIMERA_LINUX)
     add_test(NAME chimera/posix/mbt/batch_linux
         COMMAND $<TARGET_FILE:posix_mbt_replay>
                 --backend linux
-                --trace-dir ${SPECS_BUNDLE_DIR}/posix
-                --exclude-prefix step --exclude-prefix nfs3_
-                --exclude-prefix nfs4_ --exclude-prefix fuse_ --exclude-prefix smb_)
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix)
     set_tests_properties(chimera/posix/mbt/batch_linux PROPERTIES
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_linux"
         LABELS "quint;posix_mbt;linux"
@@ -403,9 +394,7 @@ if(CHIMERA_VFS_IO_URING)
     add_test(NAME chimera/posix/mbt/batch_io_uring
         COMMAND $<TARGET_FILE:posix_mbt_replay>
                 --backend io_uring
-                --trace-dir ${SPECS_BUNDLE_DIR}/posix
-                --exclude-prefix step --exclude-prefix nfs3_
-                --exclude-prefix nfs4_ --exclude-prefix fuse_ --exclude-prefix smb_)
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix)
     set_tests_properties(chimera/posix/mbt/batch_io_uring PROPERTIES
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_io_uring"
         LABELS "quint;posix_mbt;io_uring"
@@ -429,9 +418,7 @@ foreach(ptmod ${POSIX_MBT_PT_LOOPBACKS})
     add_test(NAME chimera/posix/mbt/batch_nfs3_${ptmod}
         COMMAND $<TARGET_FILE:posix_mbt_replay>
                 --backend nfs3_${ptmod}
-                --trace-dir ${SPECS_BUNDLE_DIR}/posix
-                --exclude-prefix step --exclude-prefix disk_
-                --exclude-prefix fuse_ --exclude-prefix nfs4_ --exclude-prefix smb_)
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix)
     set_tests_properties(chimera/posix/mbt/batch_nfs3_${ptmod} PROPERTIES
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs3_${ptmod}"
         LABELS "quint;posix_mbt;${ptmod};nfs3_mbt"
@@ -441,9 +428,7 @@ foreach(ptmod ${POSIX_MBT_PT_LOOPBACKS})
     add_test(NAME chimera/posix/mbt/batch_nfs4_${ptmod}
         COMMAND $<TARGET_FILE:posix_mbt_replay>
                 --backend nfs4_${ptmod}
-                --trace-dir ${SPECS_BUNDLE_DIR}/posix
-                --exclude-prefix step --exclude-prefix disk_
-                --exclude-prefix fuse_ --exclude-prefix nfs3_ --exclude-prefix smb_)
+                --trace-dir ${SPECS_BUNDLE_DIR}/posix)
     set_tests_properties(chimera/posix/mbt/batch_nfs4_${ptmod} PROPERTIES
         ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=posix_batch_nfs4_${ptmod}"
         LABELS "quint;posix_mbt;${ptmod};nfs4_mbt"

--- a/src/posix/tests/quint/posix_deviations.py
+++ b/src/posix/tests/quint/posix_deviations.py
@@ -59,7 +59,48 @@ class Deviation:
     reconcilable: bool = True           # False => documentation-only
 
 
+# The backend under replay.  Most deviations are a property of the POSIX client
+# and hold whatever is behind it, but a few belong to one transport; those guard
+# on this.  Set once by the replayer before any trace runs.
+_BACKEND = ""
+
+
+def set_backend(name):
+    global _BACKEND
+    _BACKEND = name or ""
+
+
+def _is_fuse(_op, _fs):
+    return _BACKEND.startswith("fuse")
+
+
 KNOWN_DEVIATIONS = [
+    Deviation(
+        id="PD-FUSE-SUPPGID",
+        posix="chown() (System Interfaces): a non-privileged caller may set "
+              "the group to any of its supplementary groups",
+        summary="chown to a SUPPLEMENTARY group fails EPERM over FUSE: the "
+                "protocol carries one gid in the request header, so the "
+                "server sees only the caller's primary group and cannot know "
+                "the group is one the caller belongs to",
+        root_cause="the FUSE wire format (fuse_in_header carries a single "
+                   "gid); no_default_permissions does not help, because the "
+                   "server still has to make the decision itself",
+        candidate_fix="resolve the caller's full group set server-side (NSS "
+                      "or an equivalent lookup keyed on the uid) instead of "
+                      "trusting the single gid on the wire",
+        ops=("RChown", "RFchown", "RLchown"),
+        expected_status=OK,
+        actual_status=EPERM,
+        context=_is_fuse,
+        # Reconciled at the chown itself.  NOTE this one mutates model state
+        # like PD2b: the model's object now has the new group and the server's
+        # does not, so a later step that reads the gid -- a stat, or the final
+        # audit -- still hard-fails, correctly so.  Retiring the entry needs
+        # the server to learn the caller's real group set, not a wider guard
+        # here.
+        reconcilable=True,
+    ),
     Deviation(
         id="PD2",
         posix="fcntl() F_DUPFD/F_GETFL/F_SETFL (System Interfaces)",

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -21,7 +21,10 @@
  */
 
 #define POSIX_DRIVER_ENGINE_ONLY
+/* After posix_driver.c: that unit sets the feature-test macros the system
+ * headers need, so nothing may pull them in ahead of it. */
 #include "posix_driver.c"
+#include <signal.h>
 #include "common/mbt_trace_dir.h"
 
 /* ---- small helpers over the raw ITF JSON --------------------------------- */
@@ -140,16 +143,55 @@ map_get_pair(
     return NULL;
 } /* map_get_pair */
 
+/* True when the model has `pid` holding at least one byte-range lock, on any
+ * file.  The key is the (pid, ino) pair and the value the map of locked bytes,
+ * so an entry that survived an unlock can be present but empty. */
+static int
+model_pid_holds_lock(
+    json_t *ps,
+    int64_t pid)
+{
+    json_t *pairs = ps ? json_object_get(ps, "locks") : NULL;
+    size_t  i;
+
+    pairs = json_is_object(pairs) ? json_object_get(pairs, "#map") : NULL;
+    if (!json_is_array(pairs)) {
+        return 0;
+    }
+    for (i = 0; i < json_array_size(pairs); i++) {
+        json_t *pair = json_array_get(pairs, i);
+        json_t *k    = json_array_get(pair, 0);
+        json_t *tup  = json_is_object(k) ? json_object_get(k, "#tup") : NULL;
+        json_t *v    = json_array_get(pair, 1);
+        json_t *bytes;
+
+        if (!json_is_array(tup) || json_array_size(tup) != 2 ||
+            tf_i64(json_array_get(tup, 0)) != pid) {
+            continue;
+        }
+        bytes = json_is_object(v) ? json_object_get(v, "#map") : NULL;
+        if (json_is_array(bytes) && json_array_size(bytes) > 0) {
+            return 1;
+        }
+    }
+    return 0;
+} /* model_pid_holds_lock */
+
 /* ---- replay state -------------------------------------------------------- */
 
-#define R_MAXPID 4
-#define R_MAXFD  64
-#define R_MAXSID 64
-#define R_MAXINO 8192
-#define BADFD    999999
-#define MOUNT    "/test"
+#define R_MAXPID   4
+#define R_MAXFD    64
+#define R_MAXSID   64
+#define R_MAXINO   8192
+#define BADFD      999999
+#define MOUNT      "/test"
+
+#define R_MAXSTRAY 64
 
 static int           g_fdmap[R_MAXPID][R_MAXFD]; /* (pid, model fd) -> real fd     */
+static int           g_stray_fd[R_MAXSTRAY];     /* deferred stray descriptors     */
+static int           g_stray_pid[R_MAXSTRAY];    /* ... and the pid that minted    */
+static int           g_n_stray;                  /* ... them (see stray_release)   */
 static CHIMERA_DIR  *g_dirmap[R_MAXSID];    /* model sid -> live DIR*         */
 
 struct ident { int present; long long dev, ino; };
@@ -171,10 +213,36 @@ static const struct {
     const char *trace;      /* trace file basename */
     const char *why;
 } posix_mbt_declines[] = {
-    /* Currently empty -- every entry the first diskfs rounds added has been
-     * retired by a fix.  The sentinel keeps the array non-empty; add new
-     * declines above it. */
-    { NULL, NULL, NULL },
+    /* Three traces the unified corpus reaches that the per-backend corpora
+     * never generated.  Each names a defect, not a policy difference; the
+     * sentinel keeps the array non-empty and new declines go above it.
+     *
+     * cairn: a write whose data never lands.  pid1 opens /b, writes 4096
+     * bytes, and the call reports success -- but the file is still size 0 at
+     * the audit.  The model and every other backend grow it.  Both traces are
+     * the same shape and neither depends on the clone the flavor is named
+     * for: the RCloneRange steps around them all expect EBADF or EINVAL, so
+     * reflink is never exercised.  These were invisible until the capability
+     * skip stopped pardoning divergences recorded before it fired. */
+    { "cairn",  "stepClone_128_0x1_0.itf.json",
+      "write reports success but leaves the file at size 0 (audit: /b)" },
+    { "cairn",  "stepClone_128_0x1_2.itf.json",
+      "write reports success but leaves the file at size 0 (audit: /b)" },
+
+    /* diskfs: SEEK_HOLE/SEEK_DATA over an allocated-but-unwritten extent.
+     * The model materializes the blocks a fallocate reserves and calls them
+     * data, so it seeks past them; diskfs reports the unwritten remainder as
+     * a hole and stops earlier.  POSIX lets an implementation report an
+     * allocated extent either way, so neither side is wrong -- ext4 takes the
+     * same conservative reading (recorded there as EXT4-5).  A second
+     * implementation choosing it is the argument for widening the model to an
+     * acceptance set rather than recording each one as a deviation; until
+     * then the offset mismatch has no reconciliation to hang on, because
+     * KNOWN_DEVIATIONS keys on errno and both sides here succeed. */
+    { "diskfs", "stepSparse_128_0x1_1.itf.json",
+      "SEEK_HOLE stops at the unwritten part of a fallocate'd extent" },
+
+    { NULL,     NULL,                           NULL },
 };
 
 static const char *
@@ -196,14 +264,66 @@ posix_mbt_declined(const char *path)
     return NULL;
 } /* posix_mbt_declined */
 
-static int           g_strict_atime;        /* from the trace LInit caps      */
-static int           g_nmismatch;           /* per-trace mismatch tally       */
-static const char   *g_trace;               /* current trace path (messages)  */
-static int           g_step;                /* current trace step (messages)  */
-static json_t       *g_cur_fs;              /* model post-state fs (this step) */
-static json_t       *g_prev_fs;             /* model PRE-state fs (this step)  */
-static json_t       *g_cur_ps;              /* model protocol state (ps)       */
-static const char   *g_cur_tag;             /* current op tag (for reconcile)  */
+static int         g_strict_atime;     /* harness policy, not from caps  */
+/* The errnos the model says POSIX ALSO permits for the condition this step
+ * hit, carried in the LCall label (see posix_ops.qnt's Out.alt).  Where the
+ * standard names two spellings for one condition -- rmdir on a non-empty
+ * directory is {ENOTEMPTY, EEXIST}, a sticky refusal is {EPERM, EACCES} --
+ * answering either conforms, so this is not a deviation and nothing is
+ * recorded against the implementation for it. */
+static json_t     *g_cur_alt;          /* the LCall record carrying it     */
+static int         g_nalts;            /* permitted alternates taken       */
+/* Set when a step needs an optional interface this backend does not have
+ * (copy_file_range, reflink, SEEK_DATA/SEEK_HOLE).  The corpus is generated
+ * once, for everybody, with those interfaces present; a backend without one
+ * cannot replay the trace that uses it, and says so rather than failing. */
+static const char *g_cap_skip;
+
+
+/* Defined below, with the other ITF helpers. */
+static int itf_set_has_int(
+    json_t     *rec,
+    const char *field,
+    int64_t     n);
+
+/* True when the model named `e` as an alternate POSIX also permits for the
+ * condition this step hit. */
+static int
+alt_permits(int e)
+{
+    return g_cur_alt && itf_set_has_int(g_cur_alt, "alt", (int64_t) e);
+} /* alt_permits */
+static int         g_nmismatch;             /* per-trace mismatch tally       */
+static const char *g_trace;                 /* current trace path (messages)  */
+static int         g_step;                  /* current trace step (messages)  */
+static json_t     *g_cur_fs;                /* model post-state fs (this step) */
+static json_t     *g_prev_fs;               /* model PRE-state fs (this step)  */
+static json_t     *g_cur_ps;                /* model protocol state (ps)       */
+static const char *g_cur_tag;               /* current op tag (for reconcile)  */
+
+/* Wall-clock cap on a single replayed step.  A model trace can ask for a
+ * BLOCKING acquire (F_SETLKW), and the generator only emits one where the
+ * model says it will not block -- so if it does block, the implementation is
+ * holding a lock the model does not know about and the call never returns.
+ * Without this the whole batch hangs and CI reports a timeout with nothing
+ * in it; with it, the step that wedged is named and the run fails fast. */
+#define MBT_STEP_TIMEOUT_SEC 60
+
+static void
+mbt_step_alarm(int sig)
+{
+    (void) sig;
+    /* async-signal-safe enough for a death rattle: write(2) and _exit(2). */
+    fprintf(stderr,
+            "\nHANG: %s step %d: %s did not return within %d seconds.\n"
+            "The model only issues a blocking acquire where it believes "
+            "nothing conflicts, so this means the implementation holds a "
+            "lock the model does not know about.\n",
+            g_trace ? g_trace : "?", g_step, g_cur_tag ? g_cur_tag : "?",
+            MBT_STEP_TIMEOUT_SEC);
+    fflush(stderr);
+    _exit(1);
+} /* mbt_step_alarm */
 static json_t       *g_cur_rv;              /* current op request value        */
 
 /* Known-deviation tallies for the per-trace summary (PD<id> -> count). */
@@ -1456,6 +1576,22 @@ check_status(
             return 0;
         }
     }
+    if (alt_permits(actual)) {
+        g_nalts++;
+        return 0;
+    }
+    /* An absent optional interface refuses every call to it, whatever the
+     * model expected of the arguments, so this does not test `expected`. */
+    if (actual == EOPNOTSUPP && expected != EOPNOTSUPP) {
+        if (strcmp(g_cur_tag, "RCloneRange") == 0) {
+            g_cap_skip = "clone_file_range (reflink)";
+            return 0;
+        }
+        if (strcmp(g_cur_tag, "RCopyRange") == 0) {
+            g_cap_skip = "copy_file_range";
+            return 0;
+        }
+    }
     mism("errno: expected %lld, got %d", (long long) expected, actual);
     return 0;
 } /* check_status */
@@ -1852,10 +1988,24 @@ op_open(
     } else if (tf_field(res_v, "e") != 0 && e == 0 && rc >= 0) {
         /* The model expected this open to fail but chimera minted a
          * descriptor (PD24's EMFILE; over the NFS loopback also opens whose
-         * expected EACCES the server's DAC reading does not share).  Close
-         * the stray descriptor -- the model never learned of it, so nothing
-         * downstream ever would. */
-        chimera_posix_close(rc);
+         * expected EACCES the server's DAC reading does not share).  The
+         * model never learned of it, so nothing downstream ever would --
+         * but closing it here is not free.  close(2) releases every
+         * byte-range lock the CALLING process holds on that file, and the
+         * model, whose open failed, still believes it holds them: the next
+         * process to ask for those bytes is granted them, and the F_SETLKW
+         * after that waits on a lock the model cannot see.  Hold the
+         * descriptor until the trace ends when the model has the pid
+         * holding locks, and close it in close_live_handles() with the
+         * rest.  Only lock-bearing traces pay the deferral, so the open
+         * reference cannot outlive an unlink anywhere it did not already. */
+        if (model_pid_holds_lock(g_cur_ps, pid) && g_n_stray < R_MAXSTRAY) {
+            g_stray_fd[g_n_stray]  = rc;
+            g_stray_pid[g_n_stray] = pid;
+            g_n_stray++;
+        } else {
+            chimera_posix_close(rc);
+        }
         if (tf_bool(fl, "creat")) {
             json_t *comps = json_object_get(json_object_get(rv, "pth"),
                                             "comps");
@@ -3448,6 +3598,14 @@ close_live_handles(void)
             }
         }
     }
+    /* Deferred stray descriptors (see op_open): closed last and AS the pid
+     * that minted them, for the same reason the fdmap loop above is. */
+    while (g_n_stray > 0) {
+        g_n_stray--;
+        apply_cred(g_stray_pid[g_n_stray]);
+        chimera_posix_close(g_stray_fd[g_n_stray]);
+    }
+
     /* The recycle that follows runs as root. */
     apply_root_cred();
     for (sid = 0; sid < R_MAXSID; sid++) {
@@ -3751,7 +3909,9 @@ replay_trace(const char *path)
     g_strict_atime = tf_bool(caps, "strictAtime");
 
     state_reset();
-    g_trace = path;
+    g_cap_skip = NULL;
+    g_nalts    = 0;
+    g_trace    = path;
 
     /* Per-pid credentials (creds_for): pid0 root-or-uid100, pid1 uid200. */
     setcred(0, tf_bool(caps, "withRoot") ? 0 : 100, 10, 10, 30);
@@ -3781,10 +3941,15 @@ replay_trace(const char *path)
         g_cur_ps   = state_get(st, "ps");
         g_cur_tag  = tag;
         g_cur_rv   = tf_val(req);
+        g_cur_alt  = v;
         g_cur_pid  = pid;
         g_cur_step = (int) i;
         last_fs    = g_cur_fs;
 
+        if (g_cap_skip) {
+            break;
+        }
+        alarm(MBT_STEP_TIMEOUT_SEC);
         if (dispatch(tag, pid, tf_val(req), tf_val(res)) != 0) {
             fprintf(stderr, "%s: step %zu: unimplemented op %s\n", path, i,
                     tag);
@@ -3792,6 +3957,8 @@ replay_trace(const char *path)
             return -1;
         }
     }
+
+    alarm(0);
 
     audited = last_fs ? final_audit(last_fs) : 0;
 
@@ -3819,6 +3986,23 @@ replay_trace(const char *path)
                devs);
     }
     json_decref(root);
+    if (g_cap_skip) {
+        /* A skip abandons the REST of the trace; it does not pardon what
+         * already diverged.  Reporting SKIP over a recorded mismatch would
+         * let a real defect ride out of the run behind a missing optional
+         * interface -- the trace is short one answer AND wrong about one it
+         * gave, and only the second of those is the backend's fault to
+         * hide. */
+        if (g_nmismatch) {
+            fprintf(stderr, "%s: needs %s (skipped from there), but %d "
+                    "divergence(s) were already recorded -- reporting those\n",
+                    path, g_cap_skip, g_nmismatch);
+            return 1;
+        }
+        fprintf(stderr, "%s: SKIP: needs %s, which this backend does not "
+                "implement\n", path, g_cap_skip);
+        return 2;
+    }
     return g_nmismatch ? 1 : 0;
 } /* replay_trace */
 
@@ -3829,7 +4013,7 @@ main(
 {
     const char *backend = "memfs";
     int         ntraces = 0;
-    int         i, ran = 0, failures = 0, bad = 0;
+    int         i, ran = 0, failures = 0, bad = 0, skipped = 0;
 
     /* Line-buffer stdout so a crash cannot swallow the progress output.
      * These drivers print one line per trace, and both that and chimera's log
@@ -3874,6 +4058,8 @@ main(
         return 1;
     }
 
+    signal(SIGALRM, mbt_step_alarm);
+
     if (posix_env_setup(backend, NULL) != 0) {
         mbt_free_traces(traces, ntraces);
         return 1;
@@ -3895,6 +4081,12 @@ main(
         rc = replay_trace(traces[i]);
         if (rc < 0) {
             bad++;
+        } else if (rc == 2) {
+            /* A capability skip happens PART WAY THROUGH, so the filesystem
+             * has been written to: `ran` still advances, or the next trace
+             * would start on a dirty tree. */
+            skipped++;
+            ran++;
         } else {
             ran++;
             if (rc) {
@@ -3909,8 +4101,8 @@ main(
     close_live_handles();
     posix_env_teardown();
 
-    printf("batch: %d replayed, %d failed, %d unhandled of %d trace(s)\n",
-           ran, failures, bad, ntraces);
+    printf("batch: %d replayed, %d skipped, %d failed, %d unhandled of %d "
+           "trace(s)\n", ran - skipped, skipped, failures, bad, ntraces);
     fflush(stdout);
     mbt_free_traces(traces, ntraces);
     return (failures || bad) ? 1 : 0;

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1772,6 +1772,20 @@ check_statres(
              * to the set-id bits. */
             if (g_smb && (diff & ~06000u) == 0) {
                 record_dev("SD-SETID");
+            } else if (g_nfs_version == 3 && (diff & ~06000u) == 0 &&
+                       ((unsigned) wmode & 06000u) != 0 &&
+                       ((st->st_mode & 07777) & 06000u) == 0 &&
+                       strcmp(ftag, "FReg") == 0) {
+                /* ND11: fallocate over NFSv3 clears the set-id bits, because
+                 * NFSv3 has no ALLOCATE and the client emulates it with a
+                 * SETATTR that sets the size (nfs3_allocate.c).  The server
+                 * cannot tell that from an ftruncate, and a truncate by an
+                 * unprivileged writer kills privileges -- so the bits the
+                 * model (and every direct backend) keep across a fallocate are
+                 * gone.  Confined to a regular file losing only set-id bits;
+                 * the model never expects a fallocate to touch them, so the
+                 * reverse direction is still a divergence. */
+                record_dev("ND11");
             } else {
                 mism("mode: expected %#llo, got %#o", (long long) wmode,
                      st->st_mode & 07777);

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -1597,6 +1597,33 @@ check_status(
     return 0;
 } /* check_status */
 
+/* True when the model still holds an open description on `ino`.  A silly
+ * rename lives exactly as long as one does: the NFS client renames the name
+ * out of the way at unlink and removes it at last close, so while the model
+ * has the file open chimera carries one link the model has already dropped. */
+static int
+model_ino_open(
+    json_t *ps,
+    int64_t ino)
+{
+    json_t *pairs = ps ? json_object_get(ps, "ofds") : NULL;
+    size_t  i;
+
+    pairs = json_is_object(pairs) ? json_object_get(pairs, "#map") : NULL;
+    if (!json_is_array(pairs)) {
+        return 0;
+    }
+    for (i = 0; i < json_array_size(pairs); i++) {
+        json_t *pair = json_array_get(pairs, i);
+        json_t *v    = json_array_get(pair, 1);
+
+        if (json_is_object(v) && tf_field(v, "ino") == ino) {
+            return 1;
+        }
+    }
+    return 0;
+} /* model_ino_open */
+
 static const char *
 ftype_of(const char *tag)
 {
@@ -1801,10 +1828,18 @@ check_statres(
              st->st_gid);
     }
     if ((int64_t) st->st_nlink != tf_field(rv, "nlink")) {
-        if (g_nfs_version && tf_field(rv, "nlink") == 0 &&
-            st->st_nlink == 1) {
+        if (g_nfs_version && strcmp(ftag, "FLnk") != 0 &&
+            (int64_t) st->st_nlink == tf_field(rv, "nlink") + 1 &&
+            (tf_field(rv, "nlink") == 0 ||
+             model_ino_open(g_cur_ps, tf_field(rv, "ino")))) {
             /* Unlinked-while-open: the silly-renamed name keeps one link
-             * alive until the last close (ND2). */
+             * alive until the last close (ND2).  The model may still have
+             * OTHER links to the same file -- unlinking one of two leaves the
+             * model at 1 and chimera at 2 -- so this is one more link than the
+             * model has, not necessarily exactly one.  Guarded on the model
+             * still holding the file open, which is precisely as long as the
+             * silly name lives; the nlink == 0 arm needs no such check because
+             * a file with no names left is open by construction. */
             record_dev("ND2");
         } else if (g_nfs_version && g_nexempt > 0 &&
                    strcmp(ftag, "FDir") == 0 &&
@@ -3833,6 +3868,14 @@ final_audit(json_t *fs)
                     strcmp(ftag, "FDir") == 0 &&
                     (int64_t) st.st_nlink > tf_field(cnode, "nlink")) {
                     record_dev("ND5");   /* residue subdir (see check_statres) */
+                } else if (g_nfs_version && strcmp(ftag, "FDir") != 0 &&
+                           (int64_t) st.st_nlink ==
+                           tf_field(cnode, "nlink") + 1 &&
+                           model_ino_open(g_cur_ps, cino)) {
+                    /* A silly rename outstanding at the end of the trace: the
+                     * model closed no descriptor, so the extra name is still
+                     * there.  Same rule as check_statres's ND2. */
+                    record_dev("ND2");
                 } else {
                     mism("audit: %s: nlink %llu != %lld", cpath,
                          (unsigned long long) st.st_nlink,

--- a/src/posix/tests/quint/posix_mbt_replay.c
+++ b/src/posix/tests/quint/posix_mbt_replay.c
@@ -213,32 +213,18 @@ static const struct {
     const char *trace;      /* trace file basename */
     const char *why;
 } posix_mbt_declines[] = {
-    /* Three traces the unified corpus reaches that the per-backend corpora
-     * never generated.  Each names a defect, not a policy difference; the
-     * sentinel keeps the array non-empty and new declines go above it.
-     *
-     * cairn: a write whose data never lands.  pid1 opens /b, writes 4096
-     * bytes, and the call reports success -- but the file is still size 0 at
-     * the audit.  The model and every other backend grow it.  Both traces are
-     * the same shape and neither depends on the clone the flavor is named
-     * for: the RCloneRange steps around them all expect EBADF or EINVAL, so
-     * reflink is never exercised.  These were invisible until the capability
-     * skip stopped pardoning divergences recorded before it fired. */
-    { "cairn",  "stepClone_128_0x1_0.itf.json",
-      "write reports success but leaves the file at size 0 (audit: /b)" },
-    { "cairn",  "stepClone_128_0x1_2.itf.json",
-      "write reports success but leaves the file at size 0 (audit: /b)" },
-
     /* diskfs: SEEK_HOLE/SEEK_DATA over an allocated-but-unwritten extent.
-     * The model materializes the blocks a fallocate reserves and calls them
-     * data, so it seeks past them; diskfs reports the unwritten remainder as
-     * a hole and stops earlier.  POSIX lets an implementation report an
-     * allocated extent either way, so neither side is wrong -- ext4 takes the
-     * same conservative reading (recorded there as EXT4-5).  A second
-     * implementation choosing it is the argument for widening the model to an
-     * acceptance set rather than recording each one as a deviation; until
-     * then the offset mismatch has no reconciliation to hang on, because
-     * KNOWN_DEVIATIONS keys on errno and both sides here succeed. */
+    * The model materializes the blocks a fallocate reserves and calls them
+    * data, so it seeks past them; diskfs reports the unwritten remainder as
+    * a hole and stops earlier.  POSIX lets an implementation report an
+    * allocated extent either way, so neither side is wrong -- ext4 takes the
+    * same conservative reading (recorded there as EXT4-5).  A second
+    * implementation choosing it is the argument for widening the model to an
+    * acceptance set rather than recording each one as a deviation; until
+    * then the offset mismatch has no reconciliation to hang on, because
+    * KNOWN_DEVIATIONS keys on errno and both sides here succeed.
+    *
+    * The sentinel keeps the array non-empty; new declines go above it. */
     { "diskfs", "stepSparse_128_0x1_1.itf.json",
       "SEEK_HOLE stops at the unwritten part of a fallocate'd extent" },
 
@@ -264,7 +250,22 @@ posix_mbt_declined(const char *path)
     return NULL;
 } /* posix_mbt_declined */
 
-static int         g_strict_atime;     /* harness policy, not from caps  */
+static int g_strict_atime;             /* harness policy, not from caps  */
+
+/* Whether this target marks atime on every read.  That is a property of the
+ * target -- a mount option, or what a transport chooses to carry -- and not
+ * something POSIX settles, so it is harness configuration rather than a model
+ * capability, and the unified corpus no longer ships it in caps.  These are
+ * the values the retired per-backend profiles pinned: the NFS3 loopback and
+ * the FUSE transport mark it, nothing else does.  Reading it out of caps (as
+ * this did while the profiles existed) now silently yields false everywhere,
+ * which turns the atime assertions off instead of running them. */
+static int
+posix_mbt_strict_atime(const char *module)
+{
+    return strncmp(module, "nfs3", 4) == 0 ||
+           strncmp(module, "fuse", 4) == 0;
+} /* posix_mbt_strict_atime */
 /* The errnos the model says POSIX ALSO permits for the condition this step
  * hit, carried in the LCall label (see posix_ops.qnt's Out.alt).  Where the
  * standard names two spellings for one condition -- rmdir on a non-empty
@@ -2118,6 +2119,18 @@ op_lseek(
     rc = chimera_posix_lseek(rfd(pid, tf_field(rv, "fd")),
                              (off_t) tf_field(rv, "off"), whence);
     e = ERRV(rc);
+    /* An absent SEEK_DATA/SEEK_HOLE reaches the caller as EINVAL, not
+     * EOPNOTSUPP: chimera_posix_lseek_hole_data() maps the backend's ENOTSUP
+     * that way because that is what Linux reports for a filesystem without
+     * them.  So the capability skip has to recognise EINVAL here, where for
+     * copy_file_range and reflink it recognises EOPNOTSUPP.  Guarded on the
+     * model not having expected EINVAL itself, which it does for a negative
+     * offset -- that is an argument error and says nothing about support. */
+    if (e == EINVAL && exp_e != EINVAL &&
+        (whence == SEEK_DATA || whence == SEEK_HOLE)) {
+        g_cap_skip = "SEEK_DATA/SEEK_HOLE";
+        return;
+    }
     if (e != exp_e) {
         const char *dev = reconcile("RLseek", rv, (int) exp_e, e);
         if (dev) {              /* e.g. PD22 (ENXIO vs EINVAL) */
@@ -3906,7 +3919,7 @@ replay_trace(const char *path)
         return -1;
     }
     caps           = json_object_get(tf_val(lo0), "caps");
-    g_strict_atime = tf_bool(caps, "strictAtime");
+    g_strict_atime = posix_mbt_strict_atime(g_module);
 
     state_reset();
     g_cap_skip = NULL;
@@ -3944,11 +3957,16 @@ replay_trace(const char *path)
         g_cur_alt  = v;
         g_cur_pid  = pid;
         g_cur_step = (int) i;
-        last_fs    = g_cur_fs;
 
         if (g_cap_skip) {
+            /* Stop BEFORE advancing last_fs.  The skip was set by the
+             * PREVIOUS step, so the backend's filesystem is the one this
+             * trace's previous state describes; taking this state instead
+             * would audit it against an operation it never ran, and every
+             * object that operation touched would read as a divergence. */
             break;
         }
+        last_fs = g_cur_fs;
         alarm(MBT_STEP_TIMEOUT_SEC);
         if (dispatch(tag, pid, tf_val(req), tf_val(res)) != 0) {
             fprintf(stderr, "%s: step %zu: unimplemented op %s\n", path, i,

--- a/src/posix/tests/quint/posix_replay.py
+++ b/src/posix/tests/quint/posix_replay.py
@@ -1629,6 +1629,7 @@ def replay_one(driver, trace_path, args):
     # the target -- so the harness carries it.
     caps = dict(caps)
     caps["strictAtime"] = strict_atime_for(args.backend)
+    posix_deviations.set_backend(args.backend)
 
     replayer = Replayer(driver, caps, verbose=args.verbose)
     audited = 0

--- a/src/posix/tests/quint/posix_replay.py
+++ b/src/posix/tests/quint/posix_replay.py
@@ -164,6 +164,12 @@ FUSE_PROFILE = dict(PROFILE, cloneRange=False, strictAtime=True,
 SMB_PROFILE = dict(PROFILE, cloneRange=False, seekHole=False, strictAtime=True,
                    stickyWriteArm=True, errStickyAcces=None)
 
+# The per-backend profiles are no longer a replay gate -- the corpus is
+# generated once, with every optional interface present, and a backend without
+# one skips the traces that reach for it.  The table stays because two things
+# still want it: --backend's choices, and --check-profile, which diffs what a
+# backend actually measures against what is pinned here and so catches a
+# backend drifting away from its recorded shape.
 PROFILES = {
     "memfs": PROFILE,
     "smb_memfs": SMB_PROFILE,
@@ -179,8 +185,52 @@ PROFILES = {
 }
 
 
+# Whether a target marks atime on every read.  Not a model capability -- it is
+# a mount option, or what a transport chooses to carry -- so the harness
+# carries it, and the profile table above is where its per-backend value has
+# always been written down.
+def strict_atime_for(backend):
+    return bool(PROFILES.get(backend, PROFILE).get("strictAtime"))
+
+
 class TraceFormatError(Exception):
     pass
+
+
+class NotApplicable(Exception):
+    """Raised when a step needs an optional interface the backend does not
+    have.  The corpus is generated once, with every interface present, so a
+    backend without one cannot replay the traces that use it and says so
+    rather than failing."""
+
+    def __init__(self, step, op, what):
+        self.step = step
+        self.op = op
+        self.what = what
+        super().__init__(f"step {step}: {op} needs {what}")
+
+
+# An absent optional interface answers differently depending on which one it
+# is: copy_file_range and the reflink ioctl report EOPNOTSUPP, while an absent
+# SEEK_DATA/SEEK_HOLE reaches the caller as EINVAL, because that is what Linux
+# reports for a filesystem without them (chimera_posix_lseek_hole_data maps
+# the backend's ENOTSUP that way).  Each is only read as "absent" when the
+# model did not expect that errno itself -- lseek legitimately answers EINVAL
+# for a negative offset, which says nothing about support.
+def capability_absent(tag, req, expected, actual):
+    if tag in ("RCopyRange", "RCloneRange"):
+        return actual == 95 and expected != 95
+    if tag == "RLseek":
+        wh = (req.get("wh") or {}).get("tag")
+        return wh in ("WData", "WHole") and actual == 22 and expected != 22
+    return False
+
+
+CAPABILITY_NAMES = {
+    "RCopyRange": "copy_file_range",
+    "RCloneRange": "clone_file_range (reflink)",
+    "RLseek": "SEEK_DATA/SEEK_HOLE",
+}
 
 
 class Divergence(Exception):
@@ -354,6 +404,8 @@ class Replayer:
         self.deviations_hit = {}
         self.audit_exempt = set()  # model paths of PD24 residue nodes
         self._cur_tag = None
+        self._cur_step = 0
+        self._applied = None    # last state the backend actually reached
         self._cur_req = None
         self._cur_fs = None
         self._cur_ps = None
@@ -436,6 +488,9 @@ class Replayer:
         """True if the errno matches (proceed with success-path checks)."""
         if actual == expected:
             return True
+        if capability_absent(self._cur_tag, self._cur_req, expected, actual):
+            raise NotApplicable(self._cur_step, self._cur_tag,
+                                CAPABILITY_NAMES[self._cur_tag])
         dev = posix_deviations.reconcile(self._cur_tag, self._cur_req,
                                          expected, actual, self._cur_fs)
         if dev is not None:
@@ -1330,6 +1385,7 @@ class Replayer:
             signal.alarm(60)
             mism = []
             self._cur_tag = tag
+            self._cur_step = idx
             self._cur_req = req["value"]
             self._cur_fs = state["fs"]
             self._cur_ps = state.get("ps")
@@ -1343,6 +1399,11 @@ class Replayer:
             if mism:
                 raise Divergence(idx, (tag, req["value"], res["value"]),
                                  mism)
+            # Record the state the backend has actually reached.  A capability
+            # skip aborts from the NEXT step, and auditing it against a state
+            # whose operation never ran would report every object that
+            # operation touched as a divergence.
+            self._applied = state
         signal.alarm(0)
 
 
@@ -1548,11 +1609,14 @@ def replay_one(driver, trace_path, args):
         raise TraceFormatError(f"{trace_path}: first label is not LInit")
     caps = init["value"]["caps"]
 
-    for key, want in PROFILES[args.backend].items():
-        if want is not None and caps.get(key) != want:
-            print(f"{trace_path}: SKIP: trace profile {key}="
-                  f"{caps.get(key)} does not match live profile {want}")
-            return "skip"
+    # There is no per-backend profile to match any more: the corpus is
+    # generated once, with every optional interface present, and a backend
+    # without one skips the traces that reach for it (see NotApplicable).
+    # What is left of the old profiles is strictAtime, which was never model
+    # behaviour -- whether a target marks atime on every read is a property of
+    # the target -- so the harness carries it.
+    caps = dict(caps)
+    caps["strictAtime"] = strict_atime_for(args.backend)
 
     replayer = Replayer(driver, caps, verbose=args.verbose)
     audited = 0
@@ -1563,6 +1627,20 @@ def replay_one(driver, trace_path, args):
         report_divergence(trace_path, div, replayer, driver)
         replayer.cleanup()
         return "fail"
+    except NotApplicable as na:
+        # Audit what the backend did reach, so the part of the trace that ran
+        # is still checked, then report the trace as skipped.
+        if replayer._applied is not None:
+            try:
+                replayer.final_audit(replayer._applied, na.step - 1)
+            except Divergence as div:
+                report_divergence(trace_path, div, replayer, driver)
+                replayer.cleanup()
+                return "fail"
+        replayer.cleanup()
+        print(f"{trace_path}: SKIP: needs {na.what}, which this backend "
+              f"does not implement (step {na.step}, {na.op})")
+        return "skip"
     replayer.cleanup()
 
     dev_summary = ""

--- a/src/posix/tests/quint/posix_replay.py
+++ b/src/posix/tests/quint/posix_replay.py
@@ -404,6 +404,8 @@ class Replayer:
         self.deviations_hit = {}
         self.audit_exempt = set()  # model paths of PD24 residue nodes
         self._cur_tag = None
+        self._cur_alt = []
+        self._alts_taken = 0
         self._cur_step = 0
         self._applied = None    # last state the backend actually reached
         self._cur_req = None
@@ -488,6 +490,15 @@ class Replayer:
         """True if the errno matches (proceed with success-path checks)."""
         if actual == expected:
             return True
+        # The errnos the model says POSIX ALSO permits for the condition this
+        # step hit, carried in the LCall label (posix_ops.qnt's Out.alt).
+        # Where the standard names two spellings for one condition -- a sticky
+        # refusal is {EPERM, EACCES}, rmdir on a non-empty directory is
+        # {ENOTEMPTY, EEXIST} -- answering either conforms, so nothing is
+        # recorded against the implementation for it.
+        if actual in self._cur_alt:
+            self._alts_taken += 1
+            return False
         if capability_absent(self._cur_tag, self._cur_req, expected, actual):
             raise NotApplicable(self._cur_step, self._cur_tag,
                                 CAPABILITY_NAMES[self._cur_tag])
@@ -1385,6 +1396,7 @@ class Replayer:
             signal.alarm(60)
             mism = []
             self._cur_tag = tag
+            self._cur_alt = label["value"].get("alt") or []
             self._cur_step = idx
             self._cur_req = req["value"]
             self._cur_fs = state["fs"]

--- a/src/server/fuse/tests/quint/CMakeLists.txt
+++ b/src/server/fuse/tests/quint/CMakeLists.txt
@@ -36,10 +36,13 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # One batched replay of the specs `posixFuse` corpus: the same POSIX model,
 # the same replayer, and a driver that turns every operation into FUSE
-# requests against the server.  The profile differs from posixMemfs only where
-# the FUSE transport forces it to (no reflink ioctl, strict atime, no chgrp to
-# a supplementary group), so a divergence here is the FUSE server's and not
-# the model's or the backend's.
+# requests against the server.  There is no fuse_ profile any more -- the
+# corpus is generated once for everybody -- so the three things the FUSE
+# transport used to have pinned for it are handled where they belong: the
+# absent reflink ioctl is a capability skip, strict atime is harness
+# configuration, and chgrp to a supplementary group is a FUSE defect the
+# replayer reconciles by name (one gid travels on the wire).  A divergence
+# here is still the FUSE server's and not the model's or the backend's.
 #
 # Needs no /dev/fuse, no mount and no privileges -- the harness stands a
 # socketpair in for the device -- so it runs everywhere the build does, ahead
@@ -49,8 +52,7 @@ add_test(NAME chimera/fuse/mbt/batch_memfs
             ${CMAKE_SOURCE_DIR}/src/posix/tests/quint/posix_replay.py
             --backend fuse_memfs
             --driver $<TARGET_FILE:fuse_quint_driver>
-            --trace-dir ${SPECS_BUNDLE_DIR}/posix
-            --include-prefix fuse_)
+            --trace-dir ${SPECS_BUNDLE_DIR}/posix)
 set_tests_properties(chimera/fuse/mbt/batch_memfs PROPERTIES
     ENVIRONMENT "CHIMERA_MBT_ARTIFACTS=fuse_batch_memfs"
     LABELS "quint;fuse;posix_mbt;memfs"

--- a/src/server/fuse/tests/quint/fuse_quint_driver.c
+++ b/src/server/fuse/tests/quint/fuse_quint_driver.c
@@ -902,7 +902,7 @@ fuse_exec_op(json_t *req)
             return res_int(-1, rc);
         }
 
-        rc = fsim_walk(&g_fsim, start, jstr(req, "path"), 0, &p);
+        rc = fsim_walk(&g_fsim, start, jstr(req, "path"), FSIM_LEAF_CREATE, &p);
 
         if (rc != 0) {
             return res_int(-1, rc);
@@ -944,7 +944,8 @@ fuse_exec_op(json_t *req)
             mode |= S_IFREG;
         }
 
-        rc = fsim_walk(&g_fsim, FUSE_ROOT_ID, jstr(req, "path"), 0, &p);
+        rc = fsim_walk(&g_fsim, FUSE_ROOT_ID, jstr(req, "path"),
+                       FSIM_LEAF_CREATE, &p);
 
         if (rc != 0) {
             return res_int(-1, rc);
@@ -1286,9 +1287,14 @@ fuse_exec_op(json_t *req)
             return res_int(-1, EBADF);
         }
 
-        /* lockf(3) is defined only on a descriptor open for writing, and
-         * that is checked before the filesystem is reached. */
-        if ((o->flags & O_ACCMODE) == O_RDONLY) {
+        /* lockf(3) needs a descriptor open for writing only for the commands
+         * that TAKE a lock.  F_TEST asks a question and F_ULOCK gives
+         * something back; XSH constrains neither, and gating them too refused
+         * with EBADF calls that must succeed.  Same rule, and the same fix, as
+         * chimera_posix_lockf_takes_lock() in src/posix/posix_lockf.c. */
+        if ((o->flags & O_ACCMODE) == O_RDONLY &&
+            (!cmds || strcmp(cmds, "lock") == 0 ||
+             strcmp(cmds, "tlock") == 0)) {
             return res_int(-1, EBADF);
         }
 

--- a/src/server/fuse/tests/quint/fuse_sim_vfs.h
+++ b/src/server/fuse/tests/quint/fuse_sim_vfs.h
@@ -280,7 +280,14 @@ fsim_strip_mount(const char *path)
  * Returns 0 on a completed walk -- in which case out->nodeid is 0 if the leaf
  * simply does not exist, which is not an error for a caller about to create
  * it -- or the errno the walk produced.
+ *
+ * follow_leaf is 0 (do not follow a symlink leaf), 1 (follow it), or
+ * FSIM_LEAF_CREATE for a caller that is about to create the leaf: that one
+ * does not follow either, and is additionally exempt from the trailing-slash
+ * rule on the final component.
  */
+#define FSIM_LEAF_CREATE 2
+
 static int
 fsim_walk(
     struct fsim      *f,
@@ -447,9 +454,17 @@ fsim_walk(
         /* A trailing slash forces the final symlink to be followed (XBD
          * 4.16: the slash names the directory the link resolves to), even
          * for an otherwise nofollow caller such as lstat.  The ENOTDIR check
-         * below then applies to the object the link resolved to. */
+         * below then applies to the object the link resolved to.
+         *
+         * A caller about to create the leaf is again the exception, for the
+         * same reason it is exempt from the ENOTDIR rule: the name it means
+         * to create already exists, and what it resolves to does not change
+         * that.  Following it here reported the link's own resolution failure
+         * (ELOOP for a cycle) where mkdir owes EEXIST. */
         if (S_ISLNK(e.attr.mode) &&
-            (!is_last || follow_leaf || trailing_slash)) {
+            (!is_last ||
+             (follow_leaf && follow_leaf != FSIM_LEAF_CREATE) ||
+             (trailing_slash && follow_leaf != FSIM_LEAF_CREATE))) {
             char        target[FSIM_PATH_MAX];
             const char *tgt;
             size_t      tlen;
@@ -514,7 +529,15 @@ fsim_walk(
             out->entry  = e;
             strcpy(out->leaf, comp);
 
-            if (trailing_slash && !S_ISDIR(e.attr.mode)) {
+            /* The trailing slash makes a non-directory leaf ENOTDIR for a
+             * caller that means to resolve THROUGH it.  A caller about to
+             * CREATE the leaf is not one of those: the final component has
+             * already resolved, and mkdir/mknod report what it found -- so
+             * they pass follow_leaf FSIM_LEAF_CREATE and get the entry back
+             * to judge for themselves (EEXIST).  Matches the model, whose
+             * createGate resolves the path with the trailing slash dropped. */
+            if (trailing_slash && !S_ISDIR(e.attr.mode) &&
+                follow_leaf != FSIM_LEAF_CREATE) {
                 return ENOTDIR;
             }
             return 0;

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -5200,10 +5200,14 @@ cairn_link_at(
 
     target_inode = target_ih.inode;
 
-    /* The destination is judged before the source's type: XSH link orders
-     * EEXIST and EPERM against each other not at all, and Linux checks path2
-     * in do_linkat() before vfs_link() reaches its "S_ISDIR -> -EPERM".  Same
-     * ordering as memfs and diskfs. */
+    if (S_ISDIR(target_inode->mode)) {
+        cairn_inode_handle_release(&parent_ih);
+        cairn_inode_handle_release(&target_ih);
+        request->status = CHIMERA_VFS_EISDIR;
+        request->complete(request);
+        return;
+    }
+
     dirent_key.keytype = CAIRN_KEY_DIRENT;
     dirent_key.inum    = parent_inode->inum;
     dirent_key.hash    = request->link_at.name_hash;
@@ -5215,14 +5219,6 @@ cairn_link_at(
         cairn_inode_handle_release(&target_ih);
         cairn_dirent_handle_release(&dh);
         request->status = CHIMERA_VFS_EEXIST;
-        request->complete(request);
-        return;
-    }
-
-    if (S_ISDIR(target_inode->mode)) {
-        cairn_inode_handle_release(&parent_ih);
-        cairn_inode_handle_release(&target_ih);
-        request->status = CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -3025,6 +3025,14 @@ cairn_mkdir_at(
 
     cairn_apply_attrs(&inode, request->mkdir_at.set_attr);
 
+    /* ...and a new SUBDIRECTORY inherits the set-group-ID bit itself, so the
+     * property propagates down a tree instead of stopping at the first
+     * level.  After apply_attrs, which sets the requested mode.  Matches
+     * memfs/diskfs and Linux (inode_init_owner). */
+    if (parent_inode->mode & S_ISGID) {
+        inode.mode |= S_ISGID;
+    }
+
     cairn_inherit_acl(thread, &inode, parent_inode->inum,
                       new_acl_mkdir,
                       request->cred->flavor == CHIMERA_VFS_AUTH_ATTR);
@@ -5192,14 +5200,10 @@ cairn_link_at(
 
     target_inode = target_ih.inode;
 
-    if (S_ISDIR(target_inode->mode)) {
-        cairn_inode_handle_release(&parent_ih);
-        cairn_inode_handle_release(&target_ih);
-        request->status = CHIMERA_VFS_EISDIR;
-        request->complete(request);
-        return;
-    }
-
+    /* The destination is judged before the source's type: XSH link orders
+     * EEXIST and EPERM against each other not at all, and Linux checks path2
+     * in do_linkat() before vfs_link() reaches its "S_ISDIR -> -EPERM".  Same
+     * ordering as memfs and diskfs. */
     dirent_key.keytype = CAIRN_KEY_DIRENT;
     dirent_key.inum    = parent_inode->inum;
     dirent_key.hash    = request->link_at.name_hash;
@@ -5211,6 +5215,14 @@ cairn_link_at(
         cairn_inode_handle_release(&target_ih);
         cairn_dirent_handle_release(&dh);
         request->status = CHIMERA_VFS_EEXIST;
+        request->complete(request);
+        return;
+    }
+
+    if (S_ISDIR(target_inode->mode)) {
+        cairn_inode_handle_release(&parent_ih);
+        cairn_inode_handle_release(&target_ih);
+        request->status = CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -3312,33 +3312,19 @@ diskfs_link_at_check_cb(
 
     diskfs_bt_op_free(thread, op);
 
-    /* The destination is judged before the source's type.  XSH link lists
-     * EEXIST, EACCES and EPERM without ordering them, and Linux resolves and
-     * checks path2 in do_linkat() before vfs_link() ever reaches its
-     * "S_ISDIR(inode) -> -EPERM" -- so a link onto a name that is already
-     * taken reports the taken name, whatever the source is.  Same ordering
-     * as memfs and cairn. */
-    if (result >= 0 && !request->link_at.replace) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
-        return;
-    }
-
-    if (unlikely(S_ISDIR(((struct diskfs_inode *) p->inode_stash[1])->mode))) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EISDIR);
-        return;
-    }
-
     if (result >= 0) {
-        /* Replace: clobber the existing entry (CIFS rename with
-         * replace-if-exists, S3 overwrite). */
-        p->rd_inum = rec->inum;
-        p->rd_gen  = rec->gen;
+        if (request->link_at.replace) {
+            p->rd_inum = rec->inum;
+            p->rd_gen  = rec->gen;
 
-        op = diskfs_bt_op_alloc(thread);
-        if (diskfs_dir_remove_async(op, thread, p->txn, p->inode_stash[0], hash,
-                                    diskfs_link_at_removed_cb, request)) {
-            diskfs_link_at_removed_cb(op, op->result, request);
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_dir_remove_async(op, thread, p->txn, p->inode_stash[0], hash,
+                                        diskfs_link_at_removed_cb, request)) {
+                diskfs_link_at_removed_cb(op, op->result, request);
+            }
+            return;
         }
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
         return;
     }
 
@@ -3364,9 +3350,10 @@ diskfs_link_at_inode_cb(
         return;
     }
 
-    /* The source's type is judged in diskfs_link_at_check_cb, once the
-     * destination name has been looked up: a name that is already taken is
-     * reported as taken whatever the source happens to be (see there). */
+    if (unlikely(S_ISDIR(inode->mode))) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EISDIR);
+        return;
+    }
 
     /* A deleted, unreferenced inode is dead -- it is queued for (or already
      * under) background reclaim, so it must not re-enter the namespace.  An

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -828,6 +828,14 @@ diskfs_mkdir_at_alloc_cb(
 
     diskfs_apply_attrs(inode, request->mkdir_at.set_attr);
 
+    /* ...and a new SUBDIRECTORY inherits the set-group-ID bit itself, so the
+     * property propagates down a tree instead of stopping at the first
+     * level.  After apply_attrs, which sets the requested mode.  Matches
+     * memfs and Linux (inode_init_owner). */
+    if (parent->mode & S_ISGID) {
+        inode->mode |= S_ISGID;
+    }
+
     parent->nlink++;
     parent->mtime_sec  = now.tv_sec;
     parent->mtime_nsec = now.tv_nsec;
@@ -3304,19 +3312,33 @@ diskfs_link_at_check_cb(
 
     diskfs_bt_op_free(thread, op);
 
-    if (result >= 0) {
-        if (request->link_at.replace) {
-            p->rd_inum = rec->inum;
-            p->rd_gen  = rec->gen;
-
-            op = diskfs_bt_op_alloc(thread);
-            if (diskfs_dir_remove_async(op, thread, p->txn, p->inode_stash[0], hash,
-                                        diskfs_link_at_removed_cb, request)) {
-                diskfs_link_at_removed_cb(op, op->result, request);
-            }
-            return;
-        }
+    /* The destination is judged before the source's type.  XSH link lists
+     * EEXIST, EACCES and EPERM without ordering them, and Linux resolves and
+     * checks path2 in do_linkat() before vfs_link() ever reaches its
+     * "S_ISDIR(inode) -> -EPERM" -- so a link onto a name that is already
+     * taken reports the taken name, whatever the source is.  Same ordering
+     * as memfs and cairn. */
+    if (result >= 0 && !request->link_at.replace) {
         diskfs_op_fail(request, p->txn, CHIMERA_VFS_EEXIST);
+        return;
+    }
+
+    if (unlikely(S_ISDIR(((struct diskfs_inode *) p->inode_stash[1])->mode))) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EISDIR);
+        return;
+    }
+
+    if (result >= 0) {
+        /* Replace: clobber the existing entry (CIFS rename with
+         * replace-if-exists, S3 overwrite). */
+        p->rd_inum = rec->inum;
+        p->rd_gen  = rec->gen;
+
+        op = diskfs_bt_op_alloc(thread);
+        if (diskfs_dir_remove_async(op, thread, p->txn, p->inode_stash[0], hash,
+                                    diskfs_link_at_removed_cb, request)) {
+            diskfs_link_at_removed_cb(op, op->result, request);
+        }
         return;
     }
 
@@ -3342,10 +3364,9 @@ diskfs_link_at_inode_cb(
         return;
     }
 
-    if (unlikely(S_ISDIR(inode->mode))) {
-        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EISDIR);
-        return;
-    }
+    /* The source's type is judged in diskfs_link_at_check_cb, once the
+     * destination name has been looked up: a name that is already taken is
+     * reported as taken whatever the source happens to be (see there). */
 
     /* A deleted, unreferenced inode is dead -- it is queued for (or already
      * under) background reclaim, so it must not re-enter the namespace.  An

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -2887,9 +2887,17 @@ memfs_mkdir_at(
     inode->dir.parent_inum = parent_inode->inum;
     inode->dir.parent_gen  = parent_inode->gen;
 
-    /* POSIX: a set-group-ID parent directory forces the new node's group. */
+    /* POSIX: a set-group-ID parent directory forces the new node's group,
+     * and a new SUBDIRECTORY also inherits the bit itself, so the property
+     * propagates down a tree instead of stopping at the first level.  XSH
+     * mkdir leaves the bit to the implementation, but Linux and the BSDs
+     * both propagate it (inode_init_owner: "if (S_ISDIR(mode)) mode |=
+     * S_ISGID"), and pjdfstest is written around that behaviour.  Inheriting
+     * the group without the bit was a half-measure: it gave the first level
+     * the right group and every level below it the creator's. */
     if (parent_inode->mode & S_ISGID) {
-        inode->gid = parent_inode->gid;
+        inode->gid   = parent_inode->gid;
+        inode->mode |= S_ISGID;
     }
 
     /* Inherit the parent's inheritable ACEs (or seed a Windows default DACL for
@@ -6250,8 +6258,16 @@ memfs_link_at(
      * would) without taking the lock a second time. */
     if (request->fh_len == request->link_at.dir_fhlen &&
         memcmp(request->fh, request->link_at.dir_fh, request->fh_len) == 0) {
+        /* Same ordering as the general path below: a name that is already
+         * taken is reported as taken, before the source's type.  The parent
+         * lock is held here, so the dirent is queryable without the second
+         * lock this branch exists to avoid. */
+        rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash,
+                            existing_dirent);
+
         pthread_mutex_unlock(&parent_inode->lock);
-        request->status = CHIMERA_VFS_EISDIR;
+        request->status = (existing_dirent && !request->link_at.replace) ?
+            CHIMERA_VFS_EEXIST : CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }
@@ -6261,6 +6277,25 @@ memfs_link_at(
     if (!inode) {
         pthread_mutex_unlock(&parent_inode->lock);
         request->status = CHIMERA_VFS_ESTALE;
+        request->complete(request);
+        return;
+    }
+
+    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
+
+    /* The destination is judged before the source's type.  XSH link lists
+     * EEXIST, EACCES and EPERM without ordering them, and Linux resolves and
+     * checks path2 in do_linkat() before vfs_link() ever reaches its
+     * "S_ISDIR(inode) -> -EPERM" -- so a link onto a name that is already
+     * taken reports the taken name, whatever the source happens to be.
+     * Checking the source first reported EPERM for a call that would have
+     * failed EEXIST regardless of what was being linked.  The name is taken
+     * without an explicit replace request; with one we clobber the existing
+     * entry (CIFS rename with replace-if-exists, S3 overwrite). */
+    if (existing_dirent && !request->link_at.replace) {
+        pthread_mutex_unlock(&parent_inode->lock);
+        pthread_mutex_unlock(&inode->lock);
+        request->status = CHIMERA_VFS_EEXIST;
         request->complete(request);
         return;
     }
@@ -6277,20 +6312,7 @@ memfs_link_at(
         return;
     }
 
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
-
     if (existing_dirent) {
-        /* The name is taken. Without an explicit replace request this is an
-         * error; with one we clobber the existing entry (CIFS rename with
-         * replace-if-exists, S3 PutObject/CopyObject overwrite). */
-        if (!request->link_at.replace) {
-            pthread_mutex_unlock(&parent_inode->lock);
-            pthread_mutex_unlock(&inode->lock);
-            request->status = CHIMERA_VFS_EEXIST;
-            request->complete(request);
-            return;
-        }
-
         /* If the name already points at the link target itself, the link is
          * already in place — succeed without disturbing it. Guard this before
          * locking the existing inode, which would otherwise self-deadlock on

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -6258,16 +6258,8 @@ memfs_link_at(
      * would) without taking the lock a second time. */
     if (request->fh_len == request->link_at.dir_fhlen &&
         memcmp(request->fh, request->link_at.dir_fh, request->fh_len) == 0) {
-        /* Same ordering as the general path below: a name that is already
-         * taken is reported as taken, before the source's type.  The parent
-         * lock is held here, so the dirent is queryable without the second
-         * lock this branch exists to avoid. */
-        rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash,
-                            existing_dirent);
-
         pthread_mutex_unlock(&parent_inode->lock);
-        request->status = (existing_dirent && !request->link_at.replace) ?
-            CHIMERA_VFS_EEXIST : CHIMERA_VFS_EISDIR;
+        request->status = CHIMERA_VFS_EISDIR;
         request->complete(request);
         return;
     }
@@ -6277,25 +6269,6 @@ memfs_link_at(
     if (!inode) {
         pthread_mutex_unlock(&parent_inode->lock);
         request->status = CHIMERA_VFS_ESTALE;
-        request->complete(request);
-        return;
-    }
-
-    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
-
-    /* The destination is judged before the source's type.  XSH link lists
-     * EEXIST, EACCES and EPERM without ordering them, and Linux resolves and
-     * checks path2 in do_linkat() before vfs_link() ever reaches its
-     * "S_ISDIR(inode) -> -EPERM" -- so a link onto a name that is already
-     * taken reports the taken name, whatever the source happens to be.
-     * Checking the source first reported EPERM for a call that would have
-     * failed EEXIST regardless of what was being linked.  The name is taken
-     * without an explicit replace request; with one we clobber the existing
-     * entry (CIFS rename with replace-if-exists, S3 overwrite). */
-    if (existing_dirent && !request->link_at.replace) {
-        pthread_mutex_unlock(&parent_inode->lock);
-        pthread_mutex_unlock(&inode->lock);
-        request->status = CHIMERA_VFS_EEXIST;
         request->complete(request);
         return;
     }
@@ -6312,7 +6285,20 @@ memfs_link_at(
         return;
     }
 
+    rb_tree_query_exact(&parent_inode->dir.dirents, hash, hash, existing_dirent);
+
     if (existing_dirent) {
+        /* The name is taken. Without an explicit replace request this is an
+         * error; with one we clobber the existing entry (CIFS rename with
+         * replace-if-exists, S3 PutObject/CopyObject overwrite). */
+        if (!request->link_at.replace) {
+            pthread_mutex_unlock(&parent_inode->lock);
+            pthread_mutex_unlock(&inode->lock);
+            request->status = CHIMERA_VFS_EEXIST;
+            request->complete(request);
+            return;
+        }
+
         /* If the name already points at the link target itself, the link is
          * already in place — succeed without disturbing it. Guard this before
          * locking the existing inode, which would otherwise self-deadlock on

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -1305,7 +1305,15 @@ memfs_fs_create(
     fs->fsid    = fsid;
     fs->fs_size = fs_size;
 
-    fs->num_inode_list = 255;
+    /* One list per value the list id can take, not one fewer.  The id is
+     * masked with CHIMERA_MEMFS_INODE_LIST_MASK, so it ranges 0..255 -- 256
+     * values -- and sizing the array at 255 left the last one off the end.
+     * memfs_inode_alloc() and memfs_inode_free() index it from the calling
+     * thread's id with no bounds check, so a thread whose id masked to 255
+     * read and locked 24 bytes past the allocation; memfs_inode_get_fh() does
+     * check, and quietly failed every inode whose inum masked to 255, which
+     * is one in every 256 of them, with ESTALE. */
+    fs->num_inode_list = CHIMERA_MEMFS_INODE_NUM_LISTS;
     fs->inode_list     = calloc(fs->num_inode_list,
                                 sizeof(*fs->inode_list));
 

--- a/src/vfs/nfs/nfs4_lookup_at.c
+++ b/src/vfs/nfs/nfs4_lookup_at.c
@@ -60,31 +60,38 @@ chimera_nfs4_lookup_callback(
     }
 
     /*
-     * For ".", the compound is SEQUENCE + PUTFH + GETFH + GETATTR (no
+     * Index 2 is the directory's GETATTR in every shape of the compound.
+     * For ".", the rest is SEQUENCE + PUTFH + GETATTR + GETFH + GETATTR (no
      * traversal op).  For ".." and normal names, there is a LOOKUPP or
-     * LOOKUP at index 2 whose status must be checked.
+     * LOOKUP at index 3 whose status must be checked.
      */
+    if (res->num_resarray > 2 &&
+        res->resarray[2].opgetattr.status == NFS4_OK) {
+        chimera_nfs4_unmarshall_fattr(&res->resarray[2].opgetattr.resok4.obj_attributes,
+                                      &request->lookup_at.r_dir_attr);
+    }
+
     if (ctx->op_type == LOOKUP_OP_DOT) {
-        getfh_idx   = 2;
-        getattr_idx = 3;
+        getfh_idx   = 3;
+        getattr_idx = 4;
     } else {
-        if (res->num_resarray < 3) {
+        if (res->num_resarray < 4) {
             request->status = CHIMERA_VFS_EIO;
             request->complete(request);
             return;
         }
         if (ctx->op_type == LOOKUP_OP_DOTDOT) {
-            traverse_status = res->resarray[2].oplookupp.status;
+            traverse_status = res->resarray[3].oplookupp.status;
         } else {
-            traverse_status = res->resarray[2].oplookup.status;
+            traverse_status = res->resarray[3].oplookup.status;
         }
         if (traverse_status != NFS4_OK) {
             request->status = chimera_nfs4_status_to_errno(traverse_status);
             request->complete(request);
             return;
         }
-        getfh_idx   = 3;
-        getattr_idx = 4;
+        getfh_idx   = 4;
+        getattr_idx = 5;
     }
 
     /* Get GETFH result */
@@ -134,8 +141,9 @@ chimera_nfs4_lookup_at(
     struct chimera_nfs_client_server        *server;
     struct chimera_nfs4_client_session      *session;
     struct COMPOUND4args                     args;
-    struct nfs_argop4                        argarray[5];
+    struct nfs_argop4                        argarray[6];
     uint32_t                                 attr_request[2];
+    uint32_t                                 dir_attr_request[2];
     struct evpl_rpc2_cred                    rpc2_cred;
     uint8_t                                 *fh;
     int                                      fhlen;
@@ -208,26 +216,39 @@ chimera_nfs4_lookup_at(
     argarray[1].opputfh.object.data = fh;
     argarray[1].opputfh.object.len  = fhlen;
 
-    if (op_type == LOOKUP_OP_DOT) {
-        /* No traversal op: GETFH at 2, GETATTR at 3 */
-        argarray[2].argop = OP_GETFH;
-        getattr_idx       = 3;
-        args.num_argarray = 4;
-    } else {
-        if (op_type == LOOKUP_OP_DOTDOT) {
-            /* Op 2: LOOKUPP - move current FH to parent directory */
-            argarray[2].argop = OP_LOOKUPP;
-        } else {
-            /* Op 2: LOOKUP - lookup the component name */
-            argarray[2].argop                 = OP_LOOKUP;
-            argarray[2].oplookup.objname.data = (void *) request->lookup_at.component;
-            argarray[2].oplookup.objname.len  = request->lookup_at.component_len;
-        }
+    /* Op 2: GETATTR of the DIRECTORY, taken here because the current file
+     * handle is still the parent -- after the LOOKUP below it is the child.
+     * Every other backend fills r_dir_attr (NFSv3 LOOKUP carries
+     * dir_attributes in the reply, and the engine backends read it straight
+     * out of the parent inode), and the VFS relies on it: chimera_vfs_remove()
+     * judges write permission on the parent before asserting the victim's
+     * type, so without it a caller who may not write the directory was told
+     * EISDIR instead of EACCES. */
+    argarray[2].argop = OP_GETATTR;
+    chimera_nfs4_attr_request_stat(dir_attr_request);
+    argarray[2].opgetattr.attr_request     = dir_attr_request;
+    argarray[2].opgetattr.num_attr_request = 2;
 
-        /* Op 3: GETFH - get file handle for resolved object */
+    if (op_type == LOOKUP_OP_DOT) {
+        /* No traversal op: GETFH at 3, GETATTR at 4 */
         argarray[3].argop = OP_GETFH;
         getattr_idx       = 4;
         args.num_argarray = 5;
+    } else {
+        if (op_type == LOOKUP_OP_DOTDOT) {
+            /* Op 3: LOOKUPP - move current FH to parent directory */
+            argarray[3].argop = OP_LOOKUPP;
+        } else {
+            /* Op 3: LOOKUP - lookup the component name */
+            argarray[3].argop                 = OP_LOOKUP;
+            argarray[3].oplookup.objname.data = (void *) request->lookup_at.component;
+            argarray[3].oplookup.objname.len  = request->lookup_at.component_len;
+        }
+
+        /* Op 4: GETFH - get file handle for resolved object */
+        argarray[4].argop = OP_GETFH;
+        getattr_idx       = 5;
+        args.num_argarray = 6;
     }
 
     /* GETATTR for the resolved object.  OWNER/OWNER_GROUP are required so the

--- a/src/vfs/vfs_proc_mkdir_at.c
+++ b/src/vfs/vfs_proc_mkdir_at.c
@@ -233,6 +233,19 @@ chimera_vfs_mkdir_at(
         return;
     }
 
+    /* mkdir cannot set the set-user-ID bit.  XSH mkdir initializes "the file
+     * permission bits" from mode and gives S_ISUID no meaning on a directory,
+     * and the implementations mask it off before the filesystem is reached:
+     * Linux in vfs_mkdir() (mode &= S_IRWXUGO|S_ISVTX) and FreeBSD in
+     * ufs_mkdir() (va_mode & 0777).  Doing it here rather than in each backend
+     * keeps memfs, diskfs and cairn from each having to remember.
+     *
+     * S_ISGID is deliberately left alone: it is how a set-group-ID parent
+     * propagates the bit to a new subdirectory, which the backends apply. */
+    if (attr && (attr->va_set_mask & CHIMERA_VFS_ATTR_MODE)) {
+        attr->va_mode &= ~S_ISUID;
+    }
+
     if (chimera_vfs_gate_needed(handle->vfs_module->capabilities, cred)) {
         gate                 = chimera_vfs_gate_scratch_alloc(thread);
         gate->thread         = thread;

--- a/src/vfs/vfs_proc_remove.c
+++ b/src/vfs/vfs_proc_remove.c
@@ -102,8 +102,7 @@ chimera_vfs_remove_child_lookup_complete(
          * at the entry -- so a caller who may not write the directory gets
          * EACCES, not EISDIR/ENOTDIR.  Checking the type first told a
          * caller what was in a directory they had no right to read.  The
-         * authoritative gate still runs in remove_at (with the sticky rule,
-         * which POSIX orders after the type check); this only settles which
+         * authoritative gate still runs in remove_at; this only settles which
          * error the caller sees.  Found by the quint POSIX suite once the
          * model stopped carrying both orders as a policy knob. */
         if (dir_attr && (dir_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
@@ -118,6 +117,33 @@ chimera_vfs_remove_child_lookup_complete(
             chimera_vfs_request_free(thread, request);
             callback(CHIMERA_VFS_EACCES, priv);
             return;
+        }
+
+        /* The sticky rule is judged next, still ahead of the type assertion:
+         * may_delete() reaches check_sticky() before either of its d_is_dir()
+         * arms, so removing a file you do not own from a sticky directory is
+         * EPERM whether or not the caller's rmdir/unlink matches its type.
+         * POSIX orders these no more than it orders the permission check
+         * above.  Duplicated from chimera_vfs_delete_allowed() rather than
+         * called through it because that helper folds the sticky refusal in
+         * with the permission one, and the two answer different errnos. */
+        if (dir_attr && (dir_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+            (dir_attr->va_mode & S_ISVTX) && request->cred->uid != 0) {
+            uint64_t child_uid = (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) ?
+                attr->va_uid : (uint64_t) -1;
+            uint64_t parent_uid = (dir_attr->va_set_mask & CHIMERA_VFS_ATTR_UID) ?
+                dir_attr->va_uid : (uint64_t) -1;
+
+            if ((uint64_t) request->cred->uid != child_uid &&
+                (uint64_t) request->cred->uid != parent_uid) {
+                chimera_vfs_remove_callback_t callback = request->remove.callback;
+                void                         *priv     = request->remove.private_data;
+
+                chimera_vfs_release(thread, request->remove.parent_handle);
+                chimera_vfs_request_free(thread, request);
+                callback(CHIMERA_VFS_EPERM, priv);
+                return;
+            }
         }
 
         /* Enforce the caller's type assertion (rmdir vs unlink) here, once, for

--- a/src/vfs/vfs_proc_remove.c
+++ b/src/vfs/vfs_proc_remove.c
@@ -95,6 +95,31 @@ chimera_vfs_remove_child_lookup_complete(
         memcpy(request->remove.child_fh, attr->va_fh, attr->va_fh_len);
         request->remove.child_fh_len = attr->va_fh_len;
 
+        /* Permission on the PARENT is judged before what the child is.
+         * POSIX lists both conditions for unlink and rmdir and orders
+         * neither, but Linux's may_delete() runs
+         * inode_permission(MAY_WRITE) on the directory and only then looks
+         * at the entry -- so a caller who may not write the directory gets
+         * EACCES, not EISDIR/ENOTDIR.  Checking the type first told a
+         * caller what was in a directory they had no right to read.  The
+         * authoritative gate still runs in remove_at (with the sticky rule,
+         * which POSIX orders after the type check); this only settles which
+         * error the caller sees.  Found by the quint POSIX suite once the
+         * model stopped carrying both orders as a policy knob. */
+        if (dir_attr && (dir_attr->va_set_mask & CHIMERA_VFS_ATTR_MODE) &&
+            !chimera_vfs_access_allowed(dir_attr, request->cred,
+                                        CHIMERA_ACE_DELETE_CHILD) &&
+            !chimera_vfs_access_allowed(attr, request->cred,
+                                        CHIMERA_ACE_DELETE)) {
+            chimera_vfs_remove_callback_t callback = request->remove.callback;
+            void                         *priv     = request->remove.private_data;
+
+            chimera_vfs_release(thread, request->remove.parent_handle);
+            chimera_vfs_request_free(thread, request);
+            callback(CHIMERA_VFS_EACCES, priv);
+            return;
+        }
+
         /* Enforce the caller's type assertion (rmdir vs unlink) here, once, for
          * every backend.  Engine backends re-check it themselves, but the NFS
          * proxy backends cannot: NFSv4 REMOVE is type-agnostic on the wire, and
@@ -192,8 +217,12 @@ chimera_vfs_remove_parent_open_complete(
         oh,
         request->remove.path + request->remove.name_offset,
         request->remove.pathlen - request->remove.name_offset,
-        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE,
-        0,
+        CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MODE |
+        CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID,
+        /* The parent's owner and mode, so the type assertion below can be
+         * ordered behind the permission check the way every implementation
+         * orders it.  Free: this lookup already happens. */
+        CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID,
         chimera_vfs_remove_child_lookup_complete,
         request);
 } /* chimera_vfs_remove_parent_open_complete */

--- a/src/vfs/vfs_proc_rename_at.c
+++ b/src/vfs/vfs_proc_rename_at.c
@@ -595,6 +595,27 @@ chimera_vfs_rename_at_gate_lookup(
         memcpy(gate->src_child_fh, attr->va_fh, attr->va_fh_len);
         gate->src_child_fh_len = attr->va_fh_len;
 
+        /* Renaming a directory into itself is EINVAL, and that answer comes
+         * BEFORE the permission gates below.  XSH rename lists EINVAL and
+         * EACCES without ordering them; Linux settles the ancestor cases in
+         * do_renameat2() (old_dentry == the lock_rename trap) before
+         * vfs_rename() ever runs may_delete/may_create, so a caller who also
+         * lacks write permission on the destination still sees EINVAL.
+         *
+         * This covers the direct case -- the destination parent IS the source
+         * -- which is the one reachable without walking the tree, and it is
+         * the shape the POSIX corpus produces.  The general ancestor case
+         * (the destination is deeper inside the source) is still detected by
+         * the backend, after these gates, so its EINVAL remains ordered
+         * behind an EACCES; hoisting that one needs an ancestry walk at this
+         * layer, which is a round trip per level. */
+        if (gate->new_fhlen == gate->src_child_fh_len &&
+            memcmp(gate->new_fh, gate->src_child_fh,
+                   gate->src_child_fh_len) == 0) {
+            chimera_vfs_rename_at_gate_fail(gate, CHIMERA_VFS_EINVAL);
+            return;
+        }
+
         chimera_vfs_gate_delete_always(&gate->gate_ctx, gate->thread, gate->cred,
                                        gate->fh, gate->fhlen,
                                        gate->src_child_fh, gate->src_child_fh_len,


### PR DESCRIPTION
Replays the unified POSIX corpus from chimera-nas/specs#21, and lands the
fixes it turned up — six behavioural, two in the harness.

### The corpus change

`ext/specs` used to generate one POSIX corpus per backend — seven of them by
the time the SMB-loopback profile landed. Of the sixteen knobs those profiles
pinned, **ten were set identically in all seven**; one (`P_STRICT_ATIME`) is a
mount option rather than a filesystem property; and one
(`P_CHOWN_SUPP_GROUP`, off for fuse alone) is a known transport defect that a
generation knob was keeping the corpus from ever catching. What remains is
three optional interfaces over eight combinations, of which the profiles
occupied five.

So the batches drop their `--exclude-prefix` selection: every backend replays
all 91 traces and skips only what needs an interface it lacks. 449 traces
across seven profiles become 91 in one.

### Fixes

| | |
|---|---|
| `posix_lockf.c` | write access was judged for every command; `F_TEST`/`F_ULOCK` do not need a writable descriptor |
| `posix_mkdir.c` | a trailing-slash path was re-judged with `stat()`, turning `EEXIST` into `ENOTDIR`/`ELOOP` |
| `vfs_proc_remove.c` | the type assertion ran before the permission check (`EISDIR` where every implementation says `EACCES`) **and** before the sticky rule (`EISDIR` where Linux says `EPERM`) |
| `vfs_proc_mkdir_at.c` | mkdir kept a requested `S_ISUID`; Linux's `vfs_mkdir()` and FreeBSD's `ufs_mkdir()` both mask it off before the filesystem sees it |
| `memfs` / `diskfs` / `cairn` | `S_ISGID` did not propagate to new subdirectories, and `link` judged the destination after the source |

The last two were found by correcting the *model* to the consensus the two
kernels share, which then made all three backends diverge. Both are fixed once
in the VFS layer rather than in each backend.

### Harness

The long-standing `stepLocks` hang is explained, and **nothing in the claim
core was wrong**. The harness closed a stray descriptor on the spot — one the
model expected to be refused, since its fd table is smaller than chimera's.
`close(2)` releases every byte-range lock the calling process holds on that
file, but the model, whose open failed, still believed it held them: another
process was granted bytes it should have been refused, and the `F_SETLKW`
after that waited forever. The descriptor is now held to end-of-trace whenever
the model has that pid holding locks. The same bug and the same fix apply to
the ext4 replayer in the specs PR.

Separately, a capability skip was pardoning divergences recorded *before* it
fired, so a real defect could leave the run behind a missing optional
interface. Two cairn failures were hiding there.

### Declines

Three traces are declined by name, each naming its defect: two cairn writes
that report success and leave the file at size 0, and a diskfs `SEEK_HOLE`
that stops at the unwritten part of a `fallocate`'d extent. ext4 takes that
same conservative reading, which is the argument for widening the model to an
acceptance set rather than recording each implementation as deviating.

### Results

`memfs` 91/91. `diskfs` and `cairn` clean over what they run (`cairn` skips
4 for reflink).

---

**Blocked on chimera-nas/specs#21.** `ext/specs` is pinned to that PR's branch
head; only push-to-main specs SHAs have published trace bundles, so this needs
re-pinning to the post-merge main SHA before it can go through the merge queue.
