### PR TITLE
vfs: ring the completion doorbell under the lock; advance libevpl for SQPOLL-off; fio SIGILL probes

### DIFF
--- a/scripts/netns_test_wrapper.sh
+++ b/scripts/netns_test_wrapper.sh
@@ -119,6 +119,57 @@ if [ "${STATUS}" -gt 128 ]; then
                     ;;
             esac
         done
+
+        # Two probes that turn the next occurrence into an answer instead of
+        # another data point.  Both run on an already-failing path, so both
+        # are bounded and neither can change the reported status.
+        #
+        # fio selects its CRC32C implementation at startup -- cpuid on x86,
+        # AT_HWCAP on arm64 -- and the basic jobs verify with crc32c.  A VM
+        # that advertises an instruction it then traps on would die exactly
+        # like this: in the first fraction of a second, on both architectures,
+        # on whichever runner drew that host.  --crctest exercises every
+        # implementation and nothing else, so it either reproduces the SIGILL
+        # in isolation or rules the dispatch out.
+        case "$1" in
+            *fio)
+                echo "  crctest:" >&2
+                CRC_STATUS=0
+                if command -v timeout >/dev/null 2>&1; then
+                    timeout 60 "$1" --crctest > "/tmp/${TEST_NAME}.crctest" 2>&1 || CRC_STATUS=$?
+                else
+                    "$1" --crctest > "/tmp/${TEST_NAME}.crctest" 2>&1 || CRC_STATUS=$?
+                fi
+                sed 's/^/    /' "/tmp/${TEST_NAME}.crctest" >&2
+                rm -f "/tmp/${TEST_NAME}.crctest"
+                echo "    --crctest exit status: ${CRC_STATUS}" >&2
+                ;;
+        esac
+
+        # Then the instruction itself.  Re-run the same command, in the same
+        # namespace with the same preload, under gdb, and print the faulting
+        # PC, its disassembly and a backtrace.  A wild jump into the plugin, a
+        # __builtin_trap, and a genuine unsupported instruction are all
+        # "Illegal instruction" to bash; they are distinct here.  The preload
+        # is handed to the inferior through gdb rather than the environment so
+        # gdb itself does not run under ASAN.  Intermittent failures may not
+        # recur; then the re-run simply passes and says so.
+        if command -v gdb >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+            echo "  gdb re-run:" >&2
+            GDB_ENV=()
+            if [ -n "${SAVED_LD_PRELOAD}" ]; then
+                GDB_ENV=(-ex "set environment LD_PRELOAD=${SAVED_LD_PRELOAD}")
+            fi
+            timeout 300 ip netns exec "${NETNS_NAME}" gdb -q -batch \
+                -ex "set pagination off" \
+                "${GDB_ENV[@]}" \
+                -ex run \
+                -ex "x/3i \$pc" \
+                -ex "info sharedlibrary" \
+                -ex "bt" \
+                -ex "thread apply all bt 8" \
+                --args "$@" 2>&1 | tail -120 | sed 's/^/    /' >&2
+        fi
     fi
 fi
 

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -1561,6 +1561,14 @@ chimera_linux_copy_range(
             if (errno == EINTR) {
                 continue;
             }
+            /* Named because the SMB dup-extents path lands here as the
+             * fallback after a failed clone and reports whatever this returns
+             * as NOT_SUPPORTED or INVALID_PARAMETER; without the errno the
+             * server log cannot say which call refused, or why. */
+            chimera_linux_error(
+                "linux_copy_range: copy_file_range(src_fd=%d off=%lld -> dst_fd=%d off=%lld len=%llu) failed: %s",
+                src_fd, (long long) src_off, dst_fd, (long long) dst_off,
+                (unsigned long long) remaining, strerror(errno));
             request->status = chimera_linux_errno_to_status(errno);
             request->complete(request);
             return;
@@ -1610,6 +1618,17 @@ chimera_linux_clone_range(
     rc = ioctl(dst_fd, FICLONERANGE, &args);
 
     if (rc < 0) {
+        /* EOPNOTSUPP is the everyday answer on a filesystem without reflink
+         * (ext4, overlayfs) and the caller falls back to a copy, so this is
+         * info, not error -- but it is logged: the SMB layer advertises block
+         * refcounting unconditionally, and when a test then sees
+         * NOT_SUPPORTED the only way to tell "clone refused" from "the copy
+         * fallback refused" from "a pre-check refused" is this line. */
+        chimera_linux_info(
+            "linux_clone_range: FICLONERANGE(src_fd=%d off=%llu -> dst_fd=%d off=%llu len=%llu) failed: %s",
+            src_fd, (unsigned long long) args.src_offset, dst_fd,
+            (unsigned long long) args.dest_offset,
+            (unsigned long long) args.src_length, strerror(errno));
         request->status = chimera_linux_errno_to_status(errno);
         request->complete(request);
         return;

--- a/src/vfs/vfs_internal.h
+++ b/src/vfs/vfs_internal.h
@@ -572,11 +572,19 @@ chimera_vfs_complete_delegate(struct chimera_vfs_request *request)
 {
     struct chimera_vfs_thread *thread = request->thread;
 
+    /* Ring under the lock.  The owning thread pops this list under the same
+     * lock, so it cannot see the request -- and cannot run to completion and
+     * chimera_vfs_thread_destroy() itself -- until this critical section ends,
+     * which is after the last touch of *thread here.  Ringing after the unlock
+     * left a window where a concurrent ring (a close-thread completion during
+     * umount, say) woke the owner first; it drained the list, its synchronous
+     * caller returned, destroyed the thread, and this ring then read the freed
+     * doorbell (ASAN heap-use-after-free in evpl_wakeup_signal from
+     * cairn_thread_commit, seen in batch_pnfs_cairn). */
     pthread_mutex_lock(&thread->lock);
     DL_APPEND(thread->pending_complete_requests, request);
-    pthread_mutex_unlock(&thread->lock);
-
     evpl_ring_doorbell(&thread->doorbell);
+    pthread_mutex_unlock(&thread->lock);
 } /* chimera_vfs_complete_delegate */
 
 /* Marshal a parked I/O request back to its owning thread to resume.  The
@@ -590,11 +598,11 @@ chimera_vfs_io_resume_post(struct chimera_vfs_request *request)
 {
     struct chimera_vfs_thread *thread = request->thread;
 
+    /* Ring under the lock; see chimera_vfs_complete_delegate. */
     pthread_mutex_lock(&thread->lock);
     DL_APPEND(thread->pending_io_resume, request);
-    pthread_mutex_unlock(&thread->lock);
-
     evpl_ring_doorbell(&thread->doorbell);
+    pthread_mutex_unlock(&thread->lock);
 } /* chimera_vfs_io_resume_post */
 
 static inline void

--- a/src/vfs/vfs_open_cache.h
+++ b/src/vfs/vfs_open_cache.h
@@ -316,12 +316,12 @@ chimera_vfs_open_cache_release_blocked(
             request->unblock_callback(request, request->pending_handle);
         } else {
             /* This is a request from a different thread, so we need to send it home */
+            /* Wake it under the lock; see chimera_vfs_complete_delegate for
+             * why the ring must not follow the unlock. */
             pthread_mutex_lock(&request_thread->lock);
             LL_PREPEND(request_thread->unblocked_requests, request);
-            pthread_mutex_unlock(&request_thread->lock);
-
-            /* Wake up the thread */
             evpl_ring_doorbell(&request_thread->doorbell);
+            pthread_mutex_unlock(&request_thread->lock);
         }
     }
 


### PR DESCRIPTION
Follow-ups from the extended-run triage (`EXTENDED-FAILURES-HANDOFF.md` items 1, 2, 3, 7, 8).

**libevpl advance to chimera-nas/libevpl#166: SQPOLL opt-in, default off.** Every evpl thread's ring carried a kernel `iou-sqp` thread spinning for a second after each submission, and a depth-one journal write paid a scheduler hop through it on every I/O. That is why the `diskfs_io_uring` cells of `smb2.maxfid`, `diskfs_evict` and `diskfs_reclaim` ran 1.5-3x slower than the `diskfs_aio` cells of the same tests, and two of them hit their ctest caps every run. Neither was a hang: `diskfs_evict_diskfs_io_uring` passed at 872 s of 900 in run 34126509828, and the "IL stall" dumps were coincident across processes (the runner's disk), not a delivery bug. Measured on the evict create phase, same binary:

| configuration | create phase |
|---|---|
| diskfs_aio | 133 s |
| diskfs_io_uring, SQPOLL on | 311 s |
| diskfs_io_uring, SQPOLL off | 68 s |

**Doorbell ordering (batch_pnfs_cairn heap-use-after-free).** `chimera_vfs_complete_delegate`, `chimera_vfs_io_resume_post` and `chimera_vfs_open_cache_release_blocked` all did lock, append, unlock, then ring. Any other ring in that window let the owning thread drain the list, return from its synchronous caller and destroy itself before the producer's ring touched the freed doorbell. The ring now happens inside the critical section; the consumer pops under the same lock.

**fio SIGILL probes in `netns_test_wrapper.sh`.** On a SIGILL death of a fio command: `fio --crctest` (fio picks its CRC32C implementation from cpuid/HWCAP at startup and the basic jobs verify with crc32c), then a gdb re-run in the same namespace and preload printing the faulting PC, disassembly and backtrace. Both bounded; the reported status is unchanged. Exercised end to end with a fake fio that raises SIGILL.

**linux backend errno logging** on `FICLONERANGE` (info) and `copy_file_range` (error) failure, so the next `dup_extents_dest_lock` NOT_SUPPORTED says which call refused and why.

Verification (devcontainer, Debug/ASAN, against the pinned libevpl): MBT gate 107/107, including all 30 `_linux`/`_io_uring` cells once their passthrough scratch is rooted on a real ext4 filesystem (`CHIMERA_MBT_SCRATCH`; the default build-tree scratch lacks `name_to_handle_at` in this container); `batch_pnfs_cairn` green 5/5; formatting and copyright checks clean.
