### PR TITLE
vfs/smb: store native Windows SIDs across the VFS boundary

### DIFF
--- a/docs/smb-domain-auth.md
+++ b/docs/smb-domain-auth.md
@@ -50,6 +50,30 @@ The POSIX uid and gid that chimera stamps on files created over SMB come from
 winbind's identity mapping, so the idmap backend you choose decides on-disk
 ownership.
 
+### Native SIDs in stored security descriptors
+
+Access decisions are always made from the numeric uid/gid, but the security
+descriptor a client sets is not reduced to numbers and thrown away.  When a
+SID in an incoming descriptor resolves through winbind, chimera keeps the
+native SID alongside the resolved id: on the owner and group as SID
+companions to the uid/gid, and on each DACL entry's principal.  A SID that
+does not resolve at all is kept verbatim as an opaque principal that grants
+nobody anything -- the same way NTFS keeps an entry for a departed domain
+user -- instead of being dropped from the DACL.  The native backends (memfs,
+cairn, diskfs) persist those SIDs, and a QUERY returns them byte for byte
+without consulting winbind again, so a stored descriptor survives a winbind
+outage and can be read by any other consumer of the on-disk data.
+
+Only when no native SID is known does chimera fall back to the identity
+cache and then to the algorithmic `S-1-5-88-1-<uid>` / `S-1-5-88-2-<gid>`
+scheme.  A plain chown or chgrp (over NFS, say) drops the stored owner or
+group SID, since it no longer describes the new numeric owner.
+
+The on-disk ACL encoding moved to version 2 to carry the per-entry SID;
+version 1 data written by earlier releases still reads, and an ACL with no
+native SIDs is still written as version 1.  Out-of-tree VFS modules must be
+rebuilt against SDK version 2.
+
 ### Configuration keys
 
 The chimera side of both procedures is the `server.smb_auth` object:

--- a/docs/vfs-module-sdk.md
+++ b/docs/vfs-module-sdk.md
@@ -51,8 +51,9 @@ xxhash comes from the system (`libxxhash-dev` / `xxhash`).
 | `vfs_log.h` | `chimera_vfs_debug/info/error/fatal/abort` macros, self-contained |
 | `vfs_fh.h` | **The file-handle routing contract** (see below) and the encoders that satisfy it |
 | `vfs_varint.h` | Varint primitives the inum-style file-handle encoders are built on |
-| `vfs_acl.h` | `struct chimera_acl` / `struct chimera_ace` — the canonical ACL carried by `chimera_vfs_attrs.va_acl` |
-| `vfs_acl_serialize.h` | Stable, versioned encoding of a `chimera_acl` for a backend's own persistence |
+| `vfs_sid.h` | `struct chimera_sid`, the native Windows SID value type (MS-DTYP binary form) carried on ACL principals and on the owner/group attrs, plus its binary/string codec |
+| `vfs_acl.h` | `struct chimera_acl` / `struct chimera_ace` — the canonical ACL carried by `chimera_vfs_attrs.va_acl`; each principal pairs a numeric uid/gid with an optional native SID |
+| `vfs_acl_serialize.h` | Stable, versioned encoding of a `chimera_acl` for a backend's own persistence (v2 adds the per-ACE native SID; v1 blobs still decode) |
 | `vfs_access.h` | Access-mask evaluation, so `ACCESS` answers agree across backends |
 | `vfs_xattr_name.h` | The protocol-exported `user.` xattr keyspace NFS and SMB both normalize into |
 | `vfs_tcp_flavor.h` | `enum chimera_tcp_flavor`, the value `chimera_vfs_request_tcp_flavor` returns |
@@ -126,6 +127,12 @@ The SDK contract is versioned by `CHIMERA_VFS_SDK_VERSION`
 binary fails loudly at load time instead of misinterpreting the request
 structures.  Any incompatible change to an SDK header — struct layout,
 enum values, capability semantics — must bump the version.
+
+Version history: 1 was the initial SDK; 2 widened
+`struct chimera_principal` with an inline native SID, added
+`CHIMERA_PRINCIPAL_SID`, and added the `va_owner_sid` / `va_group_sid`
+attrs and their `CHIMERA_VFS_ATTR_OWNER_SID` / `GROUP_SID` bits.  A module
+built against version 1 must be rebuilt.
 
 The `struct chimera_vfs_request` layout is exposed in full and is
 therefore ABI-stable only within an SDK version.  A public-head /

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1030,6 +1030,10 @@ struct chimera_smb_request {
             int                             sd_pending;
             uint8_t                         sd_acl_storage[sizeof(struct chimera_acl) +
                                                            64 * sizeof(struct chimera_ace)];
+            /* The stored native owner / group SIDs, copied out with the rest
+             * (len 0 = none stored). */
+            struct chimera_sid              sd_owner_sid;
+            struct chimera_sid              sd_group_sid;
             /* FileStreamInformation: the packed VFS list_streams records are
              * held here from the list_streams callback until the reply builder
              * emits them as MS-FSCC FILE_STREAM_INFORMATION entries.

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -1017,7 +1017,7 @@ struct chimera_smb_request {
             struct chimera_smb_open_file   *open_file;
             /* Security descriptor built in the getattr callback and emitted by
              * the reply builder (SMB2_INFO_SECURITY). */
-            uint8_t                         sec_buf[2048];
+            uint8_t                         sec_buf[4096];
             uint32_t                        sec_buf_len;
             /* When the SD references identities not yet in the cache, the
              * getattr'd owner/group/mode + ACL are copied here so the SD can be
@@ -1098,7 +1098,7 @@ struct chimera_smb_request {
              * wave (which races the rename and must deny it). */
             uint8_t                            recall_final;
             /* Security descriptor buffer for SMB2_INFO_SECURITY */
-            uint8_t                            sec_buf[2048];
+            uint8_t                            sec_buf[4096];
             uint32_t                           sec_buf_len;
             /* Outstanding async identity resolves before the SD is decoded for
              * the final time (fan-out join guard). */
@@ -1107,6 +1107,11 @@ struct chimera_smb_request {
              * security descriptor; vfs_attrs.va_acl points here. */
             uint8_t                            acl_storage[sizeof(struct chimera_acl) +
                                                            64 * sizeof(struct chimera_ace)];
+            /* Native owner / group SIDs decoded from the descriptor when they
+             * resolved through the identity authority; vfs_attrs.va_owner_sid
+             * / va_group_sid point here so the backend stores them. */
+            struct chimera_sid                 owner_sid;
+            struct chimera_sid                 group_sid;
             /* FILE_FULL_EA_INFORMATION set: the client's EA buffer is captured
              * in parse (malloc'd, freed at completion) and applied one EA at a
              * time in an async set_xattr/remove_xattr loop.  ea_list holds the

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -5893,17 +5893,22 @@ parse_ctx_secd(
      * phase0_contexts_test with a zeroed request (no compound/thread/shared),
      * so fall back to canonical behaviour when the server context is not
      * reachable. */
-    int canonicalize = 1;
+    int                 canonicalize = 1;
+    struct chimera_vfs *vfs          = NULL;
 
     if (request->compound) {
         canonicalize = request->compound->thread->shared->config.
             acl_inherited_canonicalize;
+        /* The identity authority lets cached real SIDs (the session's own
+         * user, for one) resolve to a uid/gid at create time; the rest are
+         * kept verbatim as opaque SID principals. */
+        vfs = request->compound->thread->shared->vfs;
     }
 
     chimera_smb_parse_sd_to_acl(data, data_len, &request->create.set_attr,
                                 request->create.acl_storage,
                                 sizeof(request->create.acl_storage),
-                                canonicalize);
+                                vfs, canonicalize);
     return true;
 } /* parse_ctx_secd */
 

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -21,6 +21,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_identity.h"
 #include "vfs/sdk/vfs_acl.h"
+#include "vfs/sdk/vfs_sid.h"
 
 /* Security information flags (addl_info) */
 #define OWNER_SECURITY_INFORMATION 0x00000001
