### PR TITLE
smb: refuse a Kerberos logon whose principal cannot be mapped

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,7 @@ Domain-authentication backends for SMB.
 | `kerberos_enabled` | bool | `false` | Enable Kerberos authentication. |
 | `kerberos_keytab` | string | - | Path to the Kerberos keytab. |
 | `kerberos_realm` | string | - | Kerberos realm. |
+| `kerberos_anonymous_fallback` | bool | `false` | Serve an authenticated Kerberos principal as uid/gid 65534 when `winbind_enabled` is off. Off, a Kerberos logon without winbind is refused with `NT_STATUS_LOGON_FAILURE`. Ignored when `winbind_enabled` is set. |
 
 Winbind and Kerberos both require setup outside chimera (a domain join, a
 keytab, and NSS pointed at winbind). See

--- a/docs/smb-domain-auth.md
+++ b/docs/smb-domain-auth.md
@@ -61,6 +61,7 @@ The chimera side of both procedures is the `server.smb_auth` object:
 | `kerberos_enabled` | bool | `false` | Accept Kerberos through SPNEGO. |
 | `kerberos_keytab` | string | - | Keytab used to accept Kerberos contexts. If unset, the MIT default (or `KRB5_KTNAME`) applies. |
 | `kerberos_realm` | string | - | Realm the host belongs to, recorded at startup. |
