### PR TITLE
posix/tests: size the diskfs stress timeouts for the slowest image

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -151,15 +151,40 @@ endif()
 
 # diskfs-only cache-eviction / cold-remount stress (not part of the
 # all-backend matrix: it shrinks the diskfs caches and remounts the devices)
+#
+# TIMEOUTS.  The diskfs workload is far slower under the ubuntu24 arm64 Debug
+# image than under any other image we test, and has been for as long as the
+# per-test timings go back.  Measured in extended run 34315998434, same commit,
+# same runner pool, all Debug/ASan:
+#
+#            test                        rocky10  ubuntu26  ubuntu24   ratio
+#            diskfs/mbt/batch              34.5s     37.7s    204.3s    5.9x
+#            diskfs_reclaim (io_uring)     71.5s     73.5s    312.6s    4.4x
+#            diskfs_evict   (io_uring)    192.5s    198.6s   (killed)
+#            smb/mbt/batch_memfs           78.4s     73.8s    132.9s    1.7x
+#
+# The last row is the control: general tests run ~1.7x slower on that image,
+# the diskfs ones 4-6x.  So evict's 192s becomes ~900s there -- exactly its old
+# cap, which is why it was killed in five consecutive extended runs while
+# passing everywhere else.  It was not hanging.  reclaim shows the identical
+# ratio and survives only because it is shorter; at 452s in run 34191238682 it
+# was inside its 600s cap by 25%, and it did time out before the SQPOLL fix
+# (libevpl#166) took ~30% off both.
+#
+# Give both caps room for that image rather than shrinking the workload -- the
+# file count was already halved once for CI timing (see EVICT_NFILES) and
+# cutting it again costs the eviction pressure the test exists to create.  Why
+# that image is 4-6x slower for diskfs specifically is a separate question and
+# is not answered here.
 add_posix_testprog(test_diskfs_evict)
 if(CHIMERA_LIMITS_TESTING)
     if(IO_URING_ENABLED)
         add_posix_test(diskfs_evict_diskfs_io_uring test_diskfs_evict diskfs_io_uring)
-        set_tests_properties(chimera/posix/diskfs_evict_diskfs_io_uring PROPERTIES TIMEOUT 900)
+        set_tests_properties(chimera/posix/diskfs_evict_diskfs_io_uring PROPERTIES TIMEOUT 1800)
     endif()
     if(HAVE_LIBAIO)
         add_posix_test(diskfs_evict_diskfs_aio test_diskfs_evict diskfs_aio)
-        set_tests_properties(chimera/posix/diskfs_evict_diskfs_aio PROPERTIES TIMEOUT 900)
+        set_tests_properties(chimera/posix/diskfs_evict_diskfs_aio PROPERTIES TIMEOUT 1800)
     endif()
 endif()
 
@@ -169,11 +194,11 @@ add_posix_testprog(test_diskfs_reclaim)
 if(CHIMERA_LIMITS_TESTING)
     if(IO_URING_ENABLED)
         add_posix_test(diskfs_reclaim_diskfs_io_uring test_diskfs_reclaim diskfs_io_uring)
-        set_tests_properties(chimera/posix/diskfs_reclaim_diskfs_io_uring PROPERTIES TIMEOUT 600)
+        set_tests_properties(chimera/posix/diskfs_reclaim_diskfs_io_uring PROPERTIES TIMEOUT 1200)
     endif()
     if(HAVE_LIBAIO)
         add_posix_test(diskfs_reclaim_diskfs_aio test_diskfs_reclaim diskfs_aio)
-        set_tests_properties(chimera/posix/diskfs_reclaim_diskfs_aio PROPERTIES TIMEOUT 600)
+        set_tests_properties(chimera/posix/diskfs_reclaim_diskfs_aio PROPERTIES TIMEOUT 1200)
     endif()
 endif()
 

