### PR TITLE
kvm: reclaim the guest, so one hung VM cannot wedge the whole shard

### DIFF
--- a/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh
+++ b/kvm/kvm_nfs3_drc_reboot_test_wrapper.sh
@@ -38,6 +38,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -64,6 +78,32 @@ cleanup() {
     fi
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -150,7 +190,7 @@ run_guest() {
     local mount_opts="vers=3,tcp,nconnect=16,nolock"
     local full="mount -t nfs -o ${mount_opts} 10.0.0.1:/share /mnt && ${guest_cmd}"
 
-    ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+    ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
         -enable-kvm -smp 4 -m 1G -cpu host \
         -kernel "$VMLINUZ" \
         $QEMU_MACHINE \

--- a/kvm/kvm_nfs_kerberos_test_wrapper.sh
+++ b/kvm/kvm_nfs_kerberos_test_wrapper.sh
@@ -32,6 +32,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -77,6 +91,32 @@ cleanup() {
     fi
     rm -f "$LOG_FILE"
     rm -rf "$KRB_DIR" "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -285,7 +325,7 @@ else
 fi
 
 # Boot the guest with the 9p krb material + krb5=1 trigger.
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_MACHINE \

--- a/kvm/kvm_nfs_multinode_test_wrapper.sh
+++ b/kvm/kvm_nfs_multinode_test_wrapper.sh
@@ -40,6 +40,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -66,6 +80,32 @@ cleanup() {
     fi
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -155,7 +195,7 @@ run_guest() {
     local mount_opts="vers=4.1,tcp,nconnect=16"
     local full="mount -t nfs -o ${mount_opts} 10.0.0.1:/share /mnt && ${guest_cmd}"
 
-    ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+    ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
         -enable-kvm -smp 4 -m 1G -cpu host \
         -kernel "$VMLINUZ" \
         $QEMU_MACHINE \

--- a/kvm/kvm_nfs_reboot_test_wrapper.sh
+++ b/kvm/kvm_nfs_reboot_test_wrapper.sh
@@ -38,6 +38,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -65,6 +79,32 @@ cleanup() {
     fi
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -155,7 +195,7 @@ run_guest() {
     local mount_opts="vers=${NFS_VERSION},tcp,nconnect=16"
     local full="mount -t nfs -o ${mount_opts} 10.0.0.1:/share /mnt && ${guest_cmd}"
 
-    ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+    ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
         -enable-kvm -smp 4 -m 1G -cpu host \
         -kernel "$VMLINUZ" \
         $QEMU_MACHINE \

--- a/kvm/kvm_nfs_test_wrapper.sh
+++ b/kvm/kvm_nfs_test_wrapper.sh
@@ -30,6 +30,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -87,6 +101,32 @@ cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_FILE"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -237,7 +277,7 @@ TEST_CMD="${NLM_PREP} mount -t nfs -o ${NFS_MOUNT_OPTS} 10.0.0.1:/share /mnt && 
 # Use -serial stdio so serial output goes to stdout in real-time (captured by ctest).
 # Pipe through tee to also write to LOG_FILE for exit code parsing.
 # This ensures guest output is visible even when ctest kills the process on timeout.
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \

--- a/kvm/kvm_nfstest_2client_test_wrapper.sh
+++ b/kvm/kvm_nfstest_2client_test_wrapper.sh
@@ -36,6 +36,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -77,6 +91,32 @@ cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_A" "$LOG_B"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -238,7 +278,7 @@ NFSTEST_MTOPTS="hard,rsize=4096,wsize=4096"
 SSHFIX='mkdir -p /run/sshd; chown root:root /run/sshd; chmod 0755 /run/sshd; chown root:root /root; chmod 700 /root; chown -R root:root /root/.ssh /etc/ssh 2>/dev/null; rm -f /etc/ssh/ssh_config.d/*.conf 2>/dev/null; chmod 700 /root/.ssh 2>/dev/null; chmod 600 /root/.ssh/id_ed25519 /root/.ssh/authorized_keys /root/.ssh/config 2>/dev/null; chmod 600 /etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_ecdsa_key 2>/dev/null; /usr/sbin/sshd'
 
 # ----- guest B (secondary client): idle with sshd up -------------------------
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 2 -m 1G -cpu host \
     -kernel "$VMLINUZ" $QEMU_INITRD $QEMU_MACHINE -nodefaults \
     -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \
@@ -338,7 +378,7 @@ TEST_CMD="${SSHFIX}; mkdir -p /mnt/t; command -v ssh >/dev/null 2>&1 || { echo C
 # 6 GiB is now just comfortable headroom (measured peak with the cap is ~1.5 GiB
 # -- ~1 GiB of rings + ~0.3 GiB of tmpfs captures + the OS); -m is only a
 # ceiling (KVM RAM is demand-paged) so it costs no host memory unless touched.
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 6G -cpu host \
     -kernel "$VMLINUZ" $QEMU_INITRD $QEMU_MACHINE -nodefaults \
     -drive file="$ROOTFS",if=virtio,format=qcow2,snapshot=on \

--- a/kvm/kvm_nfstest_test_wrapper.sh
+++ b/kvm/kvm_nfstest_test_wrapper.sh
@@ -30,6 +30,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -79,6 +93,32 @@ cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_FILE"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -325,7 +365,7 @@ case "$NFSTEST_PROGRAM" in
 esac
 
 # Boot QEMU inside the netns; the guest's /init.sh runs test_cmd (no pre-mount).
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m "${QEMU_MEM}" -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \

--- a/kvm/kvm_pnfs_block_test_wrapper.sh
+++ b/kvm/kvm_pnfs_block_test_wrapper.sh
@@ -42,6 +42,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -157,6 +171,32 @@ cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_FILE"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 # Trap TERM/INT as well as EXIT so a ctest-issued SIGTERM still tears down the
 # netns, the MDS, and the watchdog instead of orphaning them.
@@ -254,7 +294,7 @@ WATCHDOG_PID=$!
 # the first LAYOUTGET.
 TEST_CMD="${TEST_CMD_ARG}"
 
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \

--- a/kvm/kvm_pnfs_proxy_test_wrapper.sh
+++ b/kvm/kvm_pnfs_proxy_test_wrapper.sh
@@ -47,6 +47,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -111,6 +125,32 @@ cleanup() {
     ip link delete "${VETH_BE}" 2>/dev/null || true
     rm -f "$LOG_FILE"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -301,7 +341,7 @@ echo "=== proxy negotiated pNFS-MDS + established back channel ==="
 NFS_MOUNT_OPTS="vers=4.1,tcp"
 TEST_CMD="mount -t nfs -o ${NFS_MOUNT_OPTS} ${PROXY_IP}:/pshare /mnt && ${TEST_CMD_ARG}"
 
-ip netns exec "${FE_NS}" "$QEMU_BIN" \
+ip netns exec "${FE_NS}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \

--- a/kvm/kvm_pnfs_scsi_test_wrapper.sh
+++ b/kvm/kvm_pnfs_scsi_test_wrapper.sh
@@ -62,6 +62,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -116,6 +130,32 @@ cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_FILE"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -202,7 +242,7 @@ echo "=== pNFS SCSI metadata server up on ${MDS_IP}:${MDS_PORT} ==="
 # the MDS and runs the workload.
 TEST_CMD="${TEST_CMD_ARG}"
 
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \

--- a/kvm/kvm_pnfs_test_wrapper.sh
+++ b/kvm/kvm_pnfs_test_wrapper.sh
@@ -43,6 +43,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -143,6 +157,32 @@ cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_FILE"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -356,7 +396,7 @@ grep -q "backing root resolved" "$MDS_LOG" || {
 NFS_MOUNT_OPTS="vers=${NFS_VERSION},tcp"
 TEST_CMD="mount -t nfs -o ${NFS_MOUNT_OPTS} ${MDS_IP}:/share /mnt && ${TEST_CMD_ARG}"
 
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \

--- a/kvm/kvm_smb_test_wrapper.sh
+++ b/kvm/kvm_smb_test_wrapper.sh
@@ -37,6 +37,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 CHIMERA_BINARY=$1; shift
@@ -94,6 +108,32 @@ cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_FILE"
     rm -rf "$SESSION_DIR"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -258,7 +298,7 @@ TEST_CMD="mount -t cifs //10.0.0.1/share /mnt -o ${SMB_MOUNT_OPTS} && ${TEST_CMD
 # Use -serial stdio so serial output goes to stdout in real-time (captured by ctest).
 # Pipe through tee to also write to LOG_FILE for exit code parsing.
 # This ensures guest output is visible even when ctest kills the process on timeout.
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 4 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \

--- a/kvm/kvm_test_wrapper.sh
+++ b/kvm/kvm_test_wrapper.sh
@@ -29,6 +29,20 @@ else
     QEMU_CONSOLE="ttyS0"
 fi
 
+# Upper bound on a single guest, enforced by a process that is not this shell.
+#
+# ctest kills this wrapper when a test times out, and bash does run the EXIT
+# trap on SIGTERM -- but not on SIGKILL, and a foreground qemu is not a job bash
+# tears down either way.  An orphaned qemu keeps the stdout pipe open, ctest
+# blocks forever waiting for EOF on it, and the whole shard wedges until the
+# six-hour job limit: that is how one hung guest has been costing twelve runner
+# hours a night while reporting nothing.
+#
+# timeout(1) is a separate process, so it keeps enforcing after this shell is
+# gone, whatever killed it.  Generous by design -- it is a backstop, not a test
+# budget; ctest's own per-test TIMEOUT is what should normally fire first.
+KVM_QEMU_DEADLINE="${KVM_QEMU_DEADLINE:-2400}"
+
 VMLINUZ=$1; shift
 ROOTFS=$1; shift
 TEST_CMD="$*"
@@ -47,6 +61,32 @@ LOG_FILE=$(mktemp /tmp/kvm_test_XXXXXX.log)
 cleanup() {
     ip netns delete "${NETNS_NAME}" 2>/dev/null || true
     rm -f "$LOG_FILE"
+    # Reclaim the guest.  Everything above kills what this shell started by
+    # PID; qemu runs in the foreground -- and in a pipeline, so $! never named
+    # it -- and nothing was killing it at all.
+    #
+    # Walk our own descendants rather than signalling direct children only:
+    # qemu sits under timeout(1) now, so it is a grandchild, and reaching it
+    # that way would depend on timeout forwarding the signal.  It does, but a
+    # reclaim that silently degrades to a 40-minute wait if that ever changes
+    # is not worth the two saved lines.  Scoped to this shell's own tree, so a
+    # sibling test's guest is never touched -- these run under ctest -j.
+    #
+    # Collect the whole tree before killing any of it: killing a parent first
+    # reparents its children away and loses them.
+    kvm_tree=""
+    kvm_frontier="$(pgrep -P $$ 2>/dev/null)"
+    while [ -n "${kvm_frontier}" ]; do
+        kvm_tree="${kvm_tree} ${kvm_frontier}"
+        kvm_next=""
+        for kvm_p in ${kvm_frontier}; do
+            kvm_next="${kvm_next} $(pgrep -P "${kvm_p}" 2>/dev/null)"
+        done
+        kvm_frontier="${kvm_next}"
+    done
+    for kvm_p in ${kvm_tree}; do
+        kill -TERM "${kvm_p}" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -64,7 +104,7 @@ ip netns exec "${NETNS_NAME}" ip addr add 10.0.0.1/24 dev "${TAP_NAME}"
 ip netns exec "${NETNS_NAME}" ip link set "${TAP_NAME}" up
 
 # Boot QEMU inside the netns
-ip netns exec "${NETNS_NAME}" "$QEMU_BIN" \
+ip netns exec "${NETNS_NAME}" timeout --foreground --kill-after=10s "${KVM_QEMU_DEADLINE}" "$QEMU_BIN" \
     -enable-kvm -smp 2 -m 1G -cpu host \
     -kernel "$VMLINUZ" \
     $QEMU_INITRD \


### PR DESCRIPTION
Both kvm jobs have been cancelled at **exactly 6:00** in four consecutive runs — twelve runner hours a night, for no result. This is why.

## The mechanism

A guest hangs. ctest kills the wrapper on timeout. But qemu runs in the **foreground**, and in a pipeline, so `$!` never named it — and nothing killed it. The orphan keeps the stdout pipe open, ctest blocks forever waiting for EOF, and **no further test reports at all**.

That matches run 34014118017 exactly: test #236 started, the guest printed kernel messages up to `Freeing unused kernel image memory`, and then five hours of complete silence — no `***Timeout` line for that test, and nothing from any other test either, until the job was cancelled.

## Two mechanisms, because one signal is not enough

**`cleanup` walks this shell's descendant tree and terminates it.** bash *does* run an EXIT trap on SIGTERM — which is what ctest sends first — so this reclaims the guest immediately.

It walks the tree rather than signalling direct children because qemu now sits under `timeout(1)` and is a grandchild; reaching it otherwise would depend on `timeout` forwarding the signal. It does — but a reclaim that silently degrades into a forty-minute wait if that ever changes is not worth the saved lines. The tree is collected *before* anything is killed, since killing a parent first reparents its children away. Scoped to our own descendants, so a sibling test's guest is never touched — these run under `ctest -j`.

**`timeout(1)` bounds qemu itself.** No trap runs on SIGKILL, and nothing in this shell can help once it is gone — but `timeout` is a separate process and keeps enforcing after we are reaped. `KVM_QEMU_DEADLINE` defaults to 2400s: a backstop, well clear of the longest per-test `TIMEOUT` (1800) and far inside the job limit. ctest's own timeout should always fire first.

## Verification

Against a wrapper-shaped harness — foreground child in a pipeline, the **actual cleanup body** lifted from the patched wrapper, and a deliberately **non-forwarding** `timeout` stand-in so the worst case is what gets tested — checking the guest by recorded pid rather than by name:

| case | result |
|---|---|
| SIGTERM (what ctest sends) | guest reclaimed by the tree walk |
| SIGKILL (no trap possible) | guest reclaimed by the deadline |

Getting there took three attempts: my first two checks used `pgrep -f`/`pgrep -x` patterns that matched the harness's own processes and reported failures that were not real. Checking a recorded pid is the only version that means anything.

All 13 wrappers, `bash -n` clean. One was nearly missed — `kvm_test_wrapper.sh` does not match a `kvm_*_test_wrapper.sh` glob — which the per-file verification caught.

## Scope

**This fixes no hang.** It makes a hang cost one test instead of a shard, and leaves the guest serial log the wrapper already prints on the way out — which is the evidence the hang itself still needs. The point is that the shard can finish, which is the precondition for judging anything else in it, including whether the four `nfstest_posix` diskfs timeouts are still there.
