### PR TITLE
docker: build fio without -march=native, so the image's fio runs on every runner

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -114,10 +114,17 @@ RUN if [ "$ENABLE_CODEX" = "1" ] ; then \
     npm install -g @openai/codex ; \
     fi
 
+# --disable-native: fio's configure otherwise adds -march=native, so the
+# binary is tuned to whichever runner happened to build this image.  Built on
+# a host with AVX-512 it carries EVEX instructions (vpbroadcastd from a GPR in
+# fio_client_hash_init, run from a constructor) and dies with SIGILL at
+# startup on any test runner without it -- the intermittent fio SIGILL that
+# followed the runner move, which hit both amd64 and arm64 and struck before
+# fio had parsed a single argument.
 RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     git clone --depth 1 --branch fio-3.40 https://github.com/axboe/fio.git /fio && \
     cd /fio && \
-    ./configure --disable-libnfs && \
+    ./configure --disable-libnfs --disable-native && \
     make -j8 && \
     make install ; \
     fi

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -56,11 +56,13 @@ RUN dnf -y update && \
     libwbclient-devel samba-client krb5-server krb5-workstation samba samba-winbind samba-winbind-clients \
     python3-boto3 which && \
     dnf clean all
+# --disable-native below: see .devcontainer/Dockerfile for why fio must not be
+# tuned to the runner that happens to build this image.
 
 RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     git clone --depth 1 --branch fio-3.40 https://github.com/axboe/fio.git /fio && \
     cd /fio && \
-    ./configure --disable-libnfs && \
+    ./configure --disable-libnfs --disable-native && \
     make -j8 && \
     make install ; \
     fi

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -53,11 +53,13 @@ RUN dnf -y update && \
     libwbclient-devel samba-client krb5-server krb5-workstation samba samba-winbind samba-winbind-clients \
     python3-boto3 which && \
     dnf clean all
+# --disable-native below: see .devcontainer/Dockerfile for why fio must not be
+# tuned to the runner that happens to build this image.
 
 RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     git clone --depth 1 --branch fio-3.40 https://github.com/axboe/fio.git /fio && \
     cd /fio && \
-    ./configure --disable-libnfs && \
+    ./configure --disable-libnfs --disable-native && \
     make -j8 && \
     make install ; \
     fi

--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -82,11 +82,13 @@ RUN apt-get -y update && \
     libwbclient-dev smbclient krb5-kdc krb5-admin-server krb5-user samba winbind samba-dsdb-modules samba-vfs-modules && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+# --disable-native below: see .devcontainer/Dockerfile for why fio must not be
+# tuned to the runner that happens to build this image.
 
 RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     git clone --depth 1 --branch fio-3.40 https://github.com/axboe/fio.git /fio && \
     cd /fio && \
-    ./configure --disable-libnfs && \
+    ./configure --disable-libnfs --disable-native && \
     make -j8 && \
     make install ; \
     fi

--- a/Dockerfile.ubuntu24.04
+++ b/Dockerfile.ubuntu24.04
@@ -86,11 +86,13 @@ RUN apt-get -y update && \
     libwbclient-dev smbclient krb5-kdc krb5-admin-server krb5-user samba samba-ad-dc samba-ad-provision samba-dsdb-modules && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+# --disable-native below: see .devcontainer/Dockerfile for why fio must not be
+# tuned to the runner that happens to build this image.
 
 RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     git clone --depth 1 --branch fio-3.40 https://github.com/axboe/fio.git /fio && \
     cd /fio && \
-    ./configure --disable-libnfs && \
+    ./configure --disable-libnfs --disable-native && \
     make -j8 && \
     make install ; \
     fi

--- a/Dockerfile.ubuntu26.04
+++ b/Dockerfile.ubuntu26.04
@@ -86,11 +86,13 @@ RUN apt-get -y update && \
     libwbclient-dev smbclient krb5-kdc krb5-admin-server krb5-user samba samba-ad-dc samba-ad-provision samba-dsdb-modules && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+# --disable-native below: see .devcontainer/Dockerfile for why fio must not be
+# tuned to the runner that happens to build this image.
 
 RUN if [ "$ENABLE_FIO" = "1" ] ; then \
     git clone --depth 1 --branch fio-3.40 https://github.com/axboe/fio.git /fio && \
     cd /fio && \
-    ./configure --disable-libnfs && \
+    ./configure --disable-libnfs --disable-native && \
     make -j8 && \
     make install ; \
     fi


### PR DESCRIPTION
Root cause of the intermittent `chimera/fio/*` SIGILL (handoff item 3), from the gdb re-run added in #1659, run 34239900116:

```
Program received signal SIGILL, Illegal instruction.
0x0000555555575910 in fio_client_hash_init () at client.c:96
=> 0x555555575910 <fio_client_hash_init+16>:	vpbroadcastd %edx,%ymm3
#1  __libc_start_main ()
```

`vpbroadcastd ymm, r32` is the EVEX (AVX-512VL) encoding, and every failing report says `avx512f ABSENT`. fio's `configure` adds `-march=native` unless `--disable-native`, so each CI image's fio was tuned to whichever runner built that image. Built on an AVX-512 host, it dies at startup, in a constructor, on any test runner without AVX-512. That explains everything the handoff could not: the failure tracked the (image-build host, test host) pair rather than either alone, hit amd64 and arm64 alike, struck in 0.13 s before fio parsed an argument (which is why `fio --version` printed nothing in the earlier reports), and chimera's own `-march=x86-64-v3` requirements were always satisfied. `--crctest` died the same way, so it was never the CRC dispatch.

**Change:** `--disable-native` on the fio configure line in every Dockerfile that builds it (devcontainer and the five distro images). The engine's speed is not what these tests measure.

The dev image rebuilds per commit, so the next Extended run on this SHA carries the fixed binary.
