### PR TITLE
smb: do not tear down transport on unsigned request to protected conn…

### DIFF
--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -1857,20 +1857,26 @@ chimera_smb_server_handle_smb2(
              * the session encrypt-all (Session.EncryptData) — every
              * post-authentication request must be either signed or encrypted.
              * An unsigned, unencrypted request (e.g. a bare TREE_CONNECT) is a
-             * protocol violation; tear the connection down.  SESSION_SETUP is
-             * exempt (its signing key is only derived while processing it), as
-             * are NEGOTIATE and ECHO; compound related operations inherit the
-             * lead request's protection so only the unrelated lead is checked.
-             * A null (anonymous) session is exempt entirely: it has no key, so
-             * MS-SMB2 3.3.5.5.3 never enforces signing or encryption on it even
-             * when the connection negotiated signing-required (the client drops
-             * the requirement for the IS_NULL session — smb2.session.anon-
-             * signing2's second TREE_CONNECT is deliberately unsigned). */
-            chimera_smb_error("Unsigned, unencrypted request (cmd %u) on a protected connection; disconnecting",
+             * protocol violation, answer STATUS_ACCESS_DENIED rather than
+             * tearing the connection down: the spec makes ACCESS_DENIED
+             * mandatory here and a disconnect only optional (3.3.5.2.4), and
+             * this connection may carry other, unrelated sessions that a
+             * transport teardown would take down collaterally.  SESSION_SETUP
+             * is exempt (its signing key is only derived while processing it),
+             * as are NEGOTIATE and ECHO; compound related operations inherit
+             * the lead request's protection so only the unrelated lead is
+             * checked.  A null (anonymous) session is exempt entirely: it has
+             * no key, so MS-SMB2 3.3.5.5.3 never enforces signing or
+             * encryption on it even when the connection negotiated
+             * signing-required (the client drops the requirement for the
+             * IS_NULL session — smb2.session.anon-signing2's second
+             * TREE_CONNECT is deliberately unsigned). */
+            chimera_smb_error("Unsigned, unencrypted request (cmd %u) on a protected connection",
                               request->smb2_hdr.command);
-            chimera_smb_request_free(thread, request);
-            evpl_close(evpl, conn->bind);
-            return;
+            request->status                              = SMB2_STATUS_ACCESS_DENIED;
+            request->flags                              |= CHIMERA_SMB_REQUEST_FLAG_PARSE_FAILED;
+            compound->requests[compound->num_requests++] = request;
+            goto next_compound_request;
         }
 
         if (unlikely(!request->session_handle &&


### PR DESCRIPTION
## Problem

When signing or encryption is required, Chimera currently closes the TCP connection if it receives an unsigned or unencrypted request (other than NEGOTIATE, SESSION_SETUP or ECHO) without sending an SMB2 response.

As per [spec](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/85df1680-2ee7-4d25-a916-a982371ddc75), the request should instead fail with `STATUS_ACCESS_DENIED`. Disconnecting the connection is optional. 

## Spec

MS-SMB2 requires an unsigned request received with `SigningRequired` set to fail with `STATUS_ACCESS_DENIED`. The server may additionally disconnect the connection.

## Fix

Return `STATUS_ACCESS_DENIED` for the offending request instead of closing the TCP connection. This keeps the connection and other sessions using it alive. This also matches the pattern already used by every other similar per-request protection failure in this same function (eg: bad signature on a null session). All of them answer the single offending request in-band rather than tearing down the transport, so this brings the signing-required case in line with the rest.

## Verification

Some scripts I used that helped verify and confirm the fixed behaviour: 

[break-sign-negotiation.py](https://gist.github.com/sgon-nasuni/afc7d396d279184016224cbbd2de2110#file-break-sign-negotiation-py): Establishes a signed session, sends a valid signed request, then sends an unsigned one. The unsigned request now gets `STATUS_ACCESS_DENIED` instead of causing the connection to be dropped without reporting the error status.

[multi-session-over-single-tcp-test.py](https://gist.github.com/sgon-nasuni/afc7d396d279184016224cbbd2de2110#file-multi-session-over-single-tcp-test-py): Creates 5 SMB sessions over a single TCP connection and sends an unsigned request from one session. The other 4 sessions remain usable. Before the fix, closing the connection caused all 5 sessions to be lost.

Fixes #1474