### PR TITLE
vfs/diskfs: roll a transaction's block edits back when it aborts

### DIFF
--- a/src/posix/tests/CMakeLists.txt
+++ b/src/posix/tests/CMakeLists.txt
@@ -202,6 +202,29 @@ if(CHIMERA_LIMITS_TESTING)
     endif()
 endif()
 
+# diskfs-only ENOSPC-boundary test: the in-process analogue of nfstest_alloc's
+# alloc06, which is what the kvm nfstest shards run over NFSv4.2.  Reaching
+# ENOSPC needs a bounded pool, so it shrinks the device geometry to the 2 x
+# 128 MiB the kvm wrapper uses; the default 10 x 1 GiB pool never gets near it.
+add_posix_testprog(test_diskfs_enospc)
+if(CHIMERA_LIMITS_TESTING)
+    if(IO_URING_ENABLED)
+        add_posix_test(diskfs_enospc_diskfs_io_uring test_diskfs_enospc diskfs_io_uring)
+        set_tests_properties(chimera/posix/diskfs_enospc_diskfs_io_uring PROPERTIES TIMEOUT 300)
+    endif()
+    if(HAVE_LIBAIO)
+        add_posix_test(diskfs_enospc_diskfs_aio test_diskfs_enospc diskfs_aio)
+        set_tests_properties(chimera/posix/diskfs_enospc_diskfs_aio PROPERTIES TIMEOUT 300)
+    endif()
+    if(NOT IO_URING_ENABLED AND NOT HAVE_LIBAIO)
+        # Neither async block backend exists here (macOS, or a Linux host
+        # without libaio): diskfs still runs on libevpl's portable pread
+        # backend, and the defect this covers is backend-independent.
+        add_posix_test(diskfs_enospc_diskfs test_diskfs_enospc diskfs)
+        set_tests_properties(chimera/posix/diskfs_enospc_diskfs PROPERTIES TIMEOUT 300)
+    endif()
+endif()
+
 # Cross-mount EXDEV test: link/rename across two VFS mounts must fail EXDEV.  It
 # mounts a second memfs instance alongside the primary backend, so the primary
 # must be a different module from memfs (two memfs mounts share one fsid, i.e.

--- a/src/posix/tests/posix_test_common.h
+++ b/src/posix/tests/posix_test_common.h
@@ -261,7 +261,12 @@ posix_test_diskfs_device_type(const char *backend)
     if (strcmp(backend, "diskfs_aio") == 0) {
         return "libaio";
     }
-    return "io_uring";
+    if (strcmp(backend, "diskfs_io_uring") == 0) {
+        return "io_uring";
+    }
+    /* Plain "diskfs": whatever libevpl block backend this build settled on
+     * (io_uring / libaio on Linux, the portable pread backend elsewhere). */
+    return CHIMERA_DISKFS_DEVICE_TYPE;
 } // posix_test_diskfs_device_type
 
 // Helper to check if a backend name is a diskfs variant
