### PR TITLE
tests/quint: free the trace list on the unknown-security-flavor exit

### DIFF
--- a/src/server/nfs/tests/quint/nfs4_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs4_mbt_replay.c
@@ -4869,6 +4869,7 @@ main(
                 if (sec < 0) {
                     fprintf(stderr, "%s: unknown security flavor '%s'\n",
                             argv[0], optarg);
+                    mbt_free_traces(traces, ntraces);
                     return 2;
                 }
 

--- a/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_aux_mbt_replay.c
@@ -1773,6 +1773,7 @@ main(
                 if (sec < 0) {
                     fprintf(stderr, "%s: unknown security flavor '%s'\n",
                             argv[0], optarg);
+                    mbt_free_traces(traces, ntraces);
                     return 2;
                 }
 

--- a/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
+++ b/src/server/nfs/tests/quint/nfs_drc_mbt_replay.c
@@ -932,6 +932,7 @@ main(
                 if (sec < 0) {
                     fprintf(stderr, "%s: unknown security flavor '%s'\n",
                             argv[0], optarg);
+                    mbt_free_traces(traces, ntraces);
                     return 2;
                 }
 


### PR DESCRIPTION
The -S option added with the Kerberos MBT runs returns 2 on an unknown flavor without releasing the trace list mbt_collect_traces() built just above the getopt loop, while every other early exit in these mains frees it -- and nfs3_mbt_replay frees it on this very path.  The clang static analyzer reports the three as unix.Malloc leaks and fails the analysis gate.  Free it, as the siblings do.