### PR TITLE
ext: advance libevpl to drop the premature sqpoll wakeup

### DIFF
--- a/scripts/netns_test_wrapper.sh
+++ b/scripts/netns_test_wrapper.sh
@@ -89,6 +89,23 @@ if [ "${STATUS}" -gt 128 ]; then
                 printf '  isa:     %s ABSENT\n' "${f}" >&2
             fi
         done
+        # The ISA data has since ruled the hardware out -- avx2/bmi2/fma are all
+        # present on the runners that fail, so -march=x86-64-v3 is satisfied.
+        # What is left is the binary and the plugin it dlopens, which come from
+        # the container image and are built against each other's headers
+        # (src/fio builds with include_directories(/fio)).  Name the version of
+        # the binary that died, so a drift between the image's fio and the one
+        # the plugin was compiled for is visible rather than inferred.
+        echo "  binary:  $1" >&2
+        # Bounded: this runs on an already-failing path and must not be the
+        # thing that hangs.  Falls back when timeout(1) is unavailable rather
+        # than reporting its own absence as the version.
+        if command -v timeout >/dev/null 2>&1; then
+            timeout 5 "$1" --version 2>&1 | head -2 | sed 's/^/  version: /' >&2 || true
+        else
+            "$1" --version 2>&1 | head -2 | sed 's/^/  version: /' >&2 || true
+        fi
+
         # The plugin is dlopened, so a mismatch there is invisible to ldd on the
         # host binary; name it explicitly when the job file points at one.
         for arg in "$@"; do


### PR DESCRIPTION
Two commits: the libevpl pin, and one diagnostic addition. Deliberately narrow — the rest of what extended is still failing on is not yet understood well enough to fix, and I would rather say so than ship guesses.

## The pin

```
55299ff io_uring: stop waking the sqpoll thread before the SQE is visible   (libevpl#165)
```

Rebased: main has since advanced its own pin to `895056e` and adapted the
harness for it in 13c54c4e, so this is now a single-commit move.

`55299ff` **fixes a regression the previous pin introduced.** Correcting which word `IORING_SQ_NEED_WAKEUP` is read from woke up a check that had been dead for most of that file's life — and that check ran *before* `io_uring_submit()`, which is the wrong order. `io_uring_get_sqe()` advances only liburing's private tail, so the poller wakes to an unchanged ring, finds nothing to do, and sleeps again — clearing the very flag `io_uring_submit()` is about to consult. liburing then skips the syscall and the SQE sits unconsumed.

The last extended run shows exactly that. Stall dumps in `smb2.maxfid` fell from six to two under the previous pin, but the terminal stall remained:

```
IL stall: blocked on retire slot 26057 -- record seq=26057
log_offset=17436672 len=16384 chunks=1/1 outstanding entries=1
```

…while `"woke the kernel sqpoll thread"` fired **183 times** in the same log. `io_uring_submit()` already does that check in the only correct order, so the hand-rolled one is deleted rather than moved.

Whether this clears the stall is for the next extended run to say. What is certain is that the deleted path was unsound and was executing constantly in the run that still stalled.

## The diagnostic

The ISA data from the last run **rules the hardware out** for the fio SIGILL — the failing runners report `avx2`, `bmi2`, `fma`, `sse4_2` all present, so `-march=x86-64-v3` is satisfied. What remains is the binary and the plugin it dlopens: both come from the container image, and `src/fio` builds against that image's fio source tree (`include_directories(/fio)`), so the two can drift without anything in this repository changing. So: report the version of the binary that died.

## What I deliberately left out

- **fio SIGILL** — no fix, because I do not have one. fio version-checks external ioengines at load and would reject a stale plugin cleanly rather than crash, so a plain ABI mismatch does not fit either. The commit above adds the one measurement that would distinguish it.
- **wpts `ChangeStreamName`** — understood (MS-FSA treats `FILE_NOTIFY_CHANGE_STREAM_NAME` as a distinct filter bit, reported against a different object) but it is a server behaviour change and belongs in its own PR.
- **KVM `nfstest` timeouts** — the `TIMEOUT 900` hardening is already in #1650; not duplicated here.
- **`batch_pnfs_cairn` use-after-free** — a real teardown race (`chimera_server_unmount` frees its temp VFS thread while a delegated cairn commit is still in flight) with no fix yet.

## A krb5p fix that is no longer needed

The first version of this branch also adapted `nfs3_mbt_common.h`, because the
earlier pin carried `895056e` and that commit changed `krb5_local`'s contract —
the initiator provider takes an identity, not the realm. chimera compiles that
helper straight into its MBT targets, so "test-only in libevpl" was not
test-only here, and eight krb5p tests crashed with *"initiator would not start a
context"*. Both accessors return `void *`, so it compiled silently.

Main has since fixed it properly in 13c54c4e — `mbt_gss_identity(env, uid)`, a
real per-uid identity rather than my one-line substitution, which is the point
of the libevpl change. That commit is dropped.

Debug build clean; wrapper `bash -n` clean and its SIGILL path exercised with a simulated signal death.
