### PR TITLE
smb: a stream that appears is a STREAM_NAME change

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -2460,6 +2460,39 @@ chimera_smb_create_open_stream_callback(
     chimera_vfs_release(vfs_thread, base_oh);
     request->create.base_oh = NULL;
 
+    /*
+     * A stream that did not exist before now does: MS-FSA 2.1.5.1 raises
+     * FILE_NOTIFY_CHANGE_STREAM_NAME for it, and a client watching the
+     * containing directory expects to be woken (WPTS
+     * BVT_SMB2Basic_ChangeNotify_ChangeStreamName registers exactly that filter
+     * on the directory, with WATCH_TREE, and then has a second client create a
+     * stream on a file that already existed).
+     *
+     * This path returns through chimera_smb_create_finish_with_eas rather than
+     * chimera_smb_create_open_finish, so it never reached the emit there and a
+     * stream create notified nobody at all.
+     *
+     * STREAM_NAME alone: no directory entry appeared.  Raising FILE_ADDED as
+     * the file-create path does would wake FILE_NOTIFY_CHANGE_FILE_NAME
+     * watchers for a file that was already there.  The name reported is the
+     * base file's -- the entry the directory actually holds -- since the stream
+     * is not one of its entries.
+     */
+    if (request->create.r_created && request->create.parent_handle) {
+        uint64_t skip_lo, skip_hi;
+        bool     has_skip = chimera_smb_parent_lease_skip(
+            open_file->parent_lease_key, &skip_lo, &skip_hi);
+
+        chimera_vfs_notify_emit_lease(request->compound->thread->shared->vfs->vfs_notify,
+                                      request->create.parent_handle->fh,
+                                      request->create.parent_handle->fh_len,
+                                      CHIMERA_VFS_NOTIFY_STREAM_NAME,
+                                      request->create.name,
+                                      request->create.name_len,
+                                      NULL, 0,
+                                      skip_lo, skip_hi, has_skip);
+    }
+
     chimera_smb_create_release_parent(request);
     chimera_smb_create_finish_with_eas(request, open_file);
 } /* chimera_smb_create_open_stream_callback */


### PR DESCRIPTION
`BVT_SMB2Basic_ChangeNotify_ChangeStreamName` has been failing in both the plain and encryption WPTS variants for as long as we have been looking at that suite. This fixes it.

## What the test actually does

I had this recorded as "the client renames an alternate data stream". **It does not.** Reading the source rather than working from that note:

```csharp
SmbClientCreateNewFile(client1, treeIdClient1, filePath);          // file exists first
client1.ChangeNotify(treeIdClient1, fileIdDir,
    CompletionFilter_Values.FILE_NOTIFY_CHANGE_STREAM_NAME,
    flags: CHANGE_NOTIFY_Request_Flags_Values.WATCH_TREE);          // watch the DIRECTORY
...
string dataStreamPath = filePath + ":$DATA";
SmbClientWriteDataStream(client2, treeIdClient2, dataStreamPath, 12);  // CREATE + WRITE + CLOSE
```

No rename anywhere. The file is created *before* the watch is registered, so the notification the file-create path already emits does not count. The only post-registration operation is a second client creating a stream on a file that already existed.

That correction matters: I would have gone looking in `vfs_proc_rename_at.c`, which is the wrong file entirely.

## The defect

A named-stream CREATE completes through `chimera_smb_create_open_stream_callback`, which releases the parent and returns via `chimera_smb_create_finish_with_eas`. The directory notification is emitted in `chimera_smb_create_open_finish` — **which that path never enters.** So creating a stream notified nobody, of any filter.

It is structural rather than a missing case. The file-create path already emits `STREAM_NAME` for a new file's default `$DATA` stream, citing this very test, so the filter semantics were understood; what was missing was the stream path reaching an emit at all.

## The change

Emit `STREAM_NAME` when the stream did not exist before — keyed on the stream open's own `r_created` — against the parent directory, carrying the base file's name, since the stream is not itself a directory entry.

`STREAM_NAME` alone, deliberately: no directory entry appeared, so raising `FILE_ADDED` the way the file-create path does would wake `FILE_NOTIFY_CHANGE_FILE_NAME` watchers for a file that was already there. The parent dir-lease self-exemption is carried over unchanged, so the client doing the create still does not break its own cached view.

## Verification

`ctest -R smb` — **35/35 pass**, including the 11 notify/stream/MBT cases. Debug build clean, uncrustify clean.

What I cannot run locally is WPTS itself; that needs the extended run. The change is derived from the test's own source rather than from its symptom, which is the best I can do short of running it.
