### PR TITLE
smb: say when a CREATE parks on a break, and how it ended

### DIFF
--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3192,6 +3192,20 @@ chimera_smb_create_park_deadline_cb(
 
     (void) evpl;
 
+    /* No ack arrived for the whole break deadline, so the holder is revoked and
+     * this open completes anyway (MS-SMB2 break timeout).  Info, not error: a
+     * client is entitled not to ack, and smb2.lease.v2_complex1 and
+     * smb2.oplock.batch21 reach here on every run without failing.
+     *
+     * It is still worth a line, because recovery costs the full deadline
+     * (default 30 s) and a client that gives up sooner sees the create simply
+     * never answered -- a WPTS adapter times out at 20 s, so any create that
+     * gets here has already failed the test 10 s earlier. */
+    chimera_smb_info(
+        "CREATE park deadline expired with no break ack: revoking holders and completing open; fh_hash %016lx conn %p",
+        (unsigned long) request->create.park_fh_hash,
+        (void *) request->compound->conn);
+
     chimera_vfs_claim_revoke_breaks(vfs_state, request->create.park_fh,
                                     request->create.park_fh_len,
                                     request->create.park_fh_hash,
@@ -3421,6 +3435,20 @@ chimera_smb_create_open_finish(
             open_file->flags |= CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
         }
         chimera_smb_async_interim_begin(request);
+
+        /* A parked CREATE sends no reply until an ack settles the break, so
+         * from outside it is indistinguishable from a lost request.  Say so at
+         * info level: this is the only record that a create waited, and which
+         * connection it waited on -- both are needed to tell "the ack never
+         * came" from "the ack came on another channel of this session and we
+         * missed it".  Parks are rare relative to I/O. */
+        chimera_smb_info(
+            "CREATE parked on a caching break: fh_hash %016lx conn %p session %p deadline %u ms",
+            (unsigned long) request->create.park_fh_hash,
+            (void *) request->compound->conn,
+            (void *) (request->session_handle ? request->session_handle->session : NULL),
+            vfs_state->default_break_deadline_ms);
+
         /* Arm a deadline: if the holder never acks the break, fire at the
          * break timeout to revoke it and complete this open anyway (MS-SMB2
          * break-timeout).  Cancelled when an ack resumes the open first. */
@@ -3588,6 +3616,15 @@ chimera_smb_create_resume_parked_conn(
          * holder vanished outright, lift the capped lease/durable decision
          * before the deferred reply is marshaled. */
         chimera_smb_create_resume_rearbitrate(req);
+
+        /* Pairs with the "CREATE parked" line: a park with no matching resume
+         * and no deadline line is a create that was still waiting when its
+         * connection went away.  conn is logged on both so a resume arriving
+         * on a different channel of the same session is visible as such. */
+        chimera_smb_info("CREATE resumed after break ack: fh_hash %016lx conn %p",
+                         (unsigned long) req->create.park_fh_hash,
+                         (void *) conn);
+
         if (req->create.r_open_file) {
             req->create.r_open_file->flags &=
                 ~CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;


### PR DESCRIPTION
Observability only, no behaviour change. This does not fix the WPTS failure; it makes the next occurrence diagnosable, which it currently is not.

## The failure this targets

`wpts-smb2model/memfs_multichannel_persistent_encryption_s*` fails intermittently, in two of the last five extended runs, always the same way:

```
Failed ReplayCreateDurableHandleV2PersistentTestCaseS984 [20 s]
System.TimeoutException: The operation has timed out.
  at ... CreateRequest(ModelDialectRevision, ReplayModelShareType,
      ReplayModelClientSupportPersistent, ReplayModelSwitchChannelType, ...)
```

The server never replied. It is a different model state each run, S780 then S1163 then S984, with 49 of 50 passing alongside, which reads as a race rather than one wrong model state.

## Why it cannot be diagnosed today

A CREATE that conflicts with a caching holder sends an interim response and then nothing until the holder acks the break. The park, the resume and the break-timeout revoke are all silent, so the captured server output cannot distinguish:

- the create never parked, and the reply was lost some other way
- the create parked and the ack never arrived
- the ack arrived on a different channel of the session and was not matched

Those have different fixes, and guessing between them is how you ship the wrong one.

## What this adds

All three transitions at info level, carrying the file-handle hash so a park pairs with its outcome, and the connection, plus the session on the park, so a resume arriving on a different channel of the same session is visible as such.

## What it already showed

Running the oplock, lease and dirlease memfs suites, 78 tests, all passing:

| | Count |
|---|---|
| Creates parked | 76 |
| Resumed by an ack | 73 |
| Break deadline expired | 2 |

The two deadline expiries are `smb2.lease.v2_complex1` and `smb2.oplock.batch21`, and both suites pass. A client is entitled not to ack, so a forced revoke is normal server behaviour under the MS-SMB2 break timeout. That is why the deadline line is info rather than error, and it is worth knowing before someone reads the first one as a bug.

## The number that explains why a park is fatal here

Recovery from an unacknowledged break costs the full deadline, 30 s by default (`CHIMERA_VFS_CLAIM_DEFAULT_BREAK_DEADLINE_MS`), while the WPTS adapter gives up at 20 s. So any create that has to wait for that deadline has already failed the test ten seconds before the server recovers. Whatever the underlying cause, a park in this suite can never merely be slow.

I did not change the deadline. Shortening it is a real decision about what the server does on expiry and needs to be consistent with MS-SMB2; the handoff notes warn specifically against doing that blind, and it would convert an intermittent hang into a systematic wrong answer if got wrong.

## Verification

Built and run on kernel 6.8 arm64 with AddressSanitizer. The oplock, lease and dirlease memfs suites are 78 of 78 passing with the logging in place, and every park has a matching resume or deadline line. WPTS itself cannot run here, its test host takes SIGBUS on arm64, so the next natural occurrence in the nightly extended run is what this is for.