+| `kerberos_anonymous_fallback` | bool | `false` | Serve an authenticated Kerberos principal as uid/gid 65534 when `winbind_enabled` is off. Off, a Kerberos logon without winbind is refused with `NT_STATUS_LOGON_FAILURE`. Ignored when `winbind_enabled` is set. |
 
 See [server.smb_auth](configuration#serversmb_auth) in the configuration
 reference for how these sit in the wider config file.
@@ -90,10 +91,18 @@ is joined it advertises fallback names and every pass-through logon fails with
 `NT_STATUS_LOGON_FAILURE`. There is no retry: restart chimera after a join or
 a rejoin.
 
-**Enable winbind even for a Kerberos-only deployment.** The Kerberos path maps
-the authenticated principal to a uid through winbind. With `winbind_enabled`
-off, or if the mapping fails, the session silently falls back to uid and gid
-65534, and every user shares one identity on disk.
+**Enable winbind for every Kerberos deployment that has a domain behind it.**
+The Kerberos path maps the authenticated principal to a uid through winbind.
+With `winbind_enabled` set, a winbindd that is down or a principal it cannot
+map refuses the logon with `NT_STATUS_LOGON_FAILURE`; an accepted service
+ticket alone never yields a session, and chimera logs the principal and the
+reason at error level. With `winbind_enabled` off, chimera has no identity
+source for the principal and refuses the logon too, unless
+`kerberos_anonymous_fallback` is set, in which case every Kerberos user is
+served as uid and gid 65534 and shares one identity on disk. That knob exists
+for a KDC with no domain (a plain MIT realm); it is never consulted when
+winbind is enabled, so a winbind outage cannot degrade a domain deployment to
+anonymous access.
 
 **`smbd` must not be running.** Chimera binds port 445 itself. If samba's file
 server is installed as a side effect of another package, disable and mask it.
@@ -407,8 +416,7 @@ the same directory without deploying Active Directory.
 
 > **Note:** this is an NTLM-only deployment. An OpenLDAP directory has no KDC,
 > so leave `kerberos_enabled` off. Chimera's Kerberos path resolves principals
-> through winbind with no fallback, so enabling it without a KDC would map
-> every session to uid 65534.
+> through winbind and refuses any principal winbind cannot map.
 
 The worked example uses these values:
 
@@ -769,7 +777,9 @@ must fail with `NT_STATUS_LOGON_FAILURE` or `NT_STATUS_WRONG_PASSWORD`.
 | Every pass-through logon fails `NT_STATUS_LOGON_FAILURE`, but `wbinfo -a` and `ntlm_auth` succeed | Chimera started before the host was joined, so it advertises fallback names in its NTLM CHALLENGE and the domain controller's target-info check rejects the response. | Restart chimera after the join. Its log line `NTLM CHALLENGE identity: ...` shows whether the names came from `winbind` or from `fallback`. |
 | `NT_STATUS_NO_SUCH_USER` after a pause of about five seconds, while `wbinfo -u`, `wbinfo -i` and `getent` all work | The nested `getpwnam()` inside the authentication request cannot be served. | Set `winbind max domain connections = 5` and reduce `nsswitch.conf` to `files winbind`. |
 | `winbind_enabled: true` appears to be ignored | Chimera was built without libwbclient. | Install `libwbclient-dev` or `libwbclient-devel`, reconfigure, and look for `libwbclient found` in the cmake output. |
-| Everything on disk is owned by uid 65534 | Winbind is disabled, or a Kerberos principal could not be mapped. | Set `winbind_enabled: true`, and check `wbinfo -n` and `wbinfo --sid-to-uid` for the user. |
+| Everything on disk is owned by uid 65534 | `kerberos_anonymous_fallback` is set with winbind off, so every Kerberos principal is served as nobody. | Set `winbind_enabled: true` and remove `kerberos_anonymous_fallback`; check `wbinfo -n` and `wbinfo --sid-to-uid` for the user. |
+| Kerberos logons fail `NT_STATUS_LOGON_FAILURE` while NTLM logons work, and chimera logs `winbind is unavailable` | winbindd is down, or chimera was built without libwbclient. Chimera refuses the logon rather than serving the principal as uid 65534. | Restart winbindd and confirm with `wbinfo --ping`; or rebuild with libwbclient. |
+| Kerberos logons fail `NT_STATUS_LOGON_FAILURE` and chimera logs `no identity source` | `winbind_enabled` and `kerberos_anonymous_fallback` are both off. | Enable winbind. For a KDC with no domain behind it, set `kerberos_anonymous_fallback: true`, knowing every user then shares uid 65534. |
 | SMB file ownership does not match the directory's `uidNumber` | An `idmap config <workgroup>` stanza is bypassing `idmap_passdb`. | Remove it for a local SAM or ldapsam domain. |
 | `adcli join` fails intermittently with `Message stream modified` | `--domain-controller` was given a name with no `ldap/` service principal, often a round-robin alias. | Use `--domain` and let adcli discover a controller. |
 | The join reports it cannot store the machine password, and `wbinfo --ping-dc` then fails | On samba 4.16 and newer, `net changesecretpw` can only upgrade an existing record. | Seed the two `secrets.tdb` records with `tdbtool` before joining. |

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -956,6 +956,11 @@ main(
             chimera_server_config_set_smb_kerberos_realm(server_config,
                                                          json_string_value(kerberos_realm));
         }
+
+        json_t *kerberos_anonymous_fallback = json_object_get(smb_auth, "kerberos_anonymous_fallback");
+        if (kerberos_anonymous_fallback && json_is_true(kerberos_anonymous_fallback)) {
+            chimera_server_config_set_smb_kerberos_anonymous_fallback(server_config, 1);
+        }
     }
 
     // Parse NFS auth configuration (RPCSEC_GSS / Kerberos)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -45,6 +45,7 @@
 struct chimera_server_config_smb_auth {
     int  winbind_enabled;
     int  kerberos_enabled;
+    int  kerberos_anonymous_fallback;
     char winbind_domain[256];
     char kerberos_keytab[256];
     char kerberos_realm[256];
@@ -326,14 +327,15 @@ chimera_server_config_init(void)
         SMB2_SSINFO_FLAGS_PARTITION_ALIGNED_ON_DEVICE;
 
     // SMB auth config defaults - local NTLM only
-    config->smb_auth.winbind_enabled    = 0;
-    config->smb_auth.kerberos_enabled   = 0;
-    config->smb_auth.winbind_domain[0]  = '\0';
-    config->smb_auth.kerberos_keytab[0] = '\0';
-    config->smb_auth.kerberos_realm[0]  = '\0';
-    config->nfs_auth.kerberos_enabled   = 0;
-    config->nfs_auth.kerberos_keytab[0] = '\0';
-    config->nfs_auth.num_principal_map  = 0;
+    config->smb_auth.winbind_enabled             = 0;
+    config->smb_auth.kerberos_enabled            = 0;
+    config->smb_auth.kerberos_anonymous_fallback = 0;
+    config->smb_auth.winbind_domain[0]           = '\0';
+    config->smb_auth.kerberos_keytab[0]          = '\0';
+    config->smb_auth.kerberos_realm[0]           = '\0';
+    config->nfs_auth.kerberos_enabled            = 0;
+    config->nfs_auth.kerberos_keytab[0]          = '\0';
+    config->nfs_auth.num_principal_map           = 0;
 
     config->anonuid = 65534;
     config->anongid = 65534;
@@ -3386,6 +3388,20 @@ chimera_server_config_get_smb_kerberos_keytab(const struct chimera_server_config
 {
     return config->smb_auth.kerberos_keytab;
 } /* chimera_server_config_get_smb_kerberos_keytab */
+
+SYMBOL_EXPORT void
+chimera_server_config_set_smb_kerberos_anonymous_fallback(
+    struct chimera_server_config *config,
+    int                           enabled)
+{
+    config->smb_auth.kerberos_anonymous_fallback = enabled;
+} /* chimera_server_config_set_smb_kerberos_anonymous_fallback */
+
+SYMBOL_EXPORT int
+chimera_server_config_get_smb_kerberos_anonymous_fallback(const struct chimera_server_config *config)
+{
+    return config->smb_auth.kerberos_anonymous_fallback;
+} /* chimera_server_config_get_smb_kerberos_anonymous_fallback */
 
 SYMBOL_EXPORT void
 chimera_server_config_set_nfs_kerberos_enabled(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -1069,6 +1069,18 @@ const char *
 chimera_server_config_get_smb_kerberos_keytab(
     const struct chimera_server_config *config);
 
+/* Serve an authenticated Kerberos principal as uid/gid 65534 when no identity
+ * source can map it (winbind off).  Off by default: a winbind-less Kerberos
+ * logon is then refused.  Ignored when winbind is enabled. */
+void
+chimera_server_config_set_smb_kerberos_anonymous_fallback(
+    struct chimera_server_config *config,
+    int                           enabled);
+
+int
+chimera_server_config_get_smb_kerberos_anonymous_fallback(
+    const struct chimera_server_config *config);
+
 void
 chimera_server_config_set_nfs_kerberos_enabled(
     struct chimera_server_config *config,

--- a/src/server/smb/CMakeLists.txt
+++ b/src/server/smb/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(chimera_smb SHARED
     smb_proc_sparse.c smb_proc_copychunk.c smb_proc_copyoffload.c
     smb_proc_lock.c smb_proc_oplock_break.c
     smb_notify.c smb_async_interim.c smb_sharemode.c smb_ntlm.c smb_durable.c
-    smb_wbclient.c smb_auth.c smb_gssapi.c
+    smb_wbclient.c smb_auth.c smb_gssapi.c smb_kerberos_identity.c
 )
 
 # Generate NDR marshalling for the named-pipe RPC interfaces from their .idl

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -186,8 +186,10 @@ chimera_smb_server_init(
     snprintf(shared->config.identity, sizeof(shared->config.identity), "chimera");
 
     // Copy SMB auth config from server config
-    shared->config.auth.winbind_enabled  = chimera_server_config_get_smb_winbind_enabled(config);
-    shared->config.auth.kerberos_enabled = chimera_server_config_get_smb_kerberos_enabled(config);
+    shared->config.auth.winbind_enabled             = chimera_server_config_get_smb_winbind_enabled(config);
+    shared->config.auth.kerberos_enabled            = chimera_server_config_get_smb_kerberos_enabled(config);
+    shared->config.auth.kerberos_anonymous_fallback =
+        chimera_server_config_get_smb_kerberos_anonymous_fallback(config);
 
     const char *winbind_domain = chimera_server_config_get_smb_winbind_domain(config);
     if (winbind_domain && winbind_domain[0]) {
@@ -221,6 +223,18 @@ chimera_smb_server_init(
         chimera_smb_info("SMB Auth: Kerberos enabled (realm: %s, keytab: %s)",
                          shared->config.auth.kerberos_realm[0] ? shared->config.auth.kerberos_realm : "(not set)",
                          shared->config.auth.kerberos_keytab[0] ? shared->config.auth.kerberos_keytab : "(default)");
+
+        /* Say once, at startup, what a Kerberos principal turns into when no
+        * winbind is there to map it; the per-logon lines refer back here. */
+        if (!shared->config.auth.winbind_enabled) {
+            if (shared->config.auth.kerberos_anonymous_fallback) {
+                chimera_smb_info("SMB Auth: Kerberos without winbind: every authenticated principal "
+                                 "is served as uid/gid 65534 (kerberos_anonymous_fallback)");
+            } else {
+                chimera_smb_error("SMB Auth: Kerberos without winbind and without "
+                                  "kerberos_anonymous_fallback: every Kerberos logon will be refused");
+            }
+        }
     }
 
     /* Resolve the identity advertised in NTLM CHALLENGE messages once at

--- a/src/server/smb/smb.c
+++ b/src/server/smb/smb.c
@@ -234,6 +234,9 @@ chimera_smb_server_init(
                 chimera_smb_error("SMB Auth: Kerberos without winbind and without "
                                   "kerberos_anonymous_fallback: every Kerberos logon will be refused");
             }
+        } else if (shared->config.auth.kerberos_anonymous_fallback) {
+            chimera_smb_info("SMB Auth: kerberos_anonymous_fallback ignored: winbind_enabled is set, "
+                             "winbind maps every Kerberos principal");
         }
     }
 

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -198,6 +198,9 @@ struct chimera_smb_rdma_element {
 struct chimera_smb_auth_config {
     int                             winbind_enabled;
     int                             kerberos_enabled;
+    /* Serve a Kerberos principal no identity source can map as uid/gid 65534
+     * instead of refusing the logon.  Only consulted when winbind is off. */
+    int                             kerberos_anonymous_fallback;
     char                            winbind_domain[256];
     char                            kerberos_keytab[256];
     char                            kerberos_realm[256];

--- a/src/server/smb/smb_kerberos_identity.c
+++ b/src/server/smb/smb_kerberos_identity.c
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <string.h>
+
+#include "smb_internal.h"
+#include "smb_kerberos_identity.h"
+#include "smb_wbclient.h"
+
+SYMBOL_EXPORT int
+smb_kerberos_resolve_identity(
+    int                           winbind_enabled,
+    const char                   *principal,
+    struct smb_kerberos_identity *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    if (!principal || principal[0] == '\0') {
+        chimera_smb_error("Kerberos logon refused: the accepted context names no principal");
+        return -1;
+    }
+
+    if (winbind_enabled) {
+        /* The ping distinguishes "winbindd is down" from "winbind does not know
+         * this principal" in the log; either way the logon is refused. */
+        if (!smb_wbclient_available()) {
+            chimera_smb_error("Kerberos logon refused for %s: winbind_enabled is set but winbind "
+                              "is unavailable (winbindd down, or built without libwbclient)",
+                              principal);
+            return -1;
+        }
+
+        if (smb_wbclient_map_principal(principal, &out->uid, &out->gid,
+                                       &out->ngids, out->gids, out->sid) != 0) {
+            chimera_smb_error("Kerberos logon refused for %s: winbind cannot map the principal "
+                              "to a Unix identity",
+                              principal);
+            return -1;
+        }
+
+        out->is_ad_user = 1;
+        return 0;
+    }
+
+    /* No identity source: serve the principal as nobody.  Error level on
+     * purpose -- a production log must show why every Kerberos user shares one
+     * uid, and this used to be a debug line nobody saw. */
+    chimera_smb_error("Kerberos principal %s served as uid/gid %u: winbind_enabled is off",
+                      principal, SMB_KERBEROS_NOBODY_ID);
+
+    out->uid   = SMB_KERBEROS_NOBODY_ID;
+    out->gid   = SMB_KERBEROS_NOBODY_ID;
+    out->ngids = 0;
+    smb_ntlm_synthesize_unix_sid(out->uid, out->sid, sizeof(out->sid));
+    out->is_ad_user = 0;
+
+    return 0;
+} /* smb_kerberos_resolve_identity */

--- a/src/server/smb/smb_kerberos_identity.c
+++ b/src/server/smb/smb_kerberos_identity.c
@@ -11,6 +11,7 @@
 SYMBOL_EXPORT int
 smb_kerberos_resolve_identity(
     int                           winbind_enabled,
+    int                           anonymous_fallback,
     const char                   *principal,
     struct smb_kerberos_identity *out)
 {
@@ -43,11 +44,17 @@ smb_kerberos_resolve_identity(
         return 0;
     }
 
-    /* No identity source: serve the principal as nobody.  Error level on
-     * purpose -- a production log must show why every Kerberos user shares one
-     * uid, and this used to be a debug line nobody saw. */
-    chimera_smb_error("Kerberos principal %s served as uid/gid %u: winbind_enabled is off",
-                      principal, SMB_KERBEROS_NOBODY_ID);
+    if (!anonymous_fallback) {
+        chimera_smb_error("Kerberos logon refused for %s: no identity source (winbind_enabled "
+                          "and kerberos_anonymous_fallback are both off)",
+                          principal);
+        return -1;
+    }
+
+    /* Explicitly opted in: serve the principal as nobody.  Info level here; the
+     * server logs the policy itself at startup. */
+    chimera_smb_info("Kerberos principal %s served as uid/gid %u (kerberos_anonymous_fallback)",
+                     principal, SMB_KERBEROS_NOBODY_ID);
 
     out->uid   = SMB_KERBEROS_NOBODY_ID;
     out->gid   = SMB_KERBEROS_NOBODY_ID;

--- a/src/server/smb/smb_kerberos_identity.c
+++ b/src/server/smb/smb_kerberos_identity.c
@@ -41,6 +41,7 @@ smb_kerberos_resolve_identity(
         }
 
         out->is_ad_user = 1;
+        out->resolved   = 1;
         return 0;
     }
 
@@ -61,6 +62,7 @@ smb_kerberos_resolve_identity(
     out->ngids = 0;
     smb_ntlm_synthesize_unix_sid(out->uid, out->sid, sizeof(out->sid));
     out->is_ad_user = 0;
+    out->resolved   = 1;
 
     return 0;
 } /* smb_kerberos_resolve_identity */

--- a/src/server/smb/smb_kerberos_identity.h
+++ b/src/server/smb/smb_kerberos_identity.h
@@ -34,8 +34,11 @@ struct smb_kerberos_identity {
  * cannot validate.  A deployment that configured winbind asked for real
  * identities, and an anonymous session is not a degraded form of that.
  *
- * Without winbind the principal is served as SMB_KERBEROS_NOBODY_ID with a
- * synthesized Unix SID.
+ * Without winbind there is no identity source, and the logon is refused unless
+ * anonymous_fallback is set, in which case the principal is served as
+ * SMB_KERBEROS_NOBODY_ID with a synthesized Unix SID.  The knob is ignored when
+ * winbind_enabled is set: it exists for a KDC with no domain behind it (a plain
+ * MIT realm), never as a degraded mode for a winbind failure.
  *
  * Returns 0 with *out filled, or -1 when the logon must be refused (the caller
  * answers STATUS_LOGON_FAILURE).  Logs the reason for every refusal.
@@ -43,5 +46,6 @@ struct smb_kerberos_identity {
 int
 smb_kerberos_resolve_identity(
     int                           winbind_enabled,
+    int                           anonymous_fallback,
     const char                   *principal,
     struct smb_kerberos_identity *out);

--- a/src/server/smb/smb_kerberos_identity.h
+++ b/src/server/smb/smb_kerberos_identity.h
@@ -23,6 +23,9 @@ struct smb_kerberos_identity {
      * caller caches the user in the VFS user cache.  0 for the synthesized
      * nobody identity. */
     int      is_ad_user;
+    /* 1 once a policy path filled this identity; the zero value is never a
+     * valid identity. */
+    int      resolved;
 };
 
 /* Decide the Unix identity an accepted Kerberos context stands for.

--- a/src/server/smb/smb_kerberos_identity.h
+++ b/src/server/smb/smb_kerberos_identity.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+#include <stdint.h>
+
+#include "smb_wbclient.h"
+
+/* The identity an authenticated Kerberos principal is served as when the
+ * deployment has explicitly opted into serving unmapped principals as nobody. */
+#define SMB_KERBEROS_NOBODY_ID 65534
+
+/* Unix identity resolved for an authenticated Kerberos principal. */
+struct smb_kerberos_identity {
+    uint32_t uid;
+    uint32_t gid;
+    uint32_t ngids;
+    uint32_t gids[SMB_WBCLIENT_MAX_GROUPS];
+    char     sid[SMB_WBCLIENT_SID_MAX_LEN];
+    /* 1 when winbind resolved the principal: sid is the real domain SID and the
+     * caller caches the user in the VFS user cache.  0 for the synthesized
+     * nobody identity. */
+    int      is_ad_user;
+};
+
+/* Decide the Unix identity an accepted Kerberos context stands for.
+ *
+ * A GSSAPI accept only proves who the client is; it is not a logon until the
+ * principal maps to a Unix identity.  With winbind_enabled the mapping MUST come
+ * from winbind: a winbindd that is down, or a principal it cannot map, refuses
+ * the logon -- the same answer the NTLM pass-through path gives a logon winbind
+ * cannot validate.  A deployment that configured winbind asked for real
+ * identities, and an anonymous session is not a degraded form of that.
+ *
+ * Without winbind the principal is served as SMB_KERBEROS_NOBODY_ID with a
+ * synthesized Unix SID.
+ *
+ * Returns 0 with *out filled, or -1 when the logon must be refused (the caller
+ * answers STATUS_LOGON_FAILURE).  Logs the reason for every refusal.
+ */
+int
+smb_kerberos_resolve_identity(
+    int                           winbind_enabled,
+    const char                   *principal,
+    struct smb_kerberos_identity *out);

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -8,6 +8,7 @@
 #include "smb_common/smb_encrypt.h"
 #include "smb_auth.h"
 #include "smb_wbclient.h"
+#include "smb_kerberos_identity.h"
 #include "vfs/vfs.h"
 
 // Process NTLM authentication
@@ -347,6 +348,29 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
         rc = -1;
     }
 
+    /* An accepted Kerberos context is not yet a logon.  The principal still has
+     * to map to a Unix identity, and a deployment that configured winbind asked
+     * for real identities: if winbindd is down or cannot map the principal the
+     * logon is refused with STATUS_LOGON_FAILURE, the answer the NTLM
+     * pass-through path gives a logon winbind cannot validate.  Resolved here,
+     * ahead of session allocation, so the refusal takes the ordinary failure
+     * path below -- no session, and a session an earlier interim leg allocated
+     * is torn down -- instead of falling back to an anonymous identity that an
+     * accepted service ticket alone never earned. */
+    struct smb_kerberos_identity krb_ident = { 0 };
+
+    if (rc == 0 && mech == SMB_AUTH_MECH_KERBEROS &&
+        smb_kerberos_resolve_identity(shared->config.auth.winbind_enabled,
+                                      smb_gssapi_get_principal(&conn->gssapi_ctx),
+                                      &krb_ident) != 0) {
+        /* Do not hand the client the AP-REP of a logon being refused: the
+         * failure response carries an empty security buffer, like NTLM's. */
+        free(conn->ntlm_output);
+        conn->ntlm_output     = NULL;
+        conn->ntlm_output_len = 0;
+        rc                    = -1;
+    }
+
     /* Allocate the session (and its SessionId) on the first leg, whether the
      * exchange completes now or needs another round trip. The server MUST
      * return this SessionId in the interim STATUS_MORE_PROCESSING_REQUIRED
@@ -525,32 +549,18 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
                 session_key_saved_len = SMB_GSSAPI_SESSION_KEY_SIZE;
             }
 
-            // Map Kerberos principal to Unix credentials via winbind
+            /* Identity resolved before session allocation (see above): a
+             * principal that could not be mapped never reaches this point. */
             const char *principal = smb_gssapi_get_principal(&conn->gssapi_ctx);
             username = principal;
 
-            if (shared->config.auth.winbind_enabled && smb_wbclient_available()) {
-                if (smb_wbclient_map_principal(principal, &uid, &gid, &ngids, gids, sid_buf) == 0) {
-                    sid        = sid_buf;
-                    is_ad_user = 1;
-                } else {
-                    chimera_smb_error("Failed to map Kerberos principal to Unix credentials");
-                    // Use anonymous credentials as fallback
-                    uid   = 65534;
-                    gid   = 65534;
-                    ngids = 0;
-                    smb_ntlm_synthesize_unix_sid(uid, sid_buf, sizeof(sid_buf));
-                    sid = sid_buf;
-                }
-            } else {
-                // No winbind - use anonymous credentials
-                chimera_smb_debug("Kerberos auth without winbind - using anonymous credentials");
-                uid   = 65534;
-                gid   = 65534;
-                ngids = 0;
-                smb_ntlm_synthesize_unix_sid(uid, sid_buf, sizeof(sid_buf));
-                sid = sid_buf;
-            }
+            uid   = krb_ident.uid;
+            gid   = krb_ident.gid;
+            ngids = krb_ident.ngids;
+            memcpy(gids, krb_ident.gids, ngids * sizeof(uint32_t));
+            memcpy(sid_buf, krb_ident.sid, sizeof(sid_buf));
+            sid        = sid_buf;
+            is_ad_user = krb_ident.is_ad_user;
 
             chimera_smb_info("Kerberos auth complete: principal=%s uid=%u gid=%u sid=%s",
                              principal, uid, gid, sid ? sid : "none");

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -361,6 +361,7 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
 
     if (rc == 0 && mech == SMB_AUTH_MECH_KERBEROS &&
         smb_kerberos_resolve_identity(shared->config.auth.winbind_enabled,
+                                      shared->config.auth.kerberos_anonymous_fallback,
                                       smb_gssapi_get_principal(&conn->gssapi_ctx),
                                       &krb_ident) != 0) {
         /* Do not hand the client the AP-REP of a logon being refused: the

--- a/src/server/smb/smb_proc_session_setup.c
+++ b/src/server/smb/smb_proc_session_setup.c
@@ -555,9 +555,17 @@ chimera_smb_session_setup(struct chimera_smb_request *request)
             const char *principal = smb_gssapi_get_principal(&conn->gssapi_ctx);
             username = principal;
 
+            /* The resolve above is the only writer; the zero value of krb_ident is
+             * uid 0 / gid 0, so consuming an unresolved identity would be a root
+             * session.  Fail closed if control flow ever decouples the two. */
+            chimera_smb_abort_if(!krb_ident.resolved,
+                                 "Kerberos identity consumed without resolution");
+
             uid   = krb_ident.uid;
             gid   = krb_ident.gid;
             ngids = krb_ident.ngids;
+            _Static_assert(sizeof(gids) == sizeof(krb_ident.gids),
+                           "session gids and Kerberos identity gids must match");
             memcpy(gids, krb_ident.gids, ngids * sizeof(uint32_t));
             memcpy(sid_buf, krb_ident.sid, sizeof(sid_buf));
             sid        = sid_buf;

--- a/src/server/smb/smb_wbclient.c
+++ b/src/server/smb/smb_wbclient.c
@@ -13,7 +13,7 @@
 #include <pwd.h>
 #include <grp.h>
 
-int
+SYMBOL_EXPORT int
 smb_wbclient_available(void)
 {
     wbcErr wbc_err;
@@ -626,7 +626,7 @@ smb_wbclient_auth_password(
 
 // Stub implementations when libwbclient is not available
 
-int
+SYMBOL_EXPORT int
 smb_wbclient_available(void)
 {
     return 0;

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -40,6 +40,14 @@ if(CHIMERA_NETNS_TESTING)
     set_tests_properties(chimera/server/smb/smbclient_kerberos_winbind_down PROPERTIES
         SKIP_RETURN_CODE 77)
 
+    # Kerberos with winbind off and kerberos_anonymous_fallback off (the default):
+    # no identity source, so the logon must be refused rather than served as nobody.
+    add_test(NAME chimera/server/smb/smbclient_kerberos_no_fallback
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/kerberos_test_wrapper.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=kerberos-no-fallback)
+    set_tests_properties(chimera/server/smb/smbclient_kerberos_no_fallback PROPERTIES
+        SKIP_RETURN_CODE 77)
+
     find_program(SAMBA_TOOL samba-tool)
     if(SAMBA_TOOL)
         add_test(NAME chimera/server/smb/smbclient_winbind

--- a/src/server/smb/tests/CMakeLists.txt
+++ b/src/server/smb/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ add_subdirectory(quint)
 
 # SMB authentication test program
 add_executable(smb_auth_test smb_auth_test.c)
-target_link_libraries(smb_auth_test chimera_vfs urcu-cds)
+target_link_libraries(smb_auth_test chimera_server chimera_smb chimera_vfs urcu-cds)
 target_include_directories(smb_auth_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 add_test(NAME chimera/server/smb/auth_test
@@ -30,6 +30,14 @@ if(CHIMERA_NETNS_TESTING)
         COMMAND ${CMAKE_SOURCE_DIR}/scripts/kerberos_test_wrapper.sh
                 ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=kerberos)
     set_tests_properties(chimera/server/smb/smbclient_kerberos PROPERTIES
+        SKIP_RETURN_CODE 77)
+
+    # Kerberos with winbind_enabled and no winbindd: the accepted context must be
+    # refused with STATUS_LOGON_FAILURE, never established as uid 65534.
+    add_test(NAME chimera/server/smb/smbclient_kerberos_winbind_down
+        COMMAND ${CMAKE_SOURCE_DIR}/scripts/kerberos_test_wrapper.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/smbclient_auth_test --mode=kerberos-winbind-down)
+    set_tests_properties(chimera/server/smb/smbclient_kerberos_winbind_down PROPERTIES
         SKIP_RETURN_CODE 77)
 
     find_program(SAMBA_TOOL samba-tool)

--- a/src/server/smb/tests/smb_auth_test.c
+++ b/src/server/smb/tests/smb_auth_test.c
@@ -706,7 +706,7 @@ test_kerberos_identity_policy(void)
 
     /* No identity source at all: refused by default. */
     rc = smb_kerberos_resolve_identity(0, 0, "testuser1@TEST.LOCAL", &ident);
-    if (rc == -1) {
+    if (rc == -1 && ident.resolved == 0) {
         TEST_PASS("winbind disabled without the fallback knob refuses the logon");
     } else {
         TEST_FAIL("winbind disabled without the fallback knob refuses the logon");
@@ -715,7 +715,7 @@ test_kerberos_identity_policy(void)
     /* The explicit opt-in serves the principal as nobody. */
     rc = smb_kerberos_resolve_identity(0, 1, "testuser1@TEST.LOCAL", &ident);
     if (rc == 0 && ident.uid == 65534 && ident.gid == 65534 &&
-        ident.ngids == 0 && ident.is_ad_user == 0 &&
+        ident.ngids == 0 && ident.is_ad_user == 0 && ident.resolved == 1 &&
         strcmp(ident.sid, "S-1-22-1-65534") == 0) {
         TEST_PASS("anonymous fallback maps the principal to uid/gid 65534");
     } else {

--- a/src/server/smb/tests/smb_auth_test.c
+++ b/src/server/smb/tests/smb_auth_test.c
@@ -27,6 +27,7 @@
 #include "vfs/vfs.h"
 #include "vfs/vfs_user_cache.h"
 #include "server/smb/smb_wbclient.h"
+#include "server/smb/smb_kerberos_identity.h"
 
 #define TEST_PASS(name) do { fprintf(stderr, "  PASS: %s\n", name); passed++; } while (0)
 #define TEST_FAIL(name) do { fprintf(stderr, "  FAIL: %s\n", name); failed++; } while (0)
@@ -648,6 +649,62 @@ test_wbclient_lm_implied_zeros(void)
     }
 } /* test_wbclient_lm_implied_zeros */
 
+/*
+ * Test the identity policy applied to an accepted Kerberos context.
+ *
+ * A GSSAPI accept proves who the client is; it is not a logon until the
+ * principal maps to a Unix identity.  With winbind_enabled the mapping must come
+ * from winbind, so an unreachable winbindd (or a principal it cannot map)
+ * refuses the logon instead of degrading it to the 65534 identity -- which is
+ * what a deployment whose winbindd had died used to hand every Kerberos client
+ * while its NTLM logons were being refused.  The winbind-down cases are skipped
+ * when a winbindd really answers on this host.
+ */
+static void
+test_kerberos_identity_policy(void)
+{
+    struct smb_kerberos_identity ident;
+    int                          rc;
+
+    fprintf(stderr, "\nTesting Kerberos identity policy...\n");
+
+    /* No principal is never a logon, whatever the configuration. */
+    rc = smb_kerberos_resolve_identity(0, NULL, &ident);
+    if (rc == -1) {
+        TEST_PASS("NULL principal is refused");
+    } else {
+        TEST_FAIL("NULL principal is refused");
+    }
+
+    rc = smb_kerberos_resolve_identity(1, "", &ident);
+    if (rc == -1) {
+        TEST_PASS("Empty principal is refused");
+    } else {
+        TEST_FAIL("Empty principal is refused");
+    }
+
+    if (smb_wbclient_available()) {
+        TEST_SKIP("winbind_enabled without winbindd (a winbindd answers on this host)");
+    } else {
+        rc = smb_kerberos_resolve_identity(1, "testuser1@TEST.LOCAL", &ident);
+        if (rc == -1) {
+            TEST_PASS("winbind_enabled with winbindd unavailable refuses the logon");
+        } else {
+            TEST_FAIL("winbind_enabled with winbindd unavailable refuses the logon");
+        }
+    }
+
+    /* Without winbind the principal is served as nobody (gated in a follow-up). */
+    rc = smb_kerberos_resolve_identity(0, "testuser1@TEST.LOCAL", &ident);
+    if (rc == 0 && ident.uid == 65534 && ident.gid == 65534 &&
+        ident.ngids == 0 && ident.is_ad_user == 0 &&
+        strcmp(ident.sid, "S-1-22-1-65534") == 0) {
+        TEST_PASS("winbind disabled maps the principal to uid/gid 65534");
+    } else {
+        TEST_FAIL("winbind disabled maps the principal to uid/gid 65534");
+    }
+} /* test_kerberos_identity_policy */
+
 static void
 usage(const char *prog)
 {
@@ -714,6 +771,7 @@ main(
         test_user_update();
         test_cache_capacity();
         test_wbclient_lm_implied_zeros();
+        test_kerberos_identity_policy();
     }
 
     if (test_mode == TEST_MODE_ALL || test_mode == TEST_MODE_NTLM_WINBIND) {

--- a/src/server/smb/tests/smb_auth_test.c
+++ b/src/server/smb/tests/smb_auth_test.c
@@ -657,8 +657,10 @@ test_wbclient_lm_implied_zeros(void)
  * from winbind, so an unreachable winbindd (or a principal it cannot map)
  * refuses the logon instead of degrading it to the 65534 identity -- which is
  * what a deployment whose winbindd had died used to hand every Kerberos client
- * while its NTLM logons were being refused.  The winbind-down cases are skipped
- * when a winbindd really answers on this host.
+ * while its NTLM logons were being refused.  Without winbind the logon is
+ * refused unless the deployment opted into the nobody mapping, and that
+ * opt-in never overrides a configured winbind.  The winbind-down cases are
+ * skipped when a winbindd really answers on this host.
  */
 static void
 test_kerberos_identity_policy(void)
@@ -669,14 +671,14 @@ test_kerberos_identity_policy(void)
     fprintf(stderr, "\nTesting Kerberos identity policy...\n");
 
     /* No principal is never a logon, whatever the configuration. */
-    rc = smb_kerberos_resolve_identity(0, NULL, &ident);
+    rc = smb_kerberos_resolve_identity(0, 1, NULL, &ident);
     if (rc == -1) {
         TEST_PASS("NULL principal is refused");
     } else {
         TEST_FAIL("NULL principal is refused");
     }
 
-    rc = smb_kerberos_resolve_identity(1, "", &ident);
+    rc = smb_kerberos_resolve_identity(1, 1, "", &ident);
     if (rc == -1) {
         TEST_PASS("Empty principal is refused");
     } else {
@@ -686,22 +688,38 @@ test_kerberos_identity_policy(void)
     if (smb_wbclient_available()) {
         TEST_SKIP("winbind_enabled without winbindd (a winbindd answers on this host)");
     } else {
-        rc = smb_kerberos_resolve_identity(1, "testuser1@TEST.LOCAL", &ident);
+        rc = smb_kerberos_resolve_identity(1, 0, "testuser1@TEST.LOCAL", &ident);
         if (rc == -1) {
             TEST_PASS("winbind_enabled with winbindd unavailable refuses the logon");
         } else {
             TEST_FAIL("winbind_enabled with winbindd unavailable refuses the logon");
         }
+
+        /* The fallback knob never overrides a configured winbind. */
+        rc = smb_kerberos_resolve_identity(1, 1, "testuser1@TEST.LOCAL", &ident);
+        if (rc == -1) {
+            TEST_PASS("anonymous fallback is ignored when winbind_enabled is set");
+        } else {
+            TEST_FAIL("anonymous fallback is ignored when winbind_enabled is set");
+        }
     }
 
-    /* Without winbind the principal is served as nobody (gated in a follow-up). */
-    rc = smb_kerberos_resolve_identity(0, "testuser1@TEST.LOCAL", &ident);
+    /* No identity source at all: refused by default. */
+    rc = smb_kerberos_resolve_identity(0, 0, "testuser1@TEST.LOCAL", &ident);
+    if (rc == -1) {
+        TEST_PASS("winbind disabled without the fallback knob refuses the logon");
+    } else {
+        TEST_FAIL("winbind disabled without the fallback knob refuses the logon");
+    }
+
+    /* The explicit opt-in serves the principal as nobody. */
+    rc = smb_kerberos_resolve_identity(0, 1, "testuser1@TEST.LOCAL", &ident);
     if (rc == 0 && ident.uid == 65534 && ident.gid == 65534 &&
         ident.ngids == 0 && ident.is_ad_user == 0 &&
         strcmp(ident.sid, "S-1-22-1-65534") == 0) {
-        TEST_PASS("winbind disabled maps the principal to uid/gid 65534");
+        TEST_PASS("anonymous fallback maps the principal to uid/gid 65534");
     } else {
-        TEST_FAIL("winbind disabled maps the principal to uid/gid 65534");
+        TEST_FAIL("anonymous fallback maps the principal to uid/gid 65534");
     }
 } /* test_kerberos_identity_policy */
 

--- a/src/server/smb/tests/smbclient_auth_test.c
+++ b/src/server/smb/tests/smbclient_auth_test.c
@@ -8,11 +8,13 @@
  * This test verifies SMB authentication works with the standard Samba smbclient,
  * providing interoperability testing beyond libsmb2.
  *
- * Supports three authentication modes:
- *   --mode=ntlm      - Built-in NTLM authentication (default)
- *   --mode=kerberos  - Kerberos/GSSAPI authentication (requires KDC setup)
- *   --mode=winbind   - NTLM via winbind (requires AD environment)
- *   --mode=all       - Run all available auth tests
+ * Supports these authentication modes:
+ *   --mode=ntlm                   - Built-in NTLM authentication (default)
+ *   --mode=kerberos               - Kerberos/GSSAPI authentication (requires KDC setup)
+ *   --mode=kerberos-winbind-down  - Kerberos with winbind_enabled and no winbindd:
+ *                                   the logon must be REFUSED (requires KDC setup)
+ *   --mode=winbind                - NTLM via winbind (requires AD environment)
+ *   --mode=all                    - Run all available auth tests
  *
  * For Kerberos: Run via scripts/kerberos_test_wrapper.sh
  * For Winbind:  Run via scripts/ad_test_wrapper.sh
@@ -497,6 +499,65 @@ run_kerberos_tests(struct test_env *env)
     return failures;
 } /* run_kerberos_tests */
 
+/* A Kerberos logon the server must REFUSE.  The GSSAPI accept itself succeeds
+ * (the keytab is valid and the client holds a service ticket), but the server
+ * has no identity for the principal -- in the winbind-down mode because
+ * winbind_enabled is set and no winbindd answers -- so the SESSION_SETUP must
+ * complete with STATUS_LOGON_FAILURE.  Before the fix it was established as
+ * uid/gid 65534 and `ls` succeeded. */
+static int
+test_kerberos_logon_refused(void)
+{
+    char output[4096];
+    int  rc;
+
+    fprintf(stderr, "\n  Testing that the Kerberos logon is refused...\n");
+
+    rc = run_smbclient_with_output(kerberos_auth_args, "ls", output, sizeof(output));
+
+    if (rc == 0) {
+        fprintf(stderr, "    smbclient succeeded: the server granted a session it had no identity for\n");
+        test_fail("Kerberos logon refused");
+        return -1;
+    }
+
+    if (strstr(output, "NT_STATUS_LOGON_FAILURE") == NULL) {
+        fprintf(stderr, "    smbclient failed for another reason:\n%s\n", output);
+        test_fail("Kerberos logon refused with NT_STATUS_LOGON_FAILURE");
+        return -1;
+    }
+
+    test_pass("Kerberos logon refused with NT_STATUS_LOGON_FAILURE");
+    return 0;
+} /* test_kerberos_logon_refused */
+
+static int
+run_kerberos_refusal_tests(
+    struct test_env *env,
+    const char      *mode)
+{
+    int failures = 0;
+
+    fprintf(stderr, "\n========================================\n");
+    fprintf(stderr, "Kerberos Refusal Tests (%s)\n", mode);
+    fprintf(stderr, "========================================\n");
+
+    if (!env->kerberos_enabled) {
+        fprintf(stderr, "  Skipping - Kerberos not enabled on server\n");
+        return 0;
+    }
+
+    if (verify_kerberos_environment() < 0) {
+        return 0; /* Skip, not fail */
+    }
+
+    if (test_kerberos_logon_refused() < 0) {
+        failures++;
+    }
+
+    return failures;
+} /* run_kerberos_refusal_tests */
+
 /* ============================================================================
  * Winbind NTLM Tests
  * ============================================================================ */
@@ -654,6 +715,23 @@ run_winbind_tests(struct test_env *env)
     return failures;
 } /* run_winbind_tests */
 
+/* Modes that stand up a Kerberos-accepting server.  Each needs the KDC, keytab
+ * and ticket scripts/kerberos_test_wrapper.sh provides. */
+static int
+mode_uses_kerberos(const char *mode)
+{
+    return strcmp(mode, "kerberos") == 0 ||
+           strcmp(mode, "kerberos-winbind-down") == 0 ||
+           strcmp(mode, "all") == 0;
+} /* mode_uses_kerberos */
+
+/* Modes whose one assertion is that the Kerberos logon is REFUSED. */
+static int
+mode_expects_refusal(const char *mode)
+{
+    return strcmp(mode, "kerberos-winbind-down") == 0;
+} /* mode_expects_refusal */
+
 /* ============================================================================
  * Main
  * ============================================================================ */
@@ -666,6 +744,8 @@ print_usage(const char *prog)
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "  --mode=ntlm      Test built-in NTLM only (default)\n");
     fprintf(stderr, "  --mode=kerberos  Test Kerberos (requires KDC setup)\n");
+    fprintf(stderr,
+            "  --mode=kerberos-winbind-down  Kerberos with winbind_enabled and no winbindd; logon must be refused\n");
     fprintf(stderr, "  --mode=winbind   Test winbind NTLM (requires AD)\n");
     fprintf(stderr, "  --mode=all       Run all available tests\n");
     fprintf(stderr, "  -b <backend>     VFS backend (memfs, linux, diskfs)\n");
@@ -712,6 +792,20 @@ main(
         return 77;   /* ctest SKIP_RETURN_CODE */
     }
 
+    /* The refusal modes assert a security property: run with no KDC they would
+     * pass vacuously, so they skip outright unless the Kerberos wrapper set the
+     * environment up, and they need winbind to be genuinely absent. */
+    if (mode_expects_refusal(mode)) {
+        if (!getenv("KRB5_KTNAME")) {
+            fprintf(stderr, "\nSKIP: KRB5_KTNAME not set; run via scripts/kerberos_test_wrapper.sh\n");
+            return 77;
+        }
+        if (getenv("WINBINDD_SOCKET_DIR")) {
+            fprintf(stderr, "\nSKIP: WINBINDD_SOCKET_DIR is set; this mode needs winbind to be absent\n");
+            return 77;
+        }
+    }
+
     /* Initialize logging */
     ChimeraLogLevel = CHIMERA_LOG_INFO;
     evpl_set_log_fn(chimera_vlog, chimera_log_flush);
@@ -740,7 +834,7 @@ main(
 
     /* Configure authentication based on environment */
     const char *keytab = getenv("KRB5_KTNAME");
-    if (keytab && (strcmp(mode, "kerberos") == 0 || strcmp(mode, "all") == 0)) {
+    if (keytab && mode_uses_kerberos(mode)) {
         chimera_server_config_set_smb_kerberos_enabled(config, 1);
         chimera_server_config_set_smb_kerberos_keytab(config, keytab);
 
@@ -778,6 +872,14 @@ main(
         }
 
         fprintf(stderr, "Kerberos enabled: realm=%s, keytab=%s\n", realm, keytab);
+    }
+
+    if (strcmp(mode, "kerberos-winbind-down") == 0) {
+        /* winbind_enabled with nothing to answer: the Kerberos wrapper stands
+         * up an MIT KDC and no winbindd, so the principal cannot be mapped and
+         * the server must refuse the logon rather than serve it as uid 65534. */
+        chimera_server_config_set_smb_winbind_enabled(config, 1);
+        fprintf(stderr, "Winbind enabled with no winbindd running: Kerberos logons must be refused\n");
     }
 
     const char *socket_dir = getenv("WINBINDD_SOCKET_DIR");
@@ -833,6 +935,10 @@ main(
 
     if (strcmp(mode, "kerberos") == 0 || strcmp(mode, "all") == 0) {
         failures += run_kerberos_tests(&env);
+    }
+
+    if (mode_expects_refusal(mode)) {
+        failures += run_kerberos_refusal_tests(&env, mode);
     }
 
     if (strcmp(mode, "winbind") == 0 || strcmp(mode, "all") == 0) {

--- a/src/server/smb/tests/smbclient_auth_test.c
+++ b/src/server/smb/tests/smbclient_auth_test.c
@@ -13,6 +13,8 @@
  *   --mode=kerberos               - Kerberos/GSSAPI authentication (requires KDC setup)
  *   --mode=kerberos-winbind-down  - Kerberos with winbind_enabled and no winbindd:
  *                                   the logon must be REFUSED (requires KDC setup)
+ *   --mode=kerberos-no-fallback   - Kerberos with winbind off and no fallback knob:
+ *                                   the logon must be REFUSED (requires KDC setup)
  *   --mode=winbind                - NTLM via winbind (requires AD environment)
  *   --mode=all                    - Run all available auth tests
  *
@@ -721,6 +723,7 @@ static int
 mode_uses_kerberos(const char *mode)
 {
     return strcmp(mode, "kerberos") == 0 ||
+           strcmp(mode, "kerberos-no-fallback") == 0 ||
            strcmp(mode, "kerberos-winbind-down") == 0 ||
            strcmp(mode, "all") == 0;
 } /* mode_uses_kerberos */
@@ -729,7 +732,8 @@ mode_uses_kerberos(const char *mode)
 static int
 mode_expects_refusal(const char *mode)
 {
-    return strcmp(mode, "kerberos-winbind-down") == 0;
+    return strcmp(mode, "kerberos-no-fallback") == 0 ||
+           strcmp(mode, "kerberos-winbind-down") == 0;
 } /* mode_expects_refusal */
 
 /* ============================================================================
@@ -746,6 +750,8 @@ print_usage(const char *prog)
     fprintf(stderr, "  --mode=kerberos  Test Kerberos (requires KDC setup)\n");
     fprintf(stderr,
             "  --mode=kerberos-winbind-down  Kerberos with winbind_enabled and no winbindd; logon must be refused\n");
+    fprintf(stderr,
+            "  --mode=kerberos-no-fallback   Kerberos with winbind off and no fallback knob; logon must be refused\n");
     fprintf(stderr, "  --mode=winbind   Test winbind NTLM (requires AD)\n");
     fprintf(stderr, "  --mode=all       Run all available tests\n");
     fprintf(stderr, "  -b <backend>     VFS backend (memfs, linux, diskfs)\n");
@@ -838,6 +844,14 @@ main(
         chimera_server_config_set_smb_kerberos_enabled(config, 1);
         chimera_server_config_set_smb_kerberos_keytab(config, keytab);
 
+        /* The positive modes run against an MIT realm with no winbind, so the
+         * only identity a principal can get is the opt-in nobody mapping; what
+         * they exercise is the GSSAPI exchange.  The refusal modes leave the
+         * knob off. */
+        if (!mode_expects_refusal(mode)) {
+            chimera_server_config_set_smb_kerberos_anonymous_fallback(config, 1);
+        }
+
         const char *realm = getenv("KRB_REALM");
         if (!realm) {
             realm = "TEST.LOCAL";
@@ -880,6 +894,12 @@ main(
          * the server must refuse the logon rather than serve it as uid 65534. */
         chimera_server_config_set_smb_winbind_enabled(config, 1);
         fprintf(stderr, "Winbind enabled with no winbindd running: Kerberos logons must be refused\n");
+    }
+
+    if (strcmp(mode, "kerberos-no-fallback") == 0) {
+        /* Neither winbind nor the fallback knob: the server has no identity
+         * source for the principal and must refuse the logon. */
+        fprintf(stderr, "No identity source configured: Kerberos logons must be refused\n");
     }
 
     const char *socket_dir = getenv("WINBINDD_SOCKET_DIR");

--- a/src/server/smb/tests/smbclient_auth_test.c
+++ b/src/server/smb/tests/smbclient_auth_test.c
@@ -806,6 +806,14 @@ main(
             fprintf(stderr, "\nSKIP: KRB5_KTNAME not set; run via scripts/kerberos_test_wrapper.sh\n");
             return 77;
         }
+        if (!getenv("KRB5_CONFIG")) {
+            fprintf(stderr, "\nSKIP: KRB5_CONFIG not set; run via scripts/kerberos_test_wrapper.sh\n");
+            return 77;
+        }
+        if (!getenv("KRB5CCNAME")) {
+            fprintf(stderr, "\nSKIP: KRB5CCNAME not set; run via scripts/kerberos_test_wrapper.sh\n");
+            return 77;
+        }
         if (getenv("WINBINDD_SOCKET_DIR")) {
             fprintf(stderr, "\nSKIP: WINBINDD_SOCKET_DIR is set; this mode needs winbind to be absent\n");
             return 77;
@@ -963,6 +971,18 @@ main(
 
     if (strcmp(mode, "winbind") == 0 || strcmp(mode, "all") == 0) {
         failures += run_winbind_tests(&env);
+    }
+
+    /* A refusal mode asserts a security property (the logon is refused); it
+     * must never report success having asserted nothing.  The early skip above
+     * covers a missing wrapper variable, but this is the backstop: if the one
+     * assertion in run_kerberos_refusal_tests() was itself skipped (e.g.
+     * verify_kerberos_environment() still failed), tests_passed stays 0 with
+     * no failures, and that is a vacuous pass, not a PASS. */
+    if (mode_expects_refusal(mode) && tests_passed == 0 && failures == 0) {
+        fprintf(stderr, "\nSKIP: refusal mode ran no assertion\n");
+        test_cleanup(&env, 1);
+        return 77;
     }
 
     /* Summary */


### PR DESCRIPTION
With `smb_auth.winbind_enabled` set, a Kerberos SESSION_SETUP whose GSSAPI
accept succeeded was established even when winbind could not map the
principal: the server fell back to anonymous credentials (uid/gid 65534 and a
synthesized Unix SID). Two paths landed there, winbindd stopped or wedged
(`wbcPing()` failing, logged at debug level only) and a principal winbind does
not know or cannot idmap. In both the client holds a service ticket the keytab
decrypts, so it walked in as nobody with whatever share and file ACLs grant
Everyone, while NTLM logons were being refused. A deployment whose winbindd
dies between health checks handed every Kerberos client a nobody session until
it was restarted.

## What changes

- **Identity resolution is a policy step that runs before the session is
  allocated** (`src/server/smb/smb_kerberos_identity.{c,h}`,
  `smb_kerberos_resolve_identity()`). With `winbind_enabled`, winbind must
  answer *and* map the principal; otherwise the logon is refused with
  `STATUS_LOGON_FAILURE` through the existing authentication-failed branch (no
  session; a session an interim leg allocated is torn down), and the AP-REP is
  dropped from the refused response so it looks like a refused NTLM logon.
  Every refusal is logged at error level with the principal.
- **New knob `smb_auth.kerberos_anonymous_fallback`** (default `false`). With
  `winbind_enabled` off, a Kerberos logon now has no identity source and is
  refused unless this knob is set, in which case the principal is served as
  uid/gid 65534 as before (info-level log per logon, policy logged once at
  startup). The knob is ignored when `winbind_enabled` is set: a configured
  winbind never degrades to nobody. **This is a behaviour change for a
  winbind-less Kerberos deployment**, which previously worked as nobody
  silently. If preferred, defaulting the knob to `true` is a one-line change in
  `chimera_server_config_init()` plus the docs' Default cell; the
  `smbclient_kerberos_no_fallback` test would then need to clear the knob
  explicitly.
- **Hardening from review:** the resolved identity carries a `resolved` flag
  and the consumer aborts if it ever sees one that is not (the struct's zero
  value is uid 0 / gid 0); a static assert pins the two group arrays to the
  same size; the refusal tests can no longer pass vacuously outside the
  Kerberos wrapper.

## Consequences worth knowing

- Identity is resolved ahead of the multichannel bind checks, so a channel
  bind whose principal cannot be mapped is answered `LOGON_FAILURE` rather
  than `ACCESS_DENIED`; the established session and its channels survive.
- A Kerberos re-authentication during a winbind outage now invalidates the
  session (MS-SMB2 3.3.5.5.2), where the old code re-credited the live
  session, with all its open handles, as nobody.

## Tests

- `smb_auth_test` gains a unit test of the policy function: NULL/empty
  principal, and the four `winbind_enabled` x `kerberos_anonymous_fallback`
  combinations (winbind-down cases skip when a winbindd answers on the host).
- `smbclient_auth_test` gains two modes under the MIT-KDC wrapper, registered
  as `chimera/server/smb/smbclient_kerberos_winbind_down` (winbind enabled, no
  winbindd) and `chimera/server/smb/smbclient_kerberos_no_fallback` (winbind
  off, knob off). Both perform a real Kerberos logon and require
  `NT_STATUS_LOGON_FAILURE` in the client output. The existing
  `smbclient_kerberos` run opts into the knob (a plain MIT realm has no
  winbind; its purpose is the GSSAPI exchange).
- `docs/configuration.md` and `docs/smb-domain-auth.md` describe the refusal
  and the knob in place of the silent fallback they documented.