@@ -404,6 +409,11 @@ posix_test_emit_ext_module_config(
  * / posix_test_configure_diskfs. */
 static const char *posix_test_diskfs_extra_cfg = NULL;
 static int         posix_test_diskfs_reuse_devices __attribute__ ((unused)) = 0;
+/* Device geometry.  The default 10 x 1 GiB pool is effectively unbounded; a
+ * test that needs ENOSPC to be reachable shrinks it (the kvm nfstest_alloc
+ * wrapper does the same thing for the same reason). */
+static int         posix_test_diskfs_device_count = 10;
+static uint64_t    posix_test_diskfs_device_bytes = 1024ULL * 1024 * 1024;
 
 /* When non-zero (set before posix_test_init), posix_test_start_nfs_server also
  * mounts the SAME NFS backend a second time, read-only, under a subdirectory
@@ -505,7 +515,7 @@ posix_test_configure_diskfs(
     cfg     = json_object();
     devices = json_array();
 
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < posix_test_diskfs_device_count; ++i) {
         device = json_object();
         snprintf(device_path, sizeof(device_path), "%s/device-%d.img", session_dir, i);
         json_object_set_new(device, "type", json_string(device_type));
@@ -523,7 +533,7 @@ posix_test_configure_diskfs(
             exit(EXIT_FAILURE);
         }
 
-        rc = ftruncate(fd, 1024 * 1024 * 1024UL);
+        rc = ftruncate(fd, (off_t) posix_test_diskfs_device_bytes);
 
         if (rc < 0) {
             fprintf(stderr, "Failed to truncate device %s: %s\n", device_path, strerror(errno));

--- a/src/posix/tests/test_diskfs_enospc.c
+++ b/src/posix/tests/test_diskfs_enospc.c
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * diskfs ENOSPC-boundary test, the in-process analogue of nfstest_alloc's
+ * alloc06 ("Verify ALLOCATE reserves the disk space").
+ *
+ * The suite fallocates a small file, reads the remaining free space from
+ * statfs, and then fallocates all but 256 KiB of it -- which must succeed,
+ * because statfs is supposed to report what a write can still place.  Running
+ * that against a *bounded* device pool (2 x 128 MiB, the same geometry the kvm
+ * nfstest_alloc wrapper uses) is what makes ENOSPC reachable at all; the
+ * default 10 x 1 GiB pool never gets near it.
+ *
+ * After the boundary allocation the file is closed, unlinked and the space
+ * reclaimed, so the teardown path runs over whatever the failed allocation
+ * left behind.
+ */
+
+#include <inttypes.h>
+
+#include "posix_test_common.h"
+
+#define ENOSPC_DEV_COUNT 2
+#define ENOSPC_DEV_BYTES (128ULL << 20)
+
+/* alloc06 leaves this much headroom when it asks for "the rest". */
+#define ENOSPC_HEADROOM  (256ULL * 1024)
+
+static uint64_t
+free_bytes(struct posix_test_env *env)
+{
+    struct statfs sf;
+
+    if (chimera_posix_statfs("/test", &sf) != 0) {
+        fprintf(stderr, "statfs failed: %s\n", strerror(errno));
+        posix_test_fail(env);
+    }
+    return (uint64_t) sf.f_bfree * (uint64_t) sf.f_bsize;
+} /* free_bytes */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct posix_test_env env;
+    uint64_t              baseline, avail, ask, reclaimed;
+    int                   fd, rc, i, alloc_errno = 0;
+
+    posix_test_diskfs_device_count = ENOSPC_DEV_COUNT;
+    posix_test_diskfs_device_bytes = ENOSPC_DEV_BYTES;
+
+    posix_test_init(&env, argv, argc);
+    ChimeraLogLevel = CHIMERA_LOG_INFO;
+
+    if (!posix_test_is_diskfs(env.backend)) {
+        fprintf(stderr, "diskfs-only test, nothing to do for %s\n", env.backend);
+        posix_test_success(&env);
+        return 0;
+    }
+
+    rc = posix_test_mount(&env);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to mount test module: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    baseline = free_bytes(&env);
+    fprintf(stderr, "baseline free: %" PRIu64 "\n", baseline);
+
+    /* alloc06 step 1: a small allocation that must succeed. */
+    fd = chimera_posix_open("/test/small", O_CREAT | O_WRONLY, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "open /test/small failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+    if (chimera_posix_fallocate(fd, 0, 262144) != 0) {
+        fprintf(stderr, "fallocate 256K failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+    chimera_posix_close(fd);
+
+    /* alloc06 step 2: everything statfs still reports as free, less 256 KiB. */
+    avail = free_bytes(&env);
+    fprintf(stderr, "statfs reports %" PRIu64 " bytes free\n", avail);
+    if (avail <= ENOSPC_HEADROOM) {
+        fprintf(stderr, "device pool too small: only %" PRIu64 " free\n", avail);
+        posix_test_fail(&env);
+    }
+    ask = avail - ENOSPC_HEADROOM;
+
+    fd = chimera_posix_open("/test/big", O_CREAT | O_WRONLY, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "open /test/big failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+    rc          = chimera_posix_fallocate(fd, 0, (off_t) ask);
+    alloc_errno = rc ? errno : 0;
+    fprintf(stderr, "fallocate %" PRIu64 " (free - 256K): rc=%d errno=%d (%s)\n",
+            ask, rc, alloc_errno, rc ? strerror(alloc_errno) : "ok");
+    chimera_posix_close(fd);
+
+    /* Whether or not the boundary allocation succeeded, tear the file down:
+     * the failure path has to leave the space map consistent. */
+    if (chimera_posix_unlink("/test/big") != 0) {
+        fprintf(stderr, "unlink /test/big failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+    if (chimera_posix_unlink("/test/small") != 0) {
+        fprintf(stderr, "unlink /test/small failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    /* Reclaim is asynchronous; wait for the drain (and the intent log's apply
+     * pass) to run over what we just deleted. */
+    reclaimed = 0;
+    for (i = 0; i < 100; i++) {
+        reclaimed = free_bytes(&env);
+        if (reclaimed >= baseline) {
+            break;
+        }
+        usleep(100000);
+    }
+    fprintf(stderr, "free after delete: %" PRIu64 " (baseline %" PRIu64 ")\n",
+            reclaimed, baseline);
+
+    /* The point of the test.  A boundary allocation that fails has to leave the
+     * space map exactly as it found it: the blocks it drew from the per-thread
+     * reservation were never committed, so the extent records its transaction
+     * wrote must not survive the transaction's abort.  When they did, deleting
+     * the file freed ranges that were already free and the server aborted in
+     * sm_ag_free_locked ("double-free or overlap"); a run that gets here at all
+     * has cleared that.  Converging back to the baseline is the positive half:
+     * nothing the failed allocation touched leaked or double-counted. */
+    if (reclaimed < baseline) {
+        fprintf(stderr, "space did not return after delete: %" PRIu64
+                " < baseline %" PRIu64 "\n", reclaimed, baseline);
+        posix_test_fail(&env);
+    }
+
+    /* Separate, still-open defect: space held inside live reservation claims is
+     * reported free by statfs but cannot be allocated, so asking for "all of
+     * it" hits ENOSPC.  Not what this test gates -- see the diskfs enospc
+     * white-box test for the accounting numbers. */
+    if (rc != 0) {
+        fprintf(stderr, "KNOWN GAP: statfs reported %" PRIu64
+                " free but allocating %" PRIu64 " got %s\n",
+                avail, ask, strerror(alloc_errno));
+    }
+
+    rc = posix_test_umount();
+    if (rc != 0) {
+        fprintf(stderr, "umount failed: %s\n", strerror(errno));
+        posix_test_fail(&env);
+    }
+
+    posix_test_success(&env);
+    return 0;
+} /* main */

--- a/src/vfs/diskfs/diskfs_block.c
+++ b/src/vfs/diskfs/diskfs_block.c
@@ -1873,9 +1873,24 @@ diskfs_txn_unpin_blocks(struct diskfs_txn *txn)
     txn->blocks = NULL;
     while (tb) {
         n = tb->next;
-        /* Abort: no record was logged, so no tail-push will ever release this
-         * txn's claim pin -- drop it here.  The block is home (nothing of ours
-         * went un-home), so unpin marks it CLEAN once fully unpinned. */
+        /*
+         * Roll the block back to what it held before this txn touched it.  The
+         * block cache is shared, live state: unpinning alone would leave the
+         * aborted txn's half-finished edits in the cache, published as CLEAN --
+         * indistinguishable from committed content.  For a b+tree that means
+         * the file keeps extent records pointing at blocks whose ALLOC deltas
+         * were just discarded, so the allocator still counts them free: it can
+         * hand the same blocks to another file, and deleting this one frees
+         * ranges that are already free (which aborts in sm_ag_free_locked).
+         *
+         * The list is LIFO, so a block attached more than once is restored
+         * newest-first and its oldest -- i.e. true pre-txn -- image lands last.
+         */
+        memcpy(tb->block->iov.data, tb->undo, DISKFS_BLOCK_SIZE);
+
+        /* No record was logged, so no tail-push will ever release this txn's
+         * claim pin -- drop it here.  The block is home (nothing of ours went
+         * un-home), so unpin marks it CLEAN once fully unpinned. */
         diskfs_block_unpin(thread, tb->block, DISKFS_BLOCK_CLEAN);
         free(tb);
         tb = n;

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -1167,6 +1167,14 @@ struct diskfs_txn_block {
     uint64_t                 snap_csum_lo;
     uint64_t                 snap_csum_hi;
     struct diskfs_txn_block *next;
+    /* Undo image: the block's content as it was when this txn first attached it,
+     * captured before the txn mutated anything in it.  An aborting txn copies it
+     * back (diskfs_txn_unpin_blocks), which is what makes abort a true rollback:
+     * the cache keeps the block, so without this a txn's half-finished b+tree
+     * edits survive its own abort while the space they reference stays free in
+     * the allocator.  Live only while the txn is open -- a committing txn never
+     * reads it -- and last in the struct to keep the hot fields packed. */
+    uint8_t                  undo[DISKFS_BLOCK_SIZE];
 };
 
 
@@ -4410,6 +4418,10 @@ diskfs_txn_add_block(
     tb->next         = txn->blocks;
     txn->blocks      = tb;
 
+    /* Take the undo image before the caller writes into the block: every attach
+     * site claims (or CoW-forks) the block and only then mutates it. */
+    memcpy(tb->undo, block->iov.data, DISKFS_BLOCK_SIZE);
+
     /* Diag: a normal op dirties a handful of blocks.  If one txn balloons,
      * dump the call path + journal/direct split at growth thresholds so we can
      * see whether the same site repeats (re-execution loop) or varies, and
@@ -5047,10 +5059,12 @@ static inline void
 diskfs_txn_abort(struct diskfs_txn *txn)
 {
     /* Discard pending frees (their journaled FREE deltas never commit, so the
-     * ranges stay allocated).  Drop any blocks the aborted txn pinned (their
-     * contents are discarded) and release the inode locks.  NOTE: the in-memory
-     * allocator alloc deltas applied during the txn are still not rolled back
-     * here -- a pre-existing transaction-atomicity gap, separate from frees. */
+     * ranges stay allocated), roll every block this txn dirtied back to its
+     * pre-txn content, and release the inode locks.  NOTE: the txn's in-memory
+     * *inode* scalars (size, timestamps, change counter) are still not rolled
+     * back here; the failure paths that exist today all bail out before
+     * stamping them, but a future one that does not would need the same
+     * treatment. */
     diskfs_txn_discard_frees(txn);
     /* Reservation allocator: alloc deltas were never applied to the free tree
      * (only retire does that), so there is nothing to roll back there -- but each

--- a/src/vfs/diskfs/space_map.c
+++ b/src/vfs/diskfs/space_map.c
@@ -390,11 +390,11 @@ sm_ag_free_locked(
     rb_tree_query_ceil(&ag->free_by_offset, offset + length, offset, next_ext);
 
     sm_abort_if(prev_ext && prev_ext->offset + prev_ext->length > offset,
-                "double-free or overlap at offset=%lu (prev=%lu+%lu)",
-                offset, prev_ext->offset, prev_ext->length);
+                "double-free or overlap at offset=%lu length=%lu (prev=%lu+%lu)",
+                offset, length, prev_ext->offset, prev_ext->length);
     sm_abort_if(next_ext && next_ext->offset < offset + length,
-                "double-free or overlap at offset=%lu (next=%lu+%lu)",
-                offset, next_ext->offset, next_ext->length);
+                "double-free or overlap at offset=%lu length=%lu (next=%lu+%lu)",
+                offset, length, next_ext->offset, next_ext->length);
 
     /* prev (floor of offset) and next (ceil of offset+length) are necessarily
      * distinct nodes: the overlap aborts above pin prev to end <= offset and

--- a/src/vfs/diskfs/tests/CMakeLists.txt
+++ b/src/vfs/diskfs/tests/CMakeLists.txt
@@ -26,5 +26,19 @@ set_tests_properties(chimera/vfs/diskfs/smoke_test PROPERTIES
     LABELS "quint;diskfs_mbt"
     TIMEOUT 300)
 
+# ENOSPC-boundary test: mounts the bounded pool the kvm nfstest_alloc wrapper
+# uses and runs that suite's alloc06 case in-process, so the allocator's
+# out-of-space failure path is covered by the quick tier.
+add_executable(diskfs_enospc_test diskfs_enospc_test.c)
+target_include_directories(diskfs_enospc_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(diskfs_enospc_test
+    chimera_vfs chimera_vfs_diskfs chimera_vfs_memkv evpl)
+add_test(NAME chimera/vfs/diskfs/enospc_test COMMAND diskfs_enospc_test)
+set_tests_properties(chimera/vfs/diskfs/enospc_test PROPERTIES
+    LABELS "quint;diskfs_mbt"
+    TIMEOUT 300)
+
 # The quint diskfs stress model + replay harness (generated corpus).
 add_subdirectory(quint)

--- a/src/vfs/diskfs/tests/diskfs_enospc_test.c
+++ b/src/vfs/diskfs/tests/diskfs_enospc_test.c
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * diskfs ENOSPC-boundary white-box test -- the in-process analogue of the
+ * nfstest_alloc "alloc06" case (`Verify ALLOCATE reserves the disk space`),
+ * which is what the kvm nfstest shards run over NFSv4.2.
+ *
+ * alloc06 allocates a small file, reads the free space the filesystem reports,
+ * and then allocates all but 256 KiB of it -- which must succeed, because the
+ * reported free space is supposed to be what a fresh allocation can still
+ * place.  The interesting part is not the assertion but the aftermath: the
+ * boundary allocation walks the pool down to its last extents, and if it fails
+ * the failure path has to leave the space map exactly as it found it.
+ *
+ * Reaching that boundary at all needs a *bounded* pool, so this mounts the same
+ * geometry the kvm wrapper uses for alloc06 (2 x 128 MiB devices behind a
+ * 64 MiB intent log).  The default multi-gigabyte test pools never get near it,
+ * which is why no in-process suite covered this before.
+ */
+
+#include <inttypes.h>
+
+#include "diskfs_test_harness.h"
+
+#define CHECK(dh) do { \
+            char _e[256]; \
+            if (diskfs_test_check((dh)->vfs, _e, sizeof(_e)) != 0) { \
+                fprintf(stderr, "INVARIANT VIOLATION at %s:%d: %s\n", \
+                        __func__, __LINE__, _e); \
+                exit(1); \
+            } \
+} while (0)
+
+/* The geometry kvm/kvm_nfstest_test_wrapper.sh gives nfstest_alloc. */
+#define ENOSPC_NDEV      2
+#define ENOSPC_DEV_BYTES (128ULL << 20)
+#define ENOSPC_LOG_BYTES (64ULL << 20)
+
+/* alloc06's own numbers: a 256 KiB first file, and "the rest" is free-256 KiB. */
+#define ENOSPC_SMALL     (256ULL * 1024)
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct dh                       dh;
+    struct chimera_vfs_open_handle *root, *h;
+    struct diskfs_test_space        sp;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fhlen;
+    uint64_t                        free_before, ask;
+    int                             r, boundary;
+
+    (void) argc;
+    (void) argv;
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    dh_init(&dh, ENOSPC_NDEV, ENOSPC_DEV_BYTES, ENOSPC_LOG_BYTES, 16384);
+
+    root = dh_root_handle(&dh);
+    CHECK(&dh);
+
+    /* alloc06 step 1: a small allocation that must succeed. */
+    r = dh_create(&dh, root, "small", fh, &fhlen, &h);
+    assert(r == CHIMERA_VFS_OK);
+    r = dh_allocate(&dh, h, 0, ENOSPC_SMALL, 0);
+    assert(r == CHIMERA_VFS_OK);
+    dh_release(&dh, h);
+    CHECK(&dh);
+
+    /* alloc06 step 2: everything still reported free, less 256 KiB. */
+    r = diskfs_test_space(dh.vfs, &sp);
+    assert(r == 0);
+    free_before = sp.ag_free_sum;
+    printf("free before boundary allocate: %" PRIu64 "\n", free_before);
+    printf("  total=%" PRIu64 " usable=%" PRIu64 " largest_extent=%" PRIu64
+           " fragments=%" PRIu64 " claims=%" PRIu64 " devs=%u ags=%u\n",
+           sp.total_capacity, sp.usable_capacity, sp.largest_free_extent,
+           sp.total_free_extents, sp.claim_bytes, sp.num_devices, sp.num_ags);
+    assert(free_before > ENOSPC_SMALL);
+    ask = free_before - ENOSPC_SMALL;
+
+    r = dh_create(&dh, root, "big", fh, &fhlen, &h);
+    assert(r == CHIMERA_VFS_OK);
+    boundary = dh_allocate(&dh, h, 0, ask, 0);
+    printf("boundary allocate of %" PRIu64 " bytes: %d\n", ask, boundary);
+
+    r = diskfs_test_space(dh.vfs, &sp);
+    assert(r == 0);
+    printf("free after boundary allocate: %" PRIu64 "\n", sp.ag_free_sum);
+
+    /* A failed allocate must leave the file exactly as it found it.  The
+     * allocator hands blocks out of a per-thread reservation and marks them
+     * used only when the transaction's redo retires, so a transaction that
+     * aborts leaves its blocks free -- while the extent records it wrote into
+     * the file's b+tree survive the abort (the block cache keeps the mutated
+     * nodes, it does not revert them).  The file then references space the
+     * allocator believes is free, which the next allocation can hand to
+     * somebody else and which double-frees the pool when the file is deleted.
+     * The full-stack version of that is chimera/posix/diskfs_enospc_*, which
+     * has the reclaim workers this harness does not run; here the allocator's
+     * own invariants and its free-space accounting are the oracle. */
+    dh_release(&dh, h);
+
+    /* Whatever the boundary allocation returned, the allocator must still be
+     * self-consistent -- and tearing the file down must free exactly what it
+     * allocated, no more.  A failed allocation that leaves an extent record
+     * behind for space it never committed double-frees here. */
+    CHECK(&dh);
+
+    assert(dh_remove(&dh, root, "big") == CHIMERA_VFS_OK);
+    assert(dh_remove(&dh, root, "small") == CHIMERA_VFS_OK);
+
+    diskfs_test_await_reclaim(dh.vfs, dh.evpl, 30000);
+    CHECK(&dh);
+
+    r = diskfs_test_space(dh.vfs, &sp);
+    assert(r == 0);
+    printf("free after delete: %" PRIu64 " (was %" PRIu64 ")\n",
+           sp.ag_free_sum, free_before);
+
+    /* This harness runs no reclaim workers, so the deleted files' space does
+     * not come back here -- what matters is the ceiling: the pool must never
+     * report more free than it has, which is what a rolled-back-but-still-
+     * referenced extent would eventually produce. */
+    assert(sp.ag_free_sum <= sp.usable_capacity);
+
+    /* The boundary allocation is *expected* to fall short today, and that is a
+     * second, separate defect: space that sits inside a live reservation claim
+     * is counted free by statfs but cannot be handed out, so a request for
+     * "everything free" hits ENOSPC with tens of megabytes still reported.  The
+     * claim_bytes line above is the evidence.  What this test gates is the
+     * failure *path*: hitting that ENOSPC must leave the allocator exactly as
+     * it found it.  When the accounting is fixed this becomes a hard assert.
+     */
+    if (boundary != CHIMERA_VFS_OK) {
+        printf("KNOWN GAP: reported %" PRIu64 " free but could not allocate "
+               "%" PRIu64 " (status %d) -- free space inside live claims\n",
+               free_before, ask, boundary);
+    }
+
+    dh_release(&dh, root);
+    dh_fini(&dh);
+    printf("PASS\n");
+    return 0;
+} /* main */


### PR DESCRIPTION
`nfstest_alloc` times out at its 900 s cap on both diskfs backends at NFSv4.2, in all four kvm nfstest shards, every extended run. It is not hanging — **the server aborts**, and every mount after that gets `ECONNREFUSED`, so each remaining subtest burns ~2 min in mount retry until ctest kills the shard. The crash sits past the 64 KiB JUnit truncation, which is why it read as a hang.

```
double-free or overlap at offset=133869568 (prev=21012480+113205248)
  sm_ag_free_locked <- space_map_free_apply <- diskfs_txn_apply_frees
  <- diskfs_il_apply_doorbell_cb
```

Byte-identical offsets on `diskfs_io_uring` and `diskfs_aio`, every run since at least 2026-09-08.

## Root cause

The suite's `alloc06` fallocates all but 256 KiB of the reported free space. diskfs places ~159 MB of it, cannot place more, and `diskfs_op_fail` aborts the transaction.

The reservation allocator hands blocks out of a per-thread bump reservation and marks them used only when the transaction's redo *retires*, so an aborted transaction correctly leaves every block it drew still free — `discard_allocs` touches nothing but the claim refcount. But abort did not roll back the **block cache**: `unpin_blocks` dropped the pins and marked the mutated blocks `CLEAN`, leaving the transaction's half-finished b+tree edits in the cache, indistinguishable from committed content.

So the file kept extent records for 159 MB the allocator counts as free. Deleting it sent the reclaim drainer over those extents and the first free applied landed inside an already-free extent. Tracing every bump-allocation and free confirms it — the six extents of the failing fallocate have no matching `alloc_apply`, and the drainer frees them anyway.

**The abort is the benign outcome.** The same phantom extents let the allocator hand those blocks to a second file.

## Fix

Each `txn_block` carries an undo image, taken in `diskfs_txn_add_block` before the caller writes into the block (every attach site claims or CoW-forks first and mutates after), copied back in `diskfs_txn_unpin_blocks`, which only the abort path reaches. The block list is LIFO, so a block attached more than once is restored newest-first and its oldest — true pre-txn — image lands last.

An undo image rather than dropping the cache entry: invalidation is wrong for a block in `LOGGED` state, whose committed content lives only in the intent log and not yet at its home offset, so discarding it would make the running system read a stale home image.

No measurable cost — the block-heavy 4000-file smoke test runs 30.5s / 31.2s with the copy and 31.0s / 31.1s without.

The transaction's in-memory *inode* scalars are still not rolled back. Every failure path that exists today bails out before stamping them (`diskfs_allocate_reserve_step` sets `inode->size` only once the whole reservation completes; `diskfs_write_redirect_alloc` fails before `write_finish_map` runs), so nothing is exposed, but the gap is now named in the comment rather than left implicit.

## Coverage

The allocator's out-of-space path had no in-process coverage, which is why this only ever surfaced in the nightly kvm shards. Reaching ENOSPC needs a bounded pool — every in-process suite mounts multiple gigabytes — so both new tests mount the same 2 x 128 MiB geometry the kvm wrapper already uses for `alloc06`:

- `chimera/vfs/diskfs/enospc_test` — quick tier, drives diskfs through the VFS on the `dh` harness, allocator invariants as the oracle.
- `chimera/posix/diskfs_enospc_diskfs*` — extended, full stack, so the reclaim drainer walks what the failed allocation left; asserts free space converges back to the pre-test baseline.

Both abort without the fix and pass with it, in ~2 s.

## Known gap left in place

The boundary allocation itself still falls short, and both tests log that as `KNOWN GAP` rather than failing: space held inside a live reservation claim is reported free by statfs but cannot be handed out, so asking for everything free hits ENOSPC with tens of megabytes still counted (8 MiB of claims in a 184 MB pool here). That is a separate defect, and it is what walks the code into the failure path above. When it is fixed the `KNOWN GAP` becomes a hard assertion.

## Verification

Built and run natively on macOS: both new tests pass, the full local quick tier is green (79/79 `ctest -R '/mbt|enospc|smoke_test'`), and disabling the memcpy makes both new tests abort again. Formatted with the pinned uncrustify 0.78.1; `etc/copyright-year.sh --check` clean.

**Not verified on Linux against the real io_uring/libaio backends** — the container this machine uses is out of disk. The defect is in backend-independent space-map and transaction code, and the portable pread backend reproduces it identically, but the matrix run is what will confirm it.
