### PR TITLE
vfs: impersonate the caller for xattr ops on the passthrough backends

### DIFF
--- a/src/vfs/io_uring/io_uring.c
+++ b/src/vfs/io_uring/io_uring.c
@@ -3265,16 +3265,30 @@ chimera_io_uring_get_xattr(
     int                             fd      = (int) request->get_xattr.handle->vfs_private;
     char                           *scratch = (char *) request->plugin_data;
     ssize_t                         rc;
+    int                             err;
 
     --thread->inflight;
 
     TERM_STR(name, request->get_xattr.name, request->get_xattr.namelen, scratch);
 
+    /* The descriptor was opened privileged (open_by_handle_at) and the
+     * kernel checks user.* xattr access against this thread's fsuid at call
+     * time, so the xattr syscalls run impersonated like every other op. */
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
     rc = fgetxattr(fd, name, request->get_xattr.value,
                    request->get_xattr.value_maxlen);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
     } else {
         request->get_xattr.r_value_len = rc;
         request->status                = CHIMERA_VFS_OK;
@@ -3293,6 +3307,7 @@ chimera_io_uring_set_xattr(
     char                           *scratch = (char *) request->plugin_data;
     int                             flags   = 0;
     int                             rc;
+    int                             err;
     struct statx                    stx;
 
     --thread->inflight;
@@ -3313,11 +3328,21 @@ chimera_io_uring_set_xattr(
 
     TERM_STR(name, request->set_xattr.name, request->set_xattr.namelen, scratch);
 
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
     rc = fsetxattr(fd, name, request->set_xattr.value,
                    request->set_xattr.value_len, flags);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
     } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
                      CHIMERA_IO_URING_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
@@ -3337,14 +3362,26 @@ chimera_io_uring_list_xattrs(
     struct chimera_io_uring_thread *thread = private_data;
     int                             fd     = (int) request->list_xattrs.handle->vfs_private;
     ssize_t                         rc;
+    int                             err;
     char                           *p, *end;
 
     --thread->inflight;
 
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
     rc = flistxattr(fd, request->list_xattrs.buffer,
                     request->list_xattrs.max_bytes);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
+
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
         request->complete(request);
         return;
     }
@@ -3378,6 +3415,7 @@ chimera_io_uring_remove_xattr(
     int                             fd      = (int) request->remove_xattr.handle->vfs_private;
     char                           *scratch = (char *) request->plugin_data;
     int                             rc;
+    int                             err;
     struct statx                    stx;
 
     --thread->inflight;
@@ -3392,10 +3430,20 @@ chimera_io_uring_remove_xattr(
 
     TERM_STR(name, request->remove_xattr.name, request->remove_xattr.namelen, scratch);
 
-    rc = fremovexattr(fd, name);
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
+    rc  = fremovexattr(fd, name);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
     } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
                      CHIMERA_IO_URING_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);

--- a/src/vfs/linux/linux.c
+++ b/src/vfs/linux/linux.c
@@ -2597,16 +2597,30 @@ chimera_linux_get_xattr(
     int     fd      = (int) request->get_xattr.handle->vfs_private;
     char   *scratch = (char *) request->plugin_data;
     ssize_t rc;
+    int     err;
 
     (void) private_data;
 
     TERM_STR(name, request->get_xattr.name, request->get_xattr.namelen, scratch);
 
+    /* The descriptor was opened privileged (open_by_handle_at) and the
+     * kernel checks user.* xattr access against this thread's fsuid at call
+     * time, so the xattr syscalls run impersonated like every other op. */
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
     rc = fgetxattr(fd, name, request->get_xattr.value,
                    request->get_xattr.value_maxlen);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
     } else {
         request->get_xattr.r_value_len = rc;
         request->status                = CHIMERA_VFS_OK;
@@ -2624,6 +2638,7 @@ chimera_linux_set_xattr(
     char        *scratch = (char *) request->plugin_data;
     int          flags   = 0;
     int          rc;
+    int          err;
     struct statx stx;
 
     (void) private_data;
@@ -2644,11 +2659,21 @@ chimera_linux_set_xattr(
 
     TERM_STR(name, request->set_xattr.name, request->set_xattr.namelen, scratch);
 
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
     rc = fsetxattr(fd, name, request->set_xattr.value,
                    request->set_xattr.value_len, flags);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
     } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
                      CHIMERA_LINUX_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);
@@ -2667,14 +2692,26 @@ chimera_linux_list_xattrs(
 {
     int     fd = (int) request->list_xattrs.handle->vfs_private;
     ssize_t rc;
+    int     err;
     char   *p, *end;
 
     (void) private_data;
 
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
     rc = flistxattr(fd, request->list_xattrs.buffer,
                     request->list_xattrs.max_bytes);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
+
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
         request->complete(request);
         return;
     }
@@ -2707,6 +2744,7 @@ chimera_linux_remove_xattr(
     int          fd      = (int) request->remove_xattr.handle->vfs_private;
     char        *scratch = (char *) request->plugin_data;
     int          rc;
+    int          err;
     struct statx stx;
 
     (void) private_data;
@@ -2721,10 +2759,20 @@ chimera_linux_remove_xattr(
 
     TERM_STR(name, request->remove_xattr.name, request->remove_xattr.namelen, scratch);
 
-    rc = fremovexattr(fd, name);
+    err = chimera_setup_credential(request->cred, NULL);
+    if (err != 0) {
+        request->status = chimera_linux_errno_to_status(err);
+        request->complete(request);
+        return;
+    }
+
+    rc  = fremovexattr(fd, name);
+    err = errno;
+
+    chimera_restore_privilege(request->cred);
 
     if (rc < 0) {
-        request->status = chimera_linux_errno_to_status(errno);
+        request->status = chimera_linux_errno_to_status(err);
     } else if (statx(fd, "", AT_EMPTY_PATH | AT_STATX_SYNC_AS_STAT,
                      CHIMERA_LINUX_STATX_MASK, &stx) < 0) {
         request->status = chimera_linux_errno_to_status(errno);

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -99,6 +99,25 @@ if(CAIRN_ENABLED)
     add_test(NAME chimera/vfs/zerorange_cairn COMMAND vfs_zerorange_test cairn)
 endif()
 
+# xattr DAC regression, parameterized by passthrough backend: the linux and
+# io_uring modules must issue f*xattr(2) under the caller's credential, since
+# the kernel evaluates user.* xattr permission against the calling thread's
+# fsuid and their cached open_by_handle_at descriptor was opened privileged.
+# Root only (setfsuid), and the backend must be able to serve the scratch
+# directory (name_to_handle_at fails on overlayfs); the test exits 77 otherwise.
+add_executable(vfs_xattr_dac_test vfs_xattr_dac_test.c)
+target_link_libraries(vfs_xattr_dac_test chimera_vfs chimera_vfs_memkv evpl)
+if(CHIMERA_LINUX)
+    target_link_libraries(vfs_xattr_dac_test chimera_vfs_linux)
+    add_test(NAME chimera/vfs/xattr_dac_linux COMMAND vfs_xattr_dac_test linux)
+    set_tests_properties(chimera/vfs/xattr_dac_linux PROPERTIES SKIP_RETURN_CODE 77)
+endif()
+if(CHIMERA_VFS_IO_URING)
+    target_link_libraries(vfs_xattr_dac_test chimera_vfs_io_uring)
+    add_test(NAME chimera/vfs/xattr_dac_io_uring COMMAND vfs_xattr_dac_test io_uring)
+    set_tests_properties(chimera/vfs/xattr_dac_io_uring PROPERTIES SKIP_RETURN_CODE 77)
+endif()
+
 # Tag every test registered above with the 'vfs' label so the suite can be run
 # independently via `ctest -L vfs`.
 get_property(_vfs_tests DIRECTORY PROPERTY TESTS)

--- a/src/vfs/tests/vfs_xattr_dac_test.c
+++ b/src/vfs/tests/vfs_xattr_dac_test.c
@@ -1,0 +1,529 @@
+// SPDX-FileCopyrightText: 2025-2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * xattr DAC on the passthrough backends (linux, io_uring).
+ *
+ * These modules cache a privileged open_by_handle_at(2) descriptor on the
+ * open handle and leave DAC to the kernel (CHIMERA_VFS_CAP_DELEGATES_DAC).
+ * The kernel evaluates f*xattr(2) against the calling thread's fsuid at the
+ * time of the call, so every xattr op must impersonate the caller
+ * (chimera_setup_credential) or it runs as the server and grants a non-owner
+ * whatever the mode bits deny.
+ *
+ * Kernel semantics for the user.* namespace (fs/xattr.c, xattr_permission):
+ * set and remove need write access, get needs read access, list is not
+ * permission-checked at all.  On a 0600 file owned by 1000, uid 2000 must
+ * therefore be denied set/get/remove (EACCES) and allowed list, while uid
+ * 1000 is allowed everything.
+ *
+ * Usage: vfs_xattr_dac_test <linux|io_uring>
+ *
+ * Exits 77 (ctest SKIP) when not root (setfsuid needs privilege) or when the
+ * backend cannot serve the scratch directory (ENOTSUP mount, e.g. overlayfs
+ * refuses name_to_handle_at).  The scratch root is $CHIMERA_MBT_SCRATCH,
+ * defaulting to the working directory.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/sdk/vfs_attrs.h"
+#include "vfs/sdk/vfs_cred.h"
+#include "vfs/sdk/vfs_error.h"
+#include "vfs/sdk/vfs_module.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+#define SKIP_RC     77
+
+#define XATTR_NAME  "user.chimera_dac_test"
+#define XATTR_VALUE "value"
+
+/* Evaluate `expr` (a status) and fail loudly unless it equals `expected`.
+ * _exit rather than exit: the backend is still live, and a failure must
+ * report as a failure, not as a crash in its atexit teardown. */
+#define CHECK_STATUS(expr, expected)                                    \
+        do {                                                            \
+            enum chimera_vfs_error _st = (expr);                        \
+            if (_st != (expected)) {                                    \
+                fprintf(stderr, "FAIL: %s\n      expected %d, got %d\n", \
+                        #expr, (int) (expected), (int) _st);            \
+                _exit(1);                                               \
+            }                                                           \
+        } while (0)
+
+struct test_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *vfs_thread;
+    struct evpl                    *evpl;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh_len;
+    struct chimera_vfs_open_handle *handle;
+    uint32_t                        value_len;
+    char                            names[1024];
+    uint32_t                        names_len;
+    uint32_t                        count;
+};
+
+static void
+wait_done(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_done */
+
+static void
+mount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, attr->va_fh, attr->va_fh_len);
+        ctx->fh_len = attr->va_fh_len;
+    }
+    ctx->done = 1;
+} /* lookup_cb */
+
+static void
+openfh_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openfh_cb */
+
+static void
+openat_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre,
+    struct chimera_vfs_attrs       *dir_post,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, oh->fh, oh->fh_len);
+        ctx->fh_len = oh->fh_len;
+    }
+    ctx->done = 1;
+} /* openat_cb */
+
+static void
+get_xattr_cb(
+    enum chimera_vfs_error error_code,
+    uint32_t               value_len,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status    = error_code;
+    ctx->value_len = value_len;
+    ctx->done      = 1;
+} /* get_xattr_cb */
+
+static void
+set_xattr_cb(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* set_xattr_cb */
+
+static void
+list_xattrs_cb(
+    enum chimera_vfs_error error_code,
+    const char            *names,
+    uint32_t               names_len,
+    uint32_t               count,
+    uint32_t               eof,
+    uint64_t               cookie,
+    void                  *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status    = error_code;
+    ctx->names_len = 0;
+    ctx->count     = 0;
+    if (error_code == CHIMERA_VFS_OK) {
+        assert(names_len <= sizeof(ctx->names));
+        if (names && names != ctx->names) {
+            memcpy(ctx->names, names, names_len);
+        }
+        ctx->names_len = names_len;
+        ctx->count     = count;
+    }
+    ctx->done = 1;
+} /* list_xattrs_cb */
+
+static void
+remove_xattr_cb(
+    enum chimera_vfs_error          error_code,
+    const struct chimera_vfs_attrs *pre_attr,
+    const struct chimera_vfs_attrs *post_attr,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* remove_xattr_cb */
+
+/* Open `fh` as `cred` (access inferred); the handle is left in ctx->handle. */
+static enum chimera_vfs_error
+open_as(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *fh,
+    uint32_t                       fh_len)
+{
+    chimera_vfs_open_fh(ctx->vfs_thread, cred, fh, fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, ctx);
+    wait_done(ctx);
+    return ctx->status;
+} /* open_as */
+
+/* Each *_as helper opens `fh` as `cred`, runs one xattr op through the
+ * handle and releases it.  A denial at the open is reported as the result:
+ * it is a denial of the op all the same. */
+
+static enum chimera_vfs_error
+set_xattr_as(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *fh,
+    uint32_t                       fh_len,
+    const char                    *name,
+    const char                    *value)
+{
+    enum chimera_vfs_error st = open_as(ctx, cred, fh, fh_len);
+
+    if (st != CHIMERA_VFS_OK) {
+        return st;
+    }
+
+    chimera_vfs_set_xattr(ctx->vfs_thread, cred, ctx->handle,
+                          CHIMERA_VFS_XATTR_EITHER, name, strlen(name),
+                          value, strlen(value), set_xattr_cb, ctx);
+    wait_done(ctx);
+    st = ctx->status;
+
+    chimera_vfs_release(ctx->vfs_thread, ctx->handle);
+    return st;
+} /* set_xattr_as */
+
+static enum chimera_vfs_error
+get_xattr_as(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *fh,
+    uint32_t                       fh_len,
+    const char                    *name,
+    void                          *value,
+    uint32_t                       value_maxlen)
+{
+    enum chimera_vfs_error st = open_as(ctx, cred, fh, fh_len);
+
+    if (st != CHIMERA_VFS_OK) {
+        return st;
+    }
+
+    chimera_vfs_get_xattr(ctx->vfs_thread, cred, ctx->handle, name,
+                          strlen(name), value, value_maxlen, get_xattr_cb, ctx);
+    wait_done(ctx);
+    st = ctx->status;
+
+    chimera_vfs_release(ctx->vfs_thread, ctx->handle);
+    return st;
+} /* get_xattr_as */
+
+static enum chimera_vfs_error
+list_xattrs_as(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *fh,
+    uint32_t                       fh_len)
+{
+    enum chimera_vfs_error st = open_as(ctx, cred, fh, fh_len);
+
+    if (st != CHIMERA_VFS_OK) {
+        return st;
+    }
+
+    chimera_vfs_list_xattrs(ctx->vfs_thread, cred, ctx->handle, 0,
+                            ctx->names, sizeof(ctx->names), list_xattrs_cb, ctx);
+    wait_done(ctx);
+    st = ctx->status;
+
+    chimera_vfs_release(ctx->vfs_thread, ctx->handle);
+    return st;
+} /* list_xattrs_as */
+
+static enum chimera_vfs_error
+remove_xattr_as(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *fh,
+    uint32_t                       fh_len,
+    const char                    *name)
+{
+    enum chimera_vfs_error st = open_as(ctx, cred, fh, fh_len);
+
+    if (st != CHIMERA_VFS_OK) {
+        return st;
+    }
+
+    chimera_vfs_remove_xattr(ctx->vfs_thread, cred, ctx->handle, name,
+                             strlen(name), remove_xattr_cb, ctx);
+    wait_done(ctx);
+    st = ctx->status;
+
+    chimera_vfs_release(ctx->vfs_thread, ctx->handle);
+    return st;
+} /* remove_xattr_as */
+
+/* Does the last list_xattrs result (back-to-back NUL-terminated names)
+ * contain `name`? */
+static int
+listed(
+    const struct test_ctx *ctx,
+    const char            *name)
+{
+    const char *p   = ctx->names;
+    const char *end = ctx->names + ctx->names_len;
+
+    while (p < end) {
+        if (strcmp(p, name) == 0) {
+            return 1;
+        }
+        p += strlen(p) + 1;
+    }
+    return 0;
+} /* listed */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_ctx               ctx = { 0 };
+    struct chimera_vfs_module_cfg module_cfgs[2];
+    struct prometheus_metrics    *metrics;
+    struct chimera_vfs_cred       root, owner, other;
+    struct chimera_vfs_attrs      sattr;
+    const char                   *backend = argc > 1 ? argv[1] : "linux";
+    const char                   *scratch;
+    char                          scratch_buf[PATH_MAX];
+    char                          session_dir[PATH_MAX];
+    char                          file_path[PATH_MAX + 8];
+    char                          value[64];
+    uint8_t                       root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                      root_fh_len;
+    uint8_t                       file_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                      file_fh_len;
+
+    if (strcmp(backend, "linux") != 0 && strcmp(backend, "io_uring") != 0) {
+        fprintf(stderr, "usage: %s <linux|io_uring>\n", argv[0]);
+        return 2;
+    }
+
+    if (geteuid() != 0) {
+        fprintf(stderr, "SKIP: impersonation (setfsuid) needs root\n");
+        return SKIP_RC;
+    }
+
+    chimera_log_init();
+
+    scratch = getenv("CHIMERA_MBT_SCRATCH");
+    if (!scratch || !*scratch) {
+        scratch = realpath(".", scratch_buf);
+        assert(scratch != NULL);
+    }
+    snprintf(session_dir, sizeof(session_dir), "%s/vfs_xattr_dac_XXXXXX",
+             scratch);
+    assert(mkdtemp(session_dir) != NULL);
+    snprintf(file_path, sizeof(file_path), "%s/f", session_dir);
+
+    chimera_vfs_cred_init_unix(&root, 0, 0, 0, NULL);
+    chimera_vfs_cred_init_unix(&owner, 1000, 1000, 0, NULL);
+    chimera_vfs_cred_init_unix(&other, 2000, 2000, 0, NULL);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    snprintf(module_cfgs[0].module_name, sizeof(module_cfgs[0].module_name),
+             "%s", backend);
+    snprintf(module_cfgs[1].module_name, sizeof(module_cfgs[1].module_name),
+             "%s", "memkv");
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, 2, "memkv", 60, 1, 1, 0,
+                               metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", backend, session_dir,
+                      NULL, mount_cb, &ctx);
+    wait_done(&ctx);
+    if (ctx.status == CHIMERA_VFS_ENOTSUP) {
+        fprintf(stderr, "SKIP: %s cannot serve %s (ENOTSUP)\n", backend,
+                session_dir);
+        rmdir(session_dir);
+        /* _exit: skip the leak checker, this is a skip not a failure. */
+        _exit(SKIP_RC);
+    }
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
+    chimera_vfs_lookup(ctx.vfs_thread, &root, root_fh, root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    memcpy(root_fh, ctx.fh, ctx.fh_len);
+    root_fh_len = ctx.fh_len;
+
+    /* Root creates a 0600 file owned by 1000:1000 (root runs as the server
+     * identity, so the chown is privileged). */
+    {
+        struct chimera_vfs_open_handle *root_handle;
+
+        assert(open_as(&ctx, &root, root_fh, root_fh_len) == CHIMERA_VFS_OK);
+        root_handle = ctx.handle;
+
+        memset(&sattr, 0, sizeof(sattr));
+        sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_UID |
+            CHIMERA_VFS_ATTR_GID;
+        sattr.va_mode = 0600;
+        sattr.va_uid  = 1000;
+        sattr.va_gid  = 1000;
+
+        chimera_vfs_open_at(ctx.vfs_thread, &root, root_handle, "f", 1,
+                            CHIMERA_VFS_OPEN_CREATE, &sattr, CHIMERA_VFS_ATTR_FH,
+                            0, 0, openat_cb, &ctx);
+        wait_done(&ctx);
+        assert(ctx.status == CHIMERA_VFS_OK);
+        memcpy(file_fh, ctx.fh, ctx.fh_len);
+        file_fh_len = ctx.fh_len;
+
+        chimera_vfs_release(ctx.vfs_thread, ctx.handle);
+        chimera_vfs_release(ctx.vfs_thread, root_handle);
+    }
+
+    /* Non-owner first on every op, then the owner: a leaked impersonation
+     * would surface as the owner (or root, below) failing. */
+
+    /* set: write access. */
+    CHECK_STATUS(set_xattr_as(&ctx, &other, file_fh, file_fh_len,
+                              XATTR_NAME, XATTR_VALUE), CHIMERA_VFS_EACCES);
+    CHECK_STATUS(set_xattr_as(&ctx, &owner, file_fh, file_fh_len,
+                              XATTR_NAME, XATTR_VALUE), CHIMERA_VFS_OK);
+    TEST_PASS("set_xattr: non-owner denied, owner allowed (0600)");
+
+    /* get: read access. */
+    CHECK_STATUS(get_xattr_as(&ctx, &other, file_fh, file_fh_len,
+                              XATTR_NAME, value, sizeof(value)),
+                 CHIMERA_VFS_EACCES);
+    CHECK_STATUS(get_xattr_as(&ctx, &owner, file_fh, file_fh_len,
+                              XATTR_NAME, value, sizeof(value)),
+                 CHIMERA_VFS_OK);
+    assert(ctx.value_len == strlen(XATTR_VALUE));
+    assert(memcmp(value, XATTR_VALUE, ctx.value_len) == 0);
+    TEST_PASS("get_xattr: non-owner denied, owner allowed (0600)");
+
+    /* list: listxattr(2) is not permission-checked by the kernel, so both
+     * succeed and see the attribute. */
+    CHECK_STATUS(list_xattrs_as(&ctx, &other, file_fh, file_fh_len),
+                 CHIMERA_VFS_OK);
+    assert(listed(&ctx, XATTR_NAME));
+    CHECK_STATUS(list_xattrs_as(&ctx, &owner, file_fh, file_fh_len),
+                 CHIMERA_VFS_OK);
+    assert(listed(&ctx, XATTR_NAME));
+    TEST_PASS("list_xattrs: allowed for both (no kernel permission check)");
+
+    /* remove: write access; the denied attempt must leave the attribute. */
+    CHECK_STATUS(remove_xattr_as(&ctx, &other, file_fh, file_fh_len,
+                                 XATTR_NAME), CHIMERA_VFS_EACCES);
+    CHECK_STATUS(get_xattr_as(&ctx, &owner, file_fh, file_fh_len,
+                              XATTR_NAME, value, sizeof(value)),
+                 CHIMERA_VFS_OK);
+    CHECK_STATUS(remove_xattr_as(&ctx, &owner, file_fh, file_fh_len,
+                                 XATTR_NAME), CHIMERA_VFS_OK);
+    CHECK_STATUS(get_xattr_as(&ctx, &owner, file_fh, file_fh_len,
+                              XATTR_NAME, value, sizeof(value)),
+                 CHIMERA_VFS_ENODATA);
+    TEST_PASS("remove_xattr: non-owner denied, owner allowed (0600)");
+
+    /* The server identity is restored after every impersonated op. */
+    CHECK_STATUS(set_xattr_as(&ctx, &root, file_fh, file_fh_len,
+                              XATTR_NAME, XATTR_VALUE), CHIMERA_VFS_OK);
+    CHECK_STATUS(remove_xattr_as(&ctx, &root, file_fh, file_fh_len,
+                                 XATTR_NAME), CHIMERA_VFS_OK);
+    TEST_PASS("root: privilege restored after impersonated ops");
+
+    chimera_vfs_umount(ctx.vfs_thread, NULL, "/test", mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+
+    unlink(file_path);
+    rmdir(session_dir);
+
+    fprintf(stderr, "All xattr DAC tests passed (%s)\n", backend);
+    return 0;
+} /* main */


### PR DESCRIPTION
The linux and io_uring modules issued fgetxattr, fsetxattr, flistxattr and
fremovexattr without `chimera_setup_credential()` / `chimera_restore_privilege()`,
unlike every other file-touching op in those files. Their open handle is a
descriptor from a privileged open_by_handle_at(2), the engine leaves DAC to the
kernel for these backends (`CHIMERA_VFS_CAP_DELEGATES_DAC`), and the kernel
evaluates user.* xattr access against the calling thread's fsuid at the time of
the call -- so the four ops ran as the server identity. With the daemon running
as root, any client could read, set and remove user xattrs on files it cannot
read or write; under a service account the same ops failed with a spurious
EACCES instead.

Wrap each syscall in the same impersonation bracket the other ops use, with
errno captured before the privilege is restored. The pre/post statx calls stay
outside the bracket: on a descriptor they are fstat-equivalent and need no
permission. AUTH_ATTR (SMB) credentials are a no-op in
`chimera_setup_credential`, so the SMB EA path is unaffected; S3 requests,
which already run as the key's POSIX identity, now have that identity enforced
on their metadata and tagging xattrs too.

Add `chimera/vfs/xattr_dac_{linux,io_uring}`: root creates a 0600 file owned by
uid 1000, then uid 2000 must be denied set/get/remove (EACCES) and allowed list
(listxattr(2) is not permission-checked), uid 1000 must succeed, and root must
still succeed afterwards, proving the privilege is restored. The test skips
(77) when not root or when the backend cannot serve the scratch directory,
e.g. on overlayfs. Before the fix both backends returned OK where EACCES was
expected.

Follow-up worth its own change: the quint NFS4 model carries the xattr ops but
no credential dimension, which is why `mbt4/batch_linux` replays SETXATTR
against the passthrough backends without ever noticing this.