--- a/src/posix/tests/test_diskfs_evict.c
+++ b/src/posix/tests/test_diskfs_evict.c
@@ -241,6 +241,15 @@ main(
 
     evict_sweep(&env, 3);
 
+    /*
+     * Every phase from here on announces itself, and the unlink loop reports
+     * progress the way the pre-remount one does.  posix_test_success() prints
+     * nothing, so without this a clean run and a run wedged anywhere after the
+     * last sweep emit byte-identical output ending at "unlinking the rest...".
+     * A ctest timeout was therefore indistinguishable from a slow pass, and
+     * this test's timeouts were read as a hang in the unlink loop for weeks on
+     * the strength of where the output happened to stop.
+     */
     fprintf(stderr, "unlinking the rest...\n");
     for (i = 0; i < EVICT_NFILES; i++) {
         if ((i % 3) == 0) {
@@ -252,8 +261,12 @@ main(
             fprintf(stderr, "unlink %s failed: %s\n", path, strerror(errno));
             posix_test_fail(&env);
         }
+        if ((i % 6000) == 0) {
+            fprintf(stderr, "unlinked through %d\n", i);
+        }
     }
 
+    fprintf(stderr, "removing directories...\n");
     for (i = 0; i < EVICT_NDIRS; i++) {
         snprintf(path, sizeof(path), "/test/d%d", i);
         rc = chimera_posix_rmdir(path);
@@ -263,13 +276,16 @@ main(
         }
     }
 
+    fprintf(stderr, "unmounting...\n");
     rc = posix_test_umount();
     if (rc != 0) {
         fprintf(stderr, "Failed to unmount /test: %s\n", strerror(errno));
         posix_test_fail(&env);
     }
 
+    fprintf(stderr, "shutting down...\n");
     posix_test_success(&env);
+    fprintf(stderr, "done\n");
 
     return 0;
 } /* main */


### PR DESCRIPTION
`chimera/posix/diskfs_evict_diskfs_{io_uring,aio}` have been killed at their 900 s cap in five consecutive extended runs. **They are not hanging.**

## Where it fails

Exactly one job out of the twenty-two distro test jobs: **ubuntu24 arm64 Debug**. The same test passes in rocky10 arm64 Debug and in ubuntu24 amd64 Debug, which controls for architecture and for image independently.

## Why

The diskfs workload is 4 to 6 times slower under that image than under any other. From run 34315998434, same commit, same runner pool, all Debug with AddressSanitizer:

| Test | rocky10 arm64 | ubuntu26 arm64 | ubuntu24 arm64 | Ratio |
|---|---|---|---|---|
| `diskfs/mbt/batch` | 34.5 s | 37.7 s | 204.3 s | 5.9x |
| `diskfs_reclaim` (io_uring) | 71.5 s | 73.5 s | 312.6 s | 4.4x |
| `diskfs_evict` (io_uring) | 192.5 s | 198.6 s | killed at 900 s | — |
| `smb/mbt/batch_memfs` | 78.4 s | 73.8 s | 132.9 s | 1.7x |

The last row is the control. General tests run about 1.7x slower on that image; the diskfs ones run 4 to 6 times slower. Scale evict's 192 s by that and you land at roughly 900 s, which is exactly the cap it was hitting.

The slowdown is long-standing, not a regression: `diskfs_reclaim` on that job has been 394 to 452 s in every run I checked back to 2026-09-06, against 69 s on rocky10 arm64.

## What this changes

- `diskfs_evict`: 900 s to 1800 s
- `diskfs_reclaim`: 600 s to 1200 s

`diskfs_reclaim` shows the identical ratio and survives only because it is shorter. At 452 s in run 34191238682 it was inside its 600 s cap by 25%, and it did time out before libevpl#166 turned SQPOLL off by default and took roughly 30% off both. Raising it now rather than waiting for it to cross.

Raising the caps rather than shrinking the workload: `EVICT_NFILES` was already halved once for CI timing, and cutting it again costs the eviction pressure the test exists to create.

## The diagnosability fix

`posix_test_success()` prints nothing, so a clean run and a run wedged anywhere after the final sweep produced byte-identical output, both ending at `unlinking the rest...`. A timeout was therefore indistinguishable from a slow pass, and because that was the last line the failures were read as a hang in the post-remount unlink loop, for five runs, on evidence that never supported it. Each remaining phase now announces itself and the unlink loop reports progress like the pre-remount one.

## What I ruled out

- **A block-cache swap-park deadlock.** `diskfs_block_defer_retry` self-defers through `evpl_defer`, and evpl's drain is `while (num_active_deferrals)` which clears `armed` before the callback, so a re-armed deferral re-runs in the same pass rather than "next loop iteration" as its comment claims. That is a real contract violation worth fixing on its own, but instrumenting the park showed it firing **zero** times in this test at the cache size CI uses, so it is not this. Worth a separate look.
- **A hang reproducible locally.** On kernel 6.8 arm64 with AddressSanitizer the test passes in 96 to 144 s single, and four concurrent copies all pass. Shrinking the block cache does not reproduce it either; note `block_cache_blocks` is floored at 1.5x the intent log, so values below about 24576 are silently ignored.

## Not answered

Why that image is 4 to 6 times slower for diskfs specifically, and only for diskfs, is a separate question. The images differ in AddressSanitizer runtime, ubuntu24 carrying `libclang-rt-18-dev` against ubuntu26's 21, which would fit a workload this allocation-heavy, but I did not confirm it.
