### PR TITLE
s3: assemble the GET response body in file order

### DIFF
--- a/kvm/tests/CMakeLists.txt
+++ b/kvm/tests/CMakeLists.txt
@@ -509,14 +509,27 @@ foreach(image_spec ${KVM_IMAGES})
                                 ${CHIMERA_BINARY} ${backend} ${nfsver} ${prog})
                     set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
                         PROPERTIES LABELS "kvm;${IMAGE_NAME}" PROCESSORS 2)
-                    # nfstest_lock (5296 subtests, ~6.5 min) and nfstest_dio
-                    # (1 MiB direct-I/O transfers, ~5.5 min) run well past the
-                    # CI-wide `ctest --timeout 300`; give them a per-test timeout
-                    # that overrides it so they are not killed mid-run.
-                    if(prog STREQUAL "nfstest_lock" OR prog STREQUAL "nfstest_dio")
-                        set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
-                            PROPERTIES TIMEOUT 900)
-                    endif()
+                    # Every one of these boots a guest, mounts the share and
+                    # runs a client-side conformance suite against it, so the
+                    # CI-wide `ctest --timeout 300` is a poor fit for the whole
+                    # family rather than for two members of it.  nfstest_lock
+                    # (5296 subtests, ~6.5 min) and nfstest_dio (1 MiB
+                    # direct-I/O transfers, ~5.5 min) exceeded it outright and
+                    # were widened first; nfstest_alloc then began timing out at
+                    # exactly 300 s on both diskfs backends at NFSv4.2, in all
+                    # four nfstest shards of the extended run, while its captured
+                    # output was still emitting PASS lines -- it was progressing,
+                    # not hung.  The shard runs `ctest -j $(nproc)` with
+                    # PROCESSORS 2, so several guests compete for the host and
+                    # any member of the family can drift past a 5-minute budget
+                    # on the slower backends.
+                    #
+                    # This is hardening, not a fix for a diagnosed defect: it
+                    # stops the suites being killed mid-run so a real hang is
+                    # reported as one.  A test that genuinely wedges still fails,
+                    # just 15 minutes later.
+                    set_tests_properties(chimera/kvm/${IMAGE_NAME}/nfstest/${prog}_${backend}_nfs${nfsver}
+                        PROPERTIES TIMEOUT 900)
                 endforeach()
             endforeach()
         endforeach()

--- a/src/server/s3/s3.c
+++ b/src/server/s3/s3.c
@@ -139,6 +139,11 @@ chimera_s3_request_alloc(struct chimera_server_s3_thread *thread)
     request->refcount  = 1;
     request->abandoned = 0;
 
+    /* Pooled requests are not zeroed on reuse, so the GET reassembly queue has
+     * to be reset explicitly. */
+    request->read_queue      = NULL;
+    request->read_queue_tail = NULL;
+
     return request;
 } /* chimera_s3_request_alloc */
 

--- a/src/server/s3/s3_get.c
+++ b/src/server/s3/s3_get.c
@@ -50,6 +50,53 @@ chimera_s3_get_finish(struct chimera_s3_request *request)
 
 } /* chimera_s3_put_rename_callback */
 