@@ -136,109 +137,9 @@ write_unix_sid(
 #define ACE4_GENERIC_WRITE       0x00120116
 #define ACE4_GENERIC_EXECUTE     0x001200a0
 
-/*
- * Format a binary SID into "S-<rev>-<authority>-<sub>..." text.  Returns the
- * number of bytes consumed from `buf`, or -1 on a malformed/truncated SID.
- */
-static int
-sid_bin_to_str(
-    const uint8_t *buf,
-    uint32_t       len,
-    char          *out,
-    int            outlen)
-{
-    uint8_t  rev, count;
-    uint64_t authority = 0;
-    int      pos;
-
-    if (len < 8) {
-        return -1;
-    }
-    rev   = buf[0];
-    count = buf[1];
-    if (8 + (uint32_t) count * 4 > len) {
-        return -1;
-    }
-    for (int i = 0; i < 6; i++) {
-        authority = (authority << 8) | buf[2 + i];
-    }
-
-    pos = snprintf(out, outlen, "S-%u-%llu", rev, (unsigned long long) authority);
-    for (int i = 0; i < count; i++) {
-        uint32_t sa = buf[8 + i * 4] | (buf[8 + i * 4 + 1] << 8) |
-            (buf[8 + i * 4 + 2] << 16) | ((uint32_t) buf[8 + i * 4 + 3] << 24);
-
-        if (pos < 0 || pos >= outlen) {
-            return -1;
-        }
-        pos += snprintf(out + pos, outlen - pos, "-%u", sa);
-    }
-    if (pos < 0 || pos >= outlen) {
-        return -1;
-    }
-    return 8 + count * 4;
-} /* sid_bin_to_str */
-
-/*
- * Parse "S-<rev>-<authority>-<sub>..." into a binary SID.  Returns the binary
- * length written, or -1 on malformed input / insufficient capacity.
- */
-static int
-sid_str_to_bin(
-    const char *str,
-    uint8_t    *out,
-    int         outcap)
-{
-    const char *p = str;
-    uint64_t    authority;
-    uint8_t     count = 0;
-    char       *end;
-
-    if (str[0] != 'S' && str[0] != 's') {
-        return -1;
-    }
-    p++;
-    if (*p != '-') {
-        return -1;
-    }
-    p++;
-    out[0] = (uint8_t) strtoul(p, &end, 10); /* revision */
-    if (end == p || *end != '-') {
-        return -1;
-    }
-    p = end + 1;
-
-    authority = strtoull(p, &end, 10);
-    if (end == p) {
-        return -1;
-    }
-    for (int i = 0; i < 6; i++) {
-        out[2 + i] = (uint8_t) ((authority >> (8 * (5 - i))) & 0xff);
-    }
-    p = end;
-
-    while (*p == '-') {
-        uint32_t sa;
-
-        p++;
-        sa = (uint32_t) strtoul(p, &end, 10);
-        if (end == p) {
-            return -1;
-        }
-        if (8 + (count + 1) * 4 > outcap) {
-            return -1;
-        }
-        out[8 + count * 4]     = sa & 0xff;
-        out[8 + count * 4 + 1] = (sa >> 8) & 0xff;
-        out[8 + count * 4 + 2] = (sa >> 16) & 0xff;
-        out[8 + count * 4 + 3] = (sa >> 24) & 0xff;
-        count++;
-        p = end;
-    }
-
-    out[1] = count;
-    return 8 + count * 4;
-} /* sid_str_to_bin */
+/* The binary <-> string SID codec lives in vfs/sdk/vfs_sid.h
+ * (chimera_sid_bin_to_str / chimera_sid_str_to_bin) so the backends and the
+ * identity layer share one implementation. */
 
 static uint16_t
 nt_flags_to_canon(uint8_t f)
@@ -337,6 +238,8 @@ chimera_smb_sd_to_acl(
     unsigned                  acl_max_aces,
     struct chimera_vfs       *vfs,
     struct smb_unres_sids    *unres,
+    struct chimera_sid       *owner_sid_out,
+    struct chimera_sid       *group_sid_out,
     int                       canonicalize_inherited)
 {
     uint32_t offset_owner, offset_group, offset_dacl;
@@ -358,7 +261,7 @@ chimera_smb_sd_to_acl(
         if (parse_unix_sid(sd_buf + offset_owner, sd_len - offset_owner, 1, &value) == 0) {
             attrs->va_uid       = value;
             attrs->va_set_mask |= CHIMERA_VFS_ATTR_UID;
-        } else if (sid_bin_to_str(sd_buf + offset_owner, sd_len - offset_owner,
+        } else if (chimera_sid_bin_to_str(sd_buf + offset_owner, sd_len - offset_owner,
                                   sidstr, sizeof(sidstr)) > 0) {
             if (chimera_idmap_sid_to_principal(sidstr, &p) == 0 &&
                 p.type != CHIMERA_PRINCIPAL_SPECIAL) {
@@ -366,9 +269,17 @@ chimera_smb_sd_to_acl(
                 attrs->va_set_mask |= CHIMERA_VFS_ATTR_UID;
             } else if (vfs &&
                        chimera_vfs_identity_sid_to_uid(vfs, sidstr, &value) == 0) {
-                /* A real (e.g. AD) owner SID resolved via the user cache. */
+                /* A real (e.g. AD) owner SID resolved via the user cache: the
+                 * uid enforces, and the SID itself travels as the owner's
+                 * native-SID companion so it is stored and emitted verbatim. */
                 attrs->va_uid       = value;
                 attrs->va_set_mask |= CHIMERA_VFS_ATTR_UID;
+                if (owner_sid_out &&
+                    chimera_sid_from_bin(owner_sid_out, sd_buf + offset_owner,
+                                         sd_len - offset_owner) > 0) {
+                    attrs->va_owner_sid = owner_sid_out;
+                    attrs->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+                }
             } else {
                 /* Real SID not yet cached: record it for async resolution. */
                 smb_unres_record(unres, sidstr);
@@ -383,7 +294,7 @@ chimera_smb_sd_to_acl(
         if (parse_unix_sid(sd_buf + offset_group, sd_len - offset_group, 2, &value) == 0) {
             attrs->va_gid       = value;
             attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
-        } else if (sid_bin_to_str(sd_buf + offset_group, sd_len - offset_group,
+        } else if (chimera_sid_bin_to_str(sd_buf + offset_group, sd_len - offset_group,
                                   sidstr, sizeof(sidstr)) > 0) {
             if (chimera_idmap_sid_to_principal(sidstr, &p) == 0 &&
                 p.type != CHIMERA_PRINCIPAL_SPECIAL) {
@@ -391,9 +302,16 @@ chimera_smb_sd_to_acl(
                 attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
             } else if (vfs &&
                        chimera_vfs_identity_sid_to_gid(vfs, sidstr, &value) == 0) {
-                /* A real (e.g. AD) group SID resolved via the user cache. */
+                /* A real (e.g. AD) group SID resolved via the user cache; keep
+                 * the SID as the group's native-SID companion. */
                 attrs->va_gid       = value;
                 attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
+                if (group_sid_out &&
+                    chimera_sid_from_bin(group_sid_out, sd_buf + offset_group,
+                                         sd_len - offset_group) > 0) {
+                    attrs->va_group_sid = group_sid_out;
+                    attrs->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+                }
             } else {
                 /* Real SID not yet cached: record it for async resolution. */
                 smb_unres_record(unres, sidstr);
@@ -436,30 +354,55 @@ chimera_smb_sd_to_acl(
                 continue;
             }
 
-            if (sid_bin_to_str(acl_buf + pos + 8, acl_size - pos - 8,
-                               sidstr, sizeof(sidstr)) <= 0) {
-                pos += ace_size;
-                continue;
-            }
+            {
+                const uint8_t *sid_buf   = acl_buf + pos + 8;
+                uint32_t       sid_avail = acl_size - pos - 8;
+                uint32_t       cid;
 
-            if (chimera_idmap_sid_to_principal(sidstr, &p) != 0) {
-                uint32_t cid;
+                if (chimera_sid_bin_len(sid_buf, sid_avail) < 0) {
+                    /* Malformed or truncated SID: nothing storable. */
+                    pos += ace_size;
+                    continue;
+                }
 
-                /* Not an algorithmic/well-known SID: resolve a real SID to its
-                 * cached uid -- or gid, for a domain group -- via the identity
-                 * authority, else skip the ACE. */
-                if (vfs &&
-                    chimera_vfs_identity_sid_to_uid(vfs, sidstr, &cid) == 0) {
+                /* An exotic SID may have no string form that fits sidstr; it
+                 * is still storable verbatim, it just cannot be looked up. */
+                if (chimera_sid_bin_to_str(sid_buf, sid_avail, sidstr,
+                                           sizeof(sidstr)) <= 0) {
+                    sidstr[0] = '\0';
+                }
+
+                if (sidstr[0] &&
+                    chimera_idmap_sid_to_principal(sidstr, &p) == 0) {
+                    /* Algorithmic (S-1-5-88 / S-1-22) or well-known: a
+                     * numeric or special principal, re-derived on emit, so
+                     * no native SID is kept. */
+                } else if (sidstr[0] && vfs &&
+                           chimera_vfs_identity_sid_to_uid(vfs, sidstr, &cid) == 0) {
+                    /* A real user SID the identity authority knows: the uid
+                     * for enforcement plus the SID itself for storage. */
                     p = chimera_idmap_uid_principal(cid);
-                } else if (vfs &&
+                    chimera_sid_from_bin(&p.sid, sid_buf, sid_avail);
+                } else if (sidstr[0] && vfs &&
                            chimera_vfs_identity_sid_to_gid(vfs, sidstr, &cid) == 0) {
                     p = chimera_idmap_gid_principal(cid);
-                } else {
-                    /* Real SID not yet cached: record for async resolution and
-                     * skip the ACE this pass. */
+                    chimera_sid_from_bin(&p.sid, sid_buf, sid_avail);
+                } else if (unres && sidstr[0]) {
+                    /* First pass and not yet cached: record for async
+                     * resolution and skip the ACE until the re-decode. */
                     smb_unres_record(unres, sidstr);
                     pos += ace_size;
                     continue;
+                } else {
+                    /* Final pass and still unmappable (or no identity
+                     * authority at all): keep the ACE as an opaque native-SID
+                     * principal so the descriptor round-trips losslessly
+                     * instead of silently losing the entry -- as NTFS keeps
+                     * an ACE for a departed domain user.  It matches no
+                     * caller during access evaluation. */
+                    memset(&p, 0, sizeof(p));
+                    p.type = CHIMERA_PRINCIPAL_SID;
+                    chimera_sid_from_bin(&p.sid, sid_buf, sid_avail);
                 }
             }
 
@@ -525,7 +468,7 @@ chimera_smb_emit_owner_sid(
 
     if (vfs &&
         chimera_vfs_identity_uid_to_sid(vfs, uid, sidstr, sizeof(sidstr)) > 0) {
-        return sid_str_to_bin(sidstr, out, cap);
+        return chimera_sid_str_to_bin(sidstr, out, cap);
     }
 
     if (cap < SID_UNIX_SIZE) {
@@ -556,7 +499,7 @@ chimera_smb_emit_group_sid(
 
     if (vfs &&
         chimera_vfs_identity_gid_to_sid(vfs, gid, sidstr, sizeof(sidstr)) > 0) {
-        return sid_str_to_bin(sidstr, out, cap);
+        return chimera_sid_str_to_bin(sidstr, out, cap);
     }
 
     if (cap < SID_UNIX_SIZE) {
@@ -674,7 +617,7 @@ chimera_smb_acl_to_sd(
                 if (ace_pos + 8 > cap) {
                     return -1;
                 }
-                sidlen = sid_str_to_bin(sidstr, out + ace_pos + 8, cap - ace_pos - 8);
+                sidlen = chimera_sid_str_to_bin(sidstr, out + ace_pos + 8, cap - ace_pos - 8);
                 if (sidlen < 0) {
                     return -1;
                 }
@@ -857,16 +800,19 @@ chimera_smb_parse_sd_to_acl(
     struct chimera_vfs_attrs *attrs,
     void                     *acl_buf,
     uint32_t                  acl_buf_len,
+    struct chimera_vfs       *vfs,
     int                       canonicalize_inherited)
 {
     struct chimera_acl *acl     = acl_buf;
     unsigned            acl_max = (acl_buf_len - sizeof(struct chimera_acl)) /
         sizeof(struct chimera_ace);
 
-    /* Create-time SD parse: algorithmic/well-known SIDs only (no authority
-     * handle here); real-SID resolution happens on SET_SECURITY. */
-    chimera_smb_sd_to_acl(sd_buf, sd_len, attrs, acl, acl_max, NULL, NULL,
-                          canonicalize_inherited);
+    /* Create-time SD parse: a single synchronous pass.  Real SIDs already in
+     * the identity cache (the session's own user, for one) resolve to a
+     * uid/gid; anything else is kept verbatim as an opaque SID principal.
+     * The owner/group SID companions are not seeded at create. */
+    chimera_smb_sd_to_acl(sd_buf, sd_len, attrs, acl, acl_max, vfs, NULL,
+                          NULL, NULL, canonicalize_inherited);
 } /* chimera_smb_parse_sd_to_acl */
 
 /* Decode the (saved) security descriptor into vfs_attrs + ACL.  Returns the
@@ -883,13 +829,17 @@ chimera_smb_set_decode_sd(
                                          sizeof(struct chimera_acl)) /
         sizeof(struct chimera_ace);
 
-    vfs_attrs->va_req_mask = 0;
-    vfs_attrs->va_set_mask = 0;
+    vfs_attrs->va_req_mask  = 0;
+    vfs_attrs->va_set_mask  = 0;
+    vfs_attrs->va_owner_sid = NULL;
+    vfs_attrs->va_group_sid = NULL;
 
     chimera_smb_sd_to_acl(request->set_info.sec_buf,
                           request->set_info.sec_buf_len,
                           vfs_attrs, acl_buf, acl_max,
                           request->compound->thread->shared->vfs, unres,
+                          &request->set_info.owner_sid,
+                          &request->set_info.group_sid,
                           request->compound->thread->shared->config.
                           acl_inherited_canonicalize);
 } /* chimera_smb_set_decode_sd */

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -256,7 +256,7 @@ chimera_smb_sd_to_acl(
             attrs->va_uid       = value;
             attrs->va_set_mask |= CHIMERA_VFS_ATTR_UID;
         } else if (chimera_sid_bin_to_str(sd_buf + offset_owner, sd_len - offset_owner,
-                                  sidstr, sizeof(sidstr)) > 0) {
+                                          sidstr, sizeof(sidstr)) > 0) {
             if (chimera_idmap_sid_to_principal(sidstr, &p) == 0 &&
                 p.type != CHIMERA_PRINCIPAL_SPECIAL) {
                 attrs->va_uid       = p.id;
@@ -289,7 +289,7 @@ chimera_smb_sd_to_acl(
             attrs->va_gid       = value;
             attrs->va_set_mask |= CHIMERA_VFS_ATTR_GID;
         } else if (chimera_sid_bin_to_str(sd_buf + offset_group, sd_len - offset_group,
-                                  sidstr, sizeof(sidstr)) > 0) {
+                                          sidstr, sizeof(sidstr)) > 0) {
             if (chimera_idmap_sid_to_principal(sidstr, &p) == 0 &&
                 p.type != CHIMERA_PRINCIPAL_SPECIAL) {
                 attrs->va_gid       = p.id;
@@ -360,7 +360,7 @@ chimera_smb_sd_to_acl(
                 }
 
                 /* An exotic SID may have no string form that fits sidstr; it
-                 * is still storable verbatim, it just cannot be looked up. */
+                * is still storable verbatim, it just cannot be looked up. */
                 if (chimera_sid_bin_to_str(sid_buf, sid_avail, sidstr,
                                            sizeof(sidstr)) <= 0) {
                     sidstr[0] = '\0';

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -202,14 +202,8 @@ expand_generic_mask(uint32_t m)
  * translated ACE-by-ACE.  Falls back to recognising the modefromsid encoding
  * (S-1-5-88-3-<mode>) to recover a POSIX mode.  Returns 0 on success.
  */
-/* Collects real (non-algorithmic) SID strings a decode pass could not resolve,
-* so the SET_SECURITY handler can resolve them off the event loop and retry. */
-#define SMB_MAX_UNRES_SIDS 16
-struct smb_unres_sids {
-    char sids[SMB_MAX_UNRES_SIDS][CHIMERA_IDMAP_SID_MAX];
-    int  count;
-};
-
+/* struct smb_unres_sids is declared in smb_procs.h (the decoder is exported
+ * for the unit tests); this records one SID in it, deduplicated. */
 static void
 smb_unres_record(
     struct smb_unres_sids *unres,
@@ -229,7 +223,7 @@ smb_unres_record(
     unres->count++;
 } /* smb_unres_record */
 
-static int
+SYMBOL_EXPORT int
 chimera_smb_sd_to_acl(
     const uint8_t            *sd_buf,
     uint32_t                  sd_len,
@@ -528,7 +522,7 @@ chimera_smb_emit_group_sid(
     return SID_UNIX_SIZE;
 } /* chimera_smb_emit_group_sid */
 
-int
+SYMBOL_EXPORT int
 chimera_smb_acl_to_sd(
     uint32_t                  uid,
     uint32_t                  gid,
@@ -840,7 +834,7 @@ chimera_smb_parse_sd_to_attrs(
     }
 } /* chimera_smb_parse_sd_to_attrs */
 
-void
+SYMBOL_EXPORT void
 chimera_smb_parse_sd_to_acl(
     const uint8_t            *sd_buf,
     uint32_t                  sd_len,

--- a/src/server/smb/smb_proc_security.c
+++ b/src/server/smb/smb_proc_security.c
@@ -459,12 +459,22 @@ chimera_smb_sd_to_acl(
  */
 static int
 chimera_smb_emit_owner_sid(
-    uint8_t            *out,
-    int                 cap,
-    struct chimera_vfs *vfs,
-    uint32_t            uid)
+    uint8_t                  *out,
+    int                       cap,
+    struct chimera_vfs       *vfs,
+    uint32_t                  uid,
+    const struct chimera_sid *stored)
 {
     char sidstr[CHIMERA_IDMAP_SID_MAX];
+
+    /* The native SID the owner was set with, verbatim. */
+    if (chimera_sid_present(stored)) {
+        if (cap < stored->len) {
+            return -1;
+        }
+        memcpy(out, stored->data, stored->len);
+        return stored->len;
+    }
 
     if (vfs &&
         chimera_vfs_identity_uid_to_sid(vfs, uid, sidstr, sizeof(sidstr)) > 0) {
@@ -490,12 +500,21 @@ chimera_smb_emit_owner_sid(
  */
 static int
 chimera_smb_emit_group_sid(
-    uint8_t            *out,
-    int                 cap,
-    struct chimera_vfs *vfs,
-    uint32_t            gid)
+    uint8_t                  *out,
+    int                       cap,
+    struct chimera_vfs       *vfs,
+    uint32_t                  gid,
+    const struct chimera_sid *stored)
 {
     char sidstr[CHIMERA_IDMAP_SID_MAX];
+
+    if (chimera_sid_present(stored)) {
+        if (cap < stored->len) {
+            return -1;
+        }
+        memcpy(out, stored->data, stored->len);
+        return stored->len;
+    }
 
     if (vfs &&
         chimera_vfs_identity_gid_to_sid(vfs, gid, sidstr, sizeof(sidstr)) > 0) {
@@ -509,12 +528,14 @@ chimera_smb_emit_group_sid(
     return SID_UNIX_SIZE;
 } /* chimera_smb_emit_group_sid */
 
-static int
+int
 chimera_smb_acl_to_sd(
     uint32_t                  uid,
     uint32_t                  gid,
     uint32_t                  mode,
     const struct chimera_acl *acl,
+    const struct chimera_sid *owner_sid,
+    const struct chimera_sid *group_sid,
     int                       has_owner,
     int                       has_group,
     int                       has_dacl,
@@ -538,7 +559,8 @@ chimera_smb_acl_to_sd(
      * DACL-first layout is then misparsed (the DACL bytes are read as the owner
      * SID), so the owner/group SIDs must precede the DACL here. */
     if (has_owner) {
-        int n = chimera_smb_emit_owner_sid(&out[offset], cap - offset, vfs, uid);
+        int n = chimera_smb_emit_owner_sid(&out[offset], cap - offset, vfs, uid,
+                                           owner_sid);
 
         if (n < 0) {
             return -1;
@@ -548,7 +570,8 @@ chimera_smb_acl_to_sd(
     }
 
     if (has_group) {
-        int n = chimera_smb_emit_group_sid(&out[offset], cap - offset, vfs, gid);
+        int n = chimera_smb_emit_group_sid(&out[offset], cap - offset, vfs, gid,
+                                           group_sid);
 
         if (n < 0) {
             return -1;
@@ -588,38 +611,62 @@ chimera_smb_acl_to_sd(
                 uint16_t                  ace_size;
 
                 /* OWNER@/GROUP@ denote the object's current owner/group: emit
-                 * the concrete owner/group SID rather than a special SID. */
+                 * the concrete owner/group SID rather than a special SID --
+                 * the stored native one when there is one, so the ACE agrees
+                 * with the descriptor's owner/group fields. */
                 if (who.type == CHIMERA_PRINCIPAL_SPECIAL) {
                     if (who.special == CHIMERA_WHO_OWNER) {
                         who.type = CHIMERA_PRINCIPAL_USER;
                         who.id   = uid;
+                        if (chimera_sid_present(owner_sid)) {
+                            who.sid = *owner_sid;
+                        }
                     } else if (who.special == CHIMERA_WHO_GROUP) {
                         who.type = CHIMERA_PRINCIPAL_GROUP;
                         who.id   = gid;
+                        if (chimera_sid_present(group_sid)) {
+                            who.sid = *group_sid;
+                        }
                     }
                 }
 
-                /* Prefer the principal's real (cached) SID so AD users and
-                 * groups alike round trip; fall back to the algorithmic idmap
-                 * SID. */
-                if (who.type == CHIMERA_PRINCIPAL_USER && vfs &&
-                    chimera_vfs_identity_uid_to_sid(vfs, who.id, sidstr,
-                                                    sizeof(sidstr)) > 0) {
-                    /* sidstr holds the real SID */
-                } else if (who.type == CHIMERA_PRINCIPAL_GROUP && vfs &&
-                           chimera_vfs_identity_gid_to_sid(vfs, who.id, sidstr,
-                                                           sizeof(sidstr)) > 0) {
-                    /* sidstr holds the real group SID */
-                } else if (chimera_idmap_principal_to_sid(&who, sidstr,
-                                                          sizeof(sidstr)) < 0) {
-                    continue;
-                }
                 if (ace_pos + 8 > cap) {
                     return -1;
                 }
-                sidlen = chimera_sid_str_to_bin(sidstr, out + ace_pos + 8, cap - ace_pos - 8);
-                if (sidlen < 0) {
-                    return -1;
+
+                if (chimera_sid_present(&who.sid)) {
+                    /* The native SID the principal was set with -- a resolved
+                     * domain user/group or an opaque unmappable SID -- is
+                     * emitted verbatim; no cache lookup can improve on it. */
+                    if (cap - ace_pos - 8 < who.sid.len) {
+                        return -1;
+                    }
+                    memcpy(out + ace_pos + 8, who.sid.data, who.sid.len);
+                    sidlen = who.sid.len;
+                } else if (who.type == CHIMERA_PRINCIPAL_SID) {
+                    /* An opaque principal with no SID bytes is unrepresentable. */
+                    continue;
+                } else {
+                    /* Prefer the principal's real (cached) SID so AD users and
+                     * groups alike round trip; fall back to the algorithmic
+                     * idmap SID. */
+                    if (who.type == CHIMERA_PRINCIPAL_USER && vfs &&
+                        chimera_vfs_identity_uid_to_sid(vfs, who.id, sidstr,
+                                                        sizeof(sidstr)) > 0) {
+                        /* sidstr holds the real SID */
+                    } else if (who.type == CHIMERA_PRINCIPAL_GROUP && vfs &&
+                               chimera_vfs_identity_gid_to_sid(vfs, who.id, sidstr,
+                                                               sizeof(sidstr)) > 0) {
+                        /* sidstr holds the real group SID */
+                    } else if (chimera_idmap_principal_to_sid(&who, sidstr,
+                                                              sizeof(sidstr)) < 0) {
+                        continue;
+                    }
+                    sidlen = chimera_sid_str_to_bin(sidstr, out + ace_pos + 8,
+                                                    cap - ace_pos - 8);
+                    if (sidlen < 0) {
+                        return -1;
+                    }
                 }
                 ace_size = 8 + sidlen;
 
@@ -985,13 +1032,15 @@ chimera_smb_query_emit_sd(
     uint32_t                    uid,
     uint32_t                    gid,
     uint32_t                    mode,
-    const struct chimera_acl   *acl)
+    const struct chimera_acl   *acl,
+    const struct chimera_sid   *owner_sid,
+    const struct chimera_sid   *group_sid)
 {
     uint32_t addl_info = request->query_info.addl_info;
     int      sd_len;
 
     sd_len = chimera_smb_acl_to_sd(
-        uid, gid, mode & (S_IFMT | 07777), acl,
+        uid, gid, mode & (S_IFMT | 07777), acl, owner_sid, group_sid,
         !!(addl_info & OWNER_SECURITY_INFORMATION),
         !!(addl_info & GROUP_SECURITY_INFORMATION),
         !!(addl_info & DACL_SECURITY_INFORMATION),
@@ -1039,7 +1088,9 @@ chimera_smb_query_resolve_decr(struct chimera_smb_request *request)
                               request->query_info.sd_uid,
                               request->query_info.sd_gid,
                               request->query_info.sd_mode,
-                              acl);
+                              acl,
+                              &request->query_info.sd_owner_sid,
+                              &request->query_info.sd_group_sid);
 } /* chimera_smb_query_resolve_decr */
 
 static void
@@ -1061,6 +1112,8 @@ chimera_smb_query_security_getattr_callback(
     struct chimera_vfs_thread  *thread  = request->compound->thread->vfs_thread;
     struct chimera_vfs         *vfs     = request->compound->thread->shared->vfs;
     const struct chimera_acl   *acl;
+    const struct chimera_sid   *owner_sid;
+    const struct chimera_sid   *group_sid;
     unsigned                    i;
     int                         nmiss = 0;
     int                         acl_fits;
@@ -1081,19 +1134,32 @@ chimera_smb_query_security_getattr_callback(
         acl = NULL;
     }
 
+    /* The stored native owner / group SIDs, when the backend has them; an
+     * identity that already carries its SID needs no resolution. */
+    owner_sid = (attr->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) ?
+        attr->va_owner_sid : NULL;
+    group_sid = (attr->va_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) ?
+        attr->va_group_sid : NULL;
+
     /* The owner and group SIDs and any USER/GROUP ACE need a real SID; count
      * the principals not yet in the cache (those would block) so we know
-     * whether to resolve. */
-    if (!chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
+     * whether to resolve.  Principals with a stored native SID are skipped:
+     * it is emitted verbatim. */
+    if (!chimera_sid_present(owner_sid) &&
+        !chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
                                      attr->va_uid, NULL)) {
         nmiss++;
     }
-    if (!chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_GID,
+    if (!chimera_sid_present(group_sid) &&
+        !chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_GID,
                                      attr->va_gid, NULL)) {
         nmiss++;
     }
     if (acl) {
         for (i = 0; i < acl->num_aces; i++) {
+            if (acl->aces[i].who.sid.len) {
+                continue;
+            }
             if (acl->aces[i].who.type == CHIMERA_PRINCIPAL_USER &&
                 !chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
                                              acl->aces[i].who.id, NULL)) {
@@ -1113,7 +1179,7 @@ chimera_smb_query_security_getattr_callback(
      * the SD inline from the live attrs, exactly as before. */
     if (nmiss == 0 || !acl_fits) {
         chimera_smb_query_emit_sd(request, attr->va_uid, attr->va_gid,
-                                  attr->va_mode, acl);
+                                  attr->va_mode, acl, owner_sid, group_sid);
         return;
     }
 
@@ -1130,17 +1196,29 @@ chimera_smb_query_security_getattr_callback(
     } else {
         request->query_info.sd_has_acl = 0;
     }
+    if (chimera_sid_present(owner_sid)) {
+        request->query_info.sd_owner_sid = *owner_sid;
+    } else {
+        request->query_info.sd_owner_sid.len = 0;
+    }
+    if (chimera_sid_present(group_sid)) {
+        request->query_info.sd_group_sid = *group_sid;
+    } else {
+        request->query_info.sd_group_sid.len = 0;
+    }
 
     request->query_info.sd_pending = 1; /* guard until all resolves are issued */
 
-    if (!chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
+    if (!chimera_sid_present(owner_sid) &&
+        !chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
                                      attr->va_uid, NULL)) {
         request->query_info.sd_pending++;
         chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_UID,
                                      attr->va_uid, NULL,
                                      chimera_smb_query_resolve_cb, request);
     }
-    if (!chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_GID,
+    if (!chimera_sid_present(group_sid) &&
+        !chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_GID,
                                      attr->va_gid, NULL)) {
         request->query_info.sd_pending++;
         chimera_vfs_identity_resolve(thread, CHIMERA_VFS_IDENTITY_BY_GID,
@@ -1149,6 +1227,9 @@ chimera_smb_query_security_getattr_callback(
     }
     if (acl) {
         for (i = 0; i < acl->num_aces; i++) {
+            if (acl->aces[i].who.sid.len) {
+                continue;
+            }
             if (acl->aces[i].who.type == CHIMERA_PRINCIPAL_USER &&
                 !chimera_vfs_identity_cached(vfs, CHIMERA_VFS_IDENTITY_BY_UID,
                                              acl->aces[i].who.id, NULL)) {
@@ -1182,7 +1263,8 @@ chimera_smb_query_security(struct chimera_smb_request *request)
         request->compound->thread->vfs_thread,
         &request->session_handle->session->cred,
         request->query_info.open_file->handle,
-        CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL,
+        CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL |
+        CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID,
         chimera_smb_query_security_getattr_callback,
         request);
 } /* chimera_smb_query_security */

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -231,7 +231,10 @@ void chimera_smb_parse_sd_to_attrs(
  * Decode a self-relative security descriptor into owner/group/mode AND a full
  * canonical DACL.  The decoded ACL is written into `acl_buf` (capacity
  * `acl_buf_len` bytes) and, when non-empty, attrs->va_acl is pointed at it with
- * the ATTR_ACL set-mask bit raised.
+ * the ATTR_ACL set-mask bit raised.  `vfs` (may be NULL) is the identity
+ * authority used to map real SIDs that are already cached; a real SID that is
+ * not cached is kept as an opaque CHIMERA_PRINCIPAL_SID (no async resolution
+ * here -- this is the create-time path).
  */
 void chimera_smb_parse_sd_to_acl(
     const uint8_t            *sd_buf,
@@ -239,6 +242,7 @@ void chimera_smb_parse_sd_to_acl(
     struct chimera_vfs_attrs *attrs,
     void                     *acl_buf,
     uint32_t                  acl_buf_len,
+    struct chimera_vfs       *vfs,
     int                       canonicalize_inherited);
 
 int chimera_smb_parse_echo(

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include "vfs/vfs_idmap.h"
+#include "vfs/sdk/vfs_sid.h"
+
 void
 chimera_smb_complete_request(
     struct chimera_smb_request *request,
@@ -226,6 +229,39 @@ void chimera_smb_parse_sd_to_attrs(
     const uint8_t            *sd_buf,
     uint32_t                  sd_len,
     struct chimera_vfs_attrs *attrs);
+
+/* Collects real (non-algorithmic) SID strings a decode pass could not resolve,
+ * so the SET_SECURITY handler can resolve them off the event loop and retry. */
+#define SMB_MAX_UNRES_SIDS 16
+struct smb_unres_sids {
+    char sids[SMB_MAX_UNRES_SIDS][CHIMERA_IDMAP_SID_MAX];
+    int  count;
+};
+
+struct chimera_vfs;
+
+/*
+ * Decode a self-relative security descriptor into owner/group ids (and their
+ * native-SID companions, written into *owner_sid_out / *group_sid_out when
+ * non-NULL and the SID resolved through the identity authority), a POSIX mode
+ * from the modefromsid ACE, and a canonical DACL of at most `acl_max_aces`.
+ * With `unres` non-NULL (the first SET_SECURITY pass) a real SID that is not
+ * yet cached is recorded there and its ACE skipped; with `unres` NULL (the
+ * final pass, or the create-time path) it is kept as an opaque
+ * CHIMERA_PRINCIPAL_SID.  Returns 0 on success.  Exported for the SMB unit
+ * tests.
+ */
+int chimera_smb_sd_to_acl(
+    const uint8_t            *sd_buf,
+    uint32_t                  sd_len,
+    struct chimera_vfs_attrs *attrs,
+    struct chimera_acl       *acl,
+    unsigned                  acl_max_aces,
+    struct chimera_vfs       *vfs,
+    struct smb_unres_sids    *unres,
+    struct chimera_sid       *owner_sid_out,
+    struct chimera_sid       *group_sid_out,
+    int                       canonicalize_inherited);
 
 /*
  * Build a self-relative security descriptor from owner/group ids, their

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -231,7 +231,7 @@ void chimera_smb_parse_sd_to_attrs(
     struct chimera_vfs_attrs *attrs);
 
 /* Collects real (non-algorithmic) SID strings a decode pass could not resolve,
- * so the SET_SECURITY handler can resolve them off the event loop and retry. */
+* so the SET_SECURITY handler can resolve them off the event loop and retry. */
 #define SMB_MAX_UNRES_SIDS 16
 struct smb_unres_sids {
     char sids[SMB_MAX_UNRES_SIDS][CHIMERA_IDMAP_SID_MAX];

--- a/src/server/smb/smb_procs.h
+++ b/src/server/smb/smb_procs.h
@@ -228,6 +228,28 @@ void chimera_smb_parse_sd_to_attrs(
     struct chimera_vfs_attrs *attrs);
 
 /*
+ * Build a self-relative security descriptor from owner/group ids, their
+ * optional native-SID companions, and a canonical ACL into `out` (capacity
+ * `cap`).  A stored native SID (owner_sid / group_sid / an ACE principal's
+ * sid) is emitted verbatim; otherwise the identity cache is consulted and the
+ * algorithmic modefromsid SID is the last resort.  Returns the SD length, or
+ * -1 if it does not fit.  Exported for the SMB unit tests.
+ */
+int chimera_smb_acl_to_sd(
+    uint32_t                  uid,
+    uint32_t                  gid,
+    uint32_t                  mode,
+    const struct chimera_acl *acl,
+    const struct chimera_sid *owner_sid,
+    const struct chimera_sid *group_sid,
+    int                       has_owner,
+    int                       has_group,
+    int                       has_dacl,
+    uint8_t                  *out,
+    uint32_t                  cap,
+    struct chimera_vfs       *vfs);
+
+/*
  * Decode a self-relative security descriptor into owner/group/mode AND a full
  * canonical DACL.  The decoded ACL is written into `acl_buf` (capacity
  * `acl_buf_len` bytes) and, when non-empty, attrs->va_acl is pointed at it with

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -56,6 +56,16 @@ target_include_directories(phase0_contexts_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME chimera/server/smb/phase0_contexts_test
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/phase0_contexts_test)
 
+# Security-descriptor native-SID round trip: the SD decoder and
+# emitter driven directly, with and without an identity authority.
+add_executable(smb_sd_sid_test smb_sd_sid_test.c)
+target_link_libraries(smb_sd_sid_test chimera_server chimera_smb chimera_vfs
+    chimera_vfs_memfs chimera_vfs_memkv evpl)
+target_include_directories(smb_sd_sid_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+add_test(NAME chimera/server/smb/sd_sid_test
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smb_sd_sid_test)
+
 # SMB2 request-parse hardening: checked cursor primitives, safe seek, and
 # CREATE-context bounds arithmetic against malformed/adversarial input.
 add_executable(smb_harden_test smb_harden_test.c)

--- a/src/server/smb/tests/quint/smb2_info_probe.c
+++ b/src/server/smb/tests/quint/smb2_info_probe.c
@@ -751,6 +751,19 @@ probe_security(struct smb2_conn *c)
               off_owner, off_group, off_dacl);
     }
 
+    /* The descriptor decodes, and the mode-derived DACL names the owner by the
+     * same SID the owner field carries. */
+    if (st == ST_SUCCESS) {
+        struct smb2_sd d;
+
+        CHECK(smb2_sd_parse(sd, len, &d) == 0,
+              "  ... the descriptor decodes (SIDs and ACEs)");
+        CHECK(d.have_owner && d.have_group && d.have_dacl,
+              "  ... owner, group and DACL are all present");
+        CHECK(d.nace > 0, "  ... the mode-derived DACL is not empty (%d ACE(s))",
+              d.nace);
+    }
+
     /* AdditionalInformation actually selects: asking for only the owner must
      * leave the group and DACL offsets zero. */
     st = smb2_query_info(c, SMB2_INFO_SECURITY_T, 0, co.file_id, SEC_OWNER,
@@ -794,6 +807,170 @@ probe_security(struct smb2_conn *c)
 
     smb2_close(c, co.file_id);
 } /* probe_security */
+
+/* ---- native SIDs in a security descriptor -------------------------------
+ *
+ * The descriptor above is one the server authored, so setting it back proves
+ * only that the emitter and the parser agree with each other.  What matters
+ * here is what happens to a descriptor the server did NOT author: a
+ * principal named by a real Windows SID that no identity authority can map
+ * used to be dropped on the way in, because a principal was a uid/gid and an
+ * unmappable SID had no uid.  It is now carried natively -- stored as an
+ * opaque CHIMERA_PRINCIPAL_SID and re-emitted verbatim -- so a Windows ACL
+ * survives a round trip through a POSIX-backed share.
+ *
+ * That is invisible to the trace corpus (the model has no security-descriptor
+ * surface at all) and invisible to the header-level checks above, so it is
+ * pinned here: SET a descriptor naming principals from a domain this server
+ * knows nothing about, and require them back byte-for-byte.
+ *
+ * The session is an anonymous NTLM null session and no identity authority is
+ * configured, so the owner and group SIDs are the algorithmic S-1-5-88 form
+ * (MS-SMB2's modefromsid convention) and an unmappable owner SID has no uid to
+ * resolve to.  Both of those are asserted rather than worked around: the
+ * owner-side behaviour is deliberate, and a regression that silently adopted
+ * an unresolvable SID as the owner would be a real bug. */
+
+#define ACE_ALLOWED 0
+#define ACE_DENIED  1
+
+static void
+probe_security_sids(struct smb2_conn *c)
+{
+    struct smb2_create_out co;
+    struct smb2_sd         d;
+    struct smb2_sd_ace     want[3];
+    uint8_t                sd[2048], built[1024];
+    uint32_t               st, len = 0;
+    int                    nlen, i, found_denied = 0;
+
+    printf("# --- native SIDs in a security descriptor ---\n");
+
+    st = smb2_create(c, "secsid.bin", FILE_OVERWRITE_IF, FILE_ALL_ACCESS,
+                     FILE_SHARE_RWD, NULL, &co);
+    CHECK(st == ST_SUCCESS, "setup: CREATE secsid.bin -> 0x%08x", st);
+
+    if (st != ST_SUCCESS) {
+        return;
+    }
+
+    /* With nothing stored, the owner and group come from the algorithmic
+     * scheme -- S-1-5-88-1-<uid> and S-1-5-88-2-<gid>.  This is the fallback
+     * the stored-SID path must not disturb, so pin it before setting one. */
+    st = smb2_query_info(c, SMB2_INFO_SECURITY_T, 0, co.file_id,
+                         SEC_OWNER | SEC_GROUP | SEC_DACL, sd, sizeof(sd),
+                         &len);
+
+    if (st == ST_SUCCESS && smb2_sd_parse(sd, len, &d) == 0) {
+        CHECK(strncmp(d.owner, "S-1-5-88-1-", 11) == 0,
+              "a file with no stored SID reports the algorithmic owner (%s)",
+              d.owner);
+        CHECK(strncmp(d.group, "S-1-5-88-2-", 11) == 0,
+              "  ... and the algorithmic group (%s)", d.group);
+    } else {
+        CHECK(0, "QUERY SECURITY before SET -> 0x%08x", st);
+        smb2_close(c, co.file_id);
+        return;
+    }
+
+    /* A DACL from a domain this server has never heard of: an unmappable user,
+     * a well-known SID, and a DENY ace for a second unmappable user.  The DENY
+     * is there because its position is load-bearing -- a canonicalizing
+     * emitter that reorders ACEs changes the file's effective permissions. */
+    memset(want, 0, sizeof(want));
+    want[0].type        = ACE_ALLOWED;
+    want[0].access_mask = 0x001f01ffu;                    /* FILE_ALL_ACCESS */
+    snprintf(want[0].sid, sizeof(want[0].sid), "S-1-5-21-1-2-3-1001");
+    want[1].type        = ACE_ALLOWED;
+    want[1].access_mask = 0x00120089u;                    /* READ            */
+    snprintf(want[1].sid, sizeof(want[1].sid), "S-1-1-0"); /* Everyone       */
+    want[2].type        = ACE_DENIED;
+    want[2].access_mask = 0x00000004u;                    /* APPEND_DATA     */
+    snprintf(want[2].sid, sizeof(want[2].sid), "S-1-5-21-1-2-3-9999");
+
+    nlen = smb2_sd_build(built, sizeof(built), "S-1-5-21-1-2-3-500",
+                         "S-1-5-21-1-2-3-513", want, 3);
+    CHECK(nlen > 0, "built a descriptor with foreign owner/group/DACL (%d bytes)",
+          nlen);
+
+    if (nlen <= 0) {
+        smb2_close(c, co.file_id);
+        return;
+    }
+
+    st = smb2_set_info_addl(c, SMB2_INFO_SECURITY_T, 0, co.file_id,
+                            SEC_OWNER | SEC_GROUP | SEC_DACL, built,
+                            (uint32_t) nlen);
+    CHECK(st == ST_SUCCESS, "SET SECURITY with foreign SIDs -> 0x%08x", st);
+
+    st = smb2_query_info(c, SMB2_INFO_SECURITY_T, 0, co.file_id,
+                         SEC_OWNER | SEC_GROUP | SEC_DACL, sd, sizeof(sd),
+                         &len);
+    CHECK(st == ST_SUCCESS, "QUERY SECURITY after the foreign SET -> 0x%08x",
+          st);
+
+    if (st != ST_SUCCESS || smb2_sd_parse(sd, len, &d) != 0) {
+        CHECK(0, "  ... the re-read descriptor decodes");
+        smb2_close(c, co.file_id);
+        return;
+    }
+
+    /* The explicit DACL replaced the mode-derived one entirely. */
+    CHECK(d.nace == 3, "  ... the explicit DACL has all 3 ACEs (%d)", d.nace);
+
+    /* Every ACE came back verbatim, in the order it was set: an unmappable
+     * SID kept as an opaque principal, a well-known SID kept special, and the
+     * DENY still ahead of nothing it must not follow. */
+    for (i = 0; i < d.nace && i < 3; i++) {
+        CHECK(strcmp(d.ace[i].sid, want[i].sid) == 0,
+              "  ... ace[%d] SID round-trips (%s)", i, d.ace[i].sid);
+        CHECK(d.ace[i].type == want[i].type,
+              "  ... ace[%d] type is preserved (%u)", i, d.ace[i].type);
+        CHECK(d.ace[i].access_mask == want[i].access_mask,
+              "  ... ace[%d] access mask is preserved (0x%08x)", i,
+              d.ace[i].access_mask);
+
+        if (d.ace[i].type == ACE_DENIED) {
+            found_denied = 1;
+        }
+    }
+
+    CHECK(found_denied, "  ... the DENY ace survived (not dropped as unmappable)");
+
+    /* An owner SID no identity authority can resolve has no uid to become, so
+     * the owner is NOT adopted -- it stays the algorithmic form.  Pinning this
+     * guards the other direction: silently taking an unresolvable SID as the
+     * owner would detach the file's owner from every POSIX check. */
+    CHECK(strncmp(d.owner, "S-1-5-88-1-", 11) == 0,
+          "  ... an unresolvable owner SID is not adopted (%s)", d.owner);
+    CHECK(strncmp(d.group, "S-1-5-88-2-", 11) == 0,
+          "  ... nor an unresolvable group SID (%s)", d.group);
+
+    /* Setting only the DACL must not disturb owner or group. */
+    nlen = smb2_sd_build(built, sizeof(built), NULL, NULL, want, 2);
+
+    if (nlen > 0) {
+        st = smb2_set_info_addl(c, SMB2_INFO_SECURITY_T, 0, co.file_id,
+                                SEC_DACL, built, (uint32_t) nlen);
+        CHECK(st == ST_SUCCESS, "SET SECURITY(dacl only) -> 0x%08x", st);
+
+        st = smb2_query_info(c, SMB2_INFO_SECURITY_T, 0, co.file_id,
+                             SEC_OWNER | SEC_GROUP | SEC_DACL, sd, sizeof(sd),
+                             &len);
+
+        if (st == ST_SUCCESS && smb2_sd_parse(sd, len, &d) == 0) {
+            CHECK(d.nace == 2, "  ... the DACL is replaced (%d ACE(s))", d.nace);
+            CHECK(strncmp(d.owner, "S-1-5-88-1-", 11) == 0 &&
+                  strncmp(d.group, "S-1-5-88-2-", 11) == 0,
+                  "  ... owner and group are untouched (%s / %s)", d.owner,
+                  d.group);
+        } else {
+            CHECK(0, "  ... QUERY after the dacl-only SET -> 0x%08x", st);
+        }
+    }
+
+    smb2_close(c, co.file_id);
+} /* probe_security_sids */
 
 /* ---- directory enumeration ----------------------------------------------
  *
@@ -1218,6 +1395,7 @@ main(
     probe_streams(c);
     probe_link(c);
     probe_security(c);
+    probe_security_sids(c);
     probe_query_directory(c);
     probe_refusals(c);
 

--- a/src/server/smb/tests/quint/smb2_mbt_common.h
+++ b/src/server/smb/tests/quint/smb2_mbt_common.h
@@ -3172,6 +3172,349 @@ smb2_query_info(
                                65536, out, out_cap, out_len);
 } /* smb2_query_info */
 
+/* ---- security descriptors (MS-DTYP 2.4.6) -------------------------------
+ *
+ * InfoType SECURITY carries a self-relative SECURITY_DESCRIPTOR, which is the
+ * one info class whose payload is neither fixed-layout nor a flat list: the
+ * 20-byte header names byte offsets, each of the owner and group is a
+ * variable-length SID, and the DACL is a counted run of variable-length ACEs.
+ * Reading it positionally the way the fixed classes are read stops at the
+ * header, so everything below it -- which SID a principal actually got, and
+ * whether an ACE survived a round trip -- cannot be asserted at all.
+ *
+ * These helpers decode a descriptor into a comparable form.  SIDs are rendered
+ * to their string form rather than compared as bytes because that is what
+ * makes a failure legible ("S-1-5-88-1-0" against "S-1-5-21-1-2-3-1001"), and
+ * because the string is what every other layer of the server logs. */
+
+#define SMB2_SID_STR_MAX      128   /* S-1-<auth>-<15 sub-authorities>   */
+#define SMB2_SD_MAX_ACES      32
+
+#define SMB2_SEC_OWNER        0x00000001u
+#define SMB2_SEC_GROUP        0x00000002u
+#define SMB2_SEC_DACL         0x00000004u
+#define SMB2_SEC_SACL         0x00000008u
+
+#define SMB2_SE_SELF_RELATIVE 0x8000u
+#define SMB2_SE_DACL_PRESENT  0x0004u
+
+struct smb2_sd_ace {
+    uint8_t  type;
+    uint8_t  flags;
+    uint32_t access_mask;
+    char     sid[SMB2_SID_STR_MAX];
+};
+
+struct smb2_sd {
+    uint8_t            revision;
+    uint16_t           control;
+    int                have_owner;
+    int                have_group;
+    int                have_dacl;
+    char               owner[SMB2_SID_STR_MAX];
+    char               group[SMB2_SID_STR_MAX];
+    int                nace;
+    struct smb2_sd_ace ace[SMB2_SD_MAX_ACES];
+};
+
+/* Decode one binary SID (MS-DTYP 2.4.2.2) to its S-R-I-S-S string form.
+ * Returns the number of bytes consumed, or -1 if it does not fit in avail.
+ * The identifier authority is six bytes BIG-endian -- the only big-endian
+ * field in the whole descriptor. */
+static inline int
+smb2_sid_to_str(
+    const uint8_t *p,
+    uint32_t       avail,
+    char          *out,
+    size_t         cap)
+{
+    uint64_t auth = 0;
+    unsigned nsub, i;
+    size_t   n = 0;
+    int      len;
+
+    if (avail < 8) {
+        return -1;
+    }
+
+    nsub = p[1];
+
+    if (nsub > 15 || avail < 8 + nsub * 4) {
+        return -1;
+    }
+
+    for (i = 0; i < 6; i++) {
+        auth = (auth << 8) | p[2 + i];
+    }
+
+    len = snprintf(out, cap, "S-%u-%llu", p[0], (unsigned long long) auth);
+
+    if (len < 0 || (size_t) len >= cap) {
+        return -1;
+    }
+    n = (size_t) len;
+
+    for (i = 0; i < nsub; i++) {
+        len = snprintf(out + n, cap - n, "-%u", g32(p, (int) (8 + i * 4)));
+
+        if (len < 0 || n + (size_t) len >= cap) {
+            return -1;
+        }
+        n += (size_t) len;
+    }
+
+    return (int) (8 + nsub * 4);
+} /* smb2_sid_to_str */
+
+/* Decode a self-relative descriptor.  Returns 0, or -1 if any offset, SID or
+ * ACE runs outside the buffer -- a malformed descriptor is a probe failure,
+ * not something to parse best-effort. */
+static inline int
+smb2_sd_parse(
+    const uint8_t  *sd,
+    uint32_t        len,
+    struct smb2_sd *out)
+{
+    uint32_t off_owner, off_group, off_dacl;
+
+    memset(out, 0, sizeof(*out));
+
+    if (len < 20) {
+        return -1;
+    }
+
+    out->revision = sd[0];
+    out->control  = g16(sd, 2);
+    off_owner     = g32(sd, 4);
+    off_group     = g32(sd, 8);
+    off_dacl      = g32(sd, 16);
+
+    if (off_owner) {
+        if (off_owner >= len ||
+            smb2_sid_to_str(sd + off_owner, len - off_owner,
+                            out->owner, sizeof(out->owner)) < 0) {
+            return -1;
+        }
+        out->have_owner = 1;
+    }
+
+    if (off_group) {
+        if (off_group >= len ||
+            smb2_sid_to_str(sd + off_group, len - off_group,
+                            out->group, sizeof(out->group)) < 0) {
+            return -1;
+        }
+        out->have_group = 1;
+    }
+
+    if (off_dacl) {
+        uint32_t acl_size, pos;
+        uint16_t count, i;
+
+        if (off_dacl + 8 > len) {
+            return -1;
+        }
+
+        acl_size = g16(sd, (int) off_dacl + 2);
+        count    = g16(sd, (int) off_dacl + 4);
+
+        if (acl_size < 8 || off_dacl + acl_size > len) {
+            return -1;
+        }
+
+        out->have_dacl = 1;
+        pos            = off_dacl + 8;
+
+        for (i = 0; i < count; i++) {
+            struct smb2_sd_ace *a;
+            uint16_t            ace_size;
+
+            if (out->nace >= SMB2_SD_MAX_ACES) {
+                return -1;
+            }
+
+            if (pos + 8 > off_dacl + acl_size) {
+                return -1;
+            }
+
+            ace_size = g16(sd, (int) pos + 2);
+
+            if (ace_size < 8 || pos + ace_size > off_dacl + acl_size) {
+                return -1;
+            }
+
+            a              = &out->ace[out->nace];
+            a->type        = sd[pos];
+            a->flags       = sd[pos + 1];
+            a->access_mask = g32(sd, (int) pos + 4);
+
+            if (smb2_sid_to_str(sd + pos + 8, ace_size - 8,
+                                a->sid, sizeof(a->sid)) < 0) {
+                return -1;
+            }
+
+            out->nace++;
+            pos += ace_size;
+        }
+    }
+
+    return 0;
+} /* smb2_sd_parse */
+
+/* Encode an S-R-I-S-S string back to its binary form.  Returns the number of
+ * bytes written, or -1 on a malformed string or insufficient room.  This is
+ * the inverse of smb2_sid_to_str and exists so a probe can SET a descriptor
+ * naming a principal the server did not author. */
+static inline int
+smb2_sid_str_to_bin(
+    const char *str,
+    uint8_t    *out,
+    int         cap)
+{
+    unsigned long long auth;
+    unsigned           rev, nsub = 0;
+    const char        *p;
+    char              *end;
+    int                i;
+
+    if (!str || str[0] != 'S' || str[1] != '-') {
+        return -1;
+    }
+
+    rev = (unsigned) strtoul(str + 2, &end, 10);
+
+    if (end == str + 2 || *end != '-' || rev != 1) {
+        return -1;
+    }
+
+    auth = strtoull(end + 1, &end, 10);
+
+    if (auth > 0xffffffffffffULL || (*end != '-' && *end != '\0')) {
+        return -1;
+    }
+
+    /* Count the sub-authorities before writing anything, so a string that is
+     * too long for the caller's buffer fails before it has scribbled. */
+    for (p = end; *p == '-'; ) {
+        strtoul(p + 1, &end, 10);
+
+        if (end == p + 1) {
+            return -1;
+        }
+        nsub++;
+        p = end;
+    }
+
+    if (*p != '\0' || nsub > 15 || cap < (int) (8 + nsub * 4)) {
+        return -1;
+    }
+
+    out[0] = (uint8_t) rev;
+    out[1] = (uint8_t) nsub;
+
+    for (i = 0; i < 6; i++) {
+        out[2 + i] = (uint8_t) ((auth >> (8 * (5 - i))) & 0xff);
+    }
+
+    p = strchr(str + 2, '-');           /* skip revision */
+    p = strchr(p + 1, '-');             /* skip authority */
+
+    for (i = 0; i < (int) nsub; i++) {
+        p32(out, 8 + i * 4, (uint32_t) strtoul(p + 1, &end, 10));
+        p = end;
+    }
+
+    return (int) (8 + nsub * 4);
+} /* smb2_sid_str_to_bin */
+
+/* Build a minimal self-relative descriptor in canonical body order (owner SID,
+ * group SID, DACL): the order real clients decode positionally, and the order
+ * the server itself emits.  Any of the three may be omitted by passing NULL /
+ * a zero ACE count.  Returns the length written, or -1 if it does not fit. */
+static inline int
+smb2_sd_build(
+    uint8_t                  *out,
+    uint32_t                  cap,
+    const char               *owner,
+    const char               *group,
+    const struct smb2_sd_ace *aces,
+    int                       nace)
+{
+    uint32_t off = 20, dacl_off = 0;
+    uint16_t control = SMB2_SE_SELF_RELATIVE;
+    int      i, n;
+
+    if (cap < 20) {
+        return -1;
+    }
+    memset(out, 0, 20);
+    out[0] = 1;                                 /* Revision */
+
+    if (owner) {
+        n = smb2_sid_str_to_bin(owner, out + off, (int) (cap - off));
+
+        if (n < 0) {
+            return -1;
+        }
+        p32(out, 4, off);
+        off += (uint32_t) n;
+    }
+
+    if (group) {
+        n = smb2_sid_str_to_bin(group, out + off, (int) (cap - off));
+
+        if (n < 0) {
+            return -1;
+        }
+        p32(out, 8, off);
+        off += (uint32_t) n;
+    }
+
+    if (nace > 0) {
+        uint32_t acl_hdr = off;
+
+        control |= SMB2_SE_DACL_PRESENT;
+
+        if (off + 8 > cap) {
+            return -1;
+        }
+        off += 8;
+
+        for (i = 0; i < nace; i++) {
+            uint32_t ace_pos = off;
+
+            if (off + 8 > cap) {
+                return -1;
+            }
+
+            n = smb2_sid_str_to_bin(aces[i].sid, out + off + 8,
+                                    (int) (cap - off - 8));
+
+            if (n < 0) {
+                return -1;
+            }
+
+            out[ace_pos]     = aces[i].type;
+            out[ace_pos + 1] = aces[i].flags;
+            p16(out, (int) ace_pos + 2, (uint16_t) (8 + n));
+            p32(out, (int) ace_pos + 4, aces[i].access_mask);
+            off += 8 + (uint32_t) n;
+        }
+
+        out[acl_hdr]     = 2;                   /* ACL_REVISION */
+        out[acl_hdr + 1] = 0;
+        p16(out, (int) acl_hdr + 2, (uint16_t) (off - acl_hdr));
+        p16(out, (int) acl_hdr + 4, (uint16_t) nace);
+        p16(out, (int) acl_hdr + 6, 0);
+        dacl_off = acl_hdr;
+    }
+
+    p16(out, 2, control);
+    p32(out, 16, dacl_off);
+
+    return (int) off;
+} /* smb2_sd_build */
+
 /* ---- QUERY_DIRECTORY ----------------------------------------------------
  *
  * MS-SMB2 2.2.33: StructureSize 33, FileInformationClass(1), Flags(1),

--- a/src/server/smb/tests/smb_sd_sid_test.c
+++ b/src/server/smb/tests/smb_sd_sid_test.c
@@ -1,0 +1,429 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * SMB security-descriptor native-SID round trip.
+ *
+ * Drives the SD decoder (chimera_smb_sd_to_acl / chimera_smb_parse_sd_to_acl)
+ * and the SD emitter (chimera_smb_acl_to_sd) directly, without a server:
+ *
+ *   - a real SID the identity authority cannot map is kept as an opaque
+ *     CHIMERA_PRINCIPAL_SID and re-emitted byte-for-byte instead of dropped;
+ *   - a real SID the identity authority knows resolves to its uid AND keeps
+ *     the SID on the principal (and as the owner's native-SID companion);
+ *   - algorithmic (S-1-5-88) and well-known SIDs stay numeric/special;
+ *   - the emitter prefers stored SIDs (owner/group companions, ACE SIDs,
+ *     OWNER@ substitution) over the identity cache and the algorithmic form;
+ *   - the first decode pass records uncached real SIDs for async resolution
+ *     rather than storing them opaque.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_idmap.h"
+#include "vfs/sdk/vfs_attrs.h"
+#include "vfs/sdk/vfs_acl.h"
+#include "vfs/sdk/vfs_sid.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#include "server/smb/smb_internal.h"
+#include "server/smb/smb_procs.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+#define SID_OWNER_REAL   "S-1-5-21-1-2-3-500"
+#define SID_GROUP_REAL   "S-1-5-21-1-2-3-513"
+#define SID_OPAQUE       "S-1-5-21-1-2-3-1001"
+#define SID_OPAQUE2      "S-1-5-21-1-2-3-9999"
+#define SID_ALICE        "S-1-5-21-1-2-3-1105"
+#define SID_EVERYONE     "S-1-1-0"
+#define SID_UNIX_UID1000 "S-1-5-88-1-1000"
+#define SID_UNIX_GID1000 "S-1-5-88-2-1000"
+
+/* SD control bits (mirrors smb_proc_security.c). */
+#define SE_SELF_RELATIVE  0x8000
+#define SE_DACL_PRESENT   0x0004
+#define SE_DACL_PROTECTED 0x1000
+
+#define ACE_ALLOWED 0
+#define MASK_READ   0x00000001
+#define MASK_RW     0x00000003
+
+#define MAX_ACES 8
+#define ACL_BUF_SIZE (sizeof(struct chimera_acl) + MAX_ACES * sizeof(struct chimera_ace))
+
+static void
+put_le16(
+    uint8_t *b,
+    uint16_t v)
+{
+    b[0] = v & 0xff;
+    b[1] = (v >> 8) & 0xff;
+} /* put_le16 */
+
+static void
+put_le32(
+    uint8_t *b,
+    uint32_t v)
+{
+    b[0] = v & 0xff;
+    b[1] = (v >> 8) & 0xff;
+    b[2] = (v >> 16) & 0xff;
+    b[3] = (v >> 24) & 0xff;
+} /* put_le32 */
+
+static uint32_t
+get_le32(const uint8_t *b)
+{
+    return (uint32_t) b[0] | ((uint32_t) b[1] << 8) |
+           ((uint32_t) b[2] << 16) | ((uint32_t) b[3] << 24);
+} /* get_le32 */
+
+/*
+ * Assemble a self-relative SD: owner/group (either may be NULL), then a DACL
+ * of `nace` ALLOW ACEs with the given masks and SID strings.  Returns the SD
+ * length.
+ */
+static uint32_t
+build_sd(
+    uint8_t     *sd,
+    uint32_t     cap,
+    uint16_t     control,
+    const char  *owner,
+    const char  *group,
+    int          nace,
+    const uint32_t *masks,
+    const char **sids)
+{
+    uint32_t off = 20;
+    uint32_t owner_off = 0, group_off = 0, dacl_off = 0;
+    int      n;
+
+    memset(sd, 0, cap);
+    sd[0] = 1; /* revision */
+    put_le16(sd + 2, control);
+
+    if (owner) {
+        n = chimera_sid_str_to_bin(owner, sd + off, cap - off);
+        assert(n > 0);
+        owner_off = off;
+        off      += n;
+    }
+    if (group) {
+        n = chimera_sid_str_to_bin(group, sd + off, cap - off);
+        assert(n > 0);
+        group_off = off;
+        off      += n;
+    }
+    if (nace) {
+        uint32_t acl_hdr = off;
+        uint32_t ace_pos = off + 8;
+
+        for (int i = 0; i < nace; i++) {
+            n = chimera_sid_str_to_bin(sids[i], sd + ace_pos + 8, cap - ace_pos - 8);
+            assert(n > 0);
+            sd[ace_pos]     = ACE_ALLOWED;
+            sd[ace_pos + 1] = 0;
+            put_le16(sd + ace_pos + 2, 8 + n);
+            put_le32(sd + ace_pos + 4, masks[i]);
+            ace_pos += 8 + n;
+        }
+        sd[acl_hdr] = 2; /* ACL revision */
+        put_le16(sd + acl_hdr + 2, ace_pos - acl_hdr);
+        put_le16(sd + acl_hdr + 4, nace);
+        dacl_off = acl_hdr;
+        off      = ace_pos;
+    }
+
+    put_le32(sd + 4, owner_off);
+    put_le32(sd + 8, group_off);
+    put_le32(sd + 12, 0);
+    put_le32(sd + 16, dacl_off);
+    return off;
+} /* build_sd */
+
+/* Walk an emitted SD's DACL and return the i-th ACE's SID as a string. */
+static void
+sd_ace_sid(
+    const uint8_t *sd,
+    int            index,
+    char          *out,
+    int            outlen,
+    uint32_t      *mask)
+{
+    uint32_t dacl = get_le32(sd + 16);
+    uint16_t nace = sd[dacl + 4] | (sd[dacl + 5] << 8);
+    uint32_t pos  = dacl + 8;
+
+    assert(index < nace);
+    for (int i = 0; i < index; i++) {
+        pos += sd[pos + 2] | (sd[pos + 3] << 8);
+    }
+    *mask = get_le32(sd + pos + 4);
+    assert(chimera_sid_bin_to_str(sd + pos + 8, 128, out, outlen) > 0);
+} /* sd_ace_sid */
+
+static uint16_t
+sd_ace_count(const uint8_t *sd)
+{
+    uint32_t dacl = get_le32(sd + 16);
+
+    return sd[dacl + 4] | (sd[dacl + 5] << 8);
+} /* sd_ace_count */
+
+static void
+sd_owner_str(
+    const uint8_t *sd,
+    char          *out,
+    int            outlen)
+{
+    assert(chimera_sid_bin_to_str(sd + get_le32(sd + 4), 128, out, outlen) > 0);
+} /* sd_owner_str */
+
+static void
+sd_group_str(
+    const uint8_t *sd,
+    char          *out,
+    int            outlen)
+{
+    assert(chimera_sid_bin_to_str(sd + get_le32(sd + 8), 128, out, outlen) > 0);
+} /* sd_group_str */
+
+/*
+ * No identity authority (the create-time path): an unmappable real SID
+ * becomes an opaque principal and survives decode -> emit -> decode intact,
+ * while well-known and algorithmic SIDs stay special/numeric.
+ */
+static void
+test_opaque_roundtrip_no_authority(void)
+{
+    uint8_t                  sd[512], out[1024];
+    uint8_t                  acl_buf[ACL_BUF_SIZE], acl_buf2[ACL_BUF_SIZE];
+    struct chimera_acl      *acl  = (struct chimera_acl *) acl_buf;
+    struct chimera_acl      *acl2 = (struct chimera_acl *) acl_buf2;
+    struct chimera_vfs_attrs attrs;
+    struct chimera_sid       opaque, owner;
+    const uint32_t           masks[3] = { MASK_READ, MASK_READ, MASK_RW };
+    const char              *sids[3]  = { SID_OPAQUE, SID_EVERYONE, SID_UNIX_UID1000 };
+    char                     str[CHIMERA_SID_STR_MAX];
+    uint32_t                 sd_len, mask;
+    int                      out_len;
+
+    assert(chimera_sid_from_str(&opaque, SID_OPAQUE) == 0);
+    assert(chimera_sid_from_str(&owner, SID_OWNER_REAL) == 0);
+
+    sd_len = build_sd(sd, sizeof(sd),
+                      SE_SELF_RELATIVE | SE_DACL_PRESENT | SE_DACL_PROTECTED,
+                      SID_OWNER_REAL, SID_GROUP_REAL, 3, masks, sids);
+
+    memset(&attrs, 0, sizeof(attrs));
+    memset(acl_buf, 0, sizeof(acl_buf));
+    chimera_smb_parse_sd_to_acl(sd, sd_len, &attrs, acl_buf, sizeof(acl_buf),
+                                NULL, 1);
+
+    /* A real owner/group SID with no authority to map it is left alone
+     * (today's behaviour): no uid/gid and no companion is set. */
+    assert(!(attrs.va_set_mask & CHIMERA_VFS_ATTR_UID));
+    assert(!(attrs.va_set_mask & CHIMERA_VFS_ATTR_GID));
+    assert(!(attrs.va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+
+    /* All three ACEs are kept -- the unmappable one as an opaque SID. */
+    assert(attrs.va_set_mask & CHIMERA_VFS_ATTR_ACL);
+    assert(attrs.va_acl == acl);
+    assert(acl->num_aces == 3);
+    assert(acl->ctrl_flags & CHIMERA_ACL_CTRL_PROTECTED);
+    assert(acl->aces[0].who.type == CHIMERA_PRINCIPAL_SID);
+    assert(chimera_sid_equal(&acl->aces[0].who.sid, &opaque));
+    assert(acl->aces[1].who.type == CHIMERA_PRINCIPAL_SPECIAL);
+    assert(acl->aces[1].who.special == CHIMERA_WHO_EVERYONE);
+    assert(!chimera_sid_present(&acl->aces[1].who.sid));
+    assert(acl->aces[2].who.type == CHIMERA_PRINCIPAL_USER);
+    assert(acl->aces[2].who.id == 1000);
+    assert(!chimera_sid_present(&acl->aces[2].who.sid));
+    TEST_PASS("decode keeps an unmappable ACE as an opaque SID principal");
+
+    /* Emit: the owner companion verbatim, the group from the algorithmic
+     * fallback, the opaque ACE verbatim, the rest re-derived. */
+    out_len = chimera_smb_acl_to_sd(1000, 1000, 0644, acl, &owner, NULL,
+                                    1, 1, 1, out, sizeof(out), NULL);
+    assert(out_len > 0);
+    sd_owner_str(out, str, sizeof(str));
+    assert(strcmp(str, SID_OWNER_REAL) == 0);
+    sd_group_str(out, str, sizeof(str));
+    assert(strcmp(str, SID_UNIX_GID1000) == 0);
+    assert(sd_ace_count(out) == 3);
+    sd_ace_sid(out, 0, str, sizeof(str), &mask);
+    assert(strcmp(str, SID_OPAQUE) == 0 && mask == MASK_READ);
+    sd_ace_sid(out, 1, str, sizeof(str), &mask);
+    assert(strcmp(str, SID_EVERYONE) == 0);
+    sd_ace_sid(out, 2, str, sizeof(str), &mask);
+    assert(strcmp(str, SID_UNIX_UID1000) == 0 && mask == MASK_RW);
+    assert((out[2] | (out[3] << 8)) & SE_DACL_PROTECTED);
+    TEST_PASS("emit writes stored owner SID and opaque ACE SID verbatim");
+
+    /* And the emitted descriptor decodes back to the same principals. */
+    memset(&attrs, 0, sizeof(attrs));
+    memset(acl_buf2, 0, sizeof(acl_buf2));
+    chimera_smb_parse_sd_to_acl(out, out_len, &attrs, acl_buf2, sizeof(acl_buf2),
+                                NULL, 1);
+    assert(acl2->num_aces == 3);
+    assert(memcmp(acl->aces, acl2->aces, 3 * sizeof(struct chimera_ace)) == 0);
+    assert(acl2->ctrl_flags == acl->ctrl_flags);
+    TEST_PASS("decode(emit(decode(sd))) is lossless");
+} /* test_opaque_roundtrip_no_authority */
+
+/*
+ * With an identity authority: a cached real SID resolves to its uid and keeps
+ * the SID; the owner companion is captured on the SET path; an uncached real
+ * SID is recorded for async resolution on the first pass and kept opaque on
+ * the final pass; the emitter prefers every stored SID.
+ */
+static void
+test_with_identity_authority(void)
+{
+    struct chimera_vfs           *vfs;
+    struct chimera_vfs_thread    *thread;
+    struct evpl                  *evpl;
+    struct chimera_vfs_module_cfg module_cfgs[2];
+    struct prometheus_metrics    *metrics;
+    uint8_t                       sd[512], out[1024];
+    uint8_t                       acl_buf[ACL_BUF_SIZE];
+    struct chimera_acl           *acl = (struct chimera_acl *) acl_buf;
+    struct chimera_vfs_attrs      attrs;
+    struct chimera_sid            alice, opaque2, owner_out, group_out;
+    struct smb_unres_sids         unres;
+    const uint32_t                masks[2] = { MASK_RW, MASK_READ };
+    const char                   *sids[2]  = { SID_ALICE, SID_OPAQUE2 };
+    char                          str[CHIMERA_SID_STR_MAX];
+    uint32_t                      sd_len, mask;
+    int                           out_len;
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    strncpy(module_cfgs[0].module_name, "memfs",
+            sizeof(module_cfgs[0].module_name) - 1);
+    strncpy(module_cfgs[1].module_name, "memkv",
+            sizeof(module_cfgs[1].module_name) - 1);
+
+    evpl = evpl_create(NULL);
+    assert(evpl != NULL);
+    vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 1, 0, metrics);
+    assert(vfs != NULL);
+    thread = chimera_vfs_thread_init(evpl, vfs);
+    assert(thread != NULL);
+
+    /* alice is a domain user the identity authority knows, with a real SID. */
+    chimera_vfs_add_user(vfs, "alice", NULL, NULL, SID_ALICE, 4000, 4000, 0, NULL, 1);
+    assert(chimera_sid_from_str(&alice, SID_ALICE) == 0);
+    assert(chimera_sid_from_str(&opaque2, SID_OPAQUE2) == 0);
+
+    sd_len = build_sd(sd, sizeof(sd), SE_SELF_RELATIVE | SE_DACL_PRESENT,
+                      SID_ALICE, NULL, 2, masks, sids);
+
+    /* --- first pass: the uncached SID is recorded, its ACE skipped --- */
+    memset(&attrs, 0, sizeof(attrs));
+    memset(acl_buf, 0, sizeof(acl_buf));
+    memset(&unres, 0, sizeof(unres));
+    owner_out.len = 0;
+    group_out.len = 0;
+    assert(chimera_smb_sd_to_acl(sd, sd_len, &attrs, acl, MAX_ACES, vfs, &unres,
+                                 &owner_out, &group_out, 1) == 0);
+    assert(unres.count == 1);
+    assert(strcmp(unres.sids[0], SID_OPAQUE2) == 0);
+    assert(acl->num_aces == 1);
+    assert(acl->aces[0].who.type == CHIMERA_PRINCIPAL_USER);
+    assert(acl->aces[0].who.id == 4000);
+    assert(chimera_sid_equal(&acl->aces[0].who.sid, &alice));
+    TEST_PASS("first pass resolves alice with her SID and parks the unknown SID");
+
+    /* The owner resolved through the authority: uid plus the SID companion. */
+    assert(attrs.va_set_mask & CHIMERA_VFS_ATTR_UID);
+    assert(attrs.va_uid == 4000);
+    assert(attrs.va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    assert(attrs.va_owner_sid == &owner_out);
+    assert(chimera_sid_equal(&owner_out, &alice));
+    assert(!(attrs.va_set_mask & CHIMERA_VFS_ATTR_GROUP_SID));
+    TEST_PASS("owner SID resolved via the authority is kept as the companion");
+
+    /* --- final pass (unres == NULL): the still-unknown SID is stored opaque --- */
+    memset(&attrs, 0, sizeof(attrs));
+    memset(acl_buf, 0, sizeof(acl_buf));
+    owner_out.len = 0;
+    assert(chimera_smb_sd_to_acl(sd, sd_len, &attrs, acl, MAX_ACES, vfs, NULL,
+                                 &owner_out, &group_out, 1) == 0);
+    assert(acl->num_aces == 2);
+    assert(acl->aces[0].who.type == CHIMERA_PRINCIPAL_USER);
+    assert(acl->aces[0].who.id == 4000);
+    assert(acl->aces[1].who.type == CHIMERA_PRINCIPAL_SID);
+    assert(chimera_sid_equal(&acl->aces[1].who.sid, &opaque2));
+    TEST_PASS("final pass stores the unmappable ACE as an opaque SID");
+
+    /* --- emit: alice's ACE from her stored SID, the opaque one verbatim, the
+     *     owner from the companion, and an OWNER@ entry substituted with it --- */
+    {
+        uint8_t             acl3_buf[ACL_BUF_SIZE];
+        struct chimera_acl *acl3 = (struct chimera_acl *) acl3_buf;
+
+        memset(acl3_buf, 0, sizeof(acl3_buf));
+        acl3->num_aces            = 3;
+        acl3->aces[0]             = acl->aces[0];
+        acl3->aces[1]             = acl->aces[1];
+        acl3->aces[2].type        = CHIMERA_ACE_ALLOWED;
+        acl3->aces[2].access_mask = MASK_READ;
+        acl3->aces[2].who.type    = CHIMERA_PRINCIPAL_SPECIAL;
+        acl3->aces[2].who.special = CHIMERA_WHO_OWNER;
+
+        out_len = chimera_smb_acl_to_sd(4000, 4000, 0644, acl3, &owner_out, NULL,
+                                        1, 1, 1, out, sizeof(out), vfs);
+        assert(out_len > 0);
+        sd_owner_str(out, str, sizeof(str));
+        assert(strcmp(str, SID_ALICE) == 0);
+        assert(sd_ace_count(out) == 3);
+        sd_ace_sid(out, 0, str, sizeof(str), &mask);
+        assert(strcmp(str, SID_ALICE) == 0 && mask == MASK_RW);
+        sd_ace_sid(out, 1, str, sizeof(str), &mask);
+        assert(strcmp(str, SID_OPAQUE2) == 0 && mask == MASK_READ);
+        sd_ace_sid(out, 2, str, sizeof(str), &mask);
+        assert(strcmp(str, SID_ALICE) == 0);
+        TEST_PASS("emit prefers stored SIDs, including for OWNER@ substitution");
+    }
+
+    /* Without a companion the owner still comes from the identity cache. */
+    out_len = chimera_smb_acl_to_sd(4000, 4000, 0644, NULL, NULL, NULL,
+                                    1, 1, 1, out, sizeof(out), vfs);
+    assert(out_len > 0);
+    sd_owner_str(out, str, sizeof(str));
+    assert(strcmp(str, SID_ALICE) == 0);
+    sd_group_str(out, str, sizeof(str));
+    assert(strcmp(str, "S-1-5-88-2-4000") == 0);
+    TEST_PASS("without a companion the cached real SID is still used");
+
+    chimera_vfs_thread_destroy(thread);
+    chimera_vfs_destroy(vfs);
+    evpl_destroy(evpl);
+    prometheus_metrics_destroy(metrics);
+} /* test_with_identity_authority */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    chimera_log_init();
+
+    test_opaque_roundtrip_no_authority();
+    test_with_identity_authority();
+
+    fprintf(stderr, "All SMB SD native-SID tests passed\n");
+    return 0;
+} /* main */

--- a/src/server/smb/tests/smb_sd_sid_test.c
+++ b/src/server/smb/tests/smb_sd_sid_test.c
@@ -39,26 +39,26 @@
 
 #define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
 
-#define SID_OWNER_REAL   "S-1-5-21-1-2-3-500"
-#define SID_GROUP_REAL   "S-1-5-21-1-2-3-513"
-#define SID_OPAQUE       "S-1-5-21-1-2-3-1001"
-#define SID_OPAQUE2      "S-1-5-21-1-2-3-9999"
-#define SID_ALICE        "S-1-5-21-1-2-3-1105"
-#define SID_EVERYONE     "S-1-1-0"
-#define SID_UNIX_UID1000 "S-1-5-88-1-1000"
-#define SID_UNIX_GID1000 "S-1-5-88-2-1000"
+#define SID_OWNER_REAL    "S-1-5-21-1-2-3-500"
+#define SID_GROUP_REAL    "S-1-5-21-1-2-3-513"
+#define SID_OPAQUE        "S-1-5-21-1-2-3-1001"
+#define SID_OPAQUE2       "S-1-5-21-1-2-3-9999"
+#define SID_ALICE         "S-1-5-21-1-2-3-1105"
+#define SID_EVERYONE      "S-1-1-0"
+#define SID_UNIX_UID1000  "S-1-5-88-1-1000"
+#define SID_UNIX_GID1000  "S-1-5-88-2-1000"
 
 /* SD control bits (mirrors smb_proc_security.c). */
 #define SE_SELF_RELATIVE  0x8000
 #define SE_DACL_PRESENT   0x0004
 #define SE_DACL_PROTECTED 0x1000
 
-#define ACE_ALLOWED 0
-#define MASK_READ   0x00000001
-#define MASK_RW     0x00000003
+#define ACE_ALLOWED       0
+#define MASK_READ         0x00000001
+#define MASK_RW           0x00000003
 
-#define MAX_ACES 8
-#define ACL_BUF_SIZE (sizeof(struct chimera_acl) + MAX_ACES * sizeof(struct chimera_ace))
+#define MAX_ACES          8
+#define ACL_BUF_SIZE      (sizeof(struct chimera_acl) + MAX_ACES * sizeof(struct chimera_ace))
 
 static void
 put_le16(
@@ -94,14 +94,14 @@ get_le32(const uint8_t *b)
  */
 static uint32_t
 build_sd(
-    uint8_t     *sd,
-    uint32_t     cap,
-    uint16_t     control,
-    const char  *owner,
-    const char  *group,
-    int          nace,
+    uint8_t        *sd,
+    uint32_t        cap,
+    uint16_t        control,
+    const char     *owner,
+    const char     *group,
+    int             nace,
     const uint32_t *masks,
-    const char **sids)
+    const char    **sids)
 {
     uint32_t off = 20;
     uint32_t owner_off = 0, group_off = 0, dacl_off = 0;

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -15,6 +15,7 @@ add_compile_definitions(_LGPL_SOURCE)
 
 add_library(chimera_vfs SHARED vfs.c vfs_lsan.c vfs_cred.c vfs_sdk_utils.c
             vfs_acl.c vfs_acl_serialize.c vfs_access.c vfs_idmap.c vfs_identity.c
+            vfs_sid.c
             vfs_proc_mount.c vfs_proc_umount.c
             vfs_proc_mkfs.c vfs_proc_rmfs.c
             vfs_proc_mkdir_at.c vfs_proc_mknod_at.c vfs_proc_close.c vfs_proc_open_fh.c

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2379,8 +2379,8 @@ cairn_setattr(
         if (orig_set_mask & (CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID |
                              CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
             struct chimera_sid owner, group;
-            int                had     = cairn_load_sids(thread, inode->inum,
-                                                         &owner, &group);
+            int                had = cairn_load_sids(thread, inode->inum,
+                                                     &owner, &group);
             int                changed = 0;
 
             if (orig_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) {

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -52,6 +52,7 @@ void rocksdb_flush_wal(
 #define CAIRN_KEY_ACL            7
 #define CAIRN_KEY_FS             8
 #define CAIRN_KEY_PNFS           9
+#define CAIRN_KEY_SID            10
 
 /*
  * Storage layout:
@@ -135,6 +136,13 @@ struct cairn_acl_key {
  * on every lookup.  Cairn neither produces nor interprets the contents -- the
  * NFS server packs a deviceid plus a backing filehandle in there. */
 struct cairn_pnfs_key {
+    uint8_t  keytype;
+    uint64_t inum;
+} __attribute__((packed));
+
+/* Native owner / group SIDs, kept in a record separate from the
+ * ACL so "no ACL record" still means "mode-derived DACL". */
+struct cairn_sid_key {
     uint8_t  keytype;
     uint64_t inum;
 } __attribute__((packed));
@@ -975,6 +983,154 @@ cairn_load_acl(
  * if present, else one synthesised from the inode mode.  Uses a per-thread
  * scratch buffer valid for the duration of the (synchronous) completion.
  */
+/*
+ * Native owner / group SID record (CAIRN_KEY_SID): the SID companions to the
+ * inode's uid / gid.  Value layout: u8 owner_len, owner bytes, u8 group_len,
+ * group bytes; a zero length means none is known.  The record is absent when
+ * neither SID is known.
+ */
+#define CAIRN_SID_REC_MAX (2 + 2 * CHIMERA_SID_MAX_LEN)
+
+static inline void
+cairn_remove_sids(
+    struct cairn_thread *thread,
+    uint64_t             inum)
+{
+    rocksdb_transaction_t *txn = cairn_get_meta_txn(thread);
+    char                  *err = NULL;
+    struct cairn_sid_key   key;
+
+    key.keytype = CAIRN_KEY_SID;
+    key.inum    = inum;
+
+    rocksdb_transaction_delete(txn, (const char *) &key, sizeof(key), &err);
+    chimera_cairn_abort_if(err, "Error deleting sids: %s\n", err);
+} /* cairn_remove_sids */
+
+static inline void
+cairn_put_sids(
+    struct cairn_thread      *thread,
+    uint64_t                  inum,
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group)
+{
+    rocksdb_transaction_t *txn = cairn_get_meta_txn(thread);
+    char                  *err = NULL;
+    struct cairn_sid_key   key;
+    uint8_t                buf[CAIRN_SID_REC_MAX];
+    int                    len = 0;
+
+    if (!chimera_sid_present(owner) && !chimera_sid_present(group)) {
+        cairn_remove_sids(thread, inum);
+        return;
+    }
+
+    buf[len++] = chimera_sid_present(owner) ? owner->len : 0;
+    if (chimera_sid_present(owner)) {
+        memcpy(buf + len, owner->data, owner->len);
+        len += owner->len;
+    }
+    buf[len++] = chimera_sid_present(group) ? group->len : 0;
+    if (chimera_sid_present(group)) {
+        memcpy(buf + len, group->data, group->len);
+        len += group->len;
+    }
+
+    key.keytype = CAIRN_KEY_SID;
+    key.inum    = inum;
+
+    rocksdb_transaction_put(txn, (const char *) &key, sizeof(key),
+                            (const char *) buf, len, &err);
+    chimera_cairn_abort_if(err, "Error putting sids: %s\n", err);
+} /* cairn_put_sids */
+
+/*
+ * Load the stored owner / group SIDs for `inum`; each output is cleared when
+ * it is not recorded.  Returns 1 if a record was found, 0 otherwise.
+ */
+static inline int
+cairn_load_sids(
+    struct cairn_thread *thread,
+    uint64_t             inum,
+    struct chimera_sid  *owner,
+    struct chimera_sid  *group)
+{
+    rocksdb_pinnableslice_t *slice;
+    struct cairn_sid_key     key;
+    char                    *err = NULL;
+    const uint8_t           *blob;
+    size_t                   len;
+    int                      found = 0;
+
+    owner->len = 0;
+    group->len = 0;
+
+    key.keytype = CAIRN_KEY_SID;
+    key.inum    = inum;
+
+    slice = cairn_meta_get_pinned(thread, &key, sizeof(key), &err);
+    chimera_cairn_abort_if(err, "Error getting sids: %s\n", err);
+
+    if (slice) {
+        blob = (const uint8_t *) rocksdb_pinnableslice_value(slice, &len);
+        if (len >= 1) {
+            uint8_t olen = blob[0];
+
+            if (olen && 1 + olen <= len &&
+                chimera_sid_from_bin(owner, blob + 1, olen) == (int) olen &&
+                1 + olen < len) {
+                uint8_t glen = blob[1 + olen];
+
+                if (glen && 2 + olen + glen <= len) {
+                    chimera_sid_from_bin(group, blob + 2 + olen, glen);
+                }
+            } else if (!olen && len >= 2) {
+                uint8_t glen = blob[1];
+
+                if (glen && 2 + glen <= len) {
+                    chimera_sid_from_bin(group, blob + 2, glen);
+                }
+            }
+            found = 1;
+        }
+        rocksdb_pinnableslice_destroy(slice);
+    }
+
+    return found;
+} /* cairn_load_sids */
+
+/*
+ * Populate attr->va_owner_sid / va_group_sid when requested and stored, from
+ * per-thread scratch valid for the duration of the (synchronous) completion.
+ */
+static inline void
+cairn_map_sids(
+    struct cairn_thread      *thread,
+    struct chimera_vfs_attrs *attr,
+    const struct cairn_inode *inode)
+{
+    static __thread struct chimera_sid owner_scratch;
+    static __thread struct chimera_sid group_scratch;
+
+    if (!(attr->va_req_mask & (CHIMERA_VFS_ATTR_OWNER_SID |
+                               CHIMERA_VFS_ATTR_GROUP_SID))) {
+        return;
+    }
+
+    if (!cairn_load_sids(thread, inode->inum, &owner_scratch, &group_scratch)) {
+        return;
+    }
+
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_OWNER_SID) && owner_scratch.len) {
+        attr->va_owner_sid = &owner_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    }
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_GROUP_SID) && group_scratch.len) {
+        attr->va_group_sid = &group_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    }
+} /* cairn_map_sids */
+
 static inline void
 cairn_map_acl(
     struct cairn_thread      *thread,
@@ -983,6 +1139,9 @@ cairn_map_acl(
 {
     static __thread uint8_t scratch[CAIRN_ACL_STRUCT_SCRATCH];
     struct chimera_acl     *dst = (struct chimera_acl *) scratch;
+
+    /* The SID companions travel with the ACL everywhere it is mapped. */
+    cairn_map_sids(thread, attr, inode);
 
     if (!(attr->va_req_mask & CHIMERA_VFS_ATTR_ACL)) {
         return;
@@ -2212,6 +2371,52 @@ cairn_setattr(
                 cairn_put_acl(thread, inode->inum, new_acl);
             }
         }
+
+        /* Native owner / group SID coherence: an explicit OWNER_SID /
+         * GROUP_SID set stores (or clears) the companion; a bare chown /
+         * chgrp drops the stale one.  Load-modify-put on the SID record,
+         * which is separate from the ACL so a chown never touches the DACL. */
+        if (orig_set_mask & (CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID |
+                             CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+            struct chimera_sid owner, group;
+            int                had     = cairn_load_sids(thread, inode->inum,
+                                                         &owner, &group);
+            int                changed = 0;
+
+            if (orig_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) {
+                if (chimera_sid_present(sa->va_owner_sid)) {
+                    owner   = *sa->va_owner_sid;
+                    changed = 1;
+                } else if (owner.len) {
+                    owner.len = 0;
+                    changed   = 1;
+                }
+            } else if ((orig_set_mask & CHIMERA_VFS_ATTR_UID) && owner.len) {
+                owner.len = 0;
+                changed   = 1;
+            }
+
+            if (orig_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) {
+                if (chimera_sid_present(sa->va_group_sid)) {
+                    group   = *sa->va_group_sid;
+                    changed = 1;
+                } else if (group.len) {
+                    group.len = 0;
+                    changed   = 1;
+                }
+            } else if ((orig_set_mask & CHIMERA_VFS_ATTR_GID) && group.len) {
+                group.len = 0;
+                changed   = 1;
+            }
+
+            if (changed) {
+                if (owner.len || group.len) {
+                    cairn_put_sids(thread, inode->inum, &owner, &group);
+                } else if (had) {
+                    cairn_remove_sids(thread, inode->inum);
+                }
+            }
+        }
     }
 
     /* pNFS layout blob.  Keyed off orig_set_mask for the same reason the ACL
@@ -2590,6 +2795,7 @@ cairn_rmfs_delete_inode(
     struct cairn_symlink_key symlink_key;
     struct cairn_acl_key     acl_key;
     struct cairn_pnfs_key    pnfs_key;
+    struct cairn_sid_key     sid_key;
     struct cairn_xattr_key   xattr_start, *xattr_key;
     struct cairn_extent_key  extent_start, *extent_key;
     rocksdb_iterator_t      *iter;
@@ -2614,6 +2820,11 @@ cairn_rmfs_delete_inode(
     pnfs_key.inum    = inum;
     rocksdb_writebatch_delete(meta_batch,
                               (const char *) &pnfs_key, sizeof(pnfs_key));
+
+    sid_key.keytype = CAIRN_KEY_SID;
+    sid_key.inum    = inum;
+    rocksdb_writebatch_delete(meta_batch,
+                              (const char *) &sid_key, sizeof(sid_key));
 
     xattr_start.keytype = CAIRN_KEY_XATTR;
     xattr_start.inum    = inum;
@@ -3330,6 +3541,7 @@ cairn_remove_at(
             cairn_remove_inode(thread, inode);
             cairn_remove_acl(thread, inode->inum);
             cairn_remove_pnfs(thread, inode->inum);
+            cairn_remove_sids(thread, inode->inum);
         } else {
             cairn_put_inode(thread, inode);
         }
@@ -3910,6 +4122,7 @@ cairn_close(
         cairn_remove_inode(thread, inode);
         cairn_remove_acl(thread, inode->inum);
         cairn_remove_pnfs(thread, inode->inum);
+        cairn_remove_sids(thread, inode->inum);
     } else {
         cairn_put_inode(thread, inode);
     }
@@ -5065,6 +5278,7 @@ cairn_rename_at(
                     cairn_remove_inode(thread, existing_inode);
                     cairn_remove_acl(thread, existing_inode->inum);
                     cairn_remove_pnfs(thread, existing_inode->inum);
+                    cairn_remove_sids(thread, existing_inode->inum);
                 } else {
                     cairn_put_inode(thread, existing_inode);
                 }

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -888,9 +888,10 @@ cairn_map_pnfs(
     rocksdb_pinnableslice_destroy(slice);
 } /* cairn_map_pnfs */
 
-/* Scratch big enough to (de)serialize the largest permitted ACL. */
+/* Scratch big enough to (de)serialize the largest permitted ACL, every ACE
+ * carrying a maximum-length native SID (the v2 encoding is variable). */
 #define CAIRN_ACL_SCRATCH        (CHIMERA_ACL_SERIAL_HDR + \
-                                  CHIMERA_ACL_MAX_ACES * CHIMERA_ACL_SERIAL_ACE)
+                                  CHIMERA_ACL_MAX_ACES * CHIMERA_ACL_SERIAL_ACE_MAX)
 #define CAIRN_ACL_STRUCT_SCRATCH (sizeof(struct chimera_acl) + \
                                   CHIMERA_ACL_MAX_ACES * sizeof(struct chimera_ace))
 

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -200,7 +200,10 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
         CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED |
         CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS |
         CHIMERA_VFS_CAP_READ_PLUS | CHIMERA_VFS_CAP_WRITE_SAME |
-        CHIMERA_VFS_CAP_CLONE_RANGE,
+        CHIMERA_VFS_CAP_CLONE_RANGE |
+        /* diskfs persists the canonical ACL (DISKFS_REC_ACL) and the native
+         * owner/group SIDs (DISKFS_REC_SID); advertise it like memfs/cairn. */
+        CHIMERA_VFS_CAP_ACL_NATIVE,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -1276,10 +1276,10 @@ diskfs_setattr_inode_cb(
                                      DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
         static __thread uint8_t nbuf[sizeof(struct chimera_acl) +
                                      DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
-        struct chimera_acl *old_acl = (struct chimera_acl *) obuf;
-        struct chimera_acl *new_acl = (struct chimera_acl *) nbuf;
-        uint8_t             sbuf[DISKFS_ACL_REC_MAX];
-        int                 slen;
+        struct chimera_acl     *old_acl = (struct chimera_acl *) obuf;
+        struct chimera_acl     *new_acl = (struct chimera_acl *) nbuf;
+        uint8_t                 sbuf[DISKFS_ACL_REC_MAX];
+        int                     slen;
 
         if (chimera_acl_deserialize((const char *) inode->acl_serial,
                                     inode->acl_serial_len, old_acl,

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -82,6 +82,14 @@ diskfs_setattr_acl_inserted_cb(
     void                *private_data);
 
 static void
+diskfs_setattr_sids(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_setattr_sid_insert(
+    struct chimera_vfs_request *request);
+
+static void
 diskfs_setattr_acl_insert(
     struct chimera_vfs_request *request);
 
@@ -358,6 +366,113 @@ diskfs_acl_serial_install(
 
 
 /*
+ * Native owner / group SID record codec (DISKFS_REC_SID): u8 owner_len,
+ * owner bytes, u8 group_len, group bytes; a zero length means unknown.
+ * Encode returns the record length, or -1 when neither SID is present (then
+ * no record should exist).  Decode clears whichever SID is not recorded.
+ */
+int
+diskfs_sid_rec_encode(
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group,
+    uint8_t                  *buf)
+{
+    int len = 0;
+
+    if (!chimera_sid_present(owner) && !chimera_sid_present(group)) {
+        return -1;
+    }
+    buf[len++] = chimera_sid_present(owner) ? owner->len : 0;
+    if (chimera_sid_present(owner)) {
+        memcpy(buf + len, owner->data, owner->len);
+        len += owner->len;
+    }
+    buf[len++] = chimera_sid_present(group) ? group->len : 0;
+    if (chimera_sid_present(group)) {
+        memcpy(buf + len, group->data, group->len);
+        len += group->len;
+    }
+    return len;
+} /* diskfs_sid_rec_encode */
+
+void
+diskfs_sid_rec_decode(
+    const uint8_t      *serial,
+    uint32_t            len,
+    struct chimera_sid *owner,
+    struct chimera_sid *group)
+{
+    uint32_t pos = 0;
+    uint8_t  olen, glen;
+
+    owner->len = 0;
+    group->len = 0;
+
+    if (!serial || len < 2) {
+        return;
+    }
+    olen = serial[pos++];
+    if (olen) {
+        if (pos + olen > len ||
+            chimera_sid_from_bin(owner, serial + pos, olen) != (int) olen) {
+            owner->len = 0;
+            return;
+        }
+        pos += olen;
+    }
+    if (pos >= len) {
+        return;
+    }
+    glen = serial[pos++];
+    if (glen && pos + glen <= len) {
+        chimera_sid_from_bin(group, serial + pos, glen);
+    }
+} /* diskfs_sid_rec_decode */
+
+/* Replace inode->sid_serial (mirror of the DISKFS_REC_SID record) with a
+ * copy of serial[0..len), or clear it when len < 0.  Caller holds the inode
+ * write lock. */
+void
+diskfs_sid_serial_install(
+    struct diskfs_inode *inode,
+    const uint8_t       *serial,
+    int                  len)
+{
+    free(inode->sid_serial);
+    inode->sid_serial     = NULL;
+    inode->sid_serial_len = 0;
+    if (len >= 0) {
+        inode->sid_serial = malloc(len);
+        memcpy(inode->sid_serial, serial, len);
+        inode->sid_serial_len = (uint32_t) len;
+    }
+} /* diskfs_sid_serial_install */
+
+/* Decode the SID record into per-thread scratch and point the requested
+ * attr companions at it (valid through the synchronous completion). */
+void
+diskfs_sid_decode_into(
+    struct chimera_vfs_attrs *attr,
+    const uint8_t            *serial,
+    uint32_t                  len)
+{
+    static __thread struct chimera_sid owner;
+    static __thread struct chimera_sid group;
+
+    diskfs_sid_rec_decode(serial, len, &owner, &group);
+
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_OWNER_SID) && owner.len) {
+        attr->va_owner_sid = &owner;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    }
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_GROUP_SID) && group.len) {
+        attr->va_group_sid = &group;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    }
+} /* diskfs_sid_decode_into */
+
+
+/*
  * Seed a freshly-created child's ACL (mirrors memfs/cairn).  Precedence:
  *   1. an explicit ACL supplied at create (e.g. an SMB SD via SecD) -> store
  *      it and re-derive the child mode (the caller snapshots new_acl from
@@ -387,7 +502,11 @@ diskfs_inherit_acl_async(
     int                       is_dir = S_ISDIR(child->mode);
     uint16_t                  want   = CHIMERA_ACE_FLAG_FILE_INHERIT |
         (is_dir ? CHIMERA_ACE_FLAG_DIR_INHERIT : 0);
-    uint8_t                   abuf[sizeof(struct chimera_acl) +
+    /* Per-thread scratch: an ACE now carries an inline SID, so these are
+     * too large to keep on the stack. */
+    static __thread uint8_t   abuf[sizeof(struct chimera_acl) +
+                                   DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
+    static __thread uint8_t   pbuf[sizeof(struct chimera_acl) +
                                    DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
     const struct chimera_acl *store       = NULL;
     int                       derive_mode = 0;
@@ -396,8 +515,6 @@ diskfs_inherit_acl_async(
         store       = new_acl;
         derive_mode = 1;
     } else {
-        uint8_t             pbuf[sizeof(struct chimera_acl) +
-                                 DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
         struct chimera_acl *parent_acl = (struct chimera_acl *) pbuf;
         int                 has_inh    = 0;
 
@@ -439,7 +556,8 @@ diskfs_inherit_acl_async(
         }
     }
 
-    if (store && store->num_aces && store->num_aces <= DISKFS_ACL_REC_MAX_ACES) {
+    if (store && store->num_aces &&
+        chimera_acl_serialized_size(store) <= DISKFS_ACL_REC_MAX) {
         uint8_t sbuf[DISKFS_ACL_REC_MAX];
         int     len = chimera_acl_serialize(store, sbuf, sizeof(sbuf));
 
@@ -800,7 +918,7 @@ diskfs_setattr_acl_inserted_cb(
 
     (void) result;
     diskfs_bt_op_free(p->thread, op);
-    diskfs_setattr_finish(request);
+    diskfs_setattr_sids(request);
 } /* diskfs_setattr_acl_inserted_cb */
 
 
@@ -813,7 +931,7 @@ diskfs_setattr_acl_insert(struct chimera_vfs_request *request)
 
     if (!inode->acl_serial) {
         /* Remove-only chain (revert to mode-derived). */
-        diskfs_setattr_finish(request);
+        diskfs_setattr_sids(request);
         return;
     }
 
@@ -839,6 +957,92 @@ diskfs_setattr_acl_removed_cb(
     diskfs_bt_op_free(p->thread, op);
     diskfs_setattr_acl_insert(request);
 } /* diskfs_setattr_acl_removed_cb */
+
+
+/*
+ * Native owner / group SID record replay (chain tail after the ACL steps):
+ * the inode's sid_serial mirror already holds the end state; replay it into
+ * the b+tree as decided by p->sid_action, then finish.
+ */
+static void
+diskfs_setattr_sid_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+    diskfs_setattr_finish(request);
+} /* diskfs_setattr_sid_inserted_cb */
+
+static void
+diskfs_setattr_sid_insert(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p     = request->plugin_data;
+    struct diskfs_inode           *inode = p->inode_stash[0];
+    struct diskfs_bt_op           *op;
+
+    if (!inode->sid_serial) {
+        diskfs_setattr_finish(request);
+        return;
+    }
+
+    op = diskfs_bt_op_alloc(p->thread);
+    if (diskfs_bt_insert_async(op, p->thread, p->txn, inode, &diskfs_sid_key,
+                               inode->sid_serial, inode->sid_serial_len,
+                               diskfs_setattr_sid_inserted_cb, request)) {
+        diskfs_setattr_sid_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_setattr_sid_insert */
+
+static void
+diskfs_setattr_sid_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    (void) result;
+    diskfs_bt_op_free(p->thread, op);
+
+    if (p->sid_action == DISKFS_SID_ACTION_REPLACE) {
+        diskfs_setattr_sid_insert(request);
+    } else {
+        diskfs_setattr_finish(request);
+    }
+} /* diskfs_setattr_sid_removed_cb */
+
+static void
+diskfs_setattr_sids(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p     = request->plugin_data;
+    struct diskfs_inode           *inode = p->inode_stash[0];
+    struct diskfs_bt_op           *op;
+
+    switch (p->sid_action) {
+        case DISKFS_SID_ACTION_INSERT:
+            diskfs_setattr_sid_insert(request);
+            return;
+        case DISKFS_SID_ACTION_REMOVE:
+        case DISKFS_SID_ACTION_REPLACE:
+            op = diskfs_bt_op_alloc(p->thread);
+            if (diskfs_bt_remove_async(op, p->thread, p->txn, inode,
+                                       &diskfs_sid_key,
+                                       diskfs_setattr_sid_removed_cb,
+                                       request)) {
+                diskfs_setattr_sid_removed_cb(op, op->result, request);
+            }
+            return;
+        default:
+            diskfs_setattr_finish(request);
+            return;
+    } /* switch */
+} /* diskfs_setattr_sids */
 
 
 static void
@@ -930,6 +1134,64 @@ diskfs_setattr_inode_cb(
     p->inode_stash[0] = inode;
     p->inode_stash[2] = NULL;   /* refcount inode (acquired lazily on shared free) */
 
+    /*
+     * Native owner / group SID coherence (mirrors memfs/cairn): an explicit
+     * OWNER_SID / GROUP_SID set stores (or clears) the companion; a bare chown
+     * or chgrp drops the stale one.  The mirror is updated here and the
+     * record replayed by diskfs_setattr_sids at the end of the chain, after
+     * the ACL steps, so both records are in the tree before post attrs map.
+     */
+    p->sid_action = DISKFS_SID_ACTION_NONE;
+    if (orig_mask & (CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID |
+                     CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+        const struct chimera_vfs_attrs *sa = request->setattr.set_attr;
+        struct chimera_sid              owner, group;
+        int                             had     = inode->sid_serial != NULL;
+        int                             changed = 0;
+
+        diskfs_sid_rec_decode(inode->sid_serial, inode->sid_serial_len,
+                              &owner, &group);
+
+        if (orig_mask & CHIMERA_VFS_ATTR_OWNER_SID) {
+            if (chimera_sid_present(sa->va_owner_sid)) {
+                owner   = *sa->va_owner_sid;
+                changed = 1;
+            } else if (owner.len) {
+                owner.len = 0;
+                changed   = 1;
+            }
+        } else if ((orig_mask & CHIMERA_VFS_ATTR_UID) && owner.len) {
+            owner.len = 0;
+            changed   = 1;
+        }
+
+        if (orig_mask & CHIMERA_VFS_ATTR_GROUP_SID) {
+            if (chimera_sid_present(sa->va_group_sid)) {
+                group   = *sa->va_group_sid;
+                changed = 1;
+            } else if (group.len) {
+                group.len = 0;
+                changed   = 1;
+            }
+        } else if ((orig_mask & CHIMERA_VFS_ATTR_GID) && group.len) {
+            group.len = 0;
+            changed   = 1;
+        }
+
+        if (changed) {
+            uint8_t rec[DISKFS_SID_REC_MAX];
+            int     len = diskfs_sid_rec_encode(&owner, &group, rec);
+
+            diskfs_sid_serial_install(inode, rec, len);
+            if (len >= 0) {
+                p->sid_action = had ? DISKFS_SID_ACTION_REPLACE
+                                    : DISKFS_SID_ACTION_INSERT;
+            } else if (had) {
+                p->sid_action = DISKFS_SID_ACTION_REMOVE;
+            }
+        }
+    }
+
     /* Persist the opaque pNFS layout blob as this inode's single PNFS record,
      * replacing any previous one (the insert aborts on a duplicate key).  The
      * in-memory mirror is installed up front; the chain replays it into the
@@ -986,14 +1248,15 @@ diskfs_setattr_inode_cb(
             inode->mode = (inode->mode & CHIMERA_MODE_ACL_PRESERVE) |
                 chimera_acl_to_mode(acl);
         }
-        if (acl && acl->num_aces && acl->num_aces <= DISKFS_ACL_REC_MAX_ACES) {
+        if (acl && acl->num_aces &&
+            chimera_acl_serialized_size(acl) <= sizeof(sbuf)) {
             slen = chimera_acl_serialize(acl, sbuf, sizeof(sbuf));
         }
         diskfs_acl_serial_install(inode, sbuf, slen);
 
         if (!had_old && slen < 0) {
             /* No record before, none now: nothing to replay. */
-            diskfs_setattr_finish(request);
+            diskfs_setattr_sids(request);
             return;
         }
         if (had_old) {
@@ -1009,10 +1272,10 @@ diskfs_setattr_inode_cb(
         }
         return;
     } else if ((orig_mask & CHIMERA_VFS_ATTR_MODE) && inode->acl_serial) {
-        uint8_t             obuf[sizeof(struct chimera_acl) +
-                                 DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
-        uint8_t             nbuf[sizeof(struct chimera_acl) +
-                                 DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
+        static __thread uint8_t obuf[sizeof(struct chimera_acl) +
+                                     DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
+        static __thread uint8_t nbuf[sizeof(struct chimera_acl) +
+                                     DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
         struct chimera_acl *old_acl = (struct chimera_acl *) obuf;
         struct chimera_acl *new_acl = (struct chimera_acl *) nbuf;
         uint8_t             sbuf[DISKFS_ACL_REC_MAX];
@@ -1039,7 +1302,7 @@ diskfs_setattr_inode_cb(
         /* Regeneration failed: leave the stored ACL untouched. */
     }
 
-    diskfs_setattr_finish(request);
+    diskfs_setattr_sids(request);
 } /* diskfs_setattr_inode_cb */
 
 

--- a/src/vfs/diskfs/diskfs_inode.c
+++ b/src/vfs/diskfs/diskfs_inode.c
@@ -492,6 +492,12 @@ diskfs_inode_load_sync(
             diskfs_acl_serial_install(inode, rec, len);
         }
 
+        len = diskfs_bt_lookup_pump(shared, io, buf, &diskfs_sid_key,
+                                    rec, DISKFS_SID_REC_MAX);
+        if (len >= 0) {
+            diskfs_sid_serial_install(inode, rec, len);
+        }
+
         len = diskfs_bt_lookup_pump(shared, io, buf, &diskfs_pnfs_key,
                                     rec, CHIMERA_VFS_PNFS_LAYOUT_MAX);
         if (len >= 0) {

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -1098,7 +1098,7 @@ struct diskfs_xattr_rec {
         (((DISKFS_ACL_REC_MAX) -CHIMERA_ACL_SERIAL_HDR) / CHIMERA_ACL_SERIAL_ACE)
 
 /* Native owner/group SID record: two length-prefixed SIDs. */
-#define DISKFS_SID_REC_MAX  (2 + 2 * CHIMERA_SID_MAX_LEN)
+#define DISKFS_SID_REC_MAX        (2 + 2 * CHIMERA_SID_MAX_LEN)
 
 /* setattr's SID-record replay step (diskfs_request_private.sid_action). */
 #define DISKFS_SID_ACTION_NONE    0
@@ -1113,7 +1113,7 @@ struct diskfs_xattr_rec {
  * pairs, padded to a 4 KiB multiple.  Full-block redo: the record carries
  * the entire post-image of every dirty block in the transaction.
  */
-#define DISKFS_REDO_MAGIC 0x4F44455246534944ULL     /* "DISFREDO" */
+#define DISKFS_REDO_MAGIC         0x4F44455246534944ULL /* "DISFREDO" */
 
 
 /*

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -244,6 +244,9 @@ struct diskfs_request_private {
     /* Small integer scratch for ops that need to carry state across
      * async callbacks (mount path walker uses it as a path byte offset). */
     uint32_t                    op_scratch;
+    /* setattr: which DISKFS_REC_SID replay the chain tail must perform
+     * (DISKFS_SID_ACTION_*), decided when the mirror was updated. */
+    int                         sid_action;
 
     /* readdir iteration cursor + the current dirent copied out of the
      * b+tree (carried across the per-child inode fetch). */
@@ -725,6 +728,12 @@ struct diskfs_inode {
     uint32_t                    acl_serial_len;
     uint8_t                    *pnfs_blob;
     uint32_t                    pnfs_blob_len;
+    /* Native owner / group SID record (DISKFS_REC_SID): the SID
+     * companions to uid / gid, encoded as u8 owner_len, owner bytes, u8
+     * group_len, group bytes.  Kept separate from the ACL record so "no ACL
+     * record" still means "mode-derived DACL".  Same mirror discipline. */
+    uint8_t                    *sid_serial;
+    uint32_t                    sid_serial_len;
 
     /* Directory only: parent for ".." resolution (also persisted in dinode). */
     uint64_t                    parent_inum;
@@ -974,6 +983,7 @@ enum diskfs_bt_rectype {
     DISKFS_REC_ACL      = 7,  /* single record: serialized NFSv4/Windows ACL (subkey 0) */
     DISKFS_REC_REFCOUNT = 8,  /* refcount inode only: subkey = device offset of a
                                * reflink-shared extent; payload = share count */
+    DISKFS_REC_SID      = 9,  /* single record: native owner/group SIDs (subkey 0) */
 };
 
 
@@ -1080,8 +1090,21 @@ struct diskfs_xattr_rec {
 #define DISKFS_ACL_REC_MAX \
         (DISKFS_BT_ROOT_CAP - sizeof(struct diskfs_bt_node_hdr) - sizeof(struct diskfs_bt_lslot))
 
+/* Upper bound on the ACE count of an ACL that fits one record: every encoded
+ * ACE is at least CHIMERA_ACL_SERIAL_ACE bytes (a native SID makes it larger),
+ * so this bounds the decode buffers.  Whether a given ACL fits is decided by
+ * its serialized size, not its count. */
 #define DISKFS_ACL_REC_MAX_ACES \
         (((DISKFS_ACL_REC_MAX) -CHIMERA_ACL_SERIAL_HDR) / CHIMERA_ACL_SERIAL_ACE)
+
+/* Native owner/group SID record: two length-prefixed SIDs. */
+#define DISKFS_SID_REC_MAX  (2 + 2 * CHIMERA_SID_MAX_LEN)
+
+/* setattr's SID-record replay step (diskfs_request_private.sid_action). */
+#define DISKFS_SID_ACTION_NONE    0
+#define DISKFS_SID_ACTION_INSERT  1
+#define DISKFS_SID_ACTION_REMOVE  2
+#define DISKFS_SID_ACTION_REPLACE 3
 
 
 /*
@@ -2138,8 +2161,10 @@ struct diskfs_inode_load_ctx {
     /* Record-load chain state (valid once the inode is published). */
     struct diskfs_inode        *inode;
     int                         acl_len;
+    int                         sid_len;
     int                         pnfs_len;
     uint8_t                     acl_rec[DISKFS_ACL_REC_MAX];
+    uint8_t                     sid_rec[DISKFS_SID_REC_MAX];
     uint8_t                     pnfs_rec[CHIMERA_VFS_PNFS_LAYOUT_MAX];
 };
 
@@ -2350,6 +2375,10 @@ struct diskfs_mtime_flush {
 
 static const struct diskfs_bt_key diskfs_acl_key = {
     .type = DISKFS_REC_ACL, .subkey = 0
+};
+
+static const struct diskfs_bt_key diskfs_sid_key = {
+    .type = DISKFS_REC_SID, .subkey = 0
 };
 
 static const struct diskfs_bt_key diskfs_pnfs_key = {
@@ -3046,6 +3075,31 @@ diskfs_acl_serial_install(
     struct diskfs_inode *inode,
     const uint8_t       *serial,
     int                  len);
+
+int
+diskfs_sid_rec_encode(
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group,
+    uint8_t                  *buf);
+
+void
+diskfs_sid_rec_decode(
+    const uint8_t      *serial,
+    uint32_t            len,
+    struct chimera_sid *owner,
+    struct chimera_sid *group);
+
+void
+diskfs_sid_serial_install(
+    struct diskfs_inode *inode,
+    const uint8_t       *serial,
+    int                  len);
+
+void
+diskfs_sid_decode_into(
+    struct chimera_vfs_attrs *attr,
+    const uint8_t            *serial,
+    uint32_t                  len);
 
 int
 diskfs_inherit_acl_async(
@@ -4705,6 +4759,7 @@ static inline void
 diskfs_inode_struct_free(struct diskfs_inode *inode)
 {
     free(inode->acl_serial);
+    free(inode->sid_serial);
     free(inode->pnfs_blob);
     free(inode);
 } /* diskfs_inode_struct_free */
@@ -5256,6 +5311,13 @@ diskfs_map_attrs(
         diskfs_acl_decode_into(attr, inode->acl_serial,
                                inode->acl_serial ? (int) inode->acl_serial_len : -1,
                                inode->mode);
+    }
+
+    /* Native owner / group SIDs: reported only when the record exists. */
+    if ((attr->va_req_mask & (CHIMERA_VFS_ATTR_OWNER_SID |
+                              CHIMERA_VFS_ATTR_GROUP_SID)) &&
+        inode->sid_serial) {
+        diskfs_sid_decode_into(attr, inode->sid_serial, inode->sid_serial_len);
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -752,6 +752,9 @@ diskfs_inode_load_recs_done(struct diskfs_inode_load_ctx *lc)
     if (lc->acl_len >= 0) {
         diskfs_acl_serial_install(inode, lc->acl_rec, lc->acl_len);
     }
+    if (lc->sid_len >= 0) {
+        diskfs_sid_serial_install(inode, lc->sid_rec, lc->sid_len);
+    }
     if (lc->pnfs_len >= 0) {
         inode->pnfs_blob = malloc(lc->pnfs_len);
         memcpy(inode->pnfs_blob, lc->pnfs_rec, lc->pnfs_len);
@@ -781,6 +784,27 @@ diskfs_inode_load_recs_pnfs_cb(
 
 
 static void
+diskfs_inode_load_recs_sid_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct diskfs_inode_load_ctx *lc = private_data;
+
+    lc->sid_len = result;
+    diskfs_bt_op_free(lc->thread, op);
+
+    op = diskfs_bt_op_alloc(lc->thread);
+    if (diskfs_bt_lookup_async(op, lc->thread, lc->inode,
+                               DISKFS_BT_OP_LOOKUP_EXACT, &diskfs_pnfs_key,
+                               NULL, lc->pnfs_rec, sizeof(lc->pnfs_rec),
+                               diskfs_inode_load_recs_pnfs_cb, lc)) {
+        diskfs_inode_load_recs_pnfs_cb(op, op->result, lc);
+    }
+} /* diskfs_inode_load_recs_sid_cb */
+
+
+static void
 diskfs_inode_load_recs_acl_cb(
     struct diskfs_bt_op *op,
     int                  result,
@@ -793,10 +817,10 @@ diskfs_inode_load_recs_acl_cb(
 
     op = diskfs_bt_op_alloc(lc->thread);
     if (diskfs_bt_lookup_async(op, lc->thread, lc->inode,
-                               DISKFS_BT_OP_LOOKUP_EXACT, &diskfs_pnfs_key,
-                               NULL, lc->pnfs_rec, sizeof(lc->pnfs_rec),
-                               diskfs_inode_load_recs_pnfs_cb, lc)) {
-        diskfs_inode_load_recs_pnfs_cb(op, op->result, lc);
+                               DISKFS_BT_OP_LOOKUP_EXACT, &diskfs_sid_key,
+                               NULL, lc->sid_rec, sizeof(lc->sid_rec),
+                               diskfs_inode_load_recs_sid_cb, lc)) {
+        diskfs_inode_load_recs_sid_cb(op, op->result, lc);
     }
 } /* diskfs_inode_load_recs_acl_cb */
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -21,6 +21,7 @@
 #include "vfs/sdk/chimera_vfs_sdk.h"
 #include "vfs/sdk/vfs_fh.h"
 #include "vfs/sdk/vfs_acl.h"
+#include "vfs/sdk/vfs_sid.h"
 #include "vfs/sdk/vfs_access.h"
 #include "vfs/sdk/vfs_xattr_name.h"
 #include "vfs/vfs_clock.h"
@@ -195,6 +196,11 @@ struct memfs_inode {
     uint64_t                   rdev;
     uint32_t                   dos_attributes;
     struct chimera_acl        *acl; /* NULL => mode-derived; CAP_ACL_NATIVE storage */
+    /* Native Windows SIDs of the owner / owning group, the companions to
+     * uid / gid (len 0 = none known).  Kept in step with uid/gid by
+     * memfs_apply_attrs: a chown that does not restate the SID drops it. */
+    struct chimera_sid         owner_sid;
+    struct chimera_sid         group_sid;
     struct timespec            atime;
     struct timespec            mtime;
     struct timespec            ctime;
@@ -810,6 +816,8 @@ memfs_inode_alloc(
     inode->change         = 0;
     inode->dos_attributes = 0;
     inode->acl            = NULL;
+    inode->owner_sid.len  = 0;
+    inode->group_sid.len  = 0;
     inode->xattrs         = NULL;
     inode->remote         = NULL;
     inode->streams        = NULL;
@@ -1665,6 +1673,23 @@ memfs_map_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ACL;
     }
 
+    /* Native owner / group SIDs: reported only when one is stored, from a
+     * per-thread scratch for the same lock-release reason as the ACL. */
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_OWNER_SID) && inode->owner_sid.len) {
+        static __thread struct chimera_sid owner_scratch;
+
+        owner_scratch      = inode->owner_sid;
+        attr->va_owner_sid = &owner_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    }
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_GROUP_SID) && inode->group_sid.len) {
+        static __thread struct chimera_sid group_scratch;
+
+        group_scratch      = inode->group_sid;
+        attr->va_group_sid = &group_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    }
+
     /* Birth time is optional and lives outside MASK_STAT, so report it under
      * its own request bit. */
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_BTIME) {
@@ -1924,6 +1949,32 @@ memfs_apply_attrs(
         } else {
             free(tmp);
         }
+    }
+
+    /* Native owner / group SID coherence.  An explicit OWNER_SID set stores
+     * (or, with no SID supplied, clears) the companion; a bare UID set is a
+     * chown to an identity whose SID we were not told, so the stored SID no
+     * longer describes the owner and is dropped.  Group mirrors owner. */
+    if (set_mask & CHIMERA_VFS_ATTR_OWNER_SID) {
+        if (chimera_sid_present(attr->va_owner_sid)) {
+            inode->owner_sid = *attr->va_owner_sid;
+        } else {
+            inode->owner_sid.len = 0;
+        }
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    } else if (set_mask & CHIMERA_VFS_ATTR_UID) {
+        inode->owner_sid.len = 0;
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_GROUP_SID) {
+        if (chimera_sid_present(attr->va_group_sid)) {
+            inode->group_sid = *attr->va_group_sid;
+        } else {
+            inode->group_sid.len = 0;
+        }
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    } else if (set_mask & CHIMERA_VFS_ATTR_GID) {
+        inode->group_sid.len = 0;
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_BTIME) {

--- a/src/vfs/sdk/chimera_vfs_sdk.h
+++ b/src/vfs/sdk/chimera_vfs_sdk.h
@@ -57,10 +57,12 @@
 #include "vfs_varint.h"
 #include "vfs_fh.h"
 
-/* Attribute vocabularies a module fills in or interprets: the canonical
- * ACL carried by chimera_vfs_attrs.va_acl, the access-mask evaluator that
- * keeps ACCESS answers consistent across backends, and the protocol-
- * exported "user." xattr keyspace. */
+/* Attribute vocabularies a module fills in or interprets: the native SID
+ * value type, the canonical ACL carried by chimera_vfs_attrs.va_acl (whose
+ * principals may carry that SID), the access-mask evaluator that keeps
+ * ACCESS answers consistent across backends, and the protocol-exported
+ * "user." xattr keyspace. */
+#include "vfs_sid.h"
 #include "vfs_acl.h"
 #include "vfs_acl_serialize.h"
 #include "vfs_access.h"

--- a/src/vfs/sdk/vfs_acl.h
+++ b/src/vfs/sdk/vfs_acl.h
@@ -23,6 +23,8 @@
 #include <stddef.h>
 #include <sys/stat.h>
 
+#include "vfs_sid.h"
+
 struct chimera_vfs_cred;
 
 /*
@@ -88,6 +90,11 @@ enum chimera_principal_type {
     CHIMERA_PRINCIPAL_USER    = 0, /* numeric uid                            */
     CHIMERA_PRINCIPAL_GROUP   = 1, /* numeric gid                            */
     CHIMERA_PRINCIPAL_SPECIAL = 2, /* special-who below                      */
+    /* A native Windows SID the identity layer could not map to a uid or gid.
+     * It is stored and marshalled verbatim so the ACE round-trips losslessly
+     * (as NTFS keeps an ACE for a departed domain user), but it matches no
+     * caller during access evaluation and bears on no POSIX mode class. */
+    CHIMERA_PRINCIPAL_SID     = 3,
 };
 
 enum chimera_special_who {
@@ -122,10 +129,21 @@ enum chimera_special_who {
     CHIMERA_WHO_SERVICE       = 13,
 };
 
+/*
+ * Dual identity.  Access evaluation, POSIX mode projection and NFSv4 always
+ * work from `type`/`special`/`id`.  `sid` optionally carries the native
+ * Windows SID the principal was set with, so marshalling and storage can
+ * round-trip the real domain identity instead of re-deriving an algorithmic
+ * one: it is present (sid.len != 0) only on USER/GROUP principals whose SID
+ * was resolved through the identity layer, and on every PRINCIPAL_SID.
+ * SPECIAL principals never carry one (their well-known SIDs are implied).
+ */
 struct chimera_principal {
-    uint8_t  type;    /* enum chimera_principal_type   */
-    uint8_t  special; /* enum chimera_special_who      */
-    uint32_t id;      /* uid or gid when type != SPECIAL */
+    uint8_t            type;     /* enum chimera_principal_type          */
+    uint8_t            special;  /* enum chimera_special_who             */
+    uint16_t           reserved; /* zero                                 */
+    uint32_t           id;       /* uid or gid when type is USER/GROUP   */
+    struct chimera_sid sid;      /* native SID; sid.len 0 when unknown   */
 };
 
 struct chimera_ace {

--- a/src/vfs/sdk/vfs_acl_serialize.h
+++ b/src/vfs/sdk/vfs_acl_serialize.h
@@ -11,29 +11,34 @@
  * formats, which are protocol marshalling, not storage.
  *
  * Layout (all integers little-endian):
- *   u8  version (= CHIMERA_ACL_SERIAL_VERSION)
+ *   u8  version (1 or 2)
  *   u16 ctrl_flags
  *   u16 num_aces
  *   num_aces x {
  *       u16 type, u16 flags, u32 access_mask,
- *       u8 principal_type, u8 special, u32 id
+ *       u8 principal_type, u8 special, u32 id,
+ *       [version 2 only] u8 sid_len, sid_len bytes of native SID
  *   }
+ *
+ * Version 1 is the pre-native-SID encoding.  The serializer emits version 1
+ * whenever no ACE carries a SID, so a volume written by this release stays
+ * readable by an older binary unless a native SID was actually stored; the
+ * deserializer accepts both versions.
  */
 
 #include <stddef.h>
 #include "vfs_acl.h"
 
-#define CHIMERA_ACL_SERIAL_VERSION 1
+#define CHIMERA_ACL_SERIAL_VERSION 2
+#define CHIMERA_ACL_SERIAL_V1      1
 #define CHIMERA_ACL_SERIAL_HDR     5  /* version + ctrl_flags + num_aces */
-#define CHIMERA_ACL_SERIAL_ACE     14 /* type+flags+mask+ptype+special+id */
+#define CHIMERA_ACL_SERIAL_ACE     14 /* fixed part: type+flags+mask+ptype+special+id */
+/* Largest encoded ACE: the fixed part, the SID length byte, and a max SID. */
+#define CHIMERA_ACL_SERIAL_ACE_MAX (CHIMERA_ACL_SERIAL_ACE + 1 + CHIMERA_SID_MAX_LEN)
 
 /* Number of bytes chimera_acl_serialize() will write for `acl`. */
-static inline size_t
-chimera_acl_serialized_size(const struct chimera_acl *acl)
-{
-    return CHIMERA_ACL_SERIAL_HDR +
-           (size_t) acl->num_aces * CHIMERA_ACL_SERIAL_ACE;
-} /* chimera_acl_serialized_size */
+size_t chimera_acl_serialized_size(
+    const struct chimera_acl *acl);
 
 /*
  * Serialize `acl` into `buf` (capacity `buflen`).  Returns the number of bytes

--- a/src/vfs/sdk/vfs_attrs.h
+++ b/src/vfs/sdk/vfs_attrs.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <stdint.h>
 #include <time.h>
+#include "vfs_sid.h"
 
 struct chimera_acl;
 
@@ -97,6 +98,19 @@ struct chimera_acl;
  * va_named_attr (backends without named-stream support leave it unset, which the
  * NFS marshaller treats as false). */
 #define CHIMERA_VFS_ATTR_NAMED_ATTR         (1UL << 28)
+
+/* Native Windows SIDs of the owner and owning group (va_owner_sid /
+ * va_group_sid), the SID companions to va_uid / va_gid.  Optional: a backend
+ * sets the bit in va_set_mask only when it has a stored native SID for that
+ * identity; the SMB marshaller then emits it verbatim instead of re-deriving
+ * one from the identity cache or the algorithmic S-1-5-88 scheme.  On
+ * setattr, a UID (GID) set that is not accompanied by OWNER_SID (GROUP_SID)
+ * clears any stored owner (group) SID, since it would no longer describe the
+ * new numeric owner; OWNER_SID with a NULL/absent pointer clears it
+ * explicitly.  Like ACL these are pointer-valued and deliberately excluded
+ * from MASK_STAT and MASK_CACHEABLE. */
+#define CHIMERA_VFS_ATTR_OWNER_SID          (1UL << 29)
+#define CHIMERA_VFS_ATTR_GROUP_SID          (1UL << 30)
 
 #define CHIMERA_VFS_ATTR_MASK_STAT          ( \
             CHIMERA_VFS_ATTR_DEV | \
@@ -220,6 +234,13 @@ struct chimera_vfs_attrs {
      * this at storage valid only for the duration of the completion callback
      * (same contract as va_fh).  On setattr, the caller owns the buffer. */
     struct chimera_acl *va_acl;
+
+    /* Native owner / group SIDs (CHIMERA_VFS_ATTR_OWNER_SID / GROUP_SID).
+     * Same lifetime contract as va_acl: on getattr the backend points these
+     * at storage valid only for the duration of the completion callback; on
+     * setattr the caller owns the buffers. */
+    const struct chimera_sid *va_owner_sid;
+    const struct chimera_sid *va_group_sid;
 
     /* Opaque pNFS layout state, owned by the NFS server (see
      * CHIMERA_VFS_ATTR_PNFS_LAYOUT). */

--- a/src/vfs/sdk/vfs_attrs.h
+++ b/src/vfs/sdk/vfs_attrs.h
@@ -239,8 +239,8 @@ struct chimera_vfs_attrs {
      * Same lifetime contract as va_acl: on getattr the backend points these
      * at storage valid only for the duration of the completion callback; on
      * setattr the caller owns the buffers. */
-    const struct chimera_sid *va_owner_sid;
-    const struct chimera_sid *va_group_sid;
+    struct chimera_sid *va_owner_sid;
+    struct chimera_sid *va_group_sid;
 
     /* Opaque pNFS layout state, owned by the NFS server (see
      * CHIMERA_VFS_ATTR_PNFS_LAYOUT). */

--- a/src/vfs/sdk/vfs_module.h
+++ b/src/vfs/sdk/vfs_module.h
@@ -28,7 +28,7 @@ struct chimera_vfs_request;
  * chimera_vfs_register() refuses a module built against a different
  * version, so a stale out-of-tree binary fails loudly at load time
  * instead of corrupting memory. */
-#define CHIMERA_VFS_SDK_VERSION             1
+#define CHIMERA_VFS_SDK_VERSION             2
 
 /* If set, module requires open handles for path operations
  * such as mkdir, remove, open_at, etc.  Equivalent to POSIX open

--- a/src/vfs/sdk/vfs_sid.h
+++ b/src/vfs/sdk/vfs_sid.h
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * Native Windows security identifier (SID) value type.
+ *
+ * A SID is carried in its MS-DTYP 2.4.2.2 binary form: revision (1 byte),
+ * sub-authority count (1 byte), a 48-bit big-endian identifier authority
+ * (6 bytes), then count little-endian 32-bit sub-authorities.  That is the
+ * exact layout an SMB security descriptor puts on the wire, so an ACE SID can
+ * be copied in and out without a string round trip, and it is what native
+ * backends persist.  A zero length means "no native SID is known" -- the
+ * numeric uid/gid on the principal (or attrs) then stands alone and the
+ * marshaller falls back to the identity cache or the algorithmic SID.
+ *
+ * The cap of 15 sub-authorities is the MS-DTYP maximum (SID_MAX_SUB_AUTHORITIES).
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define CHIMERA_SID_MAX_SUB_AUTHS 15
+#define CHIMERA_SID_MIN_LEN       8  /* revision + count + authority */
+#define CHIMERA_SID_MAX_LEN       (CHIMERA_SID_MIN_LEN + 4 * CHIMERA_SID_MAX_SUB_AUTHS)
+
+/* "S-<rev>-<authority>" plus 15 x "-<u32>" plus NUL fits comfortably. */
+#define CHIMERA_SID_STR_MAX       192
+
+struct chimera_sid {
+    uint8_t len;                       /* 0 = absent; else 8 + 4 * count */
+    uint8_t data[CHIMERA_SID_MAX_LEN]; /* binary SID, valid for `len` bytes */
+};
+
+/*
+ * Validate the binary SID at the start of `buf` (`avail` bytes) and return
+ * its length (8 + 4 * sub_authority_count), or -1 if the buffer is too short
+ * or the sub-authority count exceeds CHIMERA_SID_MAX_SUB_AUTHS.
+ */
+int chimera_sid_bin_len(
+    const uint8_t *buf,
+    uint32_t       avail);
+
+/*
+ * Format the binary SID at `buf` (`len` bytes available) as
+ * "S-<rev>-<authority>-<sub>..." into `out`.  Returns the number of SID bytes
+ * consumed from `buf`, or -1 on a malformed/truncated SID or a too-small
+ * `out`.
+ */
+int chimera_sid_bin_to_str(
+    const uint8_t *buf,
+    uint32_t       len,
+    char          *out,
+    int            outlen);
+
+/*
+ * Parse "S-<rev>-<authority>-<sub>..." into the binary form at `out`
+ * (capacity `outcap`).  Strict: digits only, no trailing text.  Returns the
+ * binary length written, or -1 on malformed input / insufficient capacity.
+ */
+int chimera_sid_str_to_bin(
+    const char *str,
+    uint8_t    *out,
+    int         outcap);
+
+/*
+ * Copy the binary SID at the start of `buf` into `sid`.  Returns the number
+ * of bytes consumed, or -1 (and `sid` cleared) if it is malformed.
+ */
+int chimera_sid_from_bin(
+    struct chimera_sid *sid,
+    const uint8_t      *buf,
+    uint32_t            avail);
+
+/* Format `sid` as text.  Returns the string length, or -1 if absent/too small. */
+int chimera_sid_to_str(
+    const struct chimera_sid *sid,
+    char                     *out,
+    int                       outlen);
+
+/* Parse text into `sid`.  Returns 0, or -1 (and `sid` cleared) on bad input. */
+int chimera_sid_from_str(
+    struct chimera_sid *sid,
+    const char         *str);
+
+static inline int
+chimera_sid_present(const struct chimera_sid *sid)
+{
+    return sid != NULL && sid->len != 0;
+} /* chimera_sid_present */
+
+/* Two SIDs are equal only when both are present and byte-identical. */
+static inline int
+chimera_sid_equal(
+    const struct chimera_sid *a,
+    const struct chimera_sid *b)
+{
+    if (!chimera_sid_present(a) || !chimera_sid_present(b) || a->len != b->len) {
+        return 0;
+    }
+    for (unsigned i = 0; i < a->len; i++) {
+        if (a->data[i] != b->data[i]) {
+            return 0;
+        }
+    }
+    return 1;
+} /* chimera_sid_equal */

--- a/src/vfs/sdk/vfs_sid.h
+++ b/src/vfs/sdk/vfs_sid.h
@@ -29,6 +29,12 @@
 /* "S-<rev>-<authority>" plus 15 x "-<u32>" plus NUL fits comfortably. */
 #define CHIMERA_SID_STR_MAX       192
 
+/*
+ * chimera_sid_from_bin / chimera_sid_from_str fully define the struct (the
+ * bytes past `len` are zeroed, and the whole struct is zeroed on failure), so
+ * a chimera_sid -- and any ACE principal carrying one -- is byte-deterministic
+ * and safe to copy by value and compare with memcmp.
+ */
 struct chimera_sid {
     uint8_t len;                       /* 0 = absent; else 8 + 4 * count */
     uint8_t data[CHIMERA_SID_MAX_LEN]; /* binary SID, valid for `len` bytes */

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -56,6 +56,10 @@ add_executable(vfs_idmap_test vfs_idmap_test.c)
 target_link_libraries(vfs_idmap_test chimera_vfs)
 add_test(chimera/vfs/idmap_test vfs_idmap_test)
 
+add_executable(vfs_sid_test vfs_sid_test.c)
+target_link_libraries(vfs_sid_test chimera_vfs)
+add_test(chimera/vfs/sid_test vfs_sid_test)
+
 add_executable(vfs_identity_test vfs_identity_test.c)
 target_link_libraries(vfs_identity_test chimera_vfs chimera_vfs_memfs evpl)
 add_test(chimera/vfs/identity_test vfs_identity_test)

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -103,6 +103,26 @@ if(CAIRN_ENABLED)
     add_test(NAME chimera/vfs/zerorange_cairn COMMAND vfs_zerorange_test cairn)
 endif()
 
+# Native Windows SID round trip through the VFS, parameterized by
+# backend: only the engine-managed backends that store the canonical ACL
+# natively (memfs, cairn, diskfs) can persist a SID-bearing principal and the
+# owner/group SID companions.  The passthrough backends are mode-only.
+add_executable(vfs_acl_sid_test vfs_acl_sid_test.c)
+target_link_libraries(vfs_acl_sid_test chimera_vfs chimera_vfs_memfs
+    chimera_vfs_diskfs chimera_vfs_memkv evpl)
+add_test(NAME chimera/vfs/acl_sid_memfs COMMAND vfs_acl_sid_test memfs)
+if(HAVE_LIBAIO)
+    add_test(NAME chimera/vfs/acl_sid_diskfs_aio COMMAND vfs_acl_sid_test diskfs_aio)
+endif()
+if(CHIMERA_VFS_IO_URING)
+    target_link_libraries(vfs_acl_sid_test chimera_vfs_io_uring)
+    add_test(NAME chimera/vfs/acl_sid_diskfs_io_uring COMMAND vfs_acl_sid_test diskfs_io_uring)
+endif()
+if(CAIRN_ENABLED)
+    target_link_libraries(vfs_acl_sid_test chimera_vfs_cairn)
+    add_test(NAME chimera/vfs/acl_sid_cairn COMMAND vfs_acl_sid_test cairn)
+endif()
+
 # Tag every test registered above with the 'vfs' label so the suite can be run
 # independently via `ctest -L vfs`.
 get_property(_vfs_tests DIRECTORY PROPERTY TESTS)

--- a/src/vfs/tests/vfs_acl_sid_test.c
+++ b/src/vfs/tests/vfs_acl_sid_test.c
@@ -44,9 +44,9 @@
 #define DEV_SIZE_BYTES (1024ULL * 1024ULL * 1024ULL) /* 1 GiB, sparse */
 #define TEST_MAX_ACES  8
 
-#define SID_OWNER  "S-1-5-21-7-8-9-500"
-#define SID_GROUP  "S-1-5-21-7-8-9-513"
-#define SID_OPAQUE "S-1-5-21-7-8-9-1001"
+#define SID_OWNER      "S-1-5-21-7-8-9-500"
+#define SID_GROUP      "S-1-5-21-7-8-9-513"
+#define SID_OPAQUE     "S-1-5-21-7-8-9-1001"
 
 struct test_ctx {
     int                             done;

--- a/src/vfs/tests/vfs_acl_sid_test.c
+++ b/src/vfs/tests/vfs_acl_sid_test.c
@@ -1,0 +1,513 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Backend-parameterized native-SID round trip through the VFS.
+ *
+ * On an engine-authoritative backend that stores the canonical ACL natively
+ * (memfs, cairn, diskfs), an ACL whose principals carry native Windows SIDs
+ * -- including an opaque CHIMERA_PRINCIPAL_SID the identity layer could not
+ * map -- must come back byte-for-byte from getattr, and the owner/group SID
+ * companions must persist alongside va_uid/va_gid.  A chown that does not
+ * restate the owner SID must drop the stale one, and storing an owner SID on
+ * an object with no explicit DACL must not manufacture an empty ACL (the
+ * mode-derived DACL has to survive).
+ *
+ *     vfs_acl_sid_test <backend>
+ *
+ * where <backend> is memfs (default), cairn, diskfs_io_uring, or diskfs_aio.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/sdk/vfs_attrs.h"
+#include "vfs/sdk/vfs_cred.h"
+#include "vfs/sdk/vfs_error.h"
+#include "vfs/sdk/vfs_acl.h"
+#include "vfs/sdk/vfs_sid.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+#define DEV_SIZE_BYTES (1024ULL * 1024ULL * 1024ULL) /* 1 GiB, sparse */
+#define TEST_MAX_ACES  8
+
+#define SID_OWNER  "S-1-5-21-7-8-9-500"
+#define SID_GROUP  "S-1-5-21-7-8-9-513"
+#define SID_OPAQUE "S-1-5-21-7-8-9-1001"
+
+struct test_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *vfs_thread;
+    struct evpl                    *evpl;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh_len;
+    struct chimera_vfs_open_handle *handle;
+
+    /* getattr copy-out: the live attrs are only valid inside the callback */
+    uint64_t                        got_mask;
+    uint64_t                        got_uid;
+    uint64_t                        got_gid;
+    uint64_t                        got_mode;
+    struct chimera_sid              got_owner_sid;
+    struct chimera_sid              got_group_sid;
+    uint8_t                         got_acl_storage[sizeof(struct chimera_acl) +
+                                                    TEST_MAX_ACES * sizeof(struct chimera_ace)];
+};
+
+static void
+wait_done(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_done */
+
+static void
+mount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, attr->va_fh, attr->va_fh_len);
+        ctx->fh_len = attr->va_fh_len;
+    }
+    ctx->done = 1;
+} /* lookup_cb */
+
+static void
+openfh_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openfh_cb */
+
+static void
+openat_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre,
+    struct chimera_vfs_attrs       *dir_post,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openat_cb */
+
+static void
+setattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* setattr_cb */
+
+static void
+getattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    memset(&ctx->got_owner_sid, 0, sizeof(ctx->got_owner_sid));
+    memset(&ctx->got_group_sid, 0, sizeof(ctx->got_group_sid));
+    memset(ctx->got_acl_storage, 0, sizeof(ctx->got_acl_storage));
+    ctx->got_mask = 0;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        ctx->got_mask = attr->va_set_mask;
+        ctx->got_uid  = attr->va_uid;
+        ctx->got_gid  = attr->va_gid;
+        ctx->got_mode = attr->va_mode;
+        if ((attr->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) && attr->va_owner_sid) {
+            ctx->got_owner_sid = *attr->va_owner_sid;
+        }
+        if ((attr->va_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) && attr->va_group_sid) {
+            ctx->got_group_sid = *attr->va_group_sid;
+        }
+        if ((attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) && attr->va_acl &&
+            attr->va_acl->num_aces <= TEST_MAX_ACES) {
+            memcpy(ctx->got_acl_storage, attr->va_acl,
+                   chimera_acl_size(attr->va_acl->num_aces));
+        }
+    }
+    ctx->done = 1;
+} /* getattr_cb */
+
+static void
+do_getattr(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred)
+{
+    chimera_vfs_getattr(ctx->vfs_thread, cred, ctx->handle,
+                        CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL |
+                        CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID,
+                        getattr_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* do_getattr */
+
+static void
+do_setattr(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    struct chimera_vfs_attrs      *sattr)
+{
+    chimera_vfs_setattr(ctx->vfs_thread, cred, ctx->handle, sattr, 0, 0,
+                        setattr_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* do_setattr */
+
+/* Create `name` (0644, uid/gid 1000) under `dir`; leaves the file open in
+ * ctx->handle. */
+static void
+create_file(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *dir,
+    const char                     *name)
+{
+    struct chimera_vfs_attrs sattr;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_UID |
+        CHIMERA_VFS_ATTR_GID;
+    sattr.va_mode = 0644;
+    sattr.va_uid  = 1000;
+    sattr.va_gid  = 1000;
+
+    chimera_vfs_open_at(ctx->vfs_thread, cred, dir, name, strlen(name),
+                        CHIMERA_VFS_OPEN_CREATE, &sattr, CHIMERA_VFS_ATTR_FH,
+                        0, 0, openat_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    assert(ctx->handle != NULL);
+} /* create_file */
+
+/* Per-backend wiring, mirroring vfs_zerorange_test. */
+struct backend_spec {
+    int         ncfg;
+    const char *mount_module;
+    char        mount_path[300];
+    int         needs_mkfs;
+};
+
+static void
+backend_configure(
+    const char                    *backend,
+    const char                    *session_dir,
+    struct chimera_vfs_module_cfg *cfgs,
+    struct backend_spec           *spec)
+{
+    char dev_path[300];
+    char cfg[512];
+
+    memset(spec, 0, sizeof(*spec));
+
+    if (strcmp(backend, "memfs") == 0) {
+        strncpy(cfgs[0].module_name, "memfs", sizeof(cfgs[0].module_name) - 1);
+        spec->mount_module = "memfs";
+        spec->needs_mkfs   = 1;
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
+    } else if (strcmp(backend, "cairn") == 0) {
+        strncpy(cfgs[0].module_name, "cairn", sizeof(cfgs[0].module_name) - 1);
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"path\":\"%s\"}", session_dir);
+        strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
+        spec->mount_module = "cairn";
+        spec->needs_mkfs   = 1;
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
+    } else if (strcmp(backend, "diskfs_io_uring") == 0 ||
+               strcmp(backend, "diskfs_aio") == 0) {
+        const char *iotype = (strcmp(backend, "diskfs_aio") == 0) ? "libaio"
+                                                                  : "io_uring";
+        int         fd, rc;
+
+        snprintf(dev_path, sizeof(dev_path), "%s/device-0.img", session_dir);
+        fd = open(dev_path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+        assert(fd >= 0);
+        rc = ftruncate(fd, (off_t) DEV_SIZE_BYTES);
+        assert(rc == 0);
+        close(fd);
+
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"unsafe_async\":true,"
+                 "\"intent_log_size\":67108864,"
+                 "\"devices\":[{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}]}",
+                 iotype, dev_path);
+        strncpy(cfgs[0].module_name, "diskfs", sizeof(cfgs[0].module_name) - 1);
+        strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
+        spec->mount_module = "diskfs";
+        spec->needs_mkfs   = 1;
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
+    } else {
+        fprintf(stderr, "unknown backend: %s\n", backend);
+        exit(2);
+    }
+
+    strncpy(cfgs[1].module_name, "memkv", sizeof(cfgs[1].module_name) - 1);
+    spec->ncfg = 2;
+} /* backend_configure */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_ctx                 ctx = { 0 };
+    struct chimera_vfs_module_cfg   module_cfgs[2];
+    struct backend_spec             spec;
+    struct prometheus_metrics      *metrics;
+    struct chimera_vfs_cred         cred;
+    struct chimera_vfs_attrs        sattr;
+    struct chimera_vfs_open_handle *root_handle;
+    struct chimera_vfs_open_handle *f_handle;
+    struct chimera_vfs_open_handle *g_handle;
+    const char                     *backend = argc > 1 ? argv[1] : "memfs";
+    char                            tmpl[]  = "/tmp/vfs_aclsid_XXXXXX";
+    char                           *session_dir;
+    uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        root_fh_len;
+    struct chimera_sid              owner_sid, group_sid, opaque_sid;
+    uint8_t                         acl_storage[sizeof(struct chimera_acl) +
+                                                TEST_MAX_ACES * sizeof(struct chimera_ace)];
+    struct chimera_acl             *acl     = (struct chimera_acl *) acl_storage;
+    struct chimera_acl             *got_acl = (struct chimera_acl *) ctx.got_acl_storage;
+
+    chimera_log_init();
+    chimera_vfs_cred_init_unix(&cred, 0, 0, 0, NULL);
+
+    assert(chimera_sid_from_str(&owner_sid, SID_OWNER) == 0);
+    assert(chimera_sid_from_str(&group_sid, SID_GROUP) == 0);
+    assert(chimera_sid_from_str(&opaque_sid, SID_OPAQUE) == 0);
+
+    session_dir = mkdtemp(tmpl);
+    assert(session_dir != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    backend_configure(backend, session_dir, module_cfgs, &spec);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, spec.ncfg, "memkv", 60, 1, 1, 0,
+                               metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    if (spec.needs_mkfs) {
+        chimera_vfs_mkfs(ctx.vfs_thread, NULL, spec.mount_module, "fs0", NULL,
+                         mount_cb, &ctx);
+        wait_done(&ctx);
+        assert(ctx.status == CHIMERA_VFS_OK);
+    }
+
+    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", spec.mount_module,
+                      spec.mount_path, NULL, mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
+    chimera_vfs_lookup(ctx.vfs_thread, &cred, root_fh, root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    memcpy(root_fh, ctx.fh, ctx.fh_len);
+    root_fh_len = ctx.fh_len;
+
+    chimera_vfs_open_fh(ctx.vfs_thread, &cred, root_fh, root_fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    root_handle = ctx.handle;
+
+    create_file(&ctx, &cred, root_handle, "f");
+    f_handle = ctx.handle;
+
+    /* --- 1. an explicit DACL with SID-bearing principals + owner/group SIDs
+     *        round-trips byte-for-byte --- */
+    memset(acl_storage, 0, sizeof(acl_storage));
+    acl->num_aces            = 2;
+    acl->ctrl_flags          = CHIMERA_ACL_CTRL_PROTECTED;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].flags       = 0;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_SID;
+    acl->aces[0].who.sid     = opaque_sid;
+    acl->aces[1].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[1].flags       = 0;
+    acl->aces[1].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA;
+    acl->aces[1].who.type    = CHIMERA_PRINCIPAL_USER;
+    acl->aces[1].who.id      = 1000;
+    acl->aces[1].who.sid     = owner_sid;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_ACL |
+        CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_OWNER_SID |
+        CHIMERA_VFS_ATTR_GID | CHIMERA_VFS_ATTR_GROUP_SID;
+    sattr.va_acl       = acl;
+    sattr.va_uid       = 1000;
+    sattr.va_owner_sid = &owner_sid;
+    sattr.va_gid       = 1000;
+    sattr.va_group_sid = &group_sid;
+    ctx.handle         = f_handle;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_ACL);
+    assert(got_acl->num_aces == 2);
+    assert(got_acl->ctrl_flags == CHIMERA_ACL_CTRL_PROTECTED);
+    assert(memcmp(got_acl->aces, acl->aces, 2 * sizeof(struct chimera_ace)) == 0);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID);
+    assert(chimera_sid_equal(&ctx.got_group_sid, &group_sid));
+    assert(ctx.got_uid == 1000 && ctx.got_gid == 1000);
+    TEST_PASS("SID-bearing ACL and owner/group SIDs round-trip via getattr");
+
+    /* --- 2. a chown without a SID companion drops the stale owner SID and
+     *        leaves the group SID and the DACL alone --- */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_UID;
+    sattr.va_uid      = 1001;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_uid == 1001);
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+    assert(!chimera_sid_present(&ctx.got_owner_sid));
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID);
+    assert(chimera_sid_equal(&ctx.got_group_sid, &group_sid));
+    assert(got_acl->num_aces == 2);
+    assert(chimera_sid_equal(&got_acl->aces[0].who.sid, &opaque_sid));
+    TEST_PASS("chown without a SID clears the owner SID only");
+
+    /* --- 3. an explicit clear (GROUP_SID with no SID) removes the group SID --- */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_GROUP_SID;
+    sattr.va_group_sid = NULL;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID));
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+    assert(got_acl->num_aces == 2);
+    TEST_PASS("explicit GROUP_SID clear removes the group SID");
+
+    chimera_vfs_release(ctx.vfs_thread, f_handle);
+
+    /* --- 4. owner SID on an object with no explicit DACL: the mode-derived
+     *        DACL must survive (no empty ACL is manufactured) --- */
+    create_file(&ctx, &cred, root_handle, "g");
+    g_handle = ctx.handle;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_uid       = 1000;
+    sattr.va_owner_sid = &owner_sid;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_ACL);
+    assert(got_acl->num_aces >= 3); /* mode-derived OWNER@/GROUP@/EVERYONE@ */
+    assert(chimera_acl_to_mode(got_acl) == 0644);
+
+    /* and a chmod on it still regenerates from mode, not from an empty ACL */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
+    sattr.va_mode     = 0600;
+    do_setattr(&ctx, &cred, &sattr);
+    do_getattr(&ctx, &cred);
+    assert((ctx.got_mode & 0777) == 0600);
+    assert(got_acl->num_aces >= 3);
+    assert(chimera_acl_to_mode(got_acl) == 0600);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    TEST_PASS("owner SID without an explicit DACL keeps the mode-derived ACL");
+
+    chimera_vfs_release(ctx.vfs_thread, g_handle);
+    chimera_vfs_release(ctx.vfs_thread, root_handle);
+
+    chimera_vfs_umount(ctx.vfs_thread, NULL, "/test", mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    if (spec.needs_mkfs) {
+        for (int i = 0; i < 50; i++) {
+            chimera_vfs_rmfs(ctx.vfs_thread, NULL, spec.mount_module, "fs0",
+                             mount_cb, &ctx);
+            wait_done(&ctx);
+            if (ctx.status != CHIMERA_VFS_EBUSY) {
+                break;
+            }
+            usleep(100000);
+        }
+        assert(ctx.status == CHIMERA_VFS_OK);
+    }
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+
+    fprintf(stderr, "All native-SID round-trip tests passed on %s\n", backend);
+    return 0;
+} /* main */

--- a/src/vfs/tests/vfs_acl_test.c
+++ b/src/vfs/tests/vfs_acl_test.c
@@ -277,6 +277,77 @@ test_serialize_roundtrip(void)
     /* truncated input is rejected */
     assert(chimera_acl_deserialize(buf, 3, back, 8) == -1);
 
+    /* v2: an ACE carrying a native SID round-trips byte-for-byte, and the
+     * presence of any SID selects the version-2 encoding. */
+    {
+        struct chimera_sid sid;
+
+        memset(acl_storage, 0, sizeof(acl_storage));
+        memset(back_storage, 0, sizeof(back_storage));
+        assert(chimera_sid_from_str(&sid, "S-1-5-21-7-8-9-1001") == 0);
+        acl->num_aces            = 2;
+        acl->ctrl_flags          = CHIMERA_ACL_CTRL_AUTO_INHERITED;
+        acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+        acl->aces[0].flags       = CHIMERA_ACE_FLAG_FILE_INHERIT;
+        acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA;
+        acl->aces[0].who.type    = CHIMERA_PRINCIPAL_SID;
+        acl->aces[0].who.sid     = sid;
+        acl->aces[1].type        = CHIMERA_ACE_DENIED;
+        acl->aces[1].flags       = 0;
+        acl->aces[1].access_mask = CHIMERA_ACE_WRITE_DATA;
+        acl->aces[1].who.type    = CHIMERA_PRINCIPAL_USER;
+        acl->aces[1].who.id      = 4000;
+        acl->aces[1].who.sid     = sid;
+
+        len = chimera_acl_serialize(acl, buf, sizeof(buf));
+        assert(len > 0);
+        assert((size_t) len == chimera_acl_serialized_size(acl));
+        assert(buf[0] == 2); /* version 2 because a SID is present */
+        n = chimera_acl_deserialize(buf, len, back, 8);
+        assert(n == 2);
+        assert(back->ctrl_flags == acl->ctrl_flags);
+        assert(memcmp(acl->aces, back->aces, 2 * sizeof(struct chimera_ace)) == 0);
+        /* a truncated SID trailer is rejected */
+        assert(chimera_acl_deserialize(buf, len - 1, back, 8) == -1);
+    }
+
+    /* v1 is still emitted when no ACE carries a SID, so an older binary
+     * reading a volume written by this one sees what it always did. */
+    memset(acl_storage, 0, sizeof(acl_storage));
+    memset(back_storage, 0, sizeof(back_storage));
+    chimera_acl_from_mode(0644, acl, 8);
+    len = chimera_acl_serialize(acl, buf, sizeof(buf));
+    assert(len > 0);
+    assert(buf[0] == 1);
+    assert((size_t) len == chimera_acl_serialized_size(acl));
+    assert(chimera_acl_deserialize(buf, len, back, 8) == acl->num_aces);
+    assert(memcmp(acl->aces, back->aces,
+                  acl->num_aces * sizeof(struct chimera_ace)) == 0);
+
+    /* A hand-built v1 blob (as persisted by pre-SID releases) decodes with
+     * the SID absent on every ACE. */
+    {
+        static const uint8_t v1[] = {
+            1,                      /* version                              */
+            0x01, 0x00,             /* ctrl_flags = PROTECTED               */
+            0x01, 0x00,             /* num_aces = 1                         */
+            0x00, 0x00,             /* type = ALLOWED                       */
+            0x00, 0x00,             /* flags                                */
+            0x01, 0x00, 0x00, 0x00, /* access_mask = READ_DATA              */
+            0x00,                   /* principal type = USER                */
+            0x00,                   /* special                              */
+            0xe8, 0x03, 0x00, 0x00, /* id = 1000                            */
+        };
+
+        memset(back_storage, 0, sizeof(back_storage));
+        n = chimera_acl_deserialize(v1, sizeof(v1), back, 8);
+        assert(n == 1);
+        assert(back->ctrl_flags == CHIMERA_ACL_CTRL_PROTECTED);
+        assert(back->aces[0].who.type == CHIMERA_PRINCIPAL_USER);
+        assert(back->aces[0].who.id == 1000);
+        assert(!chimera_sid_present(&back->aces[0].who.sid));
+    }
+
     TEST_PASS("serialize/deserialize round-trips, rejects bad input");
 } /* test_serialize_roundtrip */
 

--- a/src/vfs/tests/vfs_acl_test.c
+++ b/src/vfs/tests/vfs_acl_test.c
@@ -328,14 +328,14 @@ test_serialize_roundtrip(void)
      * the SID absent on every ACE. */
     {
         static const uint8_t v1[] = {
-            1,                      /* version                              */
-            0x01, 0x00,             /* ctrl_flags = PROTECTED               */
-            0x01, 0x00,             /* num_aces = 1                         */
-            0x00, 0x00,             /* type = ALLOWED                       */
-            0x00, 0x00,             /* flags                                */
+            1,    /* version                              */
+            0x01, 0x00, /* ctrl_flags = PROTECTED               */
+            0x01, 0x00, /* num_aces = 1                         */
+            0x00, 0x00, /* type = ALLOWED                       */
+            0x00, 0x00, /* flags                                */
             0x01, 0x00, 0x00, 0x00, /* access_mask = READ_DATA              */
-            0x00,                   /* principal type = USER                */
-            0x00,                   /* special                              */
+            0x00, /* principal type = USER                */
+            0x00, /* special                              */
             0xe8, 0x03, 0x00, 0x00, /* id = 1000                            */
         };
 

--- a/src/vfs/tests/vfs_acl_test.c
+++ b/src/vfs/tests/vfs_acl_test.c
@@ -12,6 +12,7 @@
 #include "vfs/vfs.h"
 #include "vfs/sdk/vfs_acl.h"
 #include "vfs/sdk/vfs_acl_serialize.h"
+#include "vfs/sdk/vfs_sid.h"
 #include "vfs/sdk/vfs_access.h"
 #include "vfs/sdk/vfs_attrs.h"
 #include "vfs/sdk/vfs_cred.h"
@@ -393,6 +394,97 @@ test_delete_allowed(void)
 
 #undef INIT_ATTR
 
+/*
+ * A CHIMERA_PRINCIPAL_SID ACE is an opaque native SID with no known unix id:
+ * it is stored and marshalled verbatim but matches no caller during access
+ * evaluation, exactly like a departed-user SID does on NTFS.
+ */
+static void
+test_sid_principal_never_matches(void)
+{
+    ACL_BUF(acl, 2);
+    struct chimera_vfs_cred u = mkcred(1000, 2000);
+    uint32_t                g;
+
+    memset(acl_storage, 0, sizeof(acl_storage));
+    acl->num_aces            = 1;
+    acl->ctrl_flags          = 0;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].flags       = 0;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_SID;
+    assert(chimera_sid_from_str(&acl->aces[0].who.sid, "S-1-5-21-9-9-9-1234") == 0);
+
+    /* Neither the caller nor the owner is granted data access by a SID-only
+     * DACL; only the implicit metadata/owner rights ever apply. */
+    g = chimera_acl_access_check(acl, 0, 4242, 4243, &u,
+                                 CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA, 0);
+    assert(g == 0);
+    g = chimera_acl_access_raw(acl, 4242, 4243, &u, CHIMERA_ACE_READ_DATA);
+    assert(g == 0);
+
+    /* It does not bear on the POSIX mode projection either. */
+    assert(chimera_acl_to_mode(acl) == 0);
+
+    TEST_PASS("CHIMERA_PRINCIPAL_SID ACE matches no caller and no mode class");
+} /* test_sid_principal_never_matches */
+
+/*
+ * chmod preserves a SID-bearing named ACE with its SID intact, and
+ * inheritance carries the SID onto the child while CREATOR_* substitution
+ * never leaks a SID onto the child's OWNER@/GROUP@ entry.
+ */
+static void
+test_sid_survives_chmod_and_inherit(void)
+{
+    ACL_BUF(in, 4);
+    ACL_BUF(out, 16);
+    ACL_BUF(child, 8);
+    struct chimera_sid sid;
+    int                n;
+
+    memset(in_storage, 0, sizeof(in_storage));
+    memset(out_storage, 0, sizeof(out_storage));
+    memset(child_storage, 0, sizeof(child_storage));
+    assert(chimera_sid_from_str(&sid, "S-1-5-21-7-8-9-1001") == 0);
+
+    /* Named user 4000 carrying its real SID, plus an inheritable CREATOR_OWNER
+     * template that must never carry a SID onto the child. */
+    in->ctrl_flags          = 0;
+    in->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    in->aces[0].flags       = CHIMERA_ACE_FLAG_FILE_INHERIT;
+    in->aces[0].access_mask = CHIMERA_ACE_WRITE_DATA;
+    in->aces[0].who.type    = CHIMERA_PRINCIPAL_USER;
+    in->aces[0].who.id      = 4000;
+    in->aces[0].who.sid     = sid;
+    in->aces[1].type        = CHIMERA_ACE_ALLOWED;
+    in->aces[1].flags       = CHIMERA_ACE_FLAG_FILE_INHERIT;
+    in->aces[1].access_mask = CHIMERA_ACE_READ_DATA;
+    in->aces[1].who.type    = CHIMERA_PRINCIPAL_SPECIAL;
+    in->aces[1].who.special = CHIMERA_WHO_CREATOR_OWNER;
+    in->num_aces            = 2;
+
+    n = chimera_acl_chmod(in, 0640, out, 16);
+    assert(n > 1);
+    assert(out->aces[0].who.type == CHIMERA_PRINCIPAL_USER);
+    assert(out->aces[0].who.id == 4000);
+    assert(chimera_sid_equal(&out->aces[0].who.sid, &sid));
+    /* the regenerated special-who entries carry no SID */
+    for (int i = 1; i < n; i++) {
+        assert(!chimera_sid_present(&out->aces[i].who.sid));
+    }
+
+    n = chimera_acl_inherit(in, 0 /* file */, 0644, child, 8);
+    assert(n == 2);
+    assert(chimera_sid_equal(&child->aces[0].who.sid, &sid));
+    assert(child->aces[1].who.type == CHIMERA_PRINCIPAL_SPECIAL);
+    assert(child->aces[1].who.special == CHIMERA_WHO_OWNER);
+    assert(!chimera_sid_present(&child->aces[1].who.sid));
+
+    TEST_PASS("SID survives chmod and inherit; specials never carry one");
+} /* test_sid_survives_chmod_and_inherit */
+
+
 int
 main(
     int    argc,
@@ -409,6 +501,8 @@ main(
     test_serialize_roundtrip();
     test_gate();
     test_delete_allowed();
+    test_sid_principal_never_matches();
+    test_sid_survives_chmod_and_inherit();
 
     fprintf(stderr, "All ACL engine tests passed\n");
     return 0;

--- a/src/vfs/tests/vfs_idmap_test.c
+++ b/src/vfs/tests/vfs_idmap_test.c
@@ -94,8 +94,16 @@ test_sid_roundtrip(void)
     assert(chimera_idmap_sid_to_principal("S-1-22-2-200", &q) == 0);
     assert(q.type == CHIMERA_PRINCIPAL_GROUP && q.id == 200);
 
-    /* unrecognised SID is rejected */
+    /* a real domain SID is not algorithmic: the idmap rejects it, and it is
+     * the SMB layer that keeps it on the principal (see smb_sd_sid_test) */
     assert(chimera_idmap_sid_to_principal("S-1-5-21-1-2-3-4", &q) == -1);
+
+    /* the constructors build SID-less principals: an algorithmic identity
+     * carries no stored native SID */
+    p = chimera_idmap_uid_principal(1234);
+    assert(!chimera_sid_present(&p.sid));
+    p = chimera_idmap_special_principal(CHIMERA_WHO_EVERYONE);
+    assert(!chimera_sid_present(&p.sid));
 
     TEST_PASS("Windows SID strings round-trip (special + numeric + interop)");
 } /* test_sid_roundtrip */

--- a/src/vfs/tests/vfs_sid_test.c
+++ b/src/vfs/tests/vfs_sid_test.c
@@ -36,6 +36,20 @@ test_str_roundtrip(void)
     assert(chimera_sid_to_str(&s, buf, sizeof(buf)) > 0);
     assert(strcmp(buf, "S-1-5-21-1-2-3-1001") == 0);
 
+    /* The struct is fully defined: every byte past the SID is zero, so a
+     * copy of it (e.g. inside an ACE) compares byte-for-byte with one that
+     * was deserialized into zeroed storage. */
+    for (unsigned i = s.len; i < CHIMERA_SID_MAX_LEN; i++) {
+        assert(s.data[i] == 0);
+    }
+    /* ... and a failed parse leaves nothing of the previous contents. */
+    memset(&s, 0xa5, sizeof(s));
+    assert(chimera_sid_from_str(&s, "S-1-5-abc") == -1);
+    assert(!chimera_sid_present(&s));
+    for (unsigned i = 0; i < CHIMERA_SID_MAX_LEN; i++) {
+        assert(s.data[i] == 0);
+    }
+
     /* A well-known SID with a single sub-authority. */
     assert(chimera_sid_from_str(&s, "S-1-1-0") == 0);
     assert(s.len == 12);

--- a/src/vfs/tests/vfs_sid_test.c
+++ b/src/vfs/tests/vfs_sid_test.c
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * chimera_sid: the native Windows SID value type carried on ACL principals
+ * and owner/group attrs.  Covers the binary <-> string codec, the struct
+ * helpers, and the malformed-input rejections the SMB security-descriptor
+ * parser relies on.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "vfs/sdk/vfs_sid.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+/* A domain SID round-trips string -> binary -> string. */
+static void
+test_str_roundtrip(void)
+{
+    struct chimera_sid s;
+    char               buf[CHIMERA_SID_STR_MAX];
+
+    memset(&s, 0xa5, sizeof(s)); /* from_str must fully define the struct */
+
+    assert(chimera_sid_from_str(&s, "S-1-5-21-1-2-3-1001") == 0);
+    assert(chimera_sid_present(&s));
+    assert(s.len == 8 + 5 * 4);
+    assert(s.data[0] == 1);  /* revision */
+    assert(s.data[1] == 5);  /* sub-authority count */
+    assert(s.data[7] == 5);  /* NT authority, big-endian low byte */
+    assert(chimera_sid_to_str(&s, buf, sizeof(buf)) > 0);
+    assert(strcmp(buf, "S-1-5-21-1-2-3-1001") == 0);
+
+    /* A well-known SID with a single sub-authority. */
+    assert(chimera_sid_from_str(&s, "S-1-1-0") == 0);
+    assert(s.len == 12);
+    assert(chimera_sid_to_str(&s, buf, sizeof(buf)) == 7);
+    assert(strcmp(buf, "S-1-1-0") == 0);
+
+    TEST_PASS("SID string round-trips through binary form");
+} /* test_str_roundtrip */
+
+/* The struct copies out of (and back into) a raw wire buffer. */
+static void
+test_bin_roundtrip(void)
+{
+    struct chimera_sid a, b;
+    uint8_t            wire[CHIMERA_SID_MAX_LEN + 8];
+    char               str[CHIMERA_SID_STR_MAX];
+    int                n;
+
+    assert(chimera_sid_from_str(&a, "S-1-5-21-100-200-300-513") == 0);
+
+    /* Consume exactly the SID from a longer buffer. */
+    memset(wire, 0xee, sizeof(wire));
+    memcpy(wire, a.data, a.len);
+    n = chimera_sid_from_bin(&b, wire, sizeof(wire));
+    assert(n == (int) a.len);
+    assert(chimera_sid_equal(&a, &b));
+
+    /* Raw-buffer string codec agrees with the struct form. */
+    n = chimera_sid_bin_to_str(wire, sizeof(wire), str, sizeof(str));
+    assert(n == (int) a.len);
+    assert(strcmp(str, "S-1-5-21-100-200-300-513") == 0);
+    memset(wire, 0, sizeof(wire));
+    n = chimera_sid_str_to_bin(str, wire, sizeof(wire));
+    assert(n == (int) a.len);
+    assert(memcmp(wire, a.data, a.len) == 0);
+
+    /* Truncated: the buffer ends before the declared sub-authorities. */
+    assert(chimera_sid_from_bin(&b, a.data, a.len - 1) == -1);
+
+    /* Over-long sub-authority count is rejected, not overrun. */
+    memset(wire, 0, sizeof(wire));
+    wire[0] = 1;
+    wire[1] = CHIMERA_SID_MAX_SUB_AUTHS + 1;
+    assert(chimera_sid_from_bin(&b, wire, sizeof(wire)) == -1);
+    assert(chimera_sid_bin_to_str(wire, sizeof(wire), str, sizeof(str)) == -1);
+
+    /* Too short to even hold a header. */
+    assert(chimera_sid_from_bin(&b, wire, 7) == -1);
+
+    TEST_PASS("SID binary round-trips and rejects malformed input");
+} /* test_bin_roundtrip */
+
+/* The MS-DTYP maximum of 15 sub-authorities fits; 16 does not. */
+static void
+test_max_sub_auths(void)
+{
+    struct chimera_sid s;
+    char               buf[CHIMERA_SID_STR_MAX];
+    char               big[CHIMERA_SID_STR_MAX];
+    int                pos;
+
+    pos = snprintf(big, sizeof(big), "S-1-5");
+    for (int i = 0; i < CHIMERA_SID_MAX_SUB_AUTHS; i++) {
+        pos += snprintf(big + pos, sizeof(big) - pos, "-%u", 4000000000u + i);
+    }
+    assert(chimera_sid_from_str(&s, big) == 0);
+    assert(s.len == CHIMERA_SID_MAX_LEN);
+    assert(chimera_sid_to_str(&s, buf, sizeof(buf)) == (int) strlen(big));
+    assert(strcmp(buf, big) == 0);
+
+    /* One more sub-authority than the cap. */
+    snprintf(big + pos, sizeof(big) - pos, "-7");
+    assert(chimera_sid_from_str(&s, big) == -1);
+
+    TEST_PASS("15 sub-authorities round-trip, 16 are rejected");
+} /* test_max_sub_auths */
+
+/* Malformed strings and too-small output buffers are rejected. */
+static void
+test_bad_input(void)
+{
+    struct chimera_sid s;
+    char               tiny[4];
+    uint8_t            binsmall[8];
+
+    assert(chimera_sid_from_str(&s, "") == -1);
+    assert(chimera_sid_from_str(&s, "X-1-5-21") == -1);
+    assert(chimera_sid_from_str(&s, "S-1") == -1);
+    assert(chimera_sid_from_str(&s, "S-1-5-abc") == -1);
+    assert(chimera_sid_from_str(&s, "S-1-5-21-") == -1);
+
+    assert(chimera_sid_from_str(&s, "S-1-5-21-1-2-3-1001") == 0);
+    assert(chimera_sid_to_str(&s, tiny, sizeof(tiny)) == -1);
+    assert(chimera_sid_str_to_bin("S-1-5-21-1-2-3-1001", binsmall,
+                                  sizeof(binsmall)) == -1);
+
+    TEST_PASS("malformed strings and small buffers are rejected");
+} /* test_bad_input */
+
+/* Zero length is the absent state; equal compares length and bytes. */
+static void
+test_absent_and_equal(void)
+{
+    struct chimera_sid a, b, none;
+
+    memset(&none, 0, sizeof(none));
+    assert(!chimera_sid_present(&none));
+    assert(!chimera_sid_present(NULL));
+
+    assert(chimera_sid_from_str(&a, "S-1-5-21-1-2-3-1001") == 0);
+    assert(chimera_sid_from_str(&b, "S-1-5-21-1-2-3-1002") == 0);
+    assert(!chimera_sid_equal(&a, &b));
+    assert(chimera_sid_equal(&a, &a));
+    assert(!chimera_sid_equal(&a, &none));
+    assert(!chimera_sid_equal(&a, NULL));
+    assert(!chimera_sid_equal(NULL, NULL));
+
+    TEST_PASS("len 0 is the absent state; equality compares bytes");
+} /* test_absent_and_equal */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    test_str_roundtrip();
+    test_bin_roundtrip();
+    test_max_sub_auths();
+    test_bad_input();
+    test_absent_and_equal();
+
+    fprintf(stderr, "All SID codec tests passed\n");
+    return 0;
+} /* main */

--- a/src/vfs/vfs_acl.c
+++ b/src/vfs/vfs_acl.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <sys/stat.h>
+#include <string.h>
 
 #include "sdk/vfs_acl.h"
 #include "sdk/vfs_cred.h"
@@ -115,6 +116,10 @@ ace_applies(
             return (uint64_t) cred->uid == who->id;
         case CHIMERA_PRINCIPAL_GROUP:
             return cred_in_group(cred, who->id);
+        case CHIMERA_PRINCIPAL_SID:
+            /* An opaque native SID with no unix identity: preserved for
+             * round-tripping, but it can never describe a Unix caller. */
+            return 0;
         default:
             return 0;
     } /* switch */
@@ -341,6 +346,7 @@ chimera_acl_from_mode(
 #define EMIT(t, m, sp) \
         do { \
             if (n >= max_aces) { return -1; } \
+            memset(&out->aces[n], 0, sizeof(out->aces[n])); \
             out->aces[n].type        = (t); \
             out->aces[n].flags       = 0; \
             out->aces[n].access_mask = (m); \
@@ -382,6 +388,7 @@ chimera_acl_default_acl(
 #define EMIT(t, m, sp) \
         do { \
             if (n >= max_aces) { return -1; } \
+            memset(&out->aces[n], 0, sizeof(out->aces[n])); \
             out->aces[n].type        = (t); \
             out->aces[n].flags       = 0; \
             out->aces[n].access_mask = (m); \
@@ -555,8 +562,10 @@ inherit_subst_creator(const struct chimera_principal *who)
     if (p.type == CHIMERA_PRINCIPAL_SPECIAL) {
         if (p.special == CHIMERA_WHO_CREATOR_OWNER) {
             p.special = CHIMERA_WHO_OWNER;
+            p.sid.len = 0;
         } else if (p.special == CHIMERA_WHO_CREATOR_GROUP) {
             p.special = CHIMERA_WHO_GROUP;
+            p.sid.len = 0;
         }
     }
     return p;

--- a/src/vfs/vfs_acl_serialize.c
+++ b/src/vfs/vfs_acl_serialize.c
@@ -64,19 +64,46 @@ get_u32(const uint8_t **p)
     return v;
 } /* get_u32 */
 
+/* Non-zero if any ACE carries a native SID, which selects the v2 encoding. */
+static int
+acl_has_sid(const struct chimera_acl *acl)
+{
+    for (unsigned i = 0; i < acl->num_aces; i++) {
+        if (acl->aces[i].who.sid.len) {
+            return 1;
+        }
+    }
+    return 0;
+} /* acl_has_sid */
+
+SYMBOL_EXPORT size_t
+chimera_acl_serialized_size(const struct chimera_acl *acl)
+{
+    size_t size = CHIMERA_ACL_SERIAL_HDR +
+        (size_t) acl->num_aces * CHIMERA_ACL_SERIAL_ACE;
+
+    if (acl_has_sid(acl)) {
+        for (unsigned i = 0; i < acl->num_aces; i++) {
+            size += 1 + acl->aces[i].who.sid.len;
+        }
+    }
+    return size;
+} /* chimera_acl_serialized_size */
+
 SYMBOL_EXPORT int
 chimera_acl_serialize(
     const struct chimera_acl *acl,
     void                     *buf,
     size_t                    buflen)
 {
-    uint8_t *p = buf;
+    uint8_t *p  = buf;
+    int      v2 = acl_has_sid(acl);
 
     if (buflen < chimera_acl_serialized_size(acl)) {
         return -1;
     }
 
-    put_u8(&p, CHIMERA_ACL_SERIAL_VERSION);
+    put_u8(&p, v2 ? CHIMERA_ACL_SERIAL_VERSION : CHIMERA_ACL_SERIAL_V1);
     put_u16(&p, acl->ctrl_flags);
     put_u16(&p, acl->num_aces);
 
@@ -89,6 +116,12 @@ chimera_acl_serialize(
         put_u8(&p, ace->who.type);
         put_u8(&p, ace->who.special);
         put_u32(&p, ace->who.id);
+
+        if (v2) {
+            put_u8(&p, ace->who.sid.len);
+            memcpy(p, ace->who.sid.data, ace->who.sid.len);
+            p += ace->who.sid.len;
+        }
     }
 
     return (int) (p - (uint8_t *) buf);
@@ -101,7 +134,8 @@ chimera_acl_deserialize(
     struct chimera_acl *out,
     unsigned            max_aces)
 {
-    const uint8_t *p = buf;
+    const uint8_t *p   = buf;
+    const uint8_t *end = p + buflen;
     uint8_t        version;
     uint16_t       num_aces;
 
@@ -110,7 +144,7 @@ chimera_acl_deserialize(
     }
 
     version = get_u8(&p);
-    if (version != CHIMERA_ACL_SERIAL_VERSION) {
+    if (version != CHIMERA_ACL_SERIAL_V1 && version != CHIMERA_ACL_SERIAL_VERSION) {
         return -1;
     }
 
@@ -121,6 +155,7 @@ chimera_acl_deserialize(
         return -1;
     }
 
+    /* Lower bound; the v2 SID trailers are checked per ACE below. */
     if (buflen < CHIMERA_ACL_SERIAL_HDR +
         (size_t) num_aces * CHIMERA_ACL_SERIAL_ACE) {
         return -1;
@@ -128,6 +163,10 @@ chimera_acl_deserialize(
 
     for (unsigned i = 0; i < num_aces; i++) {
         struct chimera_ace *ace = &out->aces[i];
+
+        if (p + CHIMERA_ACL_SERIAL_ACE > end) {
+            return -1;
+        }
 
         /* Zero interior struct padding so a deserialized ACL is byte-deterministic. */
         memset(ace, 0, sizeof(*ace));
@@ -138,6 +177,24 @@ chimera_acl_deserialize(
         ace->who.type    = get_u8(&p);
         ace->who.special = get_u8(&p);
         ace->who.id      = get_u32(&p);
+
+        if (version == CHIMERA_ACL_SERIAL_VERSION) {
+            uint8_t sid_len;
+
+            if (p + 1 > end) {
+                return -1;
+            }
+            sid_len = get_u8(&p);
+            if (sid_len) {
+                if (p + sid_len > end ||
+                    chimera_sid_bin_len(p, sid_len) != (int) sid_len) {
+                    return -1;
+                }
+                memcpy(ace->who.sid.data, p, sid_len);
+                ace->who.sid.len = sid_len;
+                p               += sid_len;
+            }
+        }
     }
 
     out->num_aces = num_aces;

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -269,6 +269,18 @@ chimera_vfs_attr_cache_insert(
         entry->score = 0;
         entry->attr  = *attr;
 
+        /* The ACL and owner/group SID fields point at backend storage that is
+         * only valid for the completion callback that produced `attr`, and
+         * none of them is cacheable.  Drop the bits and the pointers on the
+         * cached copy so a later consumer can never dereference a stale
+         * per-thread scratch through a cache hit. */
+        entry->attr.va_set_mask &= ~(CHIMERA_VFS_ATTR_ACL |
+                                     CHIMERA_VFS_ATTR_OWNER_SID |
+                                     CHIMERA_VFS_ATTR_GROUP_SID);
+        entry->attr.va_acl       = NULL;
+        entry->attr.va_owner_sid = NULL;
+        entry->attr.va_group_sid = NULL;
+
         entry->expiration = chimera_vfs_now_ticks() +
             chimera_vfs_ns_to_ticks((uint64_t) cache->ttl * 1000000000ULL);
 

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -11,6 +11,7 @@
 #include "vfs_attr_cache.h"
 #include "sdk/vfs_access.h"
 #include "sdk/vfs_acl.h"
+#include "sdk/vfs_sid.h"
 #include "common/misc.h"
 #include "common/macros.h"
 
@@ -25,7 +26,9 @@
  * present, an owner/group field set to the value it already holds is not a
  * change and does not require WRITE_OWNER -- which matters because a SET_INFO
  * security descriptor commonly restates the existing owner alongside a DACL,
- * and the owner holds WRITE_ACL but not WRITE_OWNER implicitly.
+ * and the owner holds WRITE_ACL but not WRITE_OWNER implicitly.  The native
+ * owner/group SID companions follow the same rule: restating the SID the
+ * object already carries is not a chown.
  */
 static uint32_t
 chimera_vfs_setattr_required(
@@ -45,7 +48,13 @@ chimera_vfs_setattr_required(
                 cur->va_uid == set_attr->va_uid)) ||
         ((m & CHIMERA_VFS_ATTR_GID) &&
          !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_GID) &&
-           cur->va_gid == set_attr->va_gid));
+           cur->va_gid == set_attr->va_gid)) ||
+        ((m & CHIMERA_VFS_ATTR_OWNER_SID) &&
+         !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) &&
+           chimera_sid_equal(cur->va_owner_sid, set_attr->va_owner_sid))) ||
+        ((m & CHIMERA_VFS_ATTR_GROUP_SID) &&
+         !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) &&
+           chimera_sid_equal(cur->va_group_sid, set_attr->va_group_sid)));
 
     if (chowns) {
         required |= CHIMERA_ACE_WRITE_OWNER;
@@ -189,7 +198,8 @@ chimera_vfs_setattr_denied_error(
     uint64_t m = set_attr->va_set_mask;
 
     if (m & (CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_ACL |
-             CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+             CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID |
+             CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID)) {
         return CHIMERA_VFS_EPERM;
     }
 
@@ -560,7 +570,9 @@ chimera_vfs_setattr_common(
             gate->private_data   = private_data;
 
             chimera_vfs_getattr(thread, cred, handle,
-                                CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL,
+                                CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL |
+                                CHIMERA_VFS_ATTR_OWNER_SID |
+                                CHIMERA_VFS_ATTR_GROUP_SID,
                                 chimera_vfs_setattr_gate_complete, gate);
             return;
         }

--- a/src/vfs/vfs_sid.c
+++ b/src/vfs/vfs_sid.c
@@ -182,10 +182,13 @@ chimera_sid_from_bin(
     int len = chimera_sid_bin_len(buf, avail);
 
     if (len < 0) {
-        sid->len = 0;
+        memset(sid, 0, sizeof(*sid));
         return -1;
     }
+    /* Fully define the struct: zero the tail past the SID so a chimera_sid
+     * (and any ACE carrying one) is byte-deterministic and safe to memcmp. */
     memcpy(sid->data, buf, len);
+    memset(sid->data + len, 0, CHIMERA_SID_MAX_LEN - len);
     sid->len = (uint8_t) len;
     return len;
 } /* chimera_sid_from_bin */
@@ -213,9 +216,10 @@ chimera_sid_from_str(
     int len = chimera_sid_str_to_bin(str, sid->data, CHIMERA_SID_MAX_LEN);
 
     if (len < 0) {
-        sid->len = 0;
+        memset(sid, 0, sizeof(*sid));
         return -1;
     }
+    memset(sid->data + len, 0, CHIMERA_SID_MAX_LEN - len);
     sid->len = (uint8_t) len;
     return 0;
 } /* chimera_sid_from_str */

--- a/src/vfs/vfs_sid.c
+++ b/src/vfs/vfs_sid.c
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <string.h>
+
+#include "sdk/vfs_sid.h"
+#include "common/macros.h"
+
+static inline uint32_t
+sid_get_u32(const uint8_t *p)
+{
+    return (uint32_t) p[0] | ((uint32_t) p[1] << 8) |
+           ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 24);
+} /* sid_get_u32 */
+
+static inline void
+sid_put_u32(
+    uint8_t *p,
+    uint32_t v)
+{
+    p[0] = (uint8_t) (v & 0xff);
+    p[1] = (uint8_t) ((v >> 8) & 0xff);
+    p[2] = (uint8_t) ((v >> 16) & 0xff);
+    p[3] = (uint8_t) ((v >> 24) & 0xff);
+} /* sid_put_u32 */
+
+/*
+ * Parse a run of decimal digits at *pp into *out (up to `max`), advancing
+ * *pp past them.  Requires at least one digit and rejects overflow.  Returns
+ * 0 on success, -1 otherwise.
+ */
+static int
+sid_parse_dec(
+    const char **pp,
+    uint64_t     max,
+    uint64_t    *out)
+{
+    const char *p = *pp;
+    uint64_t    v = 0;
+
+    if (*p < '0' || *p > '9') {
+        return -1;
+    }
+    while (*p >= '0' && *p <= '9') {
+        uint64_t d = (uint64_t) (*p - '0');
+
+        if (v > (max - d) / 10) {
+            return -1;
+        }
+        v = v * 10 + d;
+        p++;
+    }
+    *out = v;
+    *pp  = p;
+    return 0;
+} /* sid_parse_dec */
+
+SYMBOL_EXPORT int
+chimera_sid_bin_len(
+    const uint8_t *buf,
+    uint32_t       avail)
+{
+    uint32_t count;
+
+    if (!buf || avail < CHIMERA_SID_MIN_LEN) {
+        return -1;
+    }
+    count = buf[1];
+    if (count > CHIMERA_SID_MAX_SUB_AUTHS) {
+        return -1;
+    }
+    if (CHIMERA_SID_MIN_LEN + count * 4 > avail) {
+        return -1;
+    }
+    return (int) (CHIMERA_SID_MIN_LEN + count * 4);
+} /* chimera_sid_bin_len */
+
+SYMBOL_EXPORT int
+chimera_sid_bin_to_str(
+    const uint8_t *buf,
+    uint32_t       len,
+    char          *out,
+    int            outlen)
+{
+    uint64_t authority = 0;
+    int      binlen, count, pos;
+
+    binlen = chimera_sid_bin_len(buf, len);
+    if (binlen < 0 || !out || outlen <= 0) {
+        return -1;
+    }
+    count = buf[1];
+
+    for (int i = 0; i < 6; i++) {
+        authority = (authority << 8) | buf[2 + i];
+    }
+
+    pos = snprintf(out, outlen, "S-%u-%llu", buf[0], (unsigned long long) authority);
+    if (pos < 0 || pos >= outlen) {
+        return -1;
+    }
+    for (int i = 0; i < count; i++) {
+        int n = snprintf(out + pos, outlen - pos, "-%u",
+                         sid_get_u32(buf + CHIMERA_SID_MIN_LEN + i * 4));
+
+        if (n < 0 || pos + n >= outlen) {
+            return -1;
+        }
+        pos += n;
+    }
+    return binlen;
+} /* chimera_sid_bin_to_str */
+
+SYMBOL_EXPORT int
+chimera_sid_str_to_bin(
+    const char *str,
+    uint8_t    *out,
+    int         outcap)
+{
+    const char *p = str;
+    uint64_t    v;
+    int         count = 0;
+
+    if (!str || !out || outcap < CHIMERA_SID_MIN_LEN) {
+        return -1;
+    }
+    if (str[0] != 'S' && str[0] != 's') {
+        return -1;
+    }
+    p++;
+    if (*p != '-') {
+        return -1;
+    }
+    p++;
+
+    /* revision */
+    if (sid_parse_dec(&p, 255, &v) < 0 || *p != '-') {
+        return -1;
+    }
+    out[0] = (uint8_t) v;
+    p++;
+
+    /* 48-bit identifier authority, stored big-endian */
+    if (sid_parse_dec(&p, 0xffffffffffffULL, &v) < 0) {
+        return -1;
+    }
+    for (int i = 0; i < 6; i++) {
+        out[2 + i] = (uint8_t) ((v >> (8 * (5 - i))) & 0xff);
+    }
+
+    while (*p == '-') {
+        p++;
+        if (count >= CHIMERA_SID_MAX_SUB_AUTHS) {
+            return -1;
+        }
+        if (sid_parse_dec(&p, 0xffffffffULL, &v) < 0) {
+            return -1;
+        }
+        if (CHIMERA_SID_MIN_LEN + (count + 1) * 4 > outcap) {
+            return -1;
+        }
+        sid_put_u32(out + CHIMERA_SID_MIN_LEN + count * 4, (uint32_t) v);
+        count++;
+    }
+
+    if (*p != '\0') {
+        return -1; /* trailing text is not part of a SID */
+    }
+
+    out[1] = (uint8_t) count;
+    return CHIMERA_SID_MIN_LEN + count * 4;
+} /* chimera_sid_str_to_bin */
+
+SYMBOL_EXPORT int
+chimera_sid_from_bin(
+    struct chimera_sid *sid,
+    const uint8_t      *buf,
+    uint32_t            avail)
+{
+    int len = chimera_sid_bin_len(buf, avail);
+
+    if (len < 0) {
+        sid->len = 0;
+        return -1;
+    }
+    memcpy(sid->data, buf, len);
+    sid->len = (uint8_t) len;
+    return len;
+} /* chimera_sid_from_bin */
+
+SYMBOL_EXPORT int
+chimera_sid_to_str(
+    const struct chimera_sid *sid,
+    char                     *out,
+    int                       outlen)
+{
+    if (!chimera_sid_present(sid)) {
+        return -1;
+    }
+    if (chimera_sid_bin_to_str(sid->data, sid->len, out, outlen) < 0) {
+        return -1;
+    }
+    return (int) strlen(out);
+} /* chimera_sid_to_str */
+
+SYMBOL_EXPORT int
+chimera_sid_from_str(
+    struct chimera_sid *sid,
+    const char         *str)
+{
+    int len = chimera_sid_str_to_bin(str, sid->data, CHIMERA_SID_MAX_LEN);
+
+    if (len < 0) {
+        sid->len = 0;
+        return -1;
+    }
+    sid->len = (uint8_t) len;
+    return 0;
+} /* chimera_sid_from_str */


### PR DESCRIPTION
A principal was a uid/gid, so a SID the identity layer could not map had no uid
and was dropped on the way in. A Windows client that set a DACL naming a domain
user this server has never heard of read the descriptor back with that ACE
missing -- including DENY aces, whose disappearance grants access rather than
denying it. The same was true of the owner and group fields, which were always
re-derived from uid/gid on the way out.

This series carries the native SID alongside the numeric identity, end to end,
so a Windows ACL survives a round trip through a POSIX-backed share.

Access evaluation is deliberately untouched: it still runs purely on the
numeric identity. A SID that resolves to nobody matches no caller, which is the
same thing NTFS does with a departed user's ACE.

### The value type and the SDK

`struct chimera_sid` (`src/vfs/sdk/vfs_sid.h`, `vfs_sid.c`) holds a SID in its
MS-DTYP binary form with the 15 sub-authority cap, and owns the binary/string
codec that `smb_proc_security.c` previously kept as file-local statics. The
string parser is strict -- digits only, no trailing text -- so a malformed wire
SID is rejected rather than overrunning a buffer.

`struct chimera_principal` gains an inline SID. It is populated only on USER and
GROUP principals that resolved through the identity layer, and on the new
`CHIMERA_PRINCIPAL_SID` for a SID that resolved to nothing at all; SPECIAL
principals never carry one, since `OWNER@` and friends re-derive on emit.

The principal is a published SDK type that out-of-tree modules consume, so
`CHIMERA_VFS_SDK_VERSION` moves to 2 and a module built against 1 must be
rebuilt.

On-disk ACL encoding gains a v2 that appends a length-prefixed SID to each ACE.
The serializer picks v2 only when some ACE actually carries a SID and otherwise
still writes v1, so a volume stays readable by an older binary until a real
domain SID is stored; the deserializer accepts both.
`chimera_acl_serialized_size` becomes a walk, since the encoding is now
variable-length.

### Attributes and the chown gate

`CHIMERA_VFS_ATTR_OWNER_SID` / `GROUP_SID` and the pointer-valued
`va_owner_sid` / `va_group_sid` are the SID companions to `va_uid` / `va_gid`,
with `va_acl`'s callback-lifetime contract and deliberately outside `MASK_STAT`
and `MASK_CACHEABLE`.

Two consequences are worth calling out. The setattr gate folds the SIDs into
its "is this really a chown" test the same way it already treats a restated
uid, so a SET_INFO security descriptor that restates the owner SID the object
already carries alongside a new DACL keeps requiring only `WRITE_ACL`, which
the owner holds implicitly. And the attr cache copies the whole attrs struct by
value, while the ACL and SID pointers in that copy reference per-thread backend
scratch that is dead once the producing callback returns -- so the cache now
clears those bits and NULLs those pointers on insert.

### Backends

memfs, cairn and diskfs all keep the owner/group SIDs in a record *separate*
from the ACL, so "no ACL record" keeps meaning "mode-derived DACL" and a chown
never has to touch the DACL record. cairn adds `CAIRN_KEY_SID`, diskfs adds
`DISKFS_REC_SID` with the same mirror discipline as its ACL record, and memfs
stores them on the inode.

All three keep the SIDs coherent with uid/gid: an explicit `OWNER_SID` /
`GROUP_SID` set stores or clears, while a bare chown drops the stale one that
would no longer describe the new owner.

Because a v2 ACE is variable-length, whether an ACL fits one diskfs record is
now decided by `chimera_acl_serialized_size` rather than an ACE count. diskfs
has always persisted the canonical ACL but never advertised
`CHIMERA_VFS_CAP_ACL_NATIVE`; it does now, like the other two.

### SMB

SET security keeps what it used to discard. An owner or group SID that resolves
travels as the `va_owner_sid` / `va_group_sid` companion; an ACE SID that
resolves keeps the SID on its USER/GROUP principal; and an ACE SID still
unmappable on the final resolve pass is stored as an opaque
`CHIMERA_PRINCIPAL_SID` rather than dropped. The create-context SD parse gets
the vfs too, so the session's own cached SID resolves at create time while
uncached ones are preserved verbatim.

QUERY security prefers what was stored: the owner and group fields use the
native companions when present, an ACE whose principal carries a SID is emitted
from those bytes, and an `OWNER@` / `GROUP@` entry substitutes the stored
owner/group SID so it agrees with the descriptor's own owner and group fields.
Only SID-less principals still walk the identity cache and fall back to the
algorithmic `modefromsid` form. The uncached-principal count that decides
whether to park for resolution skips anything already carrying a SID, so a
descriptor built from stored SIDs never waits on the resolver.

`sec_buf` grows 2048 -> 4096, since a 64-ACE descriptor carrying real domain
SIDs no longer fits 2 KiB.

### Coverage

`vfs/sid_test`, `vfs/acl_sid_*` across memfs/cairn/diskfs and `smb/sd_sid_test`
are all extended-tier, and the merge gate runs the quick tier -- so on their own
they would not catch a regression here until the next Extended run. The SMB2
trace corpus cannot cover it either: the quint model has no security-descriptor
surface at all, and `probe_security()` stopped at the 20-byte header without
ever decoding a SID or walking an ACE. Its own comment said the translation
layer was "otherwise dark".

The last commit closes that, in the probe that already owns this surface and
already runs in the quick tier. Following the house discipline of pinning
behaviour with a probe before a model bakes an expectation, it covers the case
that actually changed: a descriptor the server did *not* author. It SETs a DACL
carrying an unmappable domain user, a well-known SID and a DENY ace for a
second unmappable user, then requires all three back verbatim with type, access
mask and order intact. Built without the series the same probe fails, dropping
two of the three aces, the DENY among them.

It also pins the two boundaries: a file with nothing stored still reports the
algorithmic `S-1-5-88` owner and group, and an owner SID no identity authority
can resolve is deliberately *not* adopted -- silently taking one would detach
the file's owner from every POSIX check.

`smb2_sd_parse` / `smb2_sd_build` / `smb2_sid_{to_str,str_to_bin}` go in
`smb2_mbt_common.h` rather than in the probe, since nothing in the quint
harness could decode a SID or an ACE and a replayer handler for a modeled
SECURITY op will need exactly this.

### Notes for review

Deliberately out of scope, and worth saying so explicitly:

- Owner/group SID companions are not seeded at create.
- An unmappable OWNER/GROUP SID on SET is ignored rather than refused with
  `STATUS_INVALID_OWNER`.
- A stored `PRINCIPAL_SID` never upgrades if the SID later becomes resolvable.
- NFSv4 who-strings are unchanged; this is SMB-only on the protocol side.
- Modeling the security-descriptor surface in the shared quint spec is a
  separate piece of work. It needs a `READ_CONTROL` / `WRITE_DAC` /
  `WRITE_OWNER` axis on `DesiredAccess` that the model does not have today,
  without which every modeled `CSetSecurity` would return
  `STATUS_ACCESS_DENIED`.

One divergence noticed while working here but not changed: chimera does not
check `READ_CONTROL` on QUERY SECURITY, where MS-SMB2 gates it.
