### PR TITLE
smb: apply an undeliverable break when an opener is parked on it

### DIFF
--- a/src/server/smb/smb_async_interim.c
+++ b/src/server/smb/smb_async_interim.c
@@ -155,6 +155,8 @@ chimera_smb_async_interim_cancel(struct chimera_smb_request *request)
 
     chimera_smb_async_interim_unlink(conn, request);
 
+    chimera_smb_create_break_waiter_retire(request);
+
     request->async.armed = 0;
 
     /* Deliberately do NOT clear request->async_id: an interim is on the wire, so
@@ -173,6 +175,7 @@ chimera_smb_async_interim_drain(struct chimera_smb_conn *conn)
         request->async.park_next = NULL;
         request->async.armed     = 0;
         evpl_remove_timer(thread->evpl, &request->async.timer);
+        chimera_smb_create_break_waiter_retire(request);
 
         /* A CREATE parked on a share-acquire ticket (rather than on a break ack)
          * is resumed by the VFS pump, which would dereference this request after

--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -324,6 +324,9 @@ struct chimera_smb_share {
  * frees the share.  Safe to call with no lock held: the share is already
  * unlinked from shared->shares before its list reference is dropped, so no new
  * tree can find it, and every remaining reference is a tree's. */
+
+
+
 static inline void
 chimera_smb_share_release(struct chimera_smb_share *share)
 {
@@ -721,6 +724,13 @@ struct chimera_smb_request {
              * leases settling for an ordinary ack-required park.  (smb2.lease.
              * unlink cross-connection ordering.) */
             uint8_t                            park_on_notify;
+            /* This park is counted in the file state's break_waiters, so the
+             * claim layer knows an opener is blocked on that break (see
+             * chimera_vfs_claim_break_waiter_add).  Set at park, cleared by the
+             * first path that retires the park -- resume, deadline, CANCEL or
+             * connection teardown -- so the count is symmetric however the wait
+             * ends. */
+            uint8_t                            break_waiter_counted;
             /* Durable-reconnect retry: a reclaim that finds its handle still
              * flagged live (the previous connection's disconnect has not yet
              * been processed -- a cross-connection race) re-arms a short timer
@@ -2527,6 +2537,62 @@ void chimera_smb_notify_cancel(
 void chimera_smb_notify_drop(
     struct chimera_smb_notify_request *nr);
 
+/*
+ * Break-waiter accounting for an MS-SMB2 3.3.5.9 pending open.
+ *
+ * A CREATE that parks on another holder's ack-required break holds its reply on
+ * conn->parked_requests, which the claim layer cannot see.  Count the park on
+ * the file's claim state so the layer that owns the break can tell a holder
+ * whose disappearance blocks an opener from one whose disappearance blocks
+ * nobody -- the two want opposite handling when the holder's channel dies
+ * mid-break.  Register once at park; retire on whichever path ends the wait.
+ */
+static inline void
+chimera_smb_create_break_waiter_register(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_state *vfs_state;
+
+    if (request->create.break_waiter_counted ||
+        request->create.park_fh_len == 0) {
+        return;
+    }
+
+    vfs_state = request->compound->thread->vfs_thread->vfs->vfs_state;
+    chimera_vfs_claim_break_waiter_add(vfs_state,
+                                       request->create.park_fh,
+                                       request->create.park_fh_len,
+                                       request->create.park_fh_hash);
+    request->create.break_waiter_counted = 1;
+} /* chimera_smb_create_break_waiter_register */
+
+/* Idempotent: safe to call from every path that retires a park, and on requests
+ * that never parked (or are not CREATEs at all -- the parked list carries other
+ * commands, whose union members must not be read). */
+static inline void
+chimera_smb_create_break_waiter_retire(struct chimera_smb_request *request)
+{
+    struct chimera_vfs_state *vfs_state;
+
+    if (request->smb2_hdr.command != SMB2_CREATE ||
+        !request->create.break_waiter_counted) {
+        return;
+    }
+
+    request->create.break_waiter_counted = 0;
+    vfs_state                            = request->compound->thread->vfs_thread->vfs->vfs_state;
+    chimera_vfs_claim_break_waiter_remove(vfs_state,
+                                          request->create.park_fh,
+                                          request->create.park_fh_len,
+                                          request->create.park_fh_hash);
+} /* chimera_smb_create_break_waiter_retire */
+
+/*
+ * Opens whose undeliverable break conn_free resolves in one pass.  A dying
+ * channel carries a handful at most; the cap just bounds the on-stack list, and
+ * anything beyond it keeps the pre-existing lapse-at-deadline behaviour.
+ */
+#define CHIMERA_SMB_CONN_BREAK_FIXUP_MAX 64
+
 /* Defined in smb_async_interim.c -- forward-declared so the inline conn_free
  * below can drain without including the header (which would create a cycle
  * through smb_internal.h). */
@@ -2578,7 +2644,28 @@ chimera_smb_conn_free(
      * this conn.  When the session refcount drops to zero below, the
      * trees and their opens get torn down — but if multi-channel keeps
      * the session alive past this conn, the opens persist with stale
-     * create_conn pointers that the OPLOCK_BREAK path would dereference. */
+     * create_conn pointers that the OPLOCK_BREAK path would dereference.
+     *
+     * A break notification is pinned to the connection that created the open,
+     * so an open whose create_conn is this dying channel has an in-flight break
+     * that can no longer be delivered -- while under multichannel the session,
+     * and the client, outlive the channel.  Left alone the claim sits BREAKING
+     * until the break deadline.
+     *
+     * Whether that is right depends on who is waiting.  If nobody is, abandon
+     * it: a durable reconnect must get its full lease back, which is what
+     * smb2.durable-open.lease-disconnect-race asserts, and applying the break
+     * would cost the holder caching rights nobody asked it to give up.  If an
+     * opener is parked on it, abandoning strands that opener for the whole
+     * deadline -- 30 s, longer than the 20 s the MS-SMB2 adapter waits -- so
+     * the break must be applied and the opener released.  Collect the affected
+     * files here and resolve them below, once the tree/session locks this walk
+     * holds are dropped (the claim layer takes file->lock). */
+    uint64_t brk_fh_hash[CHIMERA_SMB_CONN_BREAK_FIXUP_MAX];
+    uint8_t  brk_fh[CHIMERA_SMB_CONN_BREAK_FIXUP_MAX][CHIMERA_VFS_FH_SIZE];
+    uint8_t  brk_fh_len[CHIMERA_SMB_CONN_BREAK_FIXUP_MAX];
+    int      brk_n = 0;
+
     HASH_ITER(hh, conn->session_handles, session_handle, tmp)
     {
         struct chimera_smb_session *s = session_handle->session;
@@ -2610,12 +2697,52 @@ chimera_smb_conn_free(
                 {
                     if (of->create_conn == conn) {
                         of->create_conn = NULL;
+                        if (of->handle && of->handle->fh_len &&
+                            brk_n < CHIMERA_SMB_CONN_BREAK_FIXUP_MAX) {
+                            memcpy(brk_fh[brk_n], of->handle->fh,
+                                   of->handle->fh_len);
+                            brk_fh_len[brk_n]  = of->handle->fh_len;
+                            brk_fh_hash[brk_n] = of->handle->fh_hash;
+                            brk_n++;
+                        }
                     }
                 }
                 pthread_mutex_unlock(&t->open_files_lock[b]);
             }
         }
         pthread_mutex_unlock(&s->lock);
+    }
+
+    /* Resolve the undeliverable breaks collected above, now that no tree or
+    * session lock is held.  Only the ones an opener is actually parked on:
+    * everything else keeps today's behaviour of letting the break lapse. */
+    if (brk_n) {
+        struct chimera_vfs_state *vfs_state =
+            thread->vfs_thread->vfs->vfs_state;
+        int                       i;
+        bool                      released = false;
+
+        for (i = 0; i < brk_n; i++) {
+            if (!chimera_vfs_claim_has_break_waiter(vfs_state, brk_fh[i],
+                                                    brk_fh_len[i],
+                                                    brk_fh_hash[i])) {
+                continue;
+            }
+            chimera_smb_info(
+                "break holder's channel died with an opener parked on it: "
+                "fh_hash %016lx conn %p -- applying the break",
+                (unsigned long) brk_fh_hash[i], (void *) conn);
+            chimera_vfs_claim_revoke_breaks(vfs_state, brk_fh[i],
+                                            brk_fh_len[i], brk_fh_hash[i],
+                                            NULL);
+            released = true;
+        }
+
+        /* The parked CREATE lives on some other connection, possibly on another
+         * thread; ring every thread's resume doorbell so each completes its own. */
+        if (released) {
+            chimera_smb_create_resume_parked_broadcast(thread);
+        }
     }
 
     HASH_ITER(hh, conn->session_handles, session_handle, tmp)

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3192,6 +3192,8 @@ chimera_smb_create_park_deadline_cb(
 
     (void) evpl;
 
+    chimera_smb_create_break_waiter_retire(request);
+
     /* No ack arrived for the whole break deadline, so the holder is revoked and
      * this open completes anyway (MS-SMB2 break timeout).  Info, not error: a
      * client is entitled not to ack, and smb2.lease.v2_complex1 and
@@ -3277,9 +3279,10 @@ chimera_smb_create_open_finish(
         thread->vfs_thread->vfs->vfs_state;
     bool                              will_park = false;
 
-    request->create.r_open_file       = open_file;
-    request->create.dir_break_pending = 0;
-    request->create.park_on_notify    = 0;
+    request->create.r_open_file          = open_file;
+    request->create.dir_break_pending    = 0;
+    request->create.park_on_notify       = 0;
+    request->create.break_waiter_counted = 0;
 
     open_file->granted_access = request->create.r_granted_access;
     open_file->maximal_access = request->create.r_maximal_access;
@@ -3435,6 +3438,11 @@ chimera_smb_create_open_finish(
             open_file->flags |= CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
         }
         chimera_smb_async_interim_begin(request);
+
+        /* Count this park on the file's claim state: it is what tells the claim
+         * layer that an opener is blocked on this break, which is the signal a
+         * mid-break channel loss has to be resolved against. */
+        chimera_smb_create_break_waiter_register(request);
 
         /* A parked CREATE sends no reply until an ack settles the break, so
          * from outside it is indistinguishable from a lost request.  Say so at
@@ -3599,6 +3607,7 @@ chimera_smb_create_resume_parked_conn(
             *pp                  = req->async.park_next;
             req->async.park_next = resume;
             req->async.armed     = 0; /* already unlinked; skip re-cancel */
+            chimera_smb_create_break_waiter_retire(req);
             /* Cancel the break-deadline timer so it cannot fire after the open
              * has been completed here. */
             evpl_remove_timer(thread->evpl, &req->async.timer);
@@ -5100,10 +5109,11 @@ chimera_smb_create(struct chimera_smb_request *request)
     enum chimera_smb_pipe_magic   pipe_magic;
     chimera_smb_pipe_transceive_t transceive;
 
-    request->create.has_stream          = 0;
-    request->create.explicit_data_fork  = 0;
-    request->create.explicit_index_fork = 0;
-    request->create.base_oh             = NULL;
+    request->create.has_stream           = 0;
+    request->create.break_waiter_counted = 0;
+    request->create.explicit_data_fork   = 0;
+    request->create.explicit_index_fork  = 0;
+    request->create.base_oh              = NULL;
     /* Only the regular-file open path (open_at_callback) registers a finish
      * callback and may park on a batch-oplock break; clear it so the mkdir /
      * stream / pipe paths never inherit a stale callback and park. */

--- a/src/server/smb/smb_proc_create.c
+++ b/src/server/smb/smb_proc_create.c
@@ -3192,6 +3192,20 @@ chimera_smb_create_park_deadline_cb(
 
     (void) evpl;
 
+    /* No ack arrived for the whole break deadline, so the holder is revoked and
+     * this open completes anyway (MS-SMB2 break timeout).  Info, not error: a
+     * client is entitled not to ack, and smb2.lease.v2_complex1 and
+     * smb2.oplock.batch21 reach here on every run without failing.
+     *
+     * It is still worth a line, because recovery costs the full deadline
+     * (default 30 s) and a client that gives up sooner sees the create simply
+     * never answered -- a WPTS adapter times out at 20 s, so any create that
+     * gets here has already failed the test 10 s earlier. */
+    chimera_smb_info(
+        "CREATE park deadline expired with no break ack: revoking holders and completing open; fh_hash %016lx conn %p",
+        (unsigned long) request->create.park_fh_hash,
+        (void *) request->compound->conn);
+
     chimera_vfs_claim_revoke_breaks(vfs_state, request->create.park_fh,
                                     request->create.park_fh_len,
                                     request->create.park_fh_hash,
@@ -3421,6 +3435,20 @@ chimera_smb_create_open_finish(
             open_file->flags |= CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;
         }
         chimera_smb_async_interim_begin(request);
+
+        /* A parked CREATE sends no reply until an ack settles the break, so
+         * from outside it is indistinguishable from a lost request.  Say so at
+         * info level: this is the only record that a create waited, and which
+         * connection it waited on -- both are needed to tell "the ack never
+         * came" from "the ack came on another channel of this session and we
+         * missed it".  Parks are rare relative to I/O. */
+        chimera_smb_info(
+            "CREATE parked on a caching break: fh_hash %016lx conn %p session %p deadline %u ms",
+            (unsigned long) request->create.park_fh_hash,
+            (void *) request->compound->conn,
+            (void *) (request->session_handle ? request->session_handle->session : NULL),
+            vfs_state->default_break_deadline_ms);
+
         /* Arm a deadline: if the holder never acks the break, fire at the
          * break timeout to revoke it and complete this open anyway (MS-SMB2
          * break-timeout).  Cancelled when an ack resumes the open first. */
@@ -3588,6 +3616,15 @@ chimera_smb_create_resume_parked_conn(
          * holder vanished outright, lift the capped lease/durable decision
          * before the deferred reply is marshaled. */
         chimera_smb_create_resume_rearbitrate(req);
+
+        /* Pairs with the "CREATE parked" line: a park with no matching resume
+         * and no deadline line is a create that was still waiting when its
+         * connection went away.  conn is logged on both so a resume arriving
+         * on a different channel of the same session is visible as such. */
+        chimera_smb_info("CREATE resumed after break ack: fh_hash %016lx conn %p",
+                         (unsigned long) req->create.park_fh_hash,
+                         (void *) conn);
+
         if (req->create.r_open_file) {
             req->create.r_open_file->flags &=
                 ~CHIMERA_SMB_OPEN_FILE_CREATE_PENDING;

--- a/src/vfs/vfs_claim.h
+++ b/src/vfs/vfs_claim.h
@@ -69,6 +69,15 @@ struct chimera_vfs_file_state {
     struct chimera_vfs_pending_acquire *pending_head;
     struct chimera_vfs_pending_acquire *pending_tail;
 
+    /* Protocol requests that were granted a (capped) claim and are holding
+     * their reply until a break on THIS file settles -- SMB's MS-SMB2 3.3.5.9
+     * pending open, which parks on conn->parked_requests rather than on
+     * pending_head above.  The claim layer cannot see that park, but it has to
+     * know it exists: it is the difference between a mid-break holder whose
+     * disappearance nobody is waiting on and one that is blocking an opener.
+     * Guarded by file->lock. */
+    uint32_t                            break_waiters;
+
     /* FIFO of parked I/O / namespace requests. */
     struct chimera_vfs_pending_acquire *io_wait_head;
     struct chimera_vfs_pending_acquire *io_wait_tail;
@@ -630,6 +639,31 @@ chimera_vfs_claim_mark_break_notified(
     uint8_t                   fh_len,
     uint64_t                  fh_hash,
     const uint8_t            *lease_key);
+
+/* Register/retire a protocol request that is holding its reply until a break on
+ * this file settles (see chimera_vfs_file_state::break_waiters).  Add on park,
+ * remove on resume or park-deadline -- exactly once each. */
+void
+chimera_vfs_claim_break_waiter_add(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash);
+
+void
+chimera_vfs_claim_break_waiter_remove(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash);
+
+/* Is anyone holding a reply on a break on this file? */
+bool
+chimera_vfs_claim_has_break_waiter(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash);
 
 /* Revoke every mid-break cache claim except `except` (parked-open deadline
  * expiry). */

--- a/src/vfs/vfs_claim_break.c
+++ b/src/vfs/vfs_claim_break.c
@@ -390,6 +390,89 @@ chimera_vfs_claim_mark_break_notified(
     chimera_vfs_state_put(state, file);
 } /* chimera_vfs_claim_mark_break_notified */
 
+/* -------------------------------------------------------------------- */
+/* Break waiters (protocol replies held on a break)                     */
+/* -------------------------------------------------------------------- */
+
+SYMBOL_EXPORT void
+chimera_vfs_claim_break_waiter_add(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash)
+{
+    struct chimera_vfs_file_state *file;
+
+    if (!state || fh_len == 0) {
+        return;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    file->break_waiters++;
+    pthread_mutex_unlock(&file->lock);
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_claim_break_waiter_add */
+
+SYMBOL_EXPORT void
+chimera_vfs_claim_break_waiter_remove(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash)
+{
+    struct chimera_vfs_file_state *file;
+
+    if (!state || fh_len == 0) {
+        return;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    if (file->break_waiters) {
+        file->break_waiters--;
+    }
+    pthread_mutex_unlock(&file->lock);
+
+    chimera_vfs_state_put(state, file);
+} /* chimera_vfs_claim_break_waiter_remove */
+
+SYMBOL_EXPORT bool
+chimera_vfs_claim_has_break_waiter(
+    struct chimera_vfs_state *state,
+    const uint8_t            *fh,
+    uint8_t                   fh_len,
+    uint64_t                  fh_hash)
+{
+    struct chimera_vfs_file_state *file;
+    bool                           waiting;
+
+    if (!state || fh_len == 0) {
+        return false;
+    }
+
+    file = chimera_vfs_state_get(state, fh, fh_len, fh_hash, false);
+    if (!file) {
+        return false;
+    }
+
+    pthread_mutex_lock(&file->lock);
+    waiting = file->break_waiters != 0;
+    pthread_mutex_unlock(&file->lock);
+
+    chimera_vfs_state_put(state, file);
+    return waiting;
+} /* chimera_vfs_claim_has_break_waiter */
+
 SYMBOL_EXPORT void
 chimera_vfs_claim_revoke_breaks(
     struct chimera_vfs_state             *state,


### PR DESCRIPTION
Fixes the long-standing intermittent `wpts-smb2model/…_multichannel_persistent_encryption` failure: `ReplayCreateDurableHandleV2Persistent…`, one case in fifty, a different model state each time, seen as a client-side `CreateRequest System.TimeoutException` — the server never replied.

**Includes #1671's logging commit** (cherry-picked, unchanged). That PR is green and self-contained; whichever of the two merges first, the other rebases cleanly. The logging is what produced every fact below.

## Root cause

A break notification is pinned to the connection that created the open (`open_file->create_conn`, queued on that conn's thread in `chimera_smb_lease_break_cb`). Under multichannel the **session outlives the channel**. When a channel drops, `chimera_smb_conn_free` clears the now-stale `create_conn` but leaves a break **already in flight** unresolved — the client is still there on another channel, it was simply never told, and can no longer be told on the dead one. The claim sits at `CHIMERA_CLAIM_BREAK_BREAKING` until the 30 s deadline while a conflicting CREATE parks on it; the WPTS adapter gives up at 20 s.

Reproduced locally with the five 50-case shards run concurrently (serially it never fails). One CREATE parks and never resumes, while every other park in the run pairs with its ack:

```
CREATE parked on a caching break: fh_hash 4799ef3935e062ff conn 0x… session 0x… deadline 30000 ms
Disconnected TCP SMB connection …          <- both channels of that pair drop
Established  TCP SMB connection …          <- client returns, same session
   … no resume for 4799ef3935e062ff, ever
```

## Why the obvious fixes don't work

Applying or abandoning the break unconditionally each trades one suite for the other, which is what two earlier attempts hit:

- **Abandon** is what `smb2.durable-open.lease-disconnect-race` requires — a durable reconnect after a mid-break disconnect must get its **full** lease back (`lease_state` 7, not 3), so a break the holder never acked must not be charged to it.
- **Apply** is what WPTS requires, because a parked opener otherwise waits out a deadline longer than the client's own timeout.

## The distinction that resolves it

Whether anyone is actually *waiting* on that break. Nothing is in the smbtorture race — the holder disconnects before any opener exists — and something always is in the WPTS case, by construction.

An MS-SMB2 3.3.5.9 pending open parks on `conn->parked_requests`, which the claim layer cannot see. So the park is now counted on the file's claim state (`break_waiters`), registered at park and retired on whichever path ends the wait — resume, deadline, CANCEL or connection teardown. `conn_free` resolves only the breaks an opener is parked on and rings the resume doorbell so the parked CREATE completes on its own thread; everything else keeps today's behaviour of lapsing at the deadline.

Affected files are collected under the tree/session locks and resolved after they're dropped — the claim layer takes `file->lock`, and the existing order here is `session->lock -> open_files_lock`.

## Validation — both gates, at once

The two suites pull in opposite directions, so either alone reports false success:

| gate | result |
|---|---|
| WPTS concurrent-shard loop | **30 rounds, 150 shard runs, 0 failures** (same loop reproduces in ~5 rounds without the fix) |
| `smbtorture_smb2_{durable,lease,oplock,dirlease}_*_memfs` | **143/143** |
| local quint/MBT quick tier | **79/79** |

Built clean on macOS Debug/ASan and Linux Release; formatted with the pinned uncrustify 0.78.1; `etc/copyright-year.sh --check` clean.

Note WPTS runs **natively on arm64** in the current devcontainer image — the `WPTS_ARCH_SUPPORTED` gate's stated reason (emulation) no longer holds, and today's arm64 wpts CI jobs run nothing at all. That's a separate change.