+/*
+ * Append every read at the head of the queue that has completed, stopping at
+ * the first one still outstanding.
+ *
+ * The body of a GET response is an ordered byte stream: evpl_http_request_add_datav()
+ * appends, and carries no file offset.  chimera_s3_get_send() issues all of an
+ * object's reads before any of them completes, and nothing orders those
+ * completions -- io_uring in particular reaps CQEs in whatever order the kernel
+ * finishes them, which for reads that miss page cache and go async is not
+ * submission order.  Appending as each read landed therefore permuted the
+ * object's bytes, silently, with the correct total length.
+ *
+ * So the queue is drained from the head, oldest offset first, and a read that
+ * completes early waits for its predecessors.  io_pending is decremented here
+ * rather than in the callback so the request is not finished until every byte
+ * has actually been handed to the response.
+ */
+static void
+chimera_s3_get_drain(struct chimera_s3_request *request)
+{
+    struct chimera_server_s3_thread *thread = request->thread;
+    struct evpl                     *evpl   = thread->evpl;
+    struct chimera_s3_io            *io;
+
+    while ((io = request->read_queue) != NULL && io->ready) {
+
+        request->read_queue = io->queue_next;
+
+        if (request->read_queue == NULL) {
+            request->read_queue_tail = NULL;
+        }
+
+        if (io->r_niov) {
+            chimera_s3_response_add_datav(evpl, request, io->iov, io->r_niov);
+        }
+
+        request->io_pending--;
+
+        chimera_s3_io_free(thread, io);
+    }
+
+    if (request->io_pending == 0 &&
+        request->vfs_state == CHIMERA_S3_VFS_STATE_SENT) {
+        chimera_s3_get_finish(request);
+    }
+} /* chimera_s3_get_drain */
+
 static void
 chimera_s3_get_send_callback(
     enum chimera_vfs_error    error_code,
@@ -60,32 +107,27 @@ chimera_s3_get_send_callback(
     struct chimera_vfs_attrs *attr,
     void                     *private_data)
 {
-    struct chimera_s3_io            *io      = private_data;
-    struct chimera_s3_request       *request = io->request;
-    struct chimera_server_s3_thread *thread  = request->thread;
-    struct evpl                     *evpl    = thread->evpl;
+    struct chimera_s3_io      *io      = private_data;
+    struct chimera_s3_request *request = io->request;
 
     if (error_code) {
         request->status    = chimera_s3_status_from_vfs(error_code, CHIMERA_S3_STATUS_INTERNAL_ERROR);
         request->vfs_state = CHIMERA_S3_VFS_STATE_COMPLETE;
-        chimera_s3_io_free(thread, io);
-        request->io_pending--;
-        return;
+        /* The core released the buffers on the error leg; there is nothing to
+         * append for this chunk, but it still has to leave the queue in order
+         * so the reads behind it are not stranded. */
+        io->r_niov = 0;
+    } else {
+        /* iov is request->read.iov, which is this io's own iov[] -- the array
+         * handed to chimera_vfs_read() above.  Only the returned count needs
+         * recording. */
+        io->r_niov = niov;
     }
 
-    if (niov) {
-        chimera_s3_response_add_datav(evpl, request, iov, niov);
-    }
+    io->ready = 1;
 
-    chimera_s3_io_free(thread, io);
-
-    request->io_pending--;
-
-    if (request->io_pending == 0 &&
-        request->vfs_state == CHIMERA_S3_VFS_STATE_SENT) {
-        chimera_s3_get_finish(request);
-    }
-} /* chimera_s3_put_recv_callback */
+    chimera_s3_get_drain(request);
+} /* chimera_s3_get_send_callback */
 
 void
 chimera_s3_get_send(
@@ -117,7 +159,20 @@ chimera_s3_get_send(
 
     io = chimera_s3_io_alloc(thread, request);
 
-    io->niov = CHIMERA_S3_IOV_MAX;
+    io->niov       = CHIMERA_S3_IOV_MAX;
+    io->r_niov     = 0;
+    io->ready      = 0;
+    io->queue_next = NULL;
+
+    /* Queue before dispatching: chimera_vfs_read() may complete inline (memfs
+     * and the other non-blocking backends do), and the callback drains from
+     * this queue. */
+    if (request->read_queue_tail) {
+        request->read_queue_tail->queue_next = io;
+    } else {
+        request->read_queue = io;
+    }
+    request->read_queue_tail = io;
 
     request->io_pending++;
 

--- a/src/server/s3/s3_internal.h
+++ b/src/server/s3/s3_internal.h
@@ -81,6 +81,17 @@ struct chimera_s3_config {
 struct chimera_s3_io {
     struct chimera_s3_request *request;
     int                        niov;
+    /*
+     * GET body reassembly.  A GET issues one read per io_size chunk and leaves
+     * them all in flight, but the response body is an ordered byte stream with
+     * no offsets, so the results must be appended in file order rather than in
+     * completion order.  Each io sits on the request's read_queue in submission
+     * order; `ready` marks that its callback has run and `r_niov` records how
+     * many of iov[] the read actually returned.  See chimera_s3_get_drain().
+     */
+    int                        ready;
+    int                        r_niov;
+    struct chimera_s3_io      *queue_next;
     struct chimera_s3_io      *next;
     struct evpl_iovec          iov[CHIMERA_S3_IOV_MAX];
 };
@@ -162,6 +173,15 @@ struct chimera_s3_request {
     int64_t                          file_length;
     int64_t                          file_real_length;
     int64_t                          file_left;
+
+    /*
+     * In-flight GET reads in submission order (head = lowest file offset still
+     * unappended).  chimera_s3_get_drain() pops the completed prefix so the
+     * response body is written in file order regardless of the order the
+     * backend completes the reads in.
+     */
+    struct chimera_s3_io            *read_queue;
+    struct chimera_s3_io            *read_queue_tail;
     uint64_t                         elapsed;
     uint64_t                         etag[2];
     const char                      *path;

--- a/src/server/s3/tests/s3_test.py
+++ b/src/server/s3/tests/s3_test.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import signal
 import socket
+import struct
 import subprocess
 import sys
 import tempfile
@@ -305,13 +306,27 @@ def test_get(client, bucket):
     assert len(body) == 600, f"Expected 600 bytes, got {len(body)}"
     print("  GET mykey1 (range 1000-1599) - OK")
 
-    # Large object
-    large_data = b'y' * 35000000
+    # Large object.
+    #
+    # The payload is position-dependent (a distinct counter per 4 KiB page)
+    # rather than a repeated byte, and the body is compared rather than just
+    # measured.  An object this size is served by ~270 concurrent VFS reads of
+    # io_size (128 KiB) each, whose results are appended to the response body as
+    # they complete; if those completions are not put back into file order the
+    # body comes back permuted with exactly the right length, which a length
+    # assertion cannot see.  A repeated byte is byte-identical under every
+    # permutation, so it cannot see it either.
+    large_size = 35000000
+    large_data = b''.join(struct.pack('<Q', page) * 512
+                          for page in range(large_size // 4096 + 1))[:large_size]
     client.put_object(Bucket=bucket, Key='mydir1/mydir2/mydir3/mykey4', Body=large_data)
     response = client.get_object(Bucket=bucket, Key='mydir1/mydir2/mydir3/mykey4')
     body = response['Body'].read()
-    assert len(body) == 35000000, f"Expected 35000000 bytes, got {len(body)}"
-    print("  GET mykey4 (35MB) - OK")
+    assert len(body) == large_size, f"Expected {large_size} bytes, got {len(body)}"
+    assert body == large_data, (
+        f"mykey4: content mismatch; {len(body)} bytes, first diff at offset "
+        f"{next((i for i, (a, b) in enumerate(zip(body, large_data)) if a != b), -1)}")
+    print("  GET mykey4 (35MB, position-dependent) - OK")
 
     print("GET tests passed!")
 


### PR DESCRIPTION
Two changes from extended-run triage. They are unrelated but both came out of the same run (34315998434).

## 1. S3 GET returned object bytes in the wrong order

`chimera/server/s3/boto3_v4_io_uring_streaming` failed once in eleven extended runs with

```
streamdir/multi: content corrupted; 300000 bytes stored, first diff at offset 168928
```

A GET of an object larger than the server's `io_size` (128 KiB) issues one `chimera_vfs_read` per chunk and leaves them all in flight. The completion callback appended each result straight to the response with `evpl_http_request_add_datav`, which appends to a byte stream and carries no file offset. So the order the reads completed in was the order the object's bytes went on the wire, and nothing ordered those completions. io_uring reaps CQEs in whatever order the kernel finishes them, which for reads that miss page cache and go async is not submission order.

The result is a permuted object at exactly the right length, served with a 200.

### The reported offset identifies the bug

The test payload is periodic with period 256, and both 128 KiB split points of a 300000-byte object are multiples of 256. Of the six possible completion orders, four are byte-identical to the correct one. The two that are not differ first at 168928 and at 37856. CI reported 168928.

### Reproduced

PUT a 300000-byte position-dependent object, `echo 1 > /proc/sys/vm/drop_caches` so the reads miss cache and go async, then GET and compare:

```
corrupt in 33 of 40 iterations
first_diff values observed: only 168928 and 37856
```

A probe on the callback recorded the three reads completing 262144, then 131072, then 0.

### The fix

Serialising the reads would cost the pipelining, so the reads stay concurrent and are reordered on completion. Each in-flight read hangs on the request's `read_queue` in submission order, its callback marks it ready, and the queue's completed prefix is drained head first. `io_pending` is decremented as an entry drains rather than as its callback fires, so the request is not finished until every byte has reached the response.

memfs, cairn and diskfs complete in submission order and could not hit this. The linux backend delegates to a thread pool and is not obviously immune; it simply has not been caught.

### Why it hid for so long

Every payload in the S3 suite is a single repeated byte, and a permutation of a repeated byte is byte-identical. `streamdir/multi` is the only position-dependent payload in the suite, which is why one cell was the only thing that could ever fail. Even there, four of six orderings are masked.

The 35 MB object in the GET test was a repeated byte checked only for length. It now carries a distinct counter per 4 KiB page and the body is compared. Against the unfixed server, under a loop dropping the page cache, that catches the bug in 5 runs out of 5. With the fix, 0 out of 5.

## 2. The whole nfstest family gets the 900 s timeout

`nfstest_lock` and `nfstest_dio` already had `TIMEOUT 900` because they run past the CI-wide `ctest --timeout 300`. `nfstest_alloc` now times out at exactly 300 s on both diskfs backends at NFSv4.2, in all four nfstest shards, with its captured output still emitting PASS lines. It is progressing, not hung.

Every member of the family boots a guest, mounts the share and runs a client-side conformance suite, and the shard runs `ctest -j $(nproc)` with `PROCESSORS 2`, so several guests compete for the host. Five minutes is a poor fit for the family rather than for two of its members.

This is hardening, not a fix for a diagnosed defect. A test that genuinely wedges still fails, fifteen minutes later instead of five.

Note one case this does **not** address: `nfstest_dio` on `diskfs_aio` at NFSv4.2 exceeded 900 s in one of the four shards. That one is worth chasing as a real hang.

## Verification

Built and run in a container on kernel 6.8 aarch64, with the passthrough backends on ext4 (they need `name_to_handle_at`, so virtiofs and overlayfs both fail the mount).

- Full S3 suite, SigV4, all five backends (memfs, io_uring, linux, cairn, diskfs): pass
- SigV2 subset that CI registers, memfs: pass
- Reorder reproduction: 33 of 40 iterations corrupt before, 0 of 40 after
- New GET assertion under page-cache pressure: catches 5 of 5 before, 0 of 5 after

The KVM change is not exercised locally (no qemu or `/dev/kvm` here); it is a `set_tests_properties` call moved out of an `if`, and the file's block and paren structure is unchanged.
