### PR TITLE
vfs: store native Windows SIDs across the VFS boundary

### DIFF
--- a/docs/vfs-module-sdk.md
+++ b/docs/vfs-module-sdk.md
@@ -51,8 +51,9 @@ xxhash comes from the system (`libxxhash-dev` / `xxhash`).
 | `vfs_log.h` | `chimera_vfs_debug/info/error/fatal/abort` macros, self-contained |
 | `vfs_fh.h` | **The file-handle routing contract** (see below) and the encoders that satisfy it |
 | `vfs_varint.h` | Varint primitives the inum-style file-handle encoders are built on |
-| `vfs_acl.h` | `struct chimera_acl` / `struct chimera_ace` — the canonical ACL carried by `chimera_vfs_attrs.va_acl` |
-| `vfs_acl_serialize.h` | Stable, versioned encoding of a `chimera_acl` for a backend's own persistence |
+| `vfs_sid.h` | `struct chimera_sid`, the native Windows SID value type (MS-DTYP binary form) carried on ACL principals and on the owner/group attrs, plus its binary/string codec and the owner/group SID pair record codec the native backends persist |
+| `vfs_acl.h` | `struct chimera_acl` / `struct chimera_ace` — the canonical ACL carried by `chimera_vfs_attrs.va_acl`; each principal pairs a numeric uid/gid with an optional native SID |
+| `vfs_acl_serialize.h` | Stable, versioned encoding of a `chimera_acl` for a backend's own persistence (v2 adds the per-ACE native SID; v1 blobs still decode) |
 | `vfs_access.h` | Access-mask evaluation, so `ACCESS` answers agree across backends |
 | `vfs_xattr_name.h` | The protocol-exported `user.` xattr keyspace NFS and SMB both normalize into |
 | `vfs_tcp_flavor.h` | `enum chimera_tcp_flavor`, the value `chimera_vfs_request_tcp_flavor` returns |
@@ -126,6 +127,12 @@ The SDK contract is versioned by `CHIMERA_VFS_SDK_VERSION`
 binary fails loudly at load time instead of misinterpreting the request
 structures.  Any incompatible change to an SDK header — struct layout,
 enum values, capability semantics — must bump the version.
+
+Version history: 1 was the initial SDK; 2 widened
+`struct chimera_principal` with an inline native SID, added
+`CHIMERA_PRINCIPAL_SID`, and added the `va_owner_sid` / `va_group_sid`
+attrs and their `CHIMERA_VFS_ATTR_OWNER_SID` / `GROUP_SID` bits.  A module
+built against version 1 must be rebuilt.
 
 The `struct chimera_vfs_request` layout is exposed in full and is
 therefore ABI-stable only within an SDK version.  A public-head /

--- a/src/server/nfs/nfs4_attr.h
+++ b/src/server/nfs/nfs4_attr.h
@@ -1233,6 +1233,11 @@ chimera_nfs4_unmarshall_attrs(
 
                 is_group = !!(flag & CHIMERA_ACE_FLAG_IDENTIFIER_GROUP);
 
+                /* acl_buf comes from the request's bump allocator, which is
+                 * never cleared, and an ACE is compared and stored by value:
+                 * zero it so the principal's reserved byte and native-SID
+                 * tail are defined, not whatever the previous RPC left. */
+                memset(&acl_buf->aces[i], 0, sizeof(acl_buf->aces[i]));
                 acl_buf->aces[i].type        = (uint16_t) type;
                 acl_buf->aces[i].flags       = (uint16_t) flag;
                 acl_buf->aces[i].access_mask = mask;

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -15,6 +15,7 @@ add_compile_definitions(_LGPL_SOURCE)
 
 add_library(chimera_vfs SHARED vfs.c vfs_lsan.c vfs_cred.c vfs_sdk_utils.c
             vfs_acl.c vfs_acl_serialize.c vfs_access.c vfs_idmap.c vfs_identity.c
+            vfs_sid.c
             vfs_proc_mount.c vfs_proc_umount.c
             vfs_proc_mkfs.c vfs_proc_rmfs.c
             vfs_proc_mkdir_at.c vfs_proc_mknod_at.c vfs_proc_close.c vfs_proc_open_fh.c

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -985,12 +985,10 @@ cairn_load_acl(
  */
 /*
  * Native owner / group SID record (CAIRN_KEY_SID): the SID companions to the
- * inode's uid / gid.  Value layout: u8 owner_len, owner bytes, u8 group_len,
- * group bytes; a zero length means none is known.  The record is absent when
- * neither SID is known.
+ * inode's uid / gid, in the pair record format shared with diskfs
+ * (chimera_sid_pair_encode / chimera_sid_pair_decode, vfs_sid.h).  The record
+ * is absent when neither SID is known.
  */
-#define CAIRN_SID_REC_MAX (2 + 2 * CHIMERA_SID_MAX_LEN)
-
 static inline void
 cairn_remove_sids(
     struct cairn_thread *thread,
@@ -1017,23 +1015,14 @@ cairn_put_sids(
     rocksdb_transaction_t *txn = cairn_get_meta_txn(thread);
     char                  *err = NULL;
     struct cairn_sid_key   key;
-    uint8_t                buf[CAIRN_SID_REC_MAX];
-    int                    len = 0;
+    uint8_t                buf[CHIMERA_SID_PAIR_MAX];
+    int                    len = chimera_sid_pair_encode(owner, group, buf,
+                                                         sizeof(buf));
 
-    if (!chimera_sid_present(owner) && !chimera_sid_present(group)) {
+    if (len <= 0) {
+        /* Neither SID present: no record should exist. */
         cairn_remove_sids(thread, inum);
         return;
-    }
-
-    buf[len++] = chimera_sid_present(owner) ? owner->len : 0;
-    if (chimera_sid_present(owner)) {
-        memcpy(buf + len, owner->data, owner->len);
-        len += owner->len;
-    }
-    buf[len++] = chimera_sid_present(group) ? group->len : 0;
-    if (chimera_sid_present(group)) {
-        memcpy(buf + len, group->data, group->len);
-        len += group->len;
     }
 
     key.keytype = CAIRN_KEY_SID;
@@ -1062,8 +1051,9 @@ cairn_load_sids(
     size_t                   len;
     int                      found = 0;
 
-    owner->len = 0;
-    group->len = 0;
+    /* Both outputs are fully defined whether or not a record exists. */
+    memset(owner, 0, sizeof(*owner));
+    memset(group, 0, sizeof(*group));
 
     key.keytype = CAIRN_KEY_SID;
     key.inum    = inum;
@@ -1073,26 +1063,14 @@ cairn_load_sids(
 
     if (slice) {
         blob = (const uint8_t *) rocksdb_pinnableslice_value(slice, &len);
-        if (len >= 1) {
-            uint8_t olen = blob[0];
-
-            if (olen && 1 + olen <= len &&
-                chimera_sid_from_bin(owner, blob + 1, olen) == (int) olen &&
-                1 + olen < len) {
-                uint8_t glen = blob[1 + olen];
-
-                if (glen && 2 + olen + glen <= len) {
-                    chimera_sid_from_bin(group, blob + 2 + olen, glen);
-                }
-            } else if (!olen && len >= 2) {
-                uint8_t glen = blob[1];
-
-                if (glen && 2 + glen <= len) {
-                    chimera_sid_from_bin(group, blob + 2, glen);
-                }
-            }
-            found = 1;
+        /* A record longer than the codec's maximum is corrupt past the point
+         * the decoder reads; clamp so the length fits an int and let the
+         * decoder ignore the tail. */
+        if (len > CHIMERA_SID_PAIR_MAX) {
+            len = CHIMERA_SID_PAIR_MAX;
         }
+        chimera_sid_pair_decode(blob, (int) len, owner, group);
+        found = 1;
         rocksdb_pinnableslice_destroy(slice);
     }
 

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -2379,8 +2379,8 @@ cairn_setattr(
         if (orig_set_mask & (CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID |
                              CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
             struct chimera_sid owner, group;
-            int                had     = cairn_load_sids(thread, inode->inum,
-                                                         &owner, &group);
+            int                had = cairn_load_sids(thread, inode->inum,
+                                                     &owner, &group);
             int                changed = 0;
 
             if (orig_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) {

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -52,6 +52,7 @@ void rocksdb_flush_wal(
 #define CAIRN_KEY_ACL            7
 #define CAIRN_KEY_FS             8
 #define CAIRN_KEY_PNFS           9
+#define CAIRN_KEY_SID            10
 
 /*
  * Storage layout:
@@ -135,6 +136,13 @@ struct cairn_acl_key {
  * on every lookup.  Cairn neither produces nor interprets the contents -- the
  * NFS server packs a deviceid plus a backing filehandle in there. */
 struct cairn_pnfs_key {
+    uint8_t  keytype;
+    uint64_t inum;
+} __attribute__((packed));
+
+/* Native owner / group SIDs, kept in a record separate from the
+ * ACL so "no ACL record" still means "mode-derived DACL". */
+struct cairn_sid_key {
     uint8_t  keytype;
     uint64_t inum;
 } __attribute__((packed));
@@ -975,6 +983,154 @@ cairn_load_acl(
  * if present, else one synthesised from the inode mode.  Uses a per-thread
  * scratch buffer valid for the duration of the (synchronous) completion.
  */
+/*
+ * Native owner / group SID record (CAIRN_KEY_SID): the SID companions to the
+ * inode's uid / gid.  Value layout: u8 owner_len, owner bytes, u8 group_len,
+ * group bytes; a zero length means none is known.  The record is absent when
+ * neither SID is known.
+ */
+#define CAIRN_SID_REC_MAX (2 + 2 * CHIMERA_SID_MAX_LEN)
+
+static inline void
+cairn_remove_sids(
+    struct cairn_thread *thread,
+    uint64_t             inum)
+{
+    rocksdb_transaction_t *txn = cairn_get_meta_txn(thread);
+    char                  *err = NULL;
+    struct cairn_sid_key   key;
+
+    key.keytype = CAIRN_KEY_SID;
+    key.inum    = inum;
+
+    rocksdb_transaction_delete(txn, (const char *) &key, sizeof(key), &err);
+    chimera_cairn_abort_if(err, "Error deleting sids: %s\n", err);
+} /* cairn_remove_sids */
+
+static inline void
+cairn_put_sids(
+    struct cairn_thread      *thread,
+    uint64_t                  inum,
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group)
+{
+    rocksdb_transaction_t *txn = cairn_get_meta_txn(thread);
+    char                  *err = NULL;
+    struct cairn_sid_key   key;
+    uint8_t                buf[CAIRN_SID_REC_MAX];
+    int                    len = 0;
+
+    if (!chimera_sid_present(owner) && !chimera_sid_present(group)) {
+        cairn_remove_sids(thread, inum);
+        return;
+    }
+
+    buf[len++] = chimera_sid_present(owner) ? owner->len : 0;
+    if (chimera_sid_present(owner)) {
+        memcpy(buf + len, owner->data, owner->len);
+        len += owner->len;
+    }
+    buf[len++] = chimera_sid_present(group) ? group->len : 0;
+    if (chimera_sid_present(group)) {
+        memcpy(buf + len, group->data, group->len);
+        len += group->len;
+    }
+
+    key.keytype = CAIRN_KEY_SID;
+    key.inum    = inum;
+
+    rocksdb_transaction_put(txn, (const char *) &key, sizeof(key),
+                            (const char *) buf, len, &err);
+    chimera_cairn_abort_if(err, "Error putting sids: %s\n", err);
+} /* cairn_put_sids */
+
+/*
+ * Load the stored owner / group SIDs for `inum`; each output is cleared when
+ * it is not recorded.  Returns 1 if a record was found, 0 otherwise.
+ */
+static inline int
+cairn_load_sids(
+    struct cairn_thread *thread,
+    uint64_t             inum,
+    struct chimera_sid  *owner,
+    struct chimera_sid  *group)
+{
+    rocksdb_pinnableslice_t *slice;
+    struct cairn_sid_key     key;
+    char                    *err = NULL;
+    const uint8_t           *blob;
+    size_t                   len;
+    int                      found = 0;
+
+    owner->len = 0;
+    group->len = 0;
+
+    key.keytype = CAIRN_KEY_SID;
+    key.inum    = inum;
+
+    slice = cairn_meta_get_pinned(thread, &key, sizeof(key), &err);
+    chimera_cairn_abort_if(err, "Error getting sids: %s\n", err);
+
+    if (slice) {
+        blob = (const uint8_t *) rocksdb_pinnableslice_value(slice, &len);
+        if (len >= 1) {
+            uint8_t olen = blob[0];
+
+            if (olen && 1 + olen <= len &&
+                chimera_sid_from_bin(owner, blob + 1, olen) == (int) olen &&
+                1 + olen < len) {
+                uint8_t glen = blob[1 + olen];
+
+                if (glen && 2 + olen + glen <= len) {
+                    chimera_sid_from_bin(group, blob + 2 + olen, glen);
+                }
+            } else if (!olen && len >= 2) {
+                uint8_t glen = blob[1];
+
+                if (glen && 2 + glen <= len) {
+                    chimera_sid_from_bin(group, blob + 2, glen);
+                }
+            }
+            found = 1;
+        }
+        rocksdb_pinnableslice_destroy(slice);
+    }
+
+    return found;
+} /* cairn_load_sids */
+
+/*
+ * Populate attr->va_owner_sid / va_group_sid when requested and stored, from
+ * per-thread scratch valid for the duration of the (synchronous) completion.
+ */
+static inline void
+cairn_map_sids(
+    struct cairn_thread      *thread,
+    struct chimera_vfs_attrs *attr,
+    const struct cairn_inode *inode)
+{
+    static __thread struct chimera_sid owner_scratch;
+    static __thread struct chimera_sid group_scratch;
+
+    if (!(attr->va_req_mask & (CHIMERA_VFS_ATTR_OWNER_SID |
+                               CHIMERA_VFS_ATTR_GROUP_SID))) {
+        return;
+    }
+
+    if (!cairn_load_sids(thread, inode->inum, &owner_scratch, &group_scratch)) {
+        return;
+    }
+
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_OWNER_SID) && owner_scratch.len) {
+        attr->va_owner_sid = &owner_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    }
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_GROUP_SID) && group_scratch.len) {
+        attr->va_group_sid = &group_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    }
+} /* cairn_map_sids */
+
 static inline void
 cairn_map_acl(
     struct cairn_thread      *thread,
@@ -983,6 +1139,9 @@ cairn_map_acl(
 {
     static __thread uint8_t scratch[CAIRN_ACL_STRUCT_SCRATCH];
     struct chimera_acl     *dst = (struct chimera_acl *) scratch;
+
+    /* The SID companions travel with the ACL everywhere it is mapped. */
+    cairn_map_sids(thread, attr, inode);
 
     if (!(attr->va_req_mask & CHIMERA_VFS_ATTR_ACL)) {
         return;
@@ -2212,6 +2371,52 @@ cairn_setattr(
                 cairn_put_acl(thread, inode->inum, new_acl);
             }
         }
+
+        /* Native owner / group SID coherence: an explicit OWNER_SID /
+         * GROUP_SID set stores (or clears) the companion; a bare chown /
+         * chgrp drops the stale one.  Load-modify-put on the SID record,
+         * which is separate from the ACL so a chown never touches the DACL. */
+        if (orig_set_mask & (CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID |
+                             CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+            struct chimera_sid owner, group;
+            int                had     = cairn_load_sids(thread, inode->inum,
+                                                         &owner, &group);
+            int                changed = 0;
+
+            if (orig_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) {
+                if (chimera_sid_present(sa->va_owner_sid)) {
+                    owner   = *sa->va_owner_sid;
+                    changed = 1;
+                } else if (owner.len) {
+                    owner.len = 0;
+                    changed   = 1;
+                }
+            } else if ((orig_set_mask & CHIMERA_VFS_ATTR_UID) && owner.len) {
+                owner.len = 0;
+                changed   = 1;
+            }
+
+            if (orig_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) {
+                if (chimera_sid_present(sa->va_group_sid)) {
+                    group   = *sa->va_group_sid;
+                    changed = 1;
+                } else if (group.len) {
+                    group.len = 0;
+                    changed   = 1;
+                }
+            } else if ((orig_set_mask & CHIMERA_VFS_ATTR_GID) && group.len) {
+                group.len = 0;
+                changed   = 1;
+            }
+
+            if (changed) {
+                if (owner.len || group.len) {
+                    cairn_put_sids(thread, inode->inum, &owner, &group);
+                } else if (had) {
+                    cairn_remove_sids(thread, inode->inum);
+                }
+            }
+        }
     }
 
     /* pNFS layout blob.  Keyed off orig_set_mask for the same reason the ACL
@@ -2590,6 +2795,7 @@ cairn_rmfs_delete_inode(
     struct cairn_symlink_key symlink_key;
     struct cairn_acl_key     acl_key;
     struct cairn_pnfs_key    pnfs_key;
+    struct cairn_sid_key     sid_key;
     struct cairn_xattr_key   xattr_start, *xattr_key;
     struct cairn_extent_key  extent_start, *extent_key;
     rocksdb_iterator_t      *iter;
@@ -2614,6 +2820,11 @@ cairn_rmfs_delete_inode(
     pnfs_key.inum    = inum;
     rocksdb_writebatch_delete(meta_batch,
                               (const char *) &pnfs_key, sizeof(pnfs_key));
+
+    sid_key.keytype = CAIRN_KEY_SID;
+    sid_key.inum    = inum;
+    rocksdb_writebatch_delete(meta_batch,
+                              (const char *) &sid_key, sizeof(sid_key));
 
     xattr_start.keytype = CAIRN_KEY_XATTR;
     xattr_start.inum    = inum;
@@ -3330,6 +3541,7 @@ cairn_remove_at(
             cairn_remove_inode(thread, inode);
             cairn_remove_acl(thread, inode->inum);
             cairn_remove_pnfs(thread, inode->inum);
+            cairn_remove_sids(thread, inode->inum);
         } else {
             cairn_put_inode(thread, inode);
         }
@@ -3910,6 +4122,7 @@ cairn_close(
         cairn_remove_inode(thread, inode);
         cairn_remove_acl(thread, inode->inum);
         cairn_remove_pnfs(thread, inode->inum);
+        cairn_remove_sids(thread, inode->inum);
     } else {
         cairn_put_inode(thread, inode);
     }
@@ -5065,6 +5278,7 @@ cairn_rename_at(
                     cairn_remove_inode(thread, existing_inode);
                     cairn_remove_acl(thread, existing_inode->inum);
                     cairn_remove_pnfs(thread, existing_inode->inum);
+                    cairn_remove_sids(thread, existing_inode->inum);
                 } else {
                     cairn_put_inode(thread, existing_inode);
                 }

--- a/src/vfs/cairn/cairn.c
+++ b/src/vfs/cairn/cairn.c
@@ -888,9 +888,10 @@ cairn_map_pnfs(
     rocksdb_pinnableslice_destroy(slice);
 } /* cairn_map_pnfs */
 
-/* Scratch big enough to (de)serialize the largest permitted ACL. */
+/* Scratch big enough to (de)serialize the largest permitted ACL, every ACE
+ * carrying a maximum-length native SID (the v2 encoding is variable). */
 #define CAIRN_ACL_SCRATCH        (CHIMERA_ACL_SERIAL_HDR + \
-                                  CHIMERA_ACL_MAX_ACES * CHIMERA_ACL_SERIAL_ACE)
+                                  CHIMERA_ACL_MAX_ACES * CHIMERA_ACL_SERIAL_ACE_MAX)
 #define CAIRN_ACL_STRUCT_SCRATCH (sizeof(struct chimera_acl) + \
                                   CHIMERA_ACL_MAX_ACES * sizeof(struct chimera_ace))
 

--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -200,7 +200,10 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
         CHIMERA_VFS_CAP_OPEN_FILE_REQUIRED |
         CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS |
         CHIMERA_VFS_CAP_READ_PLUS | CHIMERA_VFS_CAP_WRITE_SAME |
-        CHIMERA_VFS_CAP_CLONE_RANGE,
+        CHIMERA_VFS_CAP_CLONE_RANGE |
+        /* diskfs persists the canonical ACL (DISKFS_REC_ACL) and the native
+         * owner/group SIDs (DISKFS_REC_SID); advertise it like memfs/cairn. */
+        CHIMERA_VFS_CAP_ACL_NATIVE,
     .init           = diskfs_init,
     .destroy        = diskfs_destroy,
     .thread_init    = diskfs_thread_init,

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -82,6 +82,22 @@ diskfs_setattr_acl_inserted_cb(
     void                *private_data);
 
 static void
+diskfs_setattr_sids(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_setattr_sid_insert(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_setattr_acl(
+    struct chimera_vfs_request *request);
+
+static void
+diskfs_setattr_records(
+    struct chimera_vfs_request *request);
+
+static void
 diskfs_setattr_acl_insert(
     struct chimera_vfs_request *request);
 
@@ -358,6 +374,113 @@ diskfs_acl_serial_install(
 
 
 /*
+ * Native owner / group SID record codec (DISKFS_REC_SID): u8 owner_len,
+ * owner bytes, u8 group_len, group bytes; a zero length means unknown.
+ * Encode returns the record length, or -1 when neither SID is present (then
+ * no record should exist).  Decode clears whichever SID is not recorded.
+ */
+int
+diskfs_sid_rec_encode(
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group,
+    uint8_t                  *buf)
+{
+    int len = 0;
+
+    if (!chimera_sid_present(owner) && !chimera_sid_present(group)) {
+        return -1;
+    }
+    buf[len++] = chimera_sid_present(owner) ? owner->len : 0;
+    if (chimera_sid_present(owner)) {
+        memcpy(buf + len, owner->data, owner->len);
+        len += owner->len;
+    }
+    buf[len++] = chimera_sid_present(group) ? group->len : 0;
+    if (chimera_sid_present(group)) {
+        memcpy(buf + len, group->data, group->len);
+        len += group->len;
+    }
+    return len;
+} /* diskfs_sid_rec_encode */
+
+void
+diskfs_sid_rec_decode(
+    const uint8_t      *serial,
+    uint32_t            len,
+    struct chimera_sid *owner,
+    struct chimera_sid *group)
+{
+    uint32_t pos = 0;
+    uint8_t  olen, glen;
+
+    owner->len = 0;
+    group->len = 0;
+
+    if (!serial || len < 2) {
+        return;
+    }
+    olen = serial[pos++];
+    if (olen) {
+        if (pos + olen > len ||
+            chimera_sid_from_bin(owner, serial + pos, olen) != (int) olen) {
+            owner->len = 0;
+            return;
+        }
+        pos += olen;
+    }
+    if (pos >= len) {
+        return;
+    }
+    glen = serial[pos++];
+    if (glen && pos + glen <= len) {
+        chimera_sid_from_bin(group, serial + pos, glen);
+    }
+} /* diskfs_sid_rec_decode */
+
+/* Replace inode->sid_serial (mirror of the DISKFS_REC_SID record) with a
+ * copy of serial[0..len), or clear it when len < 0.  Caller holds the inode
+ * write lock. */
+void
+diskfs_sid_serial_install(
+    struct diskfs_inode *inode,
+    const uint8_t       *serial,
+    int                  len)
+{
+    free(inode->sid_serial);
+    inode->sid_serial     = NULL;
+    inode->sid_serial_len = 0;
+    if (len >= 0) {
+        inode->sid_serial = malloc(len);
+        memcpy(inode->sid_serial, serial, len);
+        inode->sid_serial_len = (uint32_t) len;
+    }
+} /* diskfs_sid_serial_install */
+
+/* Decode the SID record into per-thread scratch and point the requested
+ * attr companions at it (valid through the synchronous completion). */
+void
+diskfs_sid_decode_into(
+    struct chimera_vfs_attrs *attr,
+    const uint8_t            *serial,
+    uint32_t                  len)
+{
+    static __thread struct chimera_sid owner;
+    static __thread struct chimera_sid group;
+
+    diskfs_sid_rec_decode(serial, len, &owner, &group);
+
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_OWNER_SID) && owner.len) {
+        attr->va_owner_sid = &owner;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    }
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_GROUP_SID) && group.len) {
+        attr->va_group_sid = &group;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    }
+} /* diskfs_sid_decode_into */
+
+
+/*
  * Seed a freshly-created child's ACL (mirrors memfs/cairn).  Precedence:
  *   1. an explicit ACL supplied at create (e.g. an SMB SD via SecD) -> store
  *      it and re-derive the child mode (the caller snapshots new_acl from
@@ -387,7 +510,11 @@ diskfs_inherit_acl_async(
     int                       is_dir = S_ISDIR(child->mode);
     uint16_t                  want   = CHIMERA_ACE_FLAG_FILE_INHERIT |
         (is_dir ? CHIMERA_ACE_FLAG_DIR_INHERIT : 0);
-    uint8_t                   abuf[sizeof(struct chimera_acl) +
+    /* Per-thread scratch: an ACE now carries an inline SID, so these are
+     * too large to keep on the stack. */
+    static __thread uint8_t   abuf[sizeof(struct chimera_acl) +
+                                   DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
+    static __thread uint8_t   pbuf[sizeof(struct chimera_acl) +
                                    DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
     const struct chimera_acl *store       = NULL;
     int                       derive_mode = 0;
@@ -396,8 +523,6 @@ diskfs_inherit_acl_async(
         store       = new_acl;
         derive_mode = 1;
     } else {
-        uint8_t             pbuf[sizeof(struct chimera_acl) +
-                                 DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
         struct chimera_acl *parent_acl = (struct chimera_acl *) pbuf;
         int                 has_inh    = 0;
 
@@ -439,23 +564,36 @@ diskfs_inherit_acl_async(
         }
     }
 
-    if (store && store->num_aces && store->num_aces <= DISKFS_ACL_REC_MAX_ACES) {
-        uint8_t sbuf[DISKFS_ACL_REC_MAX];
-        int     len = chimera_acl_serialize(store, sbuf, sizeof(sbuf));
+    if (store && store->num_aces) {
+        if (chimera_acl_serialized_size(store) <= DISKFS_ACL_REC_MAX) {
+            uint8_t sbuf[DISKFS_ACL_REC_MAX];
+            int     len = chimera_acl_serialize(store, sbuf, sizeof(sbuf));
 
-        if (len >= 0) {
-            if (derive_mode) {
-                child->mode = (child->mode & CHIMERA_MODE_ACL_PRESERVE) |
-                    chimera_acl_to_mode(store);
+            if (len >= 0) {
+                if (derive_mode) {
+                    child->mode = (child->mode & CHIMERA_MODE_ACL_PRESERVE) |
+                        chimera_acl_to_mode(store);
+                }
+                diskfs_acl_serial_install(child, sbuf, len);
+                /* The child is brand new, so there is no existing record to
+                 * replace: a single insert suffices.  (It can still suspend --
+                 * the pre-descent split reservation may journal onto a cold
+                 * AG-log block.) */
+                return diskfs_bt_insert_async(op, thread, txn, child,
+                                              &diskfs_acl_key, sbuf, len,
+                                              cb, private_data);
             }
-            diskfs_acl_serial_install(child, sbuf, len);
-            /* The child is brand new, so there is no existing record to
-             * replace: a single insert suffices.  (It can still suspend --
-             * the pre-descent split reservation may journal onto a cold
-             * AG-log block.) */
-            return diskfs_bt_insert_async(op, thread, txn, child,
-                                          &diskfs_acl_key, sbuf, len,
-                                          cb, private_data);
+        } else {
+            /* An inherited ACL that outgrew the record must not make the new
+             * object unusable; it gets the mode-derived DACL, visibly.  (An
+             * explicit create-time ACL that does not fit is refused before
+             * the inode is allocated, in diskfs_namespace.c.) */
+            chimera_diskfs_error("inherited acl for inum %lu does not fit one "
+                                 "record (%zu > %zu bytes): storing the "
+                                 "mode-derived DACL instead",
+                                 (unsigned long) child->inum,
+                                 chimera_acl_serialized_size(store),
+                                 (size_t) DISKFS_ACL_REC_MAX);
         }
     }
 
@@ -509,15 +647,13 @@ diskfs_getattr(
 static void
 diskfs_setattr_trunc_done(struct chimera_vfs_request *request)
 {
-    struct diskfs_request_private *p      = request->plugin_data;
-    struct diskfs_thread          *thread = p->thread;
-    struct diskfs_inode           *inode  = p->inode_stash[0];
+    struct diskfs_request_private *p     = request->plugin_data;
+    struct diskfs_inode           *inode = p->inode_stash[0];
 
     /* POSIX: a successful (f)truncate marks the last data modification time.
      * Bump mtime unless the caller supplied an explicit mtime, or is an
      * AUTH_ATTR (SMB/Windows) caller managing the write time itself. */
-    int                            bump_mtime = !(request->setattr.set_attr->va_set_mask &
-                                                  CHIMERA_VFS_ATTR_MTIME) &&
+    int                            bump_mtime = !(p->setattr_mask & CHIMERA_VFS_ATTR_MTIME) &&
         request->cred->flavor != CHIMERA_VFS_AUTH_ATTR;
 
     diskfs_apply_attrs(inode, request->setattr.set_attr);
@@ -529,10 +665,13 @@ diskfs_setattr_trunc_done(struct chimera_vfs_request *request)
         inode->mtime_nsec = now.tv_nsec;
     }
 
-    diskfs_map_attrs(thread, &request->setattr.r_post_attr, inode);
-    chimera_diskfs_info("setattr trunc done inum=%lu new_size=%lu -> committing",
+    chimera_diskfs_info("setattr trunc done inum=%lu new_size=%lu -> records",
                         (unsigned long) inode->inum, (unsigned long) inode->size);
-    diskfs_op_ok(request, p->txn);
+    /* Same tail as the non-shrink path: SID mirror, then the pNFS, ACL and
+     * SID record replay, then the post attrs are mapped and the txn
+     * committed.  A shrink that also chowns or sets an ACL used to commit
+     * here directly and skip all of that. */
+    diskfs_setattr_records(request);
 } /* diskfs_setattr_trunc_done */
 
 
@@ -727,8 +866,9 @@ diskfs_setattr_finish(struct chimera_vfs_request *request)
 
 /*
  * Completion for a setattr that also persisted a pNFS layout blob: the
- * DISKFS_REC_PNFS record is now in the b+tree, so map the post attrs and
- * commit.
+ * DISKFS_REC_PNFS record is now in the b+tree; continue with the ACL and SID
+ * steps so a layout-carrying setattr gets the same coherence as any other,
+ * then the post attrs are mapped and the txn committed.
  */
 static void
 diskfs_setattr_pnfs_cb(
@@ -746,7 +886,7 @@ diskfs_setattr_pnfs_cb(
         return;
     }
 
-    diskfs_setattr_finish(request);
+    diskfs_setattr_acl(request);
 } /* diskfs_setattr_pnfs_cb */
 
 
@@ -800,7 +940,7 @@ diskfs_setattr_acl_inserted_cb(
 
     (void) result;
     diskfs_bt_op_free(p->thread, op);
-    diskfs_setattr_finish(request);
+    diskfs_setattr_sids(request);
 } /* diskfs_setattr_acl_inserted_cb */
 
 
@@ -813,7 +953,7 @@ diskfs_setattr_acl_insert(struct chimera_vfs_request *request)
 
     if (!inode->acl_serial) {
         /* Remove-only chain (revert to mode-derived). */
-        diskfs_setattr_finish(request);
+        diskfs_setattr_sids(request);
         return;
     }
 
@@ -839,6 +979,315 @@ diskfs_setattr_acl_removed_cb(
     diskfs_bt_op_free(p->thread, op);
     diskfs_setattr_acl_insert(request);
 } /* diskfs_setattr_acl_removed_cb */
+
+
+/*
+ * Native owner / group SID record replay (chain tail after the ACL steps):
+ * the inode's sid_serial mirror already holds the end state; replay it into
+ * the b+tree as decided by p->sid_action, then finish.  A b+tree error fails
+ * the request like the pNFS step does; note that, as for every step in this
+ * chain, the txn abort does not roll the in-memory mirror back, which is why
+ * anything that can be refused is refused before the mirrors are touched.
+ */
+static void
+diskfs_setattr_sid_inserted_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    diskfs_bt_op_free(p->thread, op);
+
+    if (unlikely(result < 0)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
+        return;
+    }
+
+    diskfs_setattr_finish(request);
+} /* diskfs_setattr_sid_inserted_cb */
+
+
+static void
+diskfs_setattr_sid_insert(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p     = request->plugin_data;
+    struct diskfs_inode           *inode = p->inode_stash[0];
+    struct diskfs_bt_op           *op;
+
+    if (!inode->sid_serial) {
+        diskfs_setattr_finish(request);
+        return;
+    }
+
+    op = diskfs_bt_op_alloc(p->thread);
+    if (diskfs_bt_insert_async(op, p->thread, p->txn, inode, &diskfs_sid_key,
+                               inode->sid_serial, inode->sid_serial_len,
+                               diskfs_setattr_sid_inserted_cb, request)) {
+        diskfs_setattr_sid_inserted_cb(op, op->result, request);
+    }
+} /* diskfs_setattr_sid_insert */
+
+
+static void
+diskfs_setattr_sid_removed_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct chimera_vfs_request    *request = private_data;
+    struct diskfs_request_private *p       = request->plugin_data;
+
+    diskfs_bt_op_free(p->thread, op);
+
+    if (unlikely(result < 0)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EIO);
+        return;
+    }
+    /* A remove that found no record (result 0) is not an error: for both
+     * REMOVE and REPLACE the end state asked for -- no record, or the one
+     * about to be inserted -- is unaffected by the tree having disagreed
+     * with the mirror. */
+
+    if (p->sid_action == DISKFS_SID_ACTION_REPLACE) {
+        diskfs_setattr_sid_insert(request);
+    } else {
+        diskfs_setattr_finish(request);
+    }
+} /* diskfs_setattr_sid_removed_cb */
+
+
+static void
+diskfs_setattr_sids(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p     = request->plugin_data;
+    struct diskfs_inode           *inode = p->inode_stash[0];
+    struct diskfs_bt_op           *op;
+
+    switch (p->sid_action) {
+        case DISKFS_SID_ACTION_INSERT:
+            diskfs_setattr_sid_insert(request);
+            return;
+        case DISKFS_SID_ACTION_REMOVE:
+        case DISKFS_SID_ACTION_REPLACE:
+            op = diskfs_bt_op_alloc(p->thread);
+            if (diskfs_bt_remove_async(op, p->thread, p->txn, inode,
+                                       &diskfs_sid_key,
+                                       diskfs_setattr_sid_removed_cb,
+                                       request)) {
+                diskfs_setattr_sid_removed_cb(op, op->result, request);
+            }
+            return;
+        default:
+            diskfs_setattr_finish(request);
+            return;
+    } /* switch */
+} /* diskfs_setattr_sids */
+
+
+/*
+ * ACL coherence step (mirrors memfs/cairn): an explicit ACL set is persisted
+ * and the mode re-derived; a bare chmod regenerates the special-who ACEs of
+ * any stored ACL while preserving named entries.  The new state is computed
+ * from the in-memory mirrors here and installed immediately; the async chain
+ * (remove the old record, insert the new one) replays it into the b+tree,
+ * then diskfs_setattr_sids replays the SID record and finishes.  Keys off
+ * p->setattr_mask: diskfs_apply_attrs has rewritten set_attr->va_set_mask.
+ */
+static void
+diskfs_setattr_acl(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private *p      = request->plugin_data;
+    struct diskfs_thread          *thread = p->thread;
+    struct diskfs_inode           *inode  = p->inode_stash[0];
+    uint64_t                       mask   = p->setattr_mask;
+    struct diskfs_bt_op           *op;
+
+    if (mask & CHIMERA_VFS_ATTR_ACL) {
+        const struct chimera_acl *acl     = request->setattr.set_attr->va_acl;
+        int                       had_old = inode->acl_serial != NULL;
+        uint8_t                   sbuf[DISKFS_ACL_REC_MAX];
+        int                       slen = -1;
+
+        if (acl && acl->num_aces) {
+            inode->mode = (inode->mode & CHIMERA_MODE_ACL_PRESERVE) |
+                chimera_acl_to_mode(acl);
+            /* Fits by construction: diskfs_acl_rec_fits was checked before
+             * anything was mutated. */
+            slen = chimera_acl_serialize(acl, sbuf, sizeof(sbuf));
+        }
+        diskfs_acl_serial_install(inode, sbuf, slen);
+
+        if (!had_old && slen < 0) {
+            /* No record before, none now: nothing to replay. */
+            diskfs_setattr_sids(request);
+            return;
+        }
+        if (had_old) {
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_bt_remove_async(op, thread, p->txn, inode,
+                                       &diskfs_acl_key,
+                                       diskfs_setattr_acl_removed_cb,
+                                       request)) {
+                diskfs_setattr_acl_removed_cb(op, op->result, request);
+            }
+        } else {
+            diskfs_setattr_acl_insert(request);
+        }
+        return;
+    } else if ((mask & CHIMERA_VFS_ATTR_MODE) && inode->acl_serial) {
+        static __thread uint8_t obuf[sizeof(struct chimera_acl) +
+                                     DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
+        static __thread uint8_t nbuf[sizeof(struct chimera_acl) +
+                                     DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
+        struct chimera_acl *old_acl = (struct chimera_acl *) obuf;
+        struct chimera_acl *new_acl = (struct chimera_acl *) nbuf;
+        uint8_t             sbuf[DISKFS_ACL_REC_MAX];
+        int                 slen;
+
+        if (chimera_acl_deserialize((const char *) inode->acl_serial,
+                                    inode->acl_serial_len, old_acl,
+                                    DISKFS_ACL_REC_MAX_ACES) >= 0 &&
+            chimera_acl_chmod(old_acl, inode->mode, new_acl,
+                              DISKFS_ACL_REC_MAX_ACES) >= 0 &&
+            (slen = chimera_acl_serialize(new_acl, sbuf, sizeof(sbuf))) >= 0) {
+
+            diskfs_acl_serial_install(inode, sbuf, slen);
+
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_bt_remove_async(op, thread, p->txn, inode,
+                                       &diskfs_acl_key,
+                                       diskfs_setattr_acl_removed_cb,
+                                       request)) {
+                diskfs_setattr_acl_removed_cb(op, op->result, request);
+            }
+            return;
+        }
+        /* Regeneration failed: leave the stored ACL untouched. */
+    }
+
+    diskfs_setattr_sids(request);
+} /* diskfs_setattr_acl */
+
+
+/*
+ * Common record tail, entered after diskfs_apply_attrs by every setattr path
+ * -- plain, shrink-after-extent-walk, and layout-carrying alike.  Updates the
+ * native owner/group SID mirror and decides its replay, then runs the pNFS ->
+ * ACL -> SID replay chain; diskfs_setattr_finish maps the post attrs and
+ * commits.  Keys off p->setattr_mask throughout, because set_attr->va_set_mask
+ * has already been rewritten to the scalar bits diskfs_apply_attrs applied.
+ */
+static void
+diskfs_setattr_records(struct chimera_vfs_request *request)
+{
+    struct diskfs_request_private  *p      = request->plugin_data;
+    struct diskfs_thread           *thread = p->thread;
+    struct diskfs_inode            *inode  = p->inode_stash[0];
+    const struct chimera_vfs_attrs *sa     = request->setattr.set_attr;
+    uint64_t                        mask   = p->setattr_mask;
+    struct diskfs_bt_op            *op;
+
+    /* Pooled request: never trust the previous life's value. */
+    p->sid_action = DISKFS_SID_ACTION_NONE;
+
+    /*
+     * Native owner / group SID coherence (mirrors memfs/cairn): an explicit
+     * OWNER_SID / GROUP_SID set stores (or clears) the companion; a bare chown
+     * or chgrp drops the stale one.  The mirror is updated here and the
+     * record replayed by diskfs_setattr_sids at the end of the chain, after
+     * the ACL steps, so both records are in the tree before post attrs map.
+     */
+    if (mask & (CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID |
+                CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+        struct chimera_sid owner, group;
+        int                had     = inode->sid_serial != NULL;
+        int                changed = 0;
+
+        diskfs_sid_rec_decode(inode->sid_serial, inode->sid_serial_len,
+                              &owner, &group);
+
+        if (mask & CHIMERA_VFS_ATTR_OWNER_SID) {
+            if (chimera_sid_present(sa->va_owner_sid)) {
+                owner   = *sa->va_owner_sid;
+                changed = 1;
+            } else if (owner.len) {
+                owner.len = 0;
+                changed   = 1;
+            }
+        } else if ((mask & CHIMERA_VFS_ATTR_UID) && owner.len) {
+            owner.len = 0;
+            changed   = 1;
+        }
+
+        if (mask & CHIMERA_VFS_ATTR_GROUP_SID) {
+            if (chimera_sid_present(sa->va_group_sid)) {
+                group   = *sa->va_group_sid;
+                changed = 1;
+            } else if (group.len) {
+                group.len = 0;
+                changed   = 1;
+            }
+        } else if ((mask & CHIMERA_VFS_ATTR_GID) && group.len) {
+            group.len = 0;
+            changed   = 1;
+        }
+
+        if (changed) {
+            uint8_t rec[DISKFS_SID_REC_MAX];
+            int     len = diskfs_sid_rec_encode(&owner, &group, rec);
+
+            diskfs_sid_serial_install(inode, rec, len);
+            if (len >= 0) {
+                p->sid_action = had ? DISKFS_SID_ACTION_REPLACE
+                                    : DISKFS_SID_ACTION_INSERT;
+            } else if (had) {
+                p->sid_action = DISKFS_SID_ACTION_REMOVE;
+            }
+        }
+    }
+
+    /* Persist the opaque pNFS layout blob as this inode's single PNFS record,
+     * replacing any previous one (the insert aborts on a duplicate key).  The
+     * in-memory mirror is installed up front; the chain replays it into the
+     * tree and then continues with the ACL and SID steps.
+     *
+     * p->setattr_mask, not set_attr->va_set_mask: diskfs_apply_attrs() has
+     * already rewritten the latter to what it applied, and it does not know
+     * about the pNFS blob -- so testing it silently dropped every blob a
+     * metadata server ever wrote.  A diskfs MDS then re-steered on each
+     * LAYOUTGET and handed the client a brand-new (empty) backing file,
+     * orphaning the data behind the previous one. */
+    if (mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) {
+        uint32_t blob_len = sa->va_pnfs_len;
+        int      had_old  = inode->pnfs_blob != NULL;
+
+        if (blob_len > CHIMERA_VFS_PNFS_LAYOUT_MAX) {
+            blob_len = CHIMERA_VFS_PNFS_LAYOUT_MAX;
+        }
+
+        free(inode->pnfs_blob);
+        inode->pnfs_blob = malloc(blob_len);
+        memcpy(inode->pnfs_blob, sa->va_pnfs, blob_len);
+        inode->pnfs_blob_len = blob_len;
+
+        if (had_old) {
+            op = diskfs_bt_op_alloc(thread);
+            if (diskfs_bt_remove_async(op, thread, p->txn, inode,
+                                       &diskfs_pnfs_key,
+                                       diskfs_setattr_pnfs_removed_cb,
+                                       request)) {
+                diskfs_setattr_pnfs_removed_cb(op, op->result, request);
+            }
+        } else {
+            diskfs_setattr_pnfs_insert(request);
+        }
+        return;
+    }
+
+    diskfs_setattr_acl(request);
+} /* diskfs_setattr_records */
 
 
 static void
@@ -869,6 +1318,26 @@ diskfs_setattr_inode_cb(
         return;
     }
 
+    /* An ACL is stored as one b+tree record.  Refuse one that cannot fit
+     * BEFORE anything is mutated (mode, mirrors, extents): the txn abort does
+     * not roll the in-memory inode back, so the refusal has to happen while
+     * there is nothing to roll back.  EFBIG is what Linux nfsd returns for an
+     * over-limit ACL (NFS4ERR_FBIG). */
+    if (!diskfs_acl_rec_fits(request->setattr.set_attr)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EFBIG);
+        return;
+    }
+
+    /* Stashed for every step from here on: both the truncate chain and the
+     * record tail run after diskfs_apply_attrs has rewritten
+     * set_attr->va_set_mask, and both key off the caller's mask. */
+    p->setattr_mask   = orig_mask;
+    p->inode_stash[0] = inode;
+    /* Not carried over from the pooled request's previous life: the trunc
+     * walk's ext_release acquires the refcount inode lazily on the first
+     * reflink-shared extent it frees, keyed on this being NULL. */
+    p->inode_stash[2] = NULL;
+
     diskfs_map_attrs(thread, &request->setattr.r_pre_attr, inode);
 
     /* POSIX kill-priv: truncation by an unprivileged caller clears
@@ -894,12 +1363,7 @@ diskfs_setattr_inode_cb(
         S_ISREG(inode->mode) &&
         request->setattr.set_attr->va_size < inode->size) {
 
-        p->inode_stash[0] = inode;
-        /* Not carried over from the pooled request's previous life: the trunc
-         * walk's ext_release acquires the refcount inode lazily on the first
-         * reflink-shared extent it frees, keyed on this being NULL. */
-        p->inode_stash[2] = NULL;
-        p->loop_off       = request->setattr.set_attr->va_size;
+        p->loop_off = request->setattr.set_attr->va_size;
 
         op = diskfs_bt_op_alloc(thread);
         if (diskfs_ext_floor_async(op, thread, inode, p->loop_off, p->rec_scratch,
@@ -927,119 +1391,7 @@ diskfs_setattr_inode_cb(
         inode->mtime_nsec = now.tv_nsec;
     }
 
-    p->inode_stash[0] = inode;
-    p->inode_stash[2] = NULL;   /* refcount inode (acquired lazily on shared free) */
-
-    /* Persist the opaque pNFS layout blob as this inode's single PNFS record,
-     * replacing any previous one (the insert aborts on a duplicate key).  The
-     * in-memory mirror is installed up front; the chain replays it into the
-     * tree.
-     *
-     * orig_mask, not set_attr->va_set_mask: diskfs_apply_attrs() has already
-     * rewritten the latter to what it applied, and it does not know about the
-     * pNFS blob -- so testing it silently dropped every blob a metadata server
-     * ever wrote.  A diskfs MDS then re-steered on each LAYOUTGET and handed
-     * the client a brand-new (empty) backing file, orphaning the data behind
-     * the previous one. */
-    if (orig_mask & CHIMERA_VFS_ATTR_PNFS_LAYOUT) {
-        uint32_t blob_len = request->setattr.set_attr->va_pnfs_len;
-        int      had_old  = inode->pnfs_blob != NULL;
-
-        if (blob_len > CHIMERA_VFS_PNFS_LAYOUT_MAX) {
-            blob_len = CHIMERA_VFS_PNFS_LAYOUT_MAX;
-        }
-
-        free(inode->pnfs_blob);
-        inode->pnfs_blob = malloc(blob_len);
-        memcpy(inode->pnfs_blob, request->setattr.set_attr->va_pnfs, blob_len);
-        inode->pnfs_blob_len = blob_len;
-
-        if (had_old) {
-            op = diskfs_bt_op_alloc(thread);
-            if (diskfs_bt_remove_async(op, thread, p->txn, inode,
-                                       &diskfs_pnfs_key,
-                                       diskfs_setattr_pnfs_removed_cb,
-                                       request)) {
-                diskfs_setattr_pnfs_removed_cb(op, op->result, request);
-            }
-        } else {
-            diskfs_setattr_pnfs_insert(request);
-        }
-        return;
-    }
-
-    /*
-     * ACL coherence (mirrors memfs/cairn): an explicit ACL set is persisted
-     * and the mode re-derived; a bare chmod regenerates the special-who ACEs
-     * of any stored ACL while preserving named entries.  The new state is
-     * computed from the in-memory mirrors here and installed immediately;
-     * the async chain (remove the old record, insert the new one) replays it
-     * into the b+tree before the post attrs are mapped.
-     */
-    if (orig_mask & CHIMERA_VFS_ATTR_ACL) {
-        const struct chimera_acl *acl     = request->setattr.set_attr->va_acl;
-        int                       had_old = inode->acl_serial != NULL;
-        uint8_t                   sbuf[DISKFS_ACL_REC_MAX];
-        int                       slen = -1;
-
-        if (acl && acl->num_aces) {
-            inode->mode = (inode->mode & CHIMERA_MODE_ACL_PRESERVE) |
-                chimera_acl_to_mode(acl);
-        }
-        if (acl && acl->num_aces && acl->num_aces <= DISKFS_ACL_REC_MAX_ACES) {
-            slen = chimera_acl_serialize(acl, sbuf, sizeof(sbuf));
-        }
-        diskfs_acl_serial_install(inode, sbuf, slen);
-
-        if (!had_old && slen < 0) {
-            /* No record before, none now: nothing to replay. */
-            diskfs_setattr_finish(request);
-            return;
-        }
-        if (had_old) {
-            op = diskfs_bt_op_alloc(thread);
-            if (diskfs_bt_remove_async(op, thread, p->txn, inode,
-                                       &diskfs_acl_key,
-                                       diskfs_setattr_acl_removed_cb,
-                                       request)) {
-                diskfs_setattr_acl_removed_cb(op, op->result, request);
-            }
-        } else {
-            diskfs_setattr_acl_insert(request);
-        }
-        return;
-    } else if ((orig_mask & CHIMERA_VFS_ATTR_MODE) && inode->acl_serial) {
-        uint8_t             obuf[sizeof(struct chimera_acl) +
-                                 DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
-        uint8_t             nbuf[sizeof(struct chimera_acl) +
-                                 DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
-        struct chimera_acl *old_acl = (struct chimera_acl *) obuf;
-        struct chimera_acl *new_acl = (struct chimera_acl *) nbuf;
-        uint8_t             sbuf[DISKFS_ACL_REC_MAX];
-        int                 slen;
-
-        if (chimera_acl_deserialize((const char *) inode->acl_serial,
-                                    inode->acl_serial_len, old_acl,
-                                    DISKFS_ACL_REC_MAX_ACES) >= 0 &&
-            chimera_acl_chmod(old_acl, inode->mode, new_acl,
-                              DISKFS_ACL_REC_MAX_ACES) >= 0 &&
-            (slen = chimera_acl_serialize(new_acl, sbuf, sizeof(sbuf))) >= 0) {
-
-            diskfs_acl_serial_install(inode, sbuf, slen);
-
-            op = diskfs_bt_op_alloc(thread);
-            if (diskfs_bt_remove_async(op, thread, p->txn, inode,
-                                       &diskfs_acl_key,
-                                       diskfs_setattr_acl_removed_cb,
-                                       request)) {
-                diskfs_setattr_acl_removed_cb(op, op->result, request);
-            }
-            return;
-        }
-        /* Regeneration failed: leave the stored ACL untouched. */
-    }
-
-    diskfs_setattr_finish(request);
+    diskfs_setattr_records(request);
 } /* diskfs_setattr_inode_cb */
 
 

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -1141,10 +1141,10 @@ diskfs_setattr_acl(struct chimera_vfs_request *request)
                                      DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
         static __thread uint8_t nbuf[sizeof(struct chimera_acl) +
                                      DISKFS_ACL_REC_MAX_ACES * sizeof(struct chimera_ace)];
-        struct chimera_acl *old_acl = (struct chimera_acl *) obuf;
-        struct chimera_acl *new_acl = (struct chimera_acl *) nbuf;
-        uint8_t             sbuf[DISKFS_ACL_REC_MAX];
-        int                 slen;
+        struct chimera_acl     *old_acl = (struct chimera_acl *) obuf;
+        struct chimera_acl     *new_acl = (struct chimera_acl *) nbuf;
+        uint8_t                 sbuf[DISKFS_ACL_REC_MAX];
+        int                     slen;
 
         if (chimera_acl_deserialize((const char *) inode->acl_serial,
                                     inode->acl_serial_len, old_acl,

--- a/src/vfs/diskfs/diskfs_attr.c
+++ b/src/vfs/diskfs/diskfs_attr.c
@@ -373,69 +373,8 @@ diskfs_acl_serial_install(
 } /* diskfs_acl_serial_install */
 
 
-/*
- * Native owner / group SID record codec (DISKFS_REC_SID): u8 owner_len,
- * owner bytes, u8 group_len, group bytes; a zero length means unknown.
- * Encode returns the record length, or -1 when neither SID is present (then
- * no record should exist).  Decode clears whichever SID is not recorded.
- */
-int
-diskfs_sid_rec_encode(
-    const struct chimera_sid *owner,
-    const struct chimera_sid *group,
-    uint8_t                  *buf)
-{
-    int len = 0;
-
-    if (!chimera_sid_present(owner) && !chimera_sid_present(group)) {
-        return -1;
-    }
-    buf[len++] = chimera_sid_present(owner) ? owner->len : 0;
-    if (chimera_sid_present(owner)) {
-        memcpy(buf + len, owner->data, owner->len);
-        len += owner->len;
-    }
-    buf[len++] = chimera_sid_present(group) ? group->len : 0;
-    if (chimera_sid_present(group)) {
-        memcpy(buf + len, group->data, group->len);
-        len += group->len;
-    }
-    return len;
-} /* diskfs_sid_rec_encode */
-
-void
-diskfs_sid_rec_decode(
-    const uint8_t      *serial,
-    uint32_t            len,
-    struct chimera_sid *owner,
-    struct chimera_sid *group)
-{
-    uint32_t pos = 0;
-    uint8_t  olen, glen;
-
-    owner->len = 0;
-    group->len = 0;
-
-    if (!serial || len < 2) {
-        return;
-    }
-    olen = serial[pos++];
-    if (olen) {
-        if (pos + olen > len ||
-            chimera_sid_from_bin(owner, serial + pos, olen) != (int) olen) {
-            owner->len = 0;
-            return;
-        }
-        pos += olen;
-    }
-    if (pos >= len) {
-        return;
-    }
-    glen = serial[pos++];
-    if (glen && pos + glen <= len) {
-        chimera_sid_from_bin(group, serial + pos, glen);
-    }
-} /* diskfs_sid_rec_decode */
+/* The DISKFS_REC_SID record is the owner / group SID pair record shared with
+ * cairn: chimera_sid_pair_encode / chimera_sid_pair_decode (vfs_sid.h). */
 
 /* Replace inode->sid_serial (mirror of the DISKFS_REC_SID record) with a
  * copy of serial[0..len), or clear it when len < 0.  Caller holds the inode
@@ -467,7 +406,7 @@ diskfs_sid_decode_into(
     static __thread struct chimera_sid owner;
     static __thread struct chimera_sid group;
 
-    diskfs_sid_rec_decode(serial, len, &owner, &group);
+    chimera_sid_pair_decode(serial, (int) len, &owner, &group);
 
     if ((attr->va_req_mask & CHIMERA_VFS_ATTR_OWNER_SID) && owner.len) {
         attr->va_owner_sid = &owner;
@@ -1205,8 +1144,8 @@ diskfs_setattr_records(struct chimera_vfs_request *request)
         int                had     = inode->sid_serial != NULL;
         int                changed = 0;
 
-        diskfs_sid_rec_decode(inode->sid_serial, inode->sid_serial_len,
-                              &owner, &group);
+        chimera_sid_pair_decode(inode->sid_serial, (int) inode->sid_serial_len,
+                                &owner, &group);
 
         if (mask & CHIMERA_VFS_ATTR_OWNER_SID) {
             if (chimera_sid_present(sa->va_owner_sid)) {
@@ -1235,15 +1174,21 @@ diskfs_setattr_records(struct chimera_vfs_request *request)
         }
 
         if (changed) {
-            uint8_t rec[DISKFS_SID_REC_MAX];
-            int     len = diskfs_sid_rec_encode(&owner, &group, rec);
+            uint8_t rec[CHIMERA_SID_PAIR_MAX];
+            int     len = chimera_sid_pair_encode(&owner, &group, rec,
+                                                  sizeof(rec));
 
-            diskfs_sid_serial_install(inode, rec, len);
-            if (len >= 0) {
+            /* 0 means neither SID is present: no record should exist, so the
+             * mirror is cleared rather than set to an empty record. */
+            if (len > 0) {
+                diskfs_sid_serial_install(inode, rec, len);
                 p->sid_action = had ? DISKFS_SID_ACTION_REPLACE
                                     : DISKFS_SID_ACTION_INSERT;
-            } else if (had) {
-                p->sid_action = DISKFS_SID_ACTION_REMOVE;
+            } else {
+                diskfs_sid_serial_install(inode, NULL, -1);
+                if (had) {
+                    p->sid_action = DISKFS_SID_ACTION_REMOVE;
+                }
             }
         }
     }

--- a/src/vfs/diskfs/diskfs_inode.c
+++ b/src/vfs/diskfs/diskfs_inode.c
@@ -492,6 +492,12 @@ diskfs_inode_load_sync(
             diskfs_acl_serial_install(inode, rec, len);
         }
 
+        len = diskfs_bt_lookup_pump(shared, io, buf, &diskfs_sid_key,
+                                    rec, DISKFS_SID_REC_MAX);
+        if (len >= 0) {
+            diskfs_sid_serial_install(inode, rec, len);
+        }
+
         len = diskfs_bt_lookup_pump(shared, io, buf, &diskfs_pnfs_key,
                                     rec, CHIMERA_VFS_PNFS_LAYOUT_MAX);
         if (len >= 0) {

--- a/src/vfs/diskfs/diskfs_inode.c
+++ b/src/vfs/diskfs/diskfs_inode.c
@@ -493,7 +493,7 @@ diskfs_inode_load_sync(
         }
 
         len = diskfs_bt_lookup_pump(shared, io, buf, &diskfs_sid_key,
-                                    rec, DISKFS_SID_REC_MAX);
+                                    rec, CHIMERA_SID_PAIR_MAX);
         if (len >= 0) {
             diskfs_sid_serial_install(inode, rec, len);
         }

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -209,6 +209,16 @@ struct diskfs_extent {
 };
 
 
+/* setattr's DISKFS_REC_SID replay step (diskfs_request_private.sid_action):
+ * how the chain tail brings the b+tree in line with the inode's sid_serial
+ * mirror once the SID block has updated it. */
+enum diskfs_sid_action {
+    DISKFS_SID_ACTION_NONE = 0,
+    DISKFS_SID_ACTION_INSERT,
+    DISKFS_SID_ACTION_REMOVE,
+    DISKFS_SID_ACTION_REPLACE,
+};
+
 struct diskfs_request_private {
     int                         opcode;
     int                         status;
@@ -244,6 +254,14 @@ struct diskfs_request_private {
     /* Small integer scratch for ops that need to carry state across
      * async callbacks (mount path walker uses it as a path byte offset). */
     uint32_t                    op_scratch;
+    /* setattr: the caller's va_set_mask, captured before diskfs_apply_attrs
+     * rewrites it to the scalar bits it applied.  The record steps (pNFS,
+     * ACL, SID) key off it, and the shrink path only applies attrs after its
+     * extent walk, so a local in the dispatch cannot carry it. */
+    uint64_t                    setattr_mask;
+    /* setattr: which DISKFS_REC_SID replay the chain tail must perform,
+     * decided when the mirror was updated. */
+    enum diskfs_sid_action      sid_action;
 
     /* readdir iteration cursor + the current dirent copied out of the
      * b+tree (carried across the per-child inode fetch). */
@@ -725,6 +743,12 @@ struct diskfs_inode {
     uint32_t                    acl_serial_len;
     uint8_t                    *pnfs_blob;
     uint32_t                    pnfs_blob_len;
+    /* Native owner / group SID record (DISKFS_REC_SID): the SID
+     * companions to uid / gid, encoded as u8 owner_len, owner bytes, u8
+     * group_len, group bytes.  Kept separate from the ACL record so "no ACL
+     * record" still means "mode-derived DACL".  Same mirror discipline. */
+    uint8_t                    *sid_serial;
+    uint32_t                    sid_serial_len;
 
     /* Directory only: parent for ".." resolution (also persisted in dinode). */
     uint64_t                    parent_inum;
@@ -974,6 +998,7 @@ enum diskfs_bt_rectype {
     DISKFS_REC_ACL      = 7,  /* single record: serialized NFSv4/Windows ACL (subkey 0) */
     DISKFS_REC_REFCOUNT = 8,  /* refcount inode only: subkey = device offset of a
                                * reflink-shared extent; payload = share count */
+    DISKFS_REC_SID      = 9,  /* single record: native owner/group SIDs (subkey 0) */
 };
 
 
@@ -1080,8 +1105,27 @@ struct diskfs_xattr_rec {
 #define DISKFS_ACL_REC_MAX \
         (DISKFS_BT_ROOT_CAP - sizeof(struct diskfs_bt_node_hdr) - sizeof(struct diskfs_bt_lslot))
 
+/* Upper bound on the ACE count of an ACL that fits one record: every encoded
+ * ACE is at least CHIMERA_ACL_SERIAL_ACE bytes (a native SID makes it larger),
+ * so this bounds the decode buffers.  Whether a given ACL fits is decided by
+ * its serialized size, not its count. */
 #define DISKFS_ACL_REC_MAX_ACES \
         (((DISKFS_ACL_REC_MAX) -CHIMERA_ACL_SERIAL_HDR) / CHIMERA_ACL_SERIAL_ACE)
+
+/* Native owner/group SID record: two length-prefixed SIDs. */
+#define DISKFS_SID_REC_MAX (2 + 2 * CHIMERA_SID_MAX_LEN)
+
+/* True when the ACL carried by a setattr or create (if any) serializes into
+ * one b+tree record.  Checked before anything is mutated: the txn abort does
+ * not roll the in-memory inode back, so an ACL that cannot be stored has to
+ * be refused while there is nothing to roll back. */
+static inline int
+diskfs_acl_rec_fits(const struct chimera_vfs_attrs *attr)
+{
+    return !attr || !(attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) ||
+           !attr->va_acl || !attr->va_acl->num_aces ||
+           chimera_acl_serialized_size(attr->va_acl) <= DISKFS_ACL_REC_MAX;
+} /* diskfs_acl_rec_fits */
 
 
 /*
@@ -1090,7 +1134,7 @@ struct diskfs_xattr_rec {
  * pairs, padded to a 4 KiB multiple.  Full-block redo: the record carries
  * the entire post-image of every dirty block in the transaction.
  */
-#define DISKFS_REDO_MAGIC 0x4F44455246534944ULL     /* "DISFREDO" */
+#define DISKFS_REDO_MAGIC 0x4F44455246534944ULL         /* "DISFREDO" */
 
 
 /*
@@ -2164,8 +2208,10 @@ struct diskfs_inode_load_ctx {
     /* Record-load chain state (valid once the inode is published). */
     struct diskfs_inode        *inode;
     int                         acl_len;
+    int                         sid_len;
     int                         pnfs_len;
     uint8_t                     acl_rec[DISKFS_ACL_REC_MAX];
+    uint8_t                     sid_rec[DISKFS_SID_REC_MAX];
     uint8_t                     pnfs_rec[CHIMERA_VFS_PNFS_LAYOUT_MAX];
 };
 
@@ -2376,6 +2422,10 @@ struct diskfs_mtime_flush {
 
 static const struct diskfs_bt_key diskfs_acl_key = {
     .type = DISKFS_REC_ACL, .subkey = 0
+};
+
+static const struct diskfs_bt_key diskfs_sid_key = {
+    .type = DISKFS_REC_SID, .subkey = 0
 };
 
 static const struct diskfs_bt_key diskfs_pnfs_key = {
@@ -3080,6 +3130,31 @@ diskfs_acl_serial_install(
     struct diskfs_inode *inode,
     const uint8_t       *serial,
     int                  len);
+
+int
+diskfs_sid_rec_encode(
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group,
+    uint8_t                  *buf);
+
+void
+diskfs_sid_rec_decode(
+    const uint8_t      *serial,
+    uint32_t            len,
+    struct chimera_sid *owner,
+    struct chimera_sid *group);
+
+void
+diskfs_sid_serial_install(
+    struct diskfs_inode *inode,
+    const uint8_t       *serial,
+    int                  len);
+
+void
+diskfs_sid_decode_into(
+    struct chimera_vfs_attrs *attr,
+    const uint8_t            *serial,
+    uint32_t                  len);
 
 int
 diskfs_inherit_acl_async(
@@ -4743,6 +4818,7 @@ static inline void
 diskfs_inode_struct_free(struct diskfs_inode *inode)
 {
     free(inode->acl_serial);
+    free(inode->sid_serial);
     free(inode->pnfs_blob);
     free(inode);
 } /* diskfs_inode_struct_free */
@@ -5296,6 +5372,13 @@ diskfs_map_attrs(
         diskfs_acl_decode_into(attr, inode->acl_serial,
                                inode->acl_serial ? (int) inode->acl_serial_len : -1,
                                inode->mode);
+    }
+
+    /* Native owner / group SIDs: reported only when the record exists. */
+    if ((attr->va_req_mask & (CHIMERA_VFS_ATTR_OWNER_SID |
+                              CHIMERA_VFS_ATTR_GROUP_SID)) &&
+        inode->sid_serial) {
+        diskfs_sid_decode_into(attr, inode->sid_serial, inode->sid_serial_len);
     }
 
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_MASK_STATFS_VALUES) {

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -1112,9 +1112,6 @@ struct diskfs_xattr_rec {
 #define DISKFS_ACL_REC_MAX_ACES \
         (((DISKFS_ACL_REC_MAX) -CHIMERA_ACL_SERIAL_HDR) / CHIMERA_ACL_SERIAL_ACE)
 
-/* Native owner/group SID record: two length-prefixed SIDs. */
-#define DISKFS_SID_REC_MAX (2 + 2 * CHIMERA_SID_MAX_LEN)
-
 /* True when the ACL carried by a setattr or create (if any) serializes into
  * one b+tree record.  Checked before anything is mutated: the txn abort does
  * not roll the in-memory inode back, so an ACL that cannot be stored has to
@@ -2211,7 +2208,7 @@ struct diskfs_inode_load_ctx {
     int                         sid_len;
     int                         pnfs_len;
     uint8_t                     acl_rec[DISKFS_ACL_REC_MAX];
-    uint8_t                     sid_rec[DISKFS_SID_REC_MAX];
+    uint8_t                     sid_rec[CHIMERA_SID_PAIR_MAX];
     uint8_t                     pnfs_rec[CHIMERA_VFS_PNFS_LAYOUT_MAX];
 };
 
@@ -3130,19 +3127,6 @@ diskfs_acl_serial_install(
     struct diskfs_inode *inode,
     const uint8_t       *serial,
     int                  len);
-
-int
-diskfs_sid_rec_encode(
-    const struct chimera_sid *owner,
-    const struct chimera_sid *group,
-    uint8_t                  *buf);
-
-void
-diskfs_sid_rec_decode(
-    const uint8_t      *serial,
-    uint32_t            len,
-    struct chimera_sid *owner,
-    struct chimera_sid *group);
 
 void
 diskfs_sid_serial_install(

--- a/src/vfs/diskfs/diskfs_io.c
+++ b/src/vfs/diskfs/diskfs_io.c
@@ -752,6 +752,9 @@ diskfs_inode_load_recs_done(struct diskfs_inode_load_ctx *lc)
     if (lc->acl_len >= 0) {
         diskfs_acl_serial_install(inode, lc->acl_rec, lc->acl_len);
     }
+    if (lc->sid_len >= 0) {
+        diskfs_sid_serial_install(inode, lc->sid_rec, lc->sid_len);
+    }
     if (lc->pnfs_len >= 0) {
         inode->pnfs_blob = malloc(lc->pnfs_len);
         memcpy(inode->pnfs_blob, lc->pnfs_rec, lc->pnfs_len);
@@ -781,6 +784,27 @@ diskfs_inode_load_recs_pnfs_cb(
 
 
 static void
+diskfs_inode_load_recs_sid_cb(
+    struct diskfs_bt_op *op,
+    int                  result,
+    void                *private_data)
+{
+    struct diskfs_inode_load_ctx *lc = private_data;
+
+    lc->sid_len = result;
+    diskfs_bt_op_free(lc->thread, op);
+
+    op = diskfs_bt_op_alloc(lc->thread);
+    if (diskfs_bt_lookup_async(op, lc->thread, lc->inode,
+                               DISKFS_BT_OP_LOOKUP_EXACT, &diskfs_pnfs_key,
+                               NULL, lc->pnfs_rec, sizeof(lc->pnfs_rec),
+                               diskfs_inode_load_recs_pnfs_cb, lc)) {
+        diskfs_inode_load_recs_pnfs_cb(op, op->result, lc);
+    }
+} /* diskfs_inode_load_recs_sid_cb */
+
+
+static void
 diskfs_inode_load_recs_acl_cb(
     struct diskfs_bt_op *op,
     int                  result,
@@ -793,10 +817,10 @@ diskfs_inode_load_recs_acl_cb(
 
     op = diskfs_bt_op_alloc(lc->thread);
     if (diskfs_bt_lookup_async(op, lc->thread, lc->inode,
-                               DISKFS_BT_OP_LOOKUP_EXACT, &diskfs_pnfs_key,
-                               NULL, lc->pnfs_rec, sizeof(lc->pnfs_rec),
-                               diskfs_inode_load_recs_pnfs_cb, lc)) {
-        diskfs_inode_load_recs_pnfs_cb(op, op->result, lc);
+                               DISKFS_BT_OP_LOOKUP_EXACT, &diskfs_sid_key,
+                               NULL, lc->sid_rec, sizeof(lc->sid_rec),
+                               diskfs_inode_load_recs_sid_cb, lc)) {
+        diskfs_inode_load_recs_sid_cb(op, op->result, lc);
     }
 } /* diskfs_inode_load_recs_acl_cb */
 

--- a/src/vfs/diskfs/diskfs_namespace.c
+++ b/src/vfs/diskfs/diskfs_namespace.c
@@ -871,6 +871,14 @@ diskfs_mkdir_at_check_cb(
         return;
     }
 
+    /* An explicit create-time ACL that does not fit one b+tree record is
+     * refused before the inode is allocated, while there is nothing to roll
+     * back (the txn abort does not undo in-memory state). */
+    if (!diskfs_acl_rec_fits(request->mkdir_at.set_attr)) {
+        diskfs_op_fail(request, p->txn, CHIMERA_VFS_EFBIG);
+        return;
+    }
+
     diskfs_inode_alloc_async(thread, p->txn, p->fs, diskfs_mkdir_at_alloc_cb, request);
 } /* diskfs_mkdir_at_check_cb */
 
@@ -2024,6 +2032,14 @@ diskfs_open_at_check_cb(
             !diskfs_inode_access(thread, p->inode_stash[0], request->cred,
                                  CHIMERA_ACE_WRITE_DATA | CHIMERA_ACE_EXECUTE)) {
             diskfs_op_fail(request, p->txn, CHIMERA_VFS_EACCES);
+            return;
+        }
+
+        /* An explicit create-time ACL that does not fit one b+tree record is
+         * refused before the inode is allocated, while there is nothing to
+         * roll back (the txn abort does not undo in-memory state). */
+        if (!diskfs_acl_rec_fits(request->open_at.set_attr)) {
+            diskfs_op_fail(request, p->txn, CHIMERA_VFS_EFBIG);
             return;
         }
 

--- a/src/vfs/memfs/memfs.c
+++ b/src/vfs/memfs/memfs.c
@@ -21,6 +21,7 @@
 #include "vfs/sdk/chimera_vfs_sdk.h"
 #include "vfs/sdk/vfs_fh.h"
 #include "vfs/sdk/vfs_acl.h"
+#include "vfs/sdk/vfs_sid.h"
 #include "vfs/sdk/vfs_access.h"
 #include "vfs/sdk/vfs_xattr_name.h"
 #include "vfs/vfs_clock.h"
@@ -195,6 +196,11 @@ struct memfs_inode {
     uint64_t                   rdev;
     uint32_t                   dos_attributes;
     struct chimera_acl        *acl; /* NULL => mode-derived; CAP_ACL_NATIVE storage */
+    /* Native Windows SIDs of the owner / owning group, the companions to
+     * uid / gid (len 0 = none known).  Kept in step with uid/gid by
+     * memfs_apply_attrs: a chown that does not restate the SID drops it. */
+    struct chimera_sid         owner_sid;
+    struct chimera_sid         group_sid;
     struct timespec            atime;
     struct timespec            mtime;
     struct timespec            ctime;
@@ -810,6 +816,8 @@ memfs_inode_alloc(
     inode->change         = 0;
     inode->dos_attributes = 0;
     inode->acl            = NULL;
+    inode->owner_sid.len  = 0;
+    inode->group_sid.len  = 0;
     inode->xattrs         = NULL;
     inode->remote         = NULL;
     inode->streams        = NULL;
@@ -1665,6 +1673,25 @@ memfs_map_attrs(
         attr->va_set_mask |= CHIMERA_VFS_ATTR_ACL;
     }
 
+    /* Native owner / group SIDs: reported only when one is stored, from a
+     * per-thread scratch for the same lock-release reason as the ACL. */
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_OWNER_SID) &&
+        chimera_sid_present(&inode->owner_sid)) {
+        static __thread struct chimera_sid owner_scratch;
+
+        owner_scratch      = inode->owner_sid;
+        attr->va_owner_sid = &owner_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    }
+    if ((attr->va_req_mask & CHIMERA_VFS_ATTR_GROUP_SID) &&
+        chimera_sid_present(&inode->group_sid)) {
+        static __thread struct chimera_sid group_scratch;
+
+        group_scratch      = inode->group_sid;
+        attr->va_group_sid = &group_scratch;
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    }
+
     /* Birth time is optional and lives outside MASK_STAT, so report it under
      * its own request bit. */
     if (attr->va_req_mask & CHIMERA_VFS_ATTR_BTIME) {
@@ -1924,6 +1951,32 @@ memfs_apply_attrs(
         } else {
             free(tmp);
         }
+    }
+
+    /* Native owner / group SID coherence.  An explicit OWNER_SID set stores
+     * (or, with no SID supplied, clears) the companion; a bare UID set is a
+     * chown to an identity whose SID we were not told, so the stored SID no
+     * longer describes the owner and is dropped.  Group mirrors owner. */
+    if (set_mask & CHIMERA_VFS_ATTR_OWNER_SID) {
+        if (chimera_sid_present(attr->va_owner_sid)) {
+            inode->owner_sid = *attr->va_owner_sid;
+        } else {
+            inode->owner_sid.len = 0;
+        }
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_OWNER_SID;
+    } else if (set_mask & CHIMERA_VFS_ATTR_UID) {
+        inode->owner_sid.len = 0;
+    }
+
+    if (set_mask & CHIMERA_VFS_ATTR_GROUP_SID) {
+        if (chimera_sid_present(attr->va_group_sid)) {
+            inode->group_sid = *attr->va_group_sid;
+        } else {
+            inode->group_sid.len = 0;
+        }
+        attr->va_set_mask |= CHIMERA_VFS_ATTR_GROUP_SID;
+    } else if (set_mask & CHIMERA_VFS_ATTR_GID) {
+        inode->group_sid.len = 0;
     }
 
     if (set_mask & CHIMERA_VFS_ATTR_BTIME) {

--- a/src/vfs/sdk/chimera_vfs_sdk.h
+++ b/src/vfs/sdk/chimera_vfs_sdk.h
@@ -57,10 +57,12 @@
 #include "vfs_varint.h"
 #include "vfs_fh.h"
 
-/* Attribute vocabularies a module fills in or interprets: the canonical
- * ACL carried by chimera_vfs_attrs.va_acl, the access-mask evaluator that
- * keeps ACCESS answers consistent across backends, and the protocol-
- * exported "user." xattr keyspace. */
+/* Attribute vocabularies a module fills in or interprets: the native SID
+ * value type, the canonical ACL carried by chimera_vfs_attrs.va_acl (whose
+ * principals may carry that SID), the access-mask evaluator that keeps
+ * ACCESS answers consistent across backends, and the protocol-exported
+ * "user." xattr keyspace. */
+#include "vfs_sid.h"
 #include "vfs_acl.h"
 #include "vfs_acl_serialize.h"
 #include "vfs_access.h"

--- a/src/vfs/sdk/vfs_acl.h
+++ b/src/vfs/sdk/vfs_acl.h
@@ -23,6 +23,8 @@
 #include <stddef.h>
 #include <sys/stat.h>
 
+#include "vfs_sid.h"
+
 struct chimera_vfs_cred;
 
 /*
@@ -88,6 +90,11 @@ enum chimera_principal_type {
     CHIMERA_PRINCIPAL_USER    = 0, /* numeric uid                            */
     CHIMERA_PRINCIPAL_GROUP   = 1, /* numeric gid                            */
     CHIMERA_PRINCIPAL_SPECIAL = 2, /* special-who below                      */
+    /* A native Windows SID the identity layer could not map to a uid or gid.
+     * It is stored and marshalled verbatim so the ACE round-trips losslessly
+     * (as NTFS keeps an ACE for a departed domain user), but it matches no
+     * caller during access evaluation and bears on no POSIX mode class. */
+    CHIMERA_PRINCIPAL_SID     = 3,
 };
 
 enum chimera_special_who {
@@ -122,10 +129,31 @@ enum chimera_special_who {
     CHIMERA_WHO_SERVICE       = 13,
 };
 
+/*
+ * Dual identity.  Access evaluation, POSIX mode projection and NFSv4 always
+ * work from `type`/`special`/`id`.  `sid` optionally carries the native
+ * Windows SID the principal was set with, so marshalling and storage can
+ * round-trip the real domain identity instead of re-deriving an algorithmic
+ * one: it is present (chimera_sid_present) only on USER/GROUP principals
+ * whose SID was resolved through the identity layer, and on every
+ * PRINCIPAL_SID.  SPECIAL principals never carry one (their well-known SIDs
+ * are implied).
+ *
+ * Contract: a principal is a plain value that is copied and compared by
+ * value (memcmp), so every byte of it must be defined.  Assigning `type`,
+ * `special` and `id` does NOT define one: `reserved` and the whole `sid`
+ * (its length, its pad and every byte of data[]) must be zero unless a SID
+ * is present, in which case data[] past the length must be zero.  Build a
+ * principal with memset, or with the chimera_idmap_*_principal constructors;
+ * the identity layer, the ACL builders, the serializer and the SMB parser
+ * all honour this.
+ */
 struct chimera_principal {
-    uint8_t  type;    /* enum chimera_principal_type   */
-    uint8_t  special; /* enum chimera_special_who      */
-    uint32_t id;      /* uid or gid when type != SPECIAL */
+    uint8_t            type;     /* enum chimera_principal_type          */
+    uint8_t            special;  /* enum chimera_special_who             */
+    uint16_t           reserved; /* zero                                 */
+    uint32_t           id;       /* uid or gid when type is USER/GROUP   */
+    struct chimera_sid sid;      /* native SID; absent when unknown      */
 };
 
 struct chimera_ace {
@@ -134,6 +162,13 @@ struct chimera_ace {
     uint32_t                 access_mask;
     struct chimera_principal who;
 };
+
+/* The layout is part of SDK version 2, and it must carry no compiler padding
+ * for the by-value contract above to hold on every compiler. */
+_Static_assert(sizeof(struct chimera_principal) == 80,
+               "chimera_principal layout is part of SDK version 2");
+_Static_assert(sizeof(struct chimera_ace) == 88,
+               "chimera_ace layout is part of SDK version 2");
 
 struct chimera_acl {
     uint16_t           num_aces;

--- a/src/vfs/sdk/vfs_acl_serialize.h
+++ b/src/vfs/sdk/vfs_acl_serialize.h
@@ -11,29 +11,34 @@
  * formats, which are protocol marshalling, not storage.
  *
  * Layout (all integers little-endian):
- *   u8  version (= CHIMERA_ACL_SERIAL_VERSION)
+ *   u8  version (1 or 2)
  *   u16 ctrl_flags
  *   u16 num_aces
  *   num_aces x {
  *       u16 type, u16 flags, u32 access_mask,
- *       u8 principal_type, u8 special, u32 id
+ *       u8 principal_type, u8 special, u32 id,
+ *       [version 2 only] u8 sid_len, sid_len bytes of native SID
  *   }
+ *
+ * Version 1 is the pre-native-SID encoding.  The serializer emits version 1
+ * whenever no ACE carries a SID, so a volume written by this release stays
+ * readable by an older binary unless a native SID was actually stored; the
+ * deserializer accepts both versions.
  */
 
 #include <stddef.h>
 #include "vfs_acl.h"
 
-#define CHIMERA_ACL_SERIAL_VERSION 1
+#define CHIMERA_ACL_SERIAL_VERSION 2
+#define CHIMERA_ACL_SERIAL_V1      1
 #define CHIMERA_ACL_SERIAL_HDR     5  /* version + ctrl_flags + num_aces */
-#define CHIMERA_ACL_SERIAL_ACE     14 /* type+flags+mask+ptype+special+id */
+#define CHIMERA_ACL_SERIAL_ACE     14 /* fixed part: type+flags+mask+ptype+special+id */
+/* Largest encoded ACE: the fixed part, the SID length byte, and a max SID. */
+#define CHIMERA_ACL_SERIAL_ACE_MAX (CHIMERA_ACL_SERIAL_ACE + 1 + CHIMERA_SID_MAX_LEN)
 
 /* Number of bytes chimera_acl_serialize() will write for `acl`. */
-static inline size_t
-chimera_acl_serialized_size(const struct chimera_acl *acl)
-{
-    return CHIMERA_ACL_SERIAL_HDR +
-           (size_t) acl->num_aces * CHIMERA_ACL_SERIAL_ACE;
-} /* chimera_acl_serialized_size */
+size_t chimera_acl_serialized_size(
+    const struct chimera_acl *acl);
 
 /*
  * Serialize `acl` into `buf` (capacity `buflen`).  Returns the number of bytes

--- a/src/vfs/sdk/vfs_attrs.h
+++ b/src/vfs/sdk/vfs_attrs.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <stdint.h>
 #include <time.h>
+#include "vfs_sid.h"
 
 struct chimera_acl;
 
@@ -97,6 +98,19 @@ struct chimera_acl;
  * va_named_attr (backends without named-stream support leave it unset, which the
  * NFS marshaller treats as false). */
 #define CHIMERA_VFS_ATTR_NAMED_ATTR         (1UL << 28)
+
+/* Native Windows SIDs of the owner and owning group (va_owner_sid /
+ * va_group_sid), the SID companions to va_uid / va_gid.  Optional: a backend
+ * sets the bit in va_set_mask only when it has a stored native SID for that
+ * identity; the SMB marshaller then emits it verbatim instead of re-deriving
+ * one from the identity cache or the algorithmic S-1-5-88 scheme.  On
+ * setattr, a UID (GID) set that is not accompanied by OWNER_SID (GROUP_SID)
+ * clears any stored owner (group) SID, since it would no longer describe the
+ * new numeric owner; OWNER_SID with a NULL/absent pointer clears it
+ * explicitly.  Like ACL these are pointer-valued and deliberately excluded
+ * from MASK_STAT and MASK_CACHEABLE. */
+#define CHIMERA_VFS_ATTR_OWNER_SID          (1UL << 29)
+#define CHIMERA_VFS_ATTR_GROUP_SID          (1UL << 30)
 
 #define CHIMERA_VFS_ATTR_MASK_STAT          ( \
             CHIMERA_VFS_ATTR_DEV | \
@@ -220,6 +234,13 @@ struct chimera_vfs_attrs {
      * this at storage valid only for the duration of the completion callback
      * (same contract as va_fh).  On setattr, the caller owns the buffer. */
     struct chimera_acl *va_acl;
+
+    /* Native owner / group SIDs (CHIMERA_VFS_ATTR_OWNER_SID / GROUP_SID).
+     * Same lifetime contract as va_acl: on getattr the backend points these
+     * at storage valid only for the duration of the completion callback; on
+     * setattr the caller owns the buffers. */
+    const struct chimera_sid *va_owner_sid;
+    const struct chimera_sid *va_group_sid;
 
     /* Opaque pNFS layout state, owned by the NFS server (see
      * CHIMERA_VFS_ATTR_PNFS_LAYOUT). */

--- a/src/vfs/sdk/vfs_attrs.h
+++ b/src/vfs/sdk/vfs_attrs.h
@@ -239,8 +239,8 @@ struct chimera_vfs_attrs {
      * Same lifetime contract as va_acl: on getattr the backend points these
      * at storage valid only for the duration of the completion callback; on
      * setattr the caller owns the buffers. */
-    const struct chimera_sid *va_owner_sid;
-    const struct chimera_sid *va_group_sid;
+    struct chimera_sid *va_owner_sid;
+    struct chimera_sid *va_group_sid;
 
     /* Opaque pNFS layout state, owned by the NFS server (see
      * CHIMERA_VFS_ATTR_PNFS_LAYOUT). */

--- a/src/vfs/sdk/vfs_module.h
+++ b/src/vfs/sdk/vfs_module.h
@@ -28,7 +28,7 @@ struct chimera_vfs_request;
  * chimera_vfs_register() refuses a module built against a different
  * version, so a stale out-of-tree binary fails loudly at load time
  * instead of corrupting memory. */
-#define CHIMERA_VFS_SDK_VERSION             1
+#define CHIMERA_VFS_SDK_VERSION             2
 
 /* If set, module requires open handles for path operations
  * such as mkdir, remove, open_at, etc.  Equivalent to POSIX open

--- a/src/vfs/sdk/vfs_sid.h
+++ b/src/vfs/sdk/vfs_sid.h
@@ -29,10 +29,23 @@
 /* "S-<rev>-<authority>" plus 15 x "-<u32>" plus NUL fits comfortably. */
 #define CHIMERA_SID_STR_MAX       192
 
+/*
+ * chimera_sid_from_bin / chimera_sid_from_str fully define the struct (the
+ * pad and the bytes past `len` are zeroed, and the whole struct is zeroed on
+ * failure), so a chimera_sid -- and any ACE principal carrying one -- is
+ * byte-deterministic and safe to copy by value and compare with memcmp.  The
+ * explicit pad keeps the struct free of compiler padding, so that guarantee
+ * comes from the language rather than from how a given compiler happens to
+ * copy padding bytes.
+ */
 struct chimera_sid {
     uint8_t len;                       /* 0 = absent; else 8 + 4 * count */
+    uint8_t pad[3];                    /* always zero */
     uint8_t data[CHIMERA_SID_MAX_LEN]; /* binary SID, valid for `len` bytes */
 };
+
+_Static_assert(sizeof(struct chimera_sid) == 72,
+               "chimera_sid must have no compiler padding");
 
 /*
  * Validate the binary SID at the start of `buf` (`avail` bytes) and return

--- a/src/vfs/sdk/vfs_sid.h
+++ b/src/vfs/sdk/vfs_sid.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#pragma once
+
+/*
+ * Native Windows security identifier (SID) value type.
+ *
+ * A SID is carried in its MS-DTYP 2.4.2.2 binary form: revision (1 byte),
+ * sub-authority count (1 byte), a 48-bit big-endian identifier authority
+ * (6 bytes), then count little-endian 32-bit sub-authorities.  That is the
+ * exact layout an SMB security descriptor puts on the wire, so an ACE SID can
+ * be copied in and out without a string round trip, and it is what native
+ * backends persist.  A zero length means "no native SID is known" -- the
+ * numeric uid/gid on the principal (or attrs) then stands alone and the
+ * marshaller falls back to the identity cache or the algorithmic SID.
+ *
+ * The cap of 15 sub-authorities is the MS-DTYP maximum (SID_MAX_SUB_AUTHORITIES).
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define CHIMERA_SID_MAX_SUB_AUTHS 15
+#define CHIMERA_SID_MIN_LEN       8  /* revision + count + authority */
+#define CHIMERA_SID_MAX_LEN       (CHIMERA_SID_MIN_LEN + 4 * CHIMERA_SID_MAX_SUB_AUTHS)
+
+/* "S-<rev>-<authority>" plus 15 x "-<u32>" plus NUL fits comfortably. */
+#define CHIMERA_SID_STR_MAX       192
+
+struct chimera_sid {
+    uint8_t len;                       /* 0 = absent; else 8 + 4 * count */
+    uint8_t data[CHIMERA_SID_MAX_LEN]; /* binary SID, valid for `len` bytes */
+};
+
+/*
+ * Validate the binary SID at the start of `buf` (`avail` bytes) and return
+ * its length (8 + 4 * sub_authority_count), or -1 if the buffer is too short
+ * or the sub-authority count exceeds CHIMERA_SID_MAX_SUB_AUTHS.
+ */
+int chimera_sid_bin_len(
+    const uint8_t *buf,
+    uint32_t       avail);
+
+/*
+ * Format the binary SID at `buf` (`len` bytes available) as
+ * "S-<rev>-<authority>-<sub>..." into `out`.  Returns the number of SID bytes
+ * consumed from `buf`, or -1 on a malformed/truncated SID or a too-small
+ * `out`.
+ */
+int chimera_sid_bin_to_str(
+    const uint8_t *buf,
+    uint32_t       len,
+    char          *out,
+    int            outlen);
+
+/*
+ * Parse "S-<rev>-<authority>-<sub>..." into the binary form at `out`
+ * (capacity `outcap`).  Strict: digits only, no trailing text.  Returns the
+ * binary length written, or -1 on malformed input / insufficient capacity.
+ */
+int chimera_sid_str_to_bin(
+    const char *str,
+    uint8_t    *out,
+    int         outcap);
+
+/*
+ * Copy the binary SID at the start of `buf` into `sid`.  Returns the number
+ * of bytes consumed, or -1 (and `sid` cleared) if it is malformed.
+ */
+int chimera_sid_from_bin(
+    struct chimera_sid *sid,
+    const uint8_t      *buf,
+    uint32_t            avail);
+
+/* Format `sid` as text.  Returns the string length, or -1 if absent/too small. */
+int chimera_sid_to_str(
+    const struct chimera_sid *sid,
+    char                     *out,
+    int                       outlen);
+
+/* Parse text into `sid`.  Returns 0, or -1 (and `sid` cleared) on bad input. */
+int chimera_sid_from_str(
+    struct chimera_sid *sid,
+    const char         *str);
+
+/*
+ * A SID is present only when `len` can describe one: at least the 8-byte
+ * header, at most the 15-sub-authority maximum.  Any other value -- storage
+ * that was never initialised, or a module handing back a bogus owner SID --
+ * is treated as absent, so every consumer that copies `len` bytes is bounded
+ * here rather than by trust in whoever built the struct.  This is the SDK
+ * trust boundary for the SID.
+ */
+static inline int
+chimera_sid_present(const struct chimera_sid *sid)
+{
+    return sid != NULL &&
+           sid->len >= CHIMERA_SID_MIN_LEN &&
+           sid->len <= CHIMERA_SID_MAX_LEN;
+} /* chimera_sid_present */
+
+/* Two SIDs are equal only when both are present and byte-identical. */
+static inline int
+chimera_sid_equal(
+    const struct chimera_sid *a,
+    const struct chimera_sid *b)
+{
+    if (!chimera_sid_present(a) || !chimera_sid_present(b) || a->len != b->len) {
+        return 0;
+    }
+    for (unsigned i = 0; i < a->len; i++) {
+        if (a->data[i] != b->data[i]) {
+            return 0;
+        }
+    }
+    return 1;
+} /* chimera_sid_equal */

--- a/src/vfs/sdk/vfs_sid.h
+++ b/src/vfs/sdk/vfs_sid.h
@@ -99,6 +99,45 @@ int chimera_sid_from_str(
     const char         *str);
 
 /*
+ * Owner / group SID pair record: the companions to uid / gid that the native
+ * backends persist beside (not inside) the ACL, so "no ACL record" still
+ * means "mode-derived DACL" and a chown never touches the DACL record.
+ *
+ *     u8 owner_len, owner bytes, u8 group_len, group bytes
+ *
+ * A zero length means that SID is not recorded.  Shared by cairn
+ * (CAIRN_KEY_SID) and diskfs (DISKFS_REC_SID).
+ */
+#define CHIMERA_SID_PAIR_MAX (2 + 2 * CHIMERA_SID_MAX_LEN)
+
+/*
+ * Encode `owner` / `group` (either may be NULL or absent) into `out`
+ * (capacity `outcap`).  Returns the record length (at least 2), 0 when
+ * neither SID is present -- nothing to store, and no record should exist --
+ * or -1 when `outcap` is too small.
+ */
+int chimera_sid_pair_encode(
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group,
+    uint8_t                  *out,
+    int                       outcap);
+
+/*
+ * Decode a pair record.  Both outputs are fully defined on every return: the
+ * recorded SID, or zeroed (absent) when it is not recorded, unreachable or
+ * malformed.  Returns 0 when every recorded SID decoded -- an absent record
+ * (NULL, or fewer than 2 bytes) is 0 with both outputs absent -- and -1 when
+ * a length byte runs past the record or a SID fails validation.  A SID that
+ * is still positionally reachable after a malformed one is decoded anyway,
+ * and bytes after the group SID are ignored.
+ */
+int chimera_sid_pair_decode(
+    const uint8_t      *buf,
+    int                 len,
+    struct chimera_sid *owner,
+    struct chimera_sid *group);
+
+/*
  * A SID is present only when `len` can describe one: at least the 8-byte
  * header, at most the 15-sub-authority maximum.  Any other value -- storage
  * that was never initialised, or a module handing back a bogus owner SID --

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -56,6 +56,10 @@ add_executable(vfs_idmap_test vfs_idmap_test.c)
 target_link_libraries(vfs_idmap_test chimera_vfs)
 add_test(chimera/vfs/idmap_test vfs_idmap_test)
 
+add_executable(vfs_sid_test vfs_sid_test.c)
+target_link_libraries(vfs_sid_test chimera_vfs)
+add_test(chimera/vfs/sid_test vfs_sid_test)
+
 add_executable(vfs_identity_test vfs_identity_test.c)
 target_link_libraries(vfs_identity_test chimera_vfs chimera_vfs_memfs evpl)
 add_test(chimera/vfs/identity_test vfs_identity_test)

--- a/src/vfs/tests/CMakeLists.txt
+++ b/src/vfs/tests/CMakeLists.txt
@@ -122,6 +122,26 @@ if(CHIMERA_VFS_IO_URING)
     set_tests_properties(chimera/vfs/xattr_dac_io_uring PROPERTIES SKIP_RETURN_CODE 77)
 endif()
 
+# Native Windows SID round trip through the VFS, parameterized by
+# backend: only the engine-managed backends that store the canonical ACL
+# natively (memfs, cairn, diskfs) can persist a SID-bearing principal and the
+# owner/group SID companions.  The passthrough backends are mode-only.
+add_executable(vfs_acl_sid_test vfs_acl_sid_test.c)
+target_link_libraries(vfs_acl_sid_test chimera_vfs chimera_vfs_memfs
+    chimera_vfs_diskfs chimera_vfs_memkv evpl)
+add_test(NAME chimera/vfs/acl_sid_memfs COMMAND vfs_acl_sid_test memfs)
+if(HAVE_LIBAIO)
+    add_test(NAME chimera/vfs/acl_sid_diskfs_aio COMMAND vfs_acl_sid_test diskfs_aio)
+endif()
+if(CHIMERA_VFS_IO_URING)
+    target_link_libraries(vfs_acl_sid_test chimera_vfs_io_uring)
+    add_test(NAME chimera/vfs/acl_sid_diskfs_io_uring COMMAND vfs_acl_sid_test diskfs_io_uring)
+endif()
+if(CAIRN_ENABLED)
+    target_link_libraries(vfs_acl_sid_test chimera_vfs_cairn)
+    add_test(NAME chimera/vfs/acl_sid_cairn COMMAND vfs_acl_sid_test cairn)
+endif()
+
 # Tag every test registered above with the 'vfs' label so the suite can be run
 # independently via `ctest -L vfs`.
 get_property(_vfs_tests DIRECTORY PROPERTY TESTS)

--- a/src/vfs/tests/vfs_acl_sid_test.c
+++ b/src/vfs/tests/vfs_acl_sid_test.c
@@ -44,9 +44,9 @@
 #define DEV_SIZE_BYTES (1024ULL * 1024ULL * 1024ULL) /* 1 GiB, sparse */
 #define TEST_MAX_ACES  8
 
-#define SID_OWNER  "S-1-5-21-7-8-9-500"
-#define SID_GROUP  "S-1-5-21-7-8-9-513"
-#define SID_OPAQUE "S-1-5-21-7-8-9-1001"
+#define SID_OWNER      "S-1-5-21-7-8-9-500"
+#define SID_GROUP      "S-1-5-21-7-8-9-513"
+#define SID_OPAQUE     "S-1-5-21-7-8-9-1001"
 
 struct test_ctx {
     int                             done;

--- a/src/vfs/tests/vfs_acl_sid_test.c
+++ b/src/vfs/tests/vfs_acl_sid_test.c
@@ -1,0 +1,513 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * Backend-parameterized native-SID round trip through the VFS.
+ *
+ * On an engine-authoritative backend that stores the canonical ACL natively
+ * (memfs, cairn, diskfs), an ACL whose principals carry native Windows SIDs
+ * -- including an opaque CHIMERA_PRINCIPAL_SID the identity layer could not
+ * map -- must come back byte-for-byte from getattr, and the owner/group SID
+ * companions must persist alongside va_uid/va_gid.  A chown that does not
+ * restate the owner SID must drop the stale one, and storing an owner SID on
+ * an object with no explicit DACL must not manufacture an empty ACL (the
+ * mode-derived DACL has to survive).
+ *
+ *     vfs_acl_sid_test <backend>
+ *
+ * where <backend> is memfs (default), cairn, diskfs_io_uring, or diskfs_aio.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "evpl/evpl.h"
+#include "vfs/vfs.h"
+#include "vfs/vfs_procs.h"
+#include "vfs/vfs_release.h"
+#include "vfs/sdk/vfs_attrs.h"
+#include "vfs/sdk/vfs_cred.h"
+#include "vfs/sdk/vfs_error.h"
+#include "vfs/sdk/vfs_acl.h"
+#include "vfs/sdk/vfs_sid.h"
+#include "common/logging.h"
+#include "prometheus-c.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+#define DEV_SIZE_BYTES (1024ULL * 1024ULL * 1024ULL) /* 1 GiB, sparse */
+#define TEST_MAX_ACES  8
+
+#define SID_OWNER  "S-1-5-21-7-8-9-500"
+#define SID_GROUP  "S-1-5-21-7-8-9-513"
+#define SID_OPAQUE "S-1-5-21-7-8-9-1001"
+
+struct test_ctx {
+    int                             done;
+    enum chimera_vfs_error          status;
+    struct chimera_vfs             *vfs;
+    struct chimera_vfs_thread      *vfs_thread;
+    struct evpl                    *evpl;
+    uint8_t                         fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        fh_len;
+    struct chimera_vfs_open_handle *handle;
+
+    /* getattr copy-out: the live attrs are only valid inside the callback */
+    uint64_t                        got_mask;
+    uint64_t                        got_uid;
+    uint64_t                        got_gid;
+    uint64_t                        got_mode;
+    struct chimera_sid              got_owner_sid;
+    struct chimera_sid              got_group_sid;
+    uint8_t                         got_acl_storage[sizeof(struct chimera_acl) +
+                                                    TEST_MAX_ACES * sizeof(struct chimera_ace)];
+};
+
+static void
+wait_done(struct test_ctx *ctx)
+{
+    while (!ctx->done) {
+        evpl_continue(ctx->evpl);
+    }
+    ctx->done = 0;
+} /* wait_done */
+
+static void
+mount_cb(
+    struct chimera_vfs_thread *thread,
+    enum chimera_vfs_error     status,
+    void                      *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = status;
+    ctx->done   = 1;
+} /* mount_cb */
+
+static void
+lookup_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    if (error_code == CHIMERA_VFS_OK) {
+        memcpy(ctx->fh, attr->va_fh, attr->va_fh_len);
+        ctx->fh_len = attr->va_fh_len;
+    }
+    ctx->done = 1;
+} /* lookup_cb */
+
+static void
+openfh_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openfh_cb */
+
+static void
+openat_cb(
+    enum chimera_vfs_error          error_code,
+    struct chimera_vfs_open_handle *oh,
+    struct chimera_vfs_attrs       *set_attr,
+    struct chimera_vfs_attrs       *attr,
+    struct chimera_vfs_attrs       *dir_pre,
+    struct chimera_vfs_attrs       *dir_post,
+    void                           *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->handle = oh;
+    ctx->done   = 1;
+} /* openat_cb */
+
+static void
+setattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *pre_attr,
+    struct chimera_vfs_attrs *set_attr,
+    struct chimera_vfs_attrs *post_attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    ctx->done   = 1;
+} /* setattr_cb */
+
+static void
+getattr_cb(
+    enum chimera_vfs_error    error_code,
+    struct chimera_vfs_attrs *attr,
+    void                     *private_data)
+{
+    struct test_ctx *ctx = private_data;
+
+    ctx->status = error_code;
+    memset(&ctx->got_owner_sid, 0, sizeof(ctx->got_owner_sid));
+    memset(&ctx->got_group_sid, 0, sizeof(ctx->got_group_sid));
+    memset(ctx->got_acl_storage, 0, sizeof(ctx->got_acl_storage));
+    ctx->got_mask = 0;
+
+    if (error_code == CHIMERA_VFS_OK) {
+        ctx->got_mask = attr->va_set_mask;
+        ctx->got_uid  = attr->va_uid;
+        ctx->got_gid  = attr->va_gid;
+        ctx->got_mode = attr->va_mode;
+        if ((attr->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) && attr->va_owner_sid) {
+            ctx->got_owner_sid = *attr->va_owner_sid;
+        }
+        if ((attr->va_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) && attr->va_group_sid) {
+            ctx->got_group_sid = *attr->va_group_sid;
+        }
+        if ((attr->va_set_mask & CHIMERA_VFS_ATTR_ACL) && attr->va_acl &&
+            attr->va_acl->num_aces <= TEST_MAX_ACES) {
+            memcpy(ctx->got_acl_storage, attr->va_acl,
+                   chimera_acl_size(attr->va_acl->num_aces));
+        }
+    }
+    ctx->done = 1;
+} /* getattr_cb */
+
+static void
+do_getattr(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred)
+{
+    chimera_vfs_getattr(ctx->vfs_thread, cred, ctx->handle,
+                        CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL |
+                        CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID,
+                        getattr_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* do_getattr */
+
+static void
+do_setattr(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    struct chimera_vfs_attrs      *sattr)
+{
+    chimera_vfs_setattr(ctx->vfs_thread, cred, ctx->handle, sattr, 0, 0,
+                        setattr_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* do_setattr */
+
+/* Create `name` (0644, uid/gid 1000) under `dir`; leaves the file open in
+ * ctx->handle. */
+static void
+create_file(
+    struct test_ctx                *ctx,
+    const struct chimera_vfs_cred  *cred,
+    struct chimera_vfs_open_handle *dir,
+    const char                     *name)
+{
+    struct chimera_vfs_attrs sattr;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_UID |
+        CHIMERA_VFS_ATTR_GID;
+    sattr.va_mode = 0644;
+    sattr.va_uid  = 1000;
+    sattr.va_gid  = 1000;
+
+    chimera_vfs_open_at(ctx->vfs_thread, cred, dir, name, strlen(name),
+                        CHIMERA_VFS_OPEN_CREATE, &sattr, CHIMERA_VFS_ATTR_FH,
+                        0, 0, openat_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    assert(ctx->handle != NULL);
+} /* create_file */
+
+/* Per-backend wiring, mirroring vfs_zerorange_test. */
+struct backend_spec {
+    int         ncfg;
+    const char *mount_module;
+    char        mount_path[300];
+    int         needs_mkfs;
+};
+
+static void
+backend_configure(
+    const char                    *backend,
+    const char                    *session_dir,
+    struct chimera_vfs_module_cfg *cfgs,
+    struct backend_spec           *spec)
+{
+    char dev_path[300];
+    char cfg[512];
+
+    memset(spec, 0, sizeof(*spec));
+
+    if (strcmp(backend, "memfs") == 0) {
+        strncpy(cfgs[0].module_name, "memfs", sizeof(cfgs[0].module_name) - 1);
+        spec->mount_module = "memfs";
+        spec->needs_mkfs   = 1;
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
+    } else if (strcmp(backend, "cairn") == 0) {
+        strncpy(cfgs[0].module_name, "cairn", sizeof(cfgs[0].module_name) - 1);
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"path\":\"%s\"}", session_dir);
+        strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
+        spec->mount_module = "cairn";
+        spec->needs_mkfs   = 1;
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
+    } else if (strcmp(backend, "diskfs_io_uring") == 0 ||
+               strcmp(backend, "diskfs_aio") == 0) {
+        const char *iotype = (strcmp(backend, "diskfs_aio") == 0) ? "libaio"
+                                                                  : "io_uring";
+        int         fd, rc;
+
+        snprintf(dev_path, sizeof(dev_path), "%s/device-0.img", session_dir);
+        fd = open(dev_path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+        assert(fd >= 0);
+        rc = ftruncate(fd, (off_t) DEV_SIZE_BYTES);
+        assert(rc == 0);
+        close(fd);
+
+        snprintf(cfg, sizeof(cfg),
+                 "{\"initialize\":true,\"unsafe_async\":true,"
+                 "\"intent_log_size\":67108864,"
+                 "\"devices\":[{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}]}",
+                 iotype, dev_path);
+        strncpy(cfgs[0].module_name, "diskfs", sizeof(cfgs[0].module_name) - 1);
+        strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
+        spec->mount_module = "diskfs";
+        spec->needs_mkfs   = 1;
+        snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
+    } else {
+        fprintf(stderr, "unknown backend: %s\n", backend);
+        exit(2);
+    }
+
+    strncpy(cfgs[1].module_name, "memkv", sizeof(cfgs[1].module_name) - 1);
+    spec->ncfg = 2;
+} /* backend_configure */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    struct test_ctx                 ctx = { 0 };
+    struct chimera_vfs_module_cfg   module_cfgs[2];
+    struct backend_spec             spec;
+    struct prometheus_metrics      *metrics;
+    struct chimera_vfs_cred         cred;
+    struct chimera_vfs_attrs        sattr;
+    struct chimera_vfs_open_handle *root_handle;
+    struct chimera_vfs_open_handle *f_handle;
+    struct chimera_vfs_open_handle *g_handle;
+    const char                     *backend = argc > 1 ? argv[1] : "memfs";
+    char                            tmpl[]  = "/tmp/vfs_aclsid_XXXXXX";
+    char                           *session_dir;
+    uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
+    uint32_t                        root_fh_len;
+    struct chimera_sid              owner_sid, group_sid, opaque_sid;
+    uint8_t                         acl_storage[sizeof(struct chimera_acl) +
+                                                TEST_MAX_ACES * sizeof(struct chimera_ace)];
+    struct chimera_acl             *acl     = (struct chimera_acl *) acl_storage;
+    struct chimera_acl             *got_acl = (struct chimera_acl *) ctx.got_acl_storage;
+
+    chimera_log_init();
+    chimera_vfs_cred_init_unix(&cred, 0, 0, 0, NULL);
+
+    assert(chimera_sid_from_str(&owner_sid, SID_OWNER) == 0);
+    assert(chimera_sid_from_str(&group_sid, SID_GROUP) == 0);
+    assert(chimera_sid_from_str(&opaque_sid, SID_OPAQUE) == 0);
+
+    session_dir = mkdtemp(tmpl);
+    assert(session_dir != NULL);
+
+    memset(module_cfgs, 0, sizeof(module_cfgs));
+    backend_configure(backend, session_dir, module_cfgs, &spec);
+
+    metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(metrics != NULL);
+
+    ctx.evpl = evpl_create(NULL);
+    assert(ctx.evpl != NULL);
+
+    ctx.vfs = chimera_vfs_init(0, 0, module_cfgs, spec.ncfg, "memkv", 60, 1, 1, 0,
+                               metrics);
+    assert(ctx.vfs != NULL);
+
+    ctx.vfs_thread = chimera_vfs_thread_init(ctx.evpl, ctx.vfs);
+    assert(ctx.vfs_thread != NULL);
+
+    if (spec.needs_mkfs) {
+        chimera_vfs_mkfs(ctx.vfs_thread, NULL, spec.mount_module, "fs0", NULL,
+                         mount_cb, &ctx);
+        wait_done(&ctx);
+        assert(ctx.status == CHIMERA_VFS_OK);
+    }
+
+    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", spec.mount_module,
+                      spec.mount_path, NULL, mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
+    chimera_vfs_lookup(ctx.vfs_thread, &cred, root_fh, root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    memcpy(root_fh, ctx.fh, ctx.fh_len);
+    root_fh_len = ctx.fh_len;
+
+    chimera_vfs_open_fh(ctx.vfs_thread, &cred, root_fh, root_fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+    root_handle = ctx.handle;
+
+    create_file(&ctx, &cred, root_handle, "f");
+    f_handle = ctx.handle;
+
+    /* --- 1. an explicit DACL with SID-bearing principals + owner/group SIDs
+     *        round-trips byte-for-byte --- */
+    memset(acl_storage, 0, sizeof(acl_storage));
+    acl->num_aces            = 2;
+    acl->ctrl_flags          = CHIMERA_ACL_CTRL_PROTECTED;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].flags       = 0;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_SID;
+    acl->aces[0].who.sid     = opaque_sid;
+    acl->aces[1].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[1].flags       = 0;
+    acl->aces[1].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA;
+    acl->aces[1].who.type    = CHIMERA_PRINCIPAL_USER;
+    acl->aces[1].who.id      = 1000;
+    acl->aces[1].who.sid     = owner_sid;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_ACL |
+        CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_OWNER_SID |
+        CHIMERA_VFS_ATTR_GID | CHIMERA_VFS_ATTR_GROUP_SID;
+    sattr.va_acl       = acl;
+    sattr.va_uid       = 1000;
+    sattr.va_owner_sid = &owner_sid;
+    sattr.va_gid       = 1000;
+    sattr.va_group_sid = &group_sid;
+    ctx.handle         = f_handle;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_ACL);
+    assert(got_acl->num_aces == 2);
+    assert(got_acl->ctrl_flags == CHIMERA_ACL_CTRL_PROTECTED);
+    assert(memcmp(got_acl->aces, acl->aces, 2 * sizeof(struct chimera_ace)) == 0);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID);
+    assert(chimera_sid_equal(&ctx.got_group_sid, &group_sid));
+    assert(ctx.got_uid == 1000 && ctx.got_gid == 1000);
+    TEST_PASS("SID-bearing ACL and owner/group SIDs round-trip via getattr");
+
+    /* --- 2. a chown without a SID companion drops the stale owner SID and
+     *        leaves the group SID and the DACL alone --- */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_UID;
+    sattr.va_uid      = 1001;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_uid == 1001);
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+    assert(!chimera_sid_present(&ctx.got_owner_sid));
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID);
+    assert(chimera_sid_equal(&ctx.got_group_sid, &group_sid));
+    assert(got_acl->num_aces == 2);
+    assert(chimera_sid_equal(&got_acl->aces[0].who.sid, &opaque_sid));
+    TEST_PASS("chown without a SID clears the owner SID only");
+
+    /* --- 3. an explicit clear (GROUP_SID with no SID) removes the group SID --- */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_GROUP_SID;
+    sattr.va_group_sid = NULL;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID));
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+    assert(got_acl->num_aces == 2);
+    TEST_PASS("explicit GROUP_SID clear removes the group SID");
+
+    chimera_vfs_release(ctx.vfs_thread, f_handle);
+
+    /* --- 4. owner SID on an object with no explicit DACL: the mode-derived
+     *        DACL must survive (no empty ACL is manufactured) --- */
+    create_file(&ctx, &cred, root_handle, "g");
+    g_handle = ctx.handle;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_uid       = 1000;
+    sattr.va_owner_sid = &owner_sid;
+    do_setattr(&ctx, &cred, &sattr);
+
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_ACL);
+    assert(got_acl->num_aces >= 3); /* mode-derived OWNER@/GROUP@/EVERYONE@ */
+    assert(chimera_acl_to_mode(got_acl) == 0644);
+
+    /* and a chmod on it still regenerates from mode, not from an empty ACL */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_MODE;
+    sattr.va_mode     = 0600;
+    do_setattr(&ctx, &cred, &sattr);
+    do_getattr(&ctx, &cred);
+    assert((ctx.got_mode & 0777) == 0600);
+    assert(got_acl->num_aces >= 3);
+    assert(chimera_acl_to_mode(got_acl) == 0600);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    TEST_PASS("owner SID without an explicit DACL keeps the mode-derived ACL");
+
+    chimera_vfs_release(ctx.vfs_thread, g_handle);
+    chimera_vfs_release(ctx.vfs_thread, root_handle);
+
+    chimera_vfs_umount(ctx.vfs_thread, NULL, "/test", mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    if (spec.needs_mkfs) {
+        for (int i = 0; i < 50; i++) {
+            chimera_vfs_rmfs(ctx.vfs_thread, NULL, spec.mount_module, "fs0",
+                             mount_cb, &ctx);
+            wait_done(&ctx);
+            if (ctx.status != CHIMERA_VFS_EBUSY) {
+                break;
+            }
+            usleep(100000);
+        }
+        assert(ctx.status == CHIMERA_VFS_OK);
+    }
+
+    chimera_vfs_thread_destroy(ctx.vfs_thread);
+    chimera_vfs_destroy(ctx.vfs);
+    evpl_destroy(ctx.evpl);
+    prometheus_metrics_destroy(metrics);
+
+    fprintf(stderr, "All native-SID round-trip tests passed on %s\n", backend);
+    return 0;
+} /* main */

--- a/src/vfs/tests/vfs_acl_sid_test.c
+++ b/src/vfs/tests/vfs_acl_sid_test.c
@@ -14,6 +14,13 @@
  * an object with no explicit DACL must not manufacture an empty ACL (the
  * mode-derived DACL has to survive).
  *
+ * The chown gate treats a SID as the companion of its numeric identity, so
+ * a non-root leg checks who may attach, restate, replace or clear one.  A
+ * SETATTR that shrinks a file and chowns it in one call must drop the stale
+ * owner SID like any other chown.  And on the persistent backends everything
+ * stored must come back byte for byte after a cold restart -- the in-memory
+ * record mirrors are gone, so that is what proves the on-disk replay.
+ *
  *     vfs_acl_sid_test <backend>
  *
  * where <backend> is memfs (default), cairn, diskfs_io_uring, or diskfs_aio.
@@ -63,6 +70,7 @@ struct test_ctx {
     uint64_t                        got_uid;
     uint64_t                        got_gid;
     uint64_t                        got_mode;
+    uint64_t                        got_size;
     struct chimera_sid              got_owner_sid;
     struct chimera_sid              got_group_sid;
     uint8_t                         got_acl_storage[sizeof(struct chimera_acl) +
@@ -169,6 +177,7 @@ getattr_cb(
         ctx->got_uid  = attr->va_uid;
         ctx->got_gid  = attr->va_gid;
         ctx->got_mode = attr->va_mode;
+        ctx->got_size = attr->va_size;
         if ((attr->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) && attr->va_owner_sid) {
             ctx->got_owner_sid = *attr->va_owner_sid;
         }
@@ -209,6 +218,42 @@ do_setattr(
     assert(ctx->status == CHIMERA_VFS_OK);
 } /* do_setattr */
 
+/* Like do_setattr, but hands the status back so a gate refusal can be
+ * asserted rather than aborting the test. */
+static enum chimera_vfs_error
+setattr_status(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    struct chimera_vfs_attrs      *sattr)
+{
+    chimera_vfs_setattr(ctx->vfs_thread, cred, ctx->handle, sattr, 0, 0,
+                        setattr_cb, ctx);
+    wait_done(ctx);
+    return ctx->status;
+} /* setattr_status */
+
+/* Look `name` up under `dir_fh` and open it; leaves the handle in ctx->handle. */
+static void
+open_child(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const uint8_t                 *dir_fh,
+    uint32_t                       dir_fh_len,
+    const char                    *name)
+{
+    chimera_vfs_lookup(ctx->vfs_thread, cred, dir_fh, dir_fh_len, name,
+                       strlen(name),
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+
+    chimera_vfs_open_fh(ctx->vfs_thread, cred, ctx->fh, ctx->fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+} /* open_child */
+
 /* Create `name` (0644, uid/gid 1000) under `dir`; leaves the file open in
  * ctx->handle. */
 static void
@@ -241,17 +286,23 @@ struct backend_spec {
     const char *mount_module;
     char        mount_path[300];
     int         needs_mkfs;
+    int         persistent; /* survives a cold restart of the VFS */
 };
 
+/* With `reuse` set the store created earlier in this run is opened as it is:
+ * no device is (re)created and the module is not told to initialize it, so a
+ * second chimera_vfs_init sees what the first one wrote. */
 static void
 backend_configure(
     const char                    *backend,
     const char                    *session_dir,
     struct chimera_vfs_module_cfg *cfgs,
-    struct backend_spec           *spec)
+    struct backend_spec           *spec,
+    int                            reuse)
 {
-    char dev_path[300];
-    char cfg[512];
+    const char *init = reuse ? "" : "\"initialize\":true,";
+    char        dev_path[300];
+    char        cfg[512];
 
     memset(spec, 0, sizeof(*spec));
 
@@ -262,34 +313,38 @@ backend_configure(
         snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
     } else if (strcmp(backend, "cairn") == 0) {
         strncpy(cfgs[0].module_name, "cairn", sizeof(cfgs[0].module_name) - 1);
-        snprintf(cfg, sizeof(cfg),
-                 "{\"initialize\":true,\"path\":\"%s\"}", session_dir);
+        snprintf(cfg, sizeof(cfg), "{%s\"path\":\"%s\"}", init, session_dir);
         strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
         spec->mount_module = "cairn";
         spec->needs_mkfs   = 1;
+        spec->persistent   = 1;
         snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
     } else if (strcmp(backend, "diskfs_io_uring") == 0 ||
                strcmp(backend, "diskfs_aio") == 0) {
         const char *iotype = (strcmp(backend, "diskfs_aio") == 0) ? "libaio"
                                                                   : "io_uring";
-        int         fd, rc;
 
         snprintf(dev_path, sizeof(dev_path), "%s/device-0.img", session_dir);
-        fd = open(dev_path, O_CREAT | O_TRUNC | O_RDWR, 0644);
-        assert(fd >= 0);
-        rc = ftruncate(fd, (off_t) DEV_SIZE_BYTES);
-        assert(rc == 0);
-        close(fd);
+        if (!reuse) {
+            int fd = open(dev_path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+            int rc;
+
+            assert(fd >= 0);
+            rc = ftruncate(fd, (off_t) DEV_SIZE_BYTES);
+            assert(rc == 0);
+            close(fd);
+        }
 
         snprintf(cfg, sizeof(cfg),
-                 "{\"initialize\":true,\"unsafe_async\":true,"
+                 "{%s\"unsafe_async\":true,"
                  "\"intent_log_size\":67108864,"
                  "\"devices\":[{\"type\":\"%s\",\"size\":1,\"path\":\"%s\"}]}",
-                 iotype, dev_path);
+                 init, iotype, dev_path);
         strncpy(cfgs[0].module_name, "diskfs", sizeof(cfgs[0].module_name) - 1);
         strncpy(cfgs[0].config_data, cfg, sizeof(cfgs[0].config_data) - 1);
         spec->mount_module = "diskfs";
         spec->needs_mkfs   = 1;
+        spec->persistent   = 1;
         snprintf(spec->mount_path, sizeof(spec->mount_path), "fs0");
     } else {
         fprintf(stderr, "unknown backend: %s\n", backend);
@@ -299,6 +354,67 @@ backend_configure(
     strncpy(cfgs[1].module_name, "memkv", sizeof(cfgs[1].module_name) - 1);
     spec->ncfg = 2;
 } /* backend_configure */
+
+/* Mount fs0 at /test and open its root.  Fills root_fh / root_fh_len and
+ * returns the root handle; used at start-up and again after the restart. */
+static struct chimera_vfs_open_handle *
+mount_root(
+    struct test_ctx               *ctx,
+    const struct chimera_vfs_cred *cred,
+    const struct backend_spec     *spec,
+    uint8_t                       *root_fh,
+    uint32_t                      *root_fh_len)
+{
+    chimera_vfs_mount(ctx->vfs_thread, NULL, "/test", spec->mount_module,
+                      spec->mount_path, NULL, mount_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+
+    chimera_vfs_get_root_fh(root_fh, root_fh_len);
+    chimera_vfs_lookup(ctx->vfs_thread, cred, root_fh, *root_fh_len, "test", 4,
+                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
+                       lookup_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    memcpy(root_fh, ctx->fh, ctx->fh_len);
+    *root_fh_len = ctx->fh_len;
+
+    chimera_vfs_open_fh(ctx->vfs_thread, cred, root_fh, *root_fh_len,
+                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, ctx);
+    wait_done(ctx);
+    assert(ctx->status == CHIMERA_VFS_OK);
+    return ctx->handle;
+} /* mount_root */
+
+/* Tear the VFS down and bring it back on the same store without initialising
+ * it.  The inode caches and the in-memory record mirrors die with the old
+ * instance, so whatever getattr reports afterwards was read back from the
+ * device -- an in-process umount/mount would not prove that (diskfs keeps
+ * its inode cache across umount). */
+static void
+cold_restart(
+    struct test_ctx               *ctx,
+    const char                    *backend,
+    const char                    *session_dir,
+    struct chimera_vfs_module_cfg *module_cfgs,
+    struct backend_spec           *spec,
+    struct prometheus_metrics    **metrics)
+{
+    chimera_vfs_thread_destroy(ctx->vfs_thread);
+    chimera_vfs_destroy(ctx->vfs);
+    prometheus_metrics_destroy(*metrics);
+
+    memset(module_cfgs, 0, 2 * sizeof(*module_cfgs));
+    backend_configure(backend, session_dir, module_cfgs, spec, 1 /* reuse */);
+
+    *metrics = prometheus_metrics_create(NULL, NULL, 0);
+    assert(*metrics != NULL);
+    ctx->vfs = chimera_vfs_init(0, 0, module_cfgs, spec->ncfg, "memkv", 60, 1,
+                                1, 0, *metrics);
+    assert(ctx->vfs != NULL);
+    ctx->vfs_thread = chimera_vfs_thread_init(ctx->evpl, ctx->vfs);
+    assert(ctx->vfs_thread != NULL);
+} /* cold_restart */
 
 int
 main(
@@ -314,8 +430,12 @@ main(
     struct chimera_vfs_open_handle *root_handle;
     struct chimera_vfs_open_handle *f_handle;
     struct chimera_vfs_open_handle *g_handle;
+    struct chimera_vfs_open_handle *h_handle;
+    struct chimera_vfs_open_handle *t_handle;
+    struct chimera_vfs_cred         owner_cred, other_cred;
     const char                     *backend = argc > 1 ? argv[1] : "memfs";
     char                            tmpl[]  = "/tmp/vfs_aclsid_XXXXXX";
+    char                            rmcmd[400];
     char                           *session_dir;
     uint8_t                         root_fh[CHIMERA_VFS_FH_SIZE];
     uint32_t                        root_fh_len;
@@ -327,6 +447,8 @@ main(
 
     chimera_log_init();
     chimera_vfs_cred_init_unix(&cred, 0, 0, 0, NULL);
+    chimera_vfs_cred_init_unix(&owner_cred, 1000, 1000, 0, NULL);
+    chimera_vfs_cred_init_unix(&other_cred, 2000, 2000, 0, NULL);
 
     assert(chimera_sid_from_str(&owner_sid, SID_OWNER) == 0);
     assert(chimera_sid_from_str(&group_sid, SID_GROUP) == 0);
@@ -336,7 +458,7 @@ main(
     assert(session_dir != NULL);
 
     memset(module_cfgs, 0, sizeof(module_cfgs));
-    backend_configure(backend, session_dir, module_cfgs, &spec);
+    backend_configure(backend, session_dir, module_cfgs, &spec, 0);
 
     metrics = prometheus_metrics_create(NULL, NULL, 0);
     assert(metrics != NULL);
@@ -358,25 +480,7 @@ main(
         assert(ctx.status == CHIMERA_VFS_OK);
     }
 
-    chimera_vfs_mount(ctx.vfs_thread, NULL, "/test", spec.mount_module,
-                      spec.mount_path, NULL, mount_cb, &ctx);
-    wait_done(&ctx);
-    assert(ctx.status == CHIMERA_VFS_OK);
-
-    chimera_vfs_get_root_fh(root_fh, &root_fh_len);
-    chimera_vfs_lookup(ctx.vfs_thread, &cred, root_fh, root_fh_len, "test", 4,
-                       CHIMERA_VFS_ATTR_FH | CHIMERA_VFS_ATTR_MASK_STAT, 0,
-                       lookup_cb, &ctx);
-    wait_done(&ctx);
-    assert(ctx.status == CHIMERA_VFS_OK);
-    memcpy(root_fh, ctx.fh, ctx.fh_len);
-    root_fh_len = ctx.fh_len;
-
-    chimera_vfs_open_fh(ctx.vfs_thread, &cred, root_fh, root_fh_len,
-                        CHIMERA_VFS_OPEN_INFERRED, openfh_cb, &ctx);
-    wait_done(&ctx);
-    assert(ctx.status == CHIMERA_VFS_OK);
-    root_handle = ctx.handle;
+    root_handle = mount_root(&ctx, &cred, &spec, root_fh, &root_fh_len);
 
     create_file(&ctx, &cred, root_handle, "f");
     f_handle = ctx.handle;
@@ -484,6 +588,230 @@ main(
     TEST_PASS("owner SID without an explicit DACL keeps the mode-derived ACL");
 
     chimera_vfs_release(ctx.vfs_thread, g_handle);
+
+    /* --- 5. the chown gate treats a SID as the companion of its numeric
+     *        identity: the owner may attach, restate or clear one but not
+     *        replace it, and a non-owner may name one only with WRITE_OWNER
+     *        and only alongside a uid it is taking to itself --- */
+    create_file(&ctx, &cred, root_handle, "h");
+    h_handle = ctx.handle;
+
+    memset(acl_storage, 0, sizeof(acl_storage));
+    acl->num_aces            = 1;
+    acl->ctrl_flags          = CHIMERA_ACL_CTRL_PROTECTED;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].flags       = 0;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_USER;
+    acl->aces[0].who.id      = 1000;
+
+    /* attach: the object has no SID yet, and the owner saves a DACL that
+     * names its own SID alongside (the SMB AD flow) */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_ACL | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_acl       = acl;
+    sattr.va_owner_sid = &owner_sid;
+    assert(setattr_status(&ctx, &owner_cred, &sattr) == CHIMERA_VFS_OK);
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_uid == 1000);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+
+    /* restate: not a chown.  (sattr is rebuilt before every call: a backend
+     * rewrites the caller's va_set_mask to what it applied.) */
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA;
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_ACL | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_acl       = acl;
+    sattr.va_owner_sid = &owner_sid;
+    assert(setattr_status(&ctx, &owner_cred, &sattr) == CHIMERA_VFS_OK);
+
+    /* replace: a different owner SID is an ownership change the owner may
+     * not make; nothing of the refused set is applied */
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA |
+        CHIMERA_ACE_EXECUTE;
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_ACL | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_acl       = acl;
+    sattr.va_owner_sid = &opaque_sid;
+    assert(setattr_status(&ctx, &owner_cred, &sattr) == CHIMERA_VFS_EPERM);
+    do_getattr(&ctx, &cred);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    assert(got_acl->num_aces == 1);
+    assert(got_acl->aces[0].access_mask == CHIMERA_ACE_READ_DATA);
+
+    /* a non-owner without WRITE_OWNER may not name a SID at all -- this
+     * used to be dispatched to the backend unchecked */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_owner_sid = &opaque_sid;
+    assert(setattr_status(&ctx, &other_cred, &sattr) == CHIMERA_VFS_EPERM);
+    do_getattr(&ctx, &cred);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+
+    /* clear: permitted to the owner */
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_owner_sid = NULL;
+    assert(setattr_status(&ctx, &owner_cred, &sattr) == CHIMERA_VFS_OK);
+    do_getattr(&ctx, &cred);
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+
+    /* with WRITE_OWNER granted, the other user may take the object -- the
+     * SID alongside its own uid, never on its own */
+    memset(acl_storage, 0, sizeof(acl_storage));
+    acl->num_aces            = 2;
+    acl->ctrl_flags          = CHIMERA_ACL_CTRL_PROTECTED;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_USER;
+    acl->aces[0].who.id      = 1000;
+    acl->aces[1].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[1].access_mask = CHIMERA_ACE_WRITE_OWNER | CHIMERA_ACE_READ_ACL;
+    acl->aces[1].who.type    = CHIMERA_PRINCIPAL_USER;
+    acl->aces[1].who.id      = 2000;
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_ACL;
+    sattr.va_acl      = acl;
+    do_setattr(&ctx, &cred, &sattr);
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_owner_sid = &opaque_sid;
+    assert(setattr_status(&ctx, &other_cred, &sattr) == CHIMERA_VFS_EPERM);
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_uid       = 2000;
+    sattr.va_owner_sid = &opaque_sid;
+    assert(setattr_status(&ctx, &other_cred, &sattr) == CHIMERA_VFS_OK);
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_uid == 2000);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &opaque_sid));
+    TEST_PASS("the chown gate governs the SID as the companion of its identity");
+
+    /* --- 6. a shrinking truncate that also chowns drops the stale owner SID
+     *        like any other chown, and one that also sets an ACL and a SID
+     *        stores both (diskfs finished its truncate on a separate chain
+     *        that skipped the record steps) --- */
+    create_file(&ctx, &cred, root_handle, "t");
+    t_handle = ctx.handle;
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_SIZE;
+    sattr.va_size     = 65536; /* grow first: a shrink needs a size to shrink */
+    do_setattr(&ctx, &cred, &sattr);
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask  = CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_uid       = 1000;
+    sattr.va_owner_sid = &owner_sid;
+    do_setattr(&ctx, &cred, &sattr);
+    do_getattr(&ctx, &cred);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_SIZE | CHIMERA_VFS_ATTR_UID;
+    sattr.va_size     = 4096;
+    sattr.va_uid      = 1001;
+    do_setattr(&ctx, &cred, &sattr);
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_size == 4096);
+    assert(ctx.got_uid == 1001);
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+    assert(!chimera_sid_present(&ctx.got_owner_sid));
+
+    memset(acl_storage, 0, sizeof(acl_storage));
+    acl->num_aces            = 2;
+    acl->ctrl_flags          = CHIMERA_ACL_CTRL_PROTECTED;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_SID;
+    acl->aces[0].who.sid     = opaque_sid;
+    acl->aces[1].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[1].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA;
+    acl->aces[1].who.type    = CHIMERA_PRINCIPAL_USER;
+    acl->aces[1].who.id      = 1000;
+    acl->aces[1].who.sid     = owner_sid;
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.va_set_mask = CHIMERA_VFS_ATTR_SIZE | CHIMERA_VFS_ATTR_ACL |
+        CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_OWNER_SID;
+    sattr.va_size      = 1024;
+    sattr.va_acl       = acl;
+    sattr.va_uid       = 1000;
+    sattr.va_owner_sid = &owner_sid;
+    do_setattr(&ctx, &cred, &sattr);
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_size == 1024);
+    assert(ctx.got_uid == 1000);
+    assert(ctx.got_mask & CHIMERA_VFS_ATTR_ACL);
+    assert(got_acl->num_aces == 2);
+    assert(memcmp(got_acl->aces, acl->aces, 2 * sizeof(struct chimera_ace)) == 0);
+    assert((ctx.got_mode & 0777) == (chimera_acl_to_mode(acl) & 0777));
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    TEST_PASS("a shrinking truncate keeps SID and ACL coherence");
+
+    /* --- 7. everything stored comes back after a cold restart (memfs: after
+     *        a plain umount/mount) --- */
+    chimera_vfs_release(ctx.vfs_thread, h_handle);
+    chimera_vfs_release(ctx.vfs_thread, t_handle);
+    chimera_vfs_release(ctx.vfs_thread, root_handle);
+
+    chimera_vfs_umount(ctx.vfs_thread, NULL, "/test", mount_cb, &ctx);
+    wait_done(&ctx);
+    assert(ctx.status == CHIMERA_VFS_OK);
+
+    if (spec.persistent) {
+        cold_restart(&ctx, backend, session_dir, module_cfgs, &spec, &metrics);
+    }
+    root_handle = mount_root(&ctx, &cred, &spec, root_fh, &root_fh_len);
+
+    /* f: two SID-bearing ACEs, chowned to 1001 (owner SID dropped), group
+     * SID cleared explicitly */
+    open_child(&ctx, &cred, root_fh, root_fh_len, "f");
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_uid == 1001 && ctx.got_gid == 1000);
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_OWNER_SID));
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID));
+    assert(got_acl->num_aces == 2);
+    assert(got_acl->ctrl_flags == CHIMERA_ACL_CTRL_PROTECTED);
+    assert(got_acl->aces[0].who.type == CHIMERA_PRINCIPAL_SID);
+    assert(chimera_sid_equal(&got_acl->aces[0].who.sid, &opaque_sid));
+    assert(got_acl->aces[1].who.id == 1000);
+    assert(chimera_sid_equal(&got_acl->aces[1].who.sid, &owner_sid));
+    chimera_vfs_release(ctx.vfs_thread, ctx.handle);
+
+    /* g: an owner SID with no ACL record -- the mode-derived DACL must still
+     * be what comes back, so the SID record really is separate */
+    open_child(&ctx, &cred, root_fh, root_fh_len, "g");
+    do_getattr(&ctx, &cred);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    assert(!(ctx.got_mask & CHIMERA_VFS_ATTR_GROUP_SID));
+    assert((ctx.got_mode & 0777) == 0600);
+    assert(got_acl->num_aces >= 3);
+    assert(chimera_acl_to_mode(got_acl) == 0600);
+    chimera_vfs_release(ctx.vfs_thread, ctx.handle);
+
+    /* h: taken over by uid 2000 with the opaque SID as its companion */
+    open_child(&ctx, &cred, root_fh, root_fh_len, "h");
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_uid == 2000);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &opaque_sid));
+    assert(got_acl->num_aces == 2);
+    chimera_vfs_release(ctx.vfs_thread, ctx.handle);
+
+    /* t: the truncate-and-set state */
+    open_child(&ctx, &cred, root_fh, root_fh_len, "t");
+    do_getattr(&ctx, &cred);
+    assert(ctx.got_size == 1024);
+    assert(ctx.got_uid == 1000);
+    assert(chimera_sid_equal(&ctx.got_owner_sid, &owner_sid));
+    assert(got_acl->num_aces == 2);
+    assert(memcmp(got_acl->aces, acl->aces, 2 * sizeof(struct chimera_ace)) == 0);
+    chimera_vfs_release(ctx.vfs_thread, ctx.handle);
+    TEST_PASS(spec.persistent ? "SIDs and ACLs survive a cold restart"
+                              : "SIDs and ACLs survive umount and mount");
+
     chimera_vfs_release(ctx.vfs_thread, root_handle);
 
     chimera_vfs_umount(ctx.vfs_thread, NULL, "/test", mount_cb, &ctx);
@@ -507,6 +835,11 @@ main(
     chimera_vfs_destroy(ctx.vfs);
     evpl_destroy(ctx.evpl);
     prometheus_metrics_destroy(metrics);
+
+    snprintf(rmcmd, sizeof(rmcmd), "rm -rf %s", session_dir);
+    if (system(rmcmd) != 0) {
+        fprintf(stderr, "warning: could not remove %s\n", session_dir);
+    }
 
     fprintf(stderr, "All native-SID round-trip tests passed on %s\n", backend);
     return 0;

--- a/src/vfs/tests/vfs_acl_test.c
+++ b/src/vfs/tests/vfs_acl_test.c
@@ -277,6 +277,77 @@ test_serialize_roundtrip(void)
     /* truncated input is rejected */
     assert(chimera_acl_deserialize(buf, 3, back, 8) == -1);
 
+    /* v2: an ACE carrying a native SID round-trips byte-for-byte, and the
+     * presence of any SID selects the version-2 encoding. */
+    {
+        struct chimera_sid sid;
+
+        memset(acl_storage, 0, sizeof(acl_storage));
+        memset(back_storage, 0, sizeof(back_storage));
+        assert(chimera_sid_from_str(&sid, "S-1-5-21-7-8-9-1001") == 0);
+        acl->num_aces            = 2;
+        acl->ctrl_flags          = CHIMERA_ACL_CTRL_AUTO_INHERITED;
+        acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+        acl->aces[0].flags       = CHIMERA_ACE_FLAG_FILE_INHERIT;
+        acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA;
+        acl->aces[0].who.type    = CHIMERA_PRINCIPAL_SID;
+        acl->aces[0].who.sid     = sid;
+        acl->aces[1].type        = CHIMERA_ACE_DENIED;
+        acl->aces[1].flags       = 0;
+        acl->aces[1].access_mask = CHIMERA_ACE_WRITE_DATA;
+        acl->aces[1].who.type    = CHIMERA_PRINCIPAL_USER;
+        acl->aces[1].who.id      = 4000;
+        acl->aces[1].who.sid     = sid;
+
+        len = chimera_acl_serialize(acl, buf, sizeof(buf));
+        assert(len > 0);
+        assert((size_t) len == chimera_acl_serialized_size(acl));
+        assert(buf[0] == 2); /* version 2 because a SID is present */
+        n = chimera_acl_deserialize(buf, len, back, 8);
+        assert(n == 2);
+        assert(back->ctrl_flags == acl->ctrl_flags);
+        assert(memcmp(acl->aces, back->aces, 2 * sizeof(struct chimera_ace)) == 0);
+        /* a truncated SID trailer is rejected */
+        assert(chimera_acl_deserialize(buf, len - 1, back, 8) == -1);
+    }
+
+    /* v1 is still emitted when no ACE carries a SID, so an older binary
+     * reading a volume written by this one sees what it always did. */
+    memset(acl_storage, 0, sizeof(acl_storage));
+    memset(back_storage, 0, sizeof(back_storage));
+    chimera_acl_from_mode(0644, acl, 8);
+    len = chimera_acl_serialize(acl, buf, sizeof(buf));
+    assert(len > 0);
+    assert(buf[0] == 1);
+    assert((size_t) len == chimera_acl_serialized_size(acl));
+    assert(chimera_acl_deserialize(buf, len, back, 8) == acl->num_aces);
+    assert(memcmp(acl->aces, back->aces,
+                  acl->num_aces * sizeof(struct chimera_ace)) == 0);
+
+    /* A hand-built v1 blob (as persisted by pre-SID releases) decodes with
+     * the SID absent on every ACE. */
+    {
+        static const uint8_t v1[] = {
+            1,                      /* version                              */
+            0x01, 0x00,             /* ctrl_flags = PROTECTED               */
+            0x01, 0x00,             /* num_aces = 1                         */
+            0x00, 0x00,             /* type = ALLOWED                       */
+            0x00, 0x00,             /* flags                                */
+            0x01, 0x00, 0x00, 0x00, /* access_mask = READ_DATA              */
+            0x00,                   /* principal type = USER                */
+            0x00,                   /* special                              */
+            0xe8, 0x03, 0x00, 0x00, /* id = 1000                            */
+        };
+
+        memset(back_storage, 0, sizeof(back_storage));
+        n = chimera_acl_deserialize(v1, sizeof(v1), back, 8);
+        assert(n == 1);
+        assert(back->ctrl_flags == CHIMERA_ACL_CTRL_PROTECTED);
+        assert(back->aces[0].who.type == CHIMERA_PRINCIPAL_USER);
+        assert(back->aces[0].who.id == 1000);
+        assert(!chimera_sid_present(&back->aces[0].who.sid));
+    }
+
     TEST_PASS("serialize/deserialize round-trips, rejects bad input");
 } /* test_serialize_roundtrip */
 

--- a/src/vfs/tests/vfs_acl_test.c
+++ b/src/vfs/tests/vfs_acl_test.c
@@ -328,14 +328,14 @@ test_serialize_roundtrip(void)
      * the SID absent on every ACE. */
     {
         static const uint8_t v1[] = {
-            1,                      /* version                              */
-            0x01, 0x00,             /* ctrl_flags = PROTECTED               */
-            0x01, 0x00,             /* num_aces = 1                         */
-            0x00, 0x00,             /* type = ALLOWED                       */
-            0x00, 0x00,             /* flags                                */
+            1,    /* version                              */
+            0x01, 0x00, /* ctrl_flags = PROTECTED               */
+            0x01, 0x00, /* num_aces = 1                         */
+            0x00, 0x00, /* type = ALLOWED                       */
+            0x00, 0x00, /* flags                                */
             0x01, 0x00, 0x00, 0x00, /* access_mask = READ_DATA              */
-            0x00,                   /* principal type = USER                */
-            0x00,                   /* special                              */
+            0x00, /* principal type = USER                */
+            0x00, /* special                              */
             0xe8, 0x03, 0x00, 0x00, /* id = 1000                            */
         };
 

--- a/src/vfs/tests/vfs_acl_test.c
+++ b/src/vfs/tests/vfs_acl_test.c
@@ -12,6 +12,7 @@
 #include "vfs/vfs.h"
 #include "vfs/sdk/vfs_acl.h"
 #include "vfs/sdk/vfs_acl_serialize.h"
+#include "vfs/sdk/vfs_sid.h"
 #include "vfs/sdk/vfs_access.h"
 #include "vfs/sdk/vfs_attrs.h"
 #include "vfs/sdk/vfs_cred.h"
@@ -393,6 +394,97 @@ test_delete_allowed(void)
 
 #undef INIT_ATTR
 
+/*
+ * A CHIMERA_PRINCIPAL_SID ACE is an opaque native SID with no known unix id:
+ * it is stored and marshalled verbatim but matches no caller during access
+ * evaluation, exactly like a departed-user SID does on NTFS.
+ */
+static void
+test_sid_principal_never_matches(void)
+{
+    ACL_BUF(acl, 2);
+    struct chimera_vfs_cred u = mkcred(1000, 2000);
+    uint32_t                g;
+
+    memset(acl_storage, 0, sizeof(acl_storage));
+    acl->num_aces            = 1;
+    acl->ctrl_flags          = 0;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].flags       = 0;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_SID;
+    assert(chimera_sid_from_str(&acl->aces[0].who.sid, "S-1-5-21-9-9-9-1234") == 0);
+
+    /* Neither the caller nor the owner is granted data access by a SID-only
+     * DACL; only the implicit metadata/owner rights ever apply. */
+    g = chimera_acl_access_check(acl, 0, 4242, 4243, &u,
+                                 CHIMERA_ACE_READ_DATA | CHIMERA_ACE_WRITE_DATA, 0);
+    assert(g == 0);
+    g = chimera_acl_access_raw(acl, 4242, 4243, &u, CHIMERA_ACE_READ_DATA);
+    assert(g == 0);
+
+    /* It does not bear on the POSIX mode projection either. */
+    assert(chimera_acl_to_mode(acl) == 0);
+
+    TEST_PASS("CHIMERA_PRINCIPAL_SID ACE matches no caller and no mode class");
+} /* test_sid_principal_never_matches */
+
+/*
+ * chmod preserves a SID-bearing named ACE with its SID intact, and
+ * inheritance carries the SID onto the child while CREATOR_* substitution
+ * never leaks a SID onto the child's OWNER@/GROUP@ entry.
+ */
+static void
+test_sid_survives_chmod_and_inherit(void)
+{
+    ACL_BUF(in, 4);
+    ACL_BUF(out, 16);
+    ACL_BUF(child, 8);
+    struct chimera_sid sid;
+    int                n;
+
+    memset(in_storage, 0, sizeof(in_storage));
+    memset(out_storage, 0, sizeof(out_storage));
+    memset(child_storage, 0, sizeof(child_storage));
+    assert(chimera_sid_from_str(&sid, "S-1-5-21-7-8-9-1001") == 0);
+
+    /* Named user 4000 carrying its real SID, plus an inheritable CREATOR_OWNER
+     * template that must never carry a SID onto the child. */
+    in->ctrl_flags          = 0;
+    in->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    in->aces[0].flags       = CHIMERA_ACE_FLAG_FILE_INHERIT;
+    in->aces[0].access_mask = CHIMERA_ACE_WRITE_DATA;
+    in->aces[0].who.type    = CHIMERA_PRINCIPAL_USER;
+    in->aces[0].who.id      = 4000;
+    in->aces[0].who.sid     = sid;
+    in->aces[1].type        = CHIMERA_ACE_ALLOWED;
+    in->aces[1].flags       = CHIMERA_ACE_FLAG_FILE_INHERIT;
+    in->aces[1].access_mask = CHIMERA_ACE_READ_DATA;
+    in->aces[1].who.type    = CHIMERA_PRINCIPAL_SPECIAL;
+    in->aces[1].who.special = CHIMERA_WHO_CREATOR_OWNER;
+    in->num_aces            = 2;
+
+    n = chimera_acl_chmod(in, 0640, out, 16);
+    assert(n > 1);
+    assert(out->aces[0].who.type == CHIMERA_PRINCIPAL_USER);
+    assert(out->aces[0].who.id == 4000);
+    assert(chimera_sid_equal(&out->aces[0].who.sid, &sid));
+    /* the regenerated special-who entries carry no SID */
+    for (int i = 1; i < n; i++) {
+        assert(!chimera_sid_present(&out->aces[i].who.sid));
+    }
+
+    n = chimera_acl_inherit(in, 0 /* file */, 0644, child, 8);
+    assert(n == 2);
+    assert(chimera_sid_equal(&child->aces[0].who.sid, &sid));
+    assert(child->aces[1].who.type == CHIMERA_PRINCIPAL_SPECIAL);
+    assert(child->aces[1].who.special == CHIMERA_WHO_OWNER);
+    assert(!chimera_sid_present(&child->aces[1].who.sid));
+
+    TEST_PASS("SID survives chmod and inherit; specials never carry one");
+} /* test_sid_survives_chmod_and_inherit */
+
+
 int
 main(
     int    argc,
@@ -409,6 +501,8 @@ main(
     test_serialize_roundtrip();
     test_gate();
     test_delete_allowed();
+    test_sid_principal_never_matches();
+    test_sid_survives_chmod_and_inherit();
 
     fprintf(stderr, "All ACL engine tests passed\n");
     return 0;

--- a/src/vfs/tests/vfs_acl_test.c
+++ b/src/vfs/tests/vfs_acl_test.c
@@ -552,8 +552,89 @@ test_sid_survives_chmod_and_inherit(void)
     assert(child->aces[1].who.special == CHIMERA_WHO_OWNER);
     assert(!chimera_sid_present(&child->aces[1].who.sid));
 
+    /* Even a template that (against the contract) carries a SID hands the
+     * child a substituted OWNER@ whose SID is zero in every byte, not just in
+     * its length: an ACE is compared by value. */
+    memset(child_storage, 0, sizeof(child_storage));
+    in->aces[1].who.sid = sid;
+    n                   = chimera_acl_inherit(in, 0 /* file */, 0644, child, 8);
+    assert(n == 2);
+    assert(child->aces[1].who.special == CHIMERA_WHO_OWNER);
+    {
+        const uint8_t *b = (const uint8_t *) &child->aces[1].who.sid;
+
+        for (unsigned i = 0; i < sizeof(child->aces[1].who.sid); i++) {
+            assert(b[i] == 0);
+        }
+    }
+
     TEST_PASS("SID survives chmod and inherit; specials never carry one");
 } /* test_sid_survives_chmod_and_inherit */
+
+/*
+ * A SID whose length is out of range is not a SID.  The serializer encodes it
+ * as absent -- v1 when nothing else carries one, a zero-length trailer
+ * otherwise -- rather than copying `len` bytes of whatever data[] holds.
+ * That is the trust boundary: a producer that never initialised the struct,
+ * or an out-of-tree module returning a bogus owner SID, must not be able to
+ * put those bytes on disk or on the wire.
+ */
+static void
+test_serialize_bogus_sid_len(void)
+{
+    ACL_BUF(acl, 8);
+    ACL_BUF(back, 8);
+    struct chimera_sid sid;
+    uint8_t            buf[512];
+    int                len, n;
+
+    memset(acl_storage, 0, sizeof(acl_storage));
+    memset(back_storage, 0, sizeof(back_storage));
+
+    /* The only "SID" is bogus: v1, exactly as if none were present. */
+    acl->num_aces            = 1;
+    acl->ctrl_flags          = 0;
+    acl->aces[0].type        = CHIMERA_ACE_ALLOWED;
+    acl->aces[0].flags       = 0;
+    acl->aces[0].access_mask = CHIMERA_ACE_READ_DATA;
+    acl->aces[0].who.type    = CHIMERA_PRINCIPAL_USER;
+    acl->aces[0].who.id      = 4000;
+    acl->aces[0].who.sid.len = 200;
+    memset(acl->aces[0].who.sid.data, 0xee, sizeof(acl->aces[0].who.sid.data));
+    assert(!chimera_sid_present(&acl->aces[0].who.sid));
+
+    assert(chimera_acl_serialized_size(acl) ==
+           CHIMERA_ACL_SERIAL_HDR + CHIMERA_ACL_SERIAL_ACE);
+    len = chimera_acl_serialize(acl, buf, sizeof(buf));
+    assert(len == (int) chimera_acl_serialized_size(acl));
+    assert(buf[0] == 1);
+    n = chimera_acl_deserialize(buf, len, back, 8);
+    assert(n == 1);
+    assert(back->aces[0].who.type == CHIMERA_PRINCIPAL_USER);
+    assert(back->aces[0].who.id == 4000);
+    assert(!chimera_sid_present(&back->aces[0].who.sid));
+
+    /* One real SID and one bogus: v2, and the bogus one gets a zero trailer
+     * instead of 200 bytes of 0xee. */
+    assert(chimera_sid_from_str(&sid, "S-1-5-21-7-8-9-1001") == 0);
+    acl->num_aces        = 2;
+    acl->aces[1]         = acl->aces[0];
+    acl->aces[1].who.id  = 4001;
+    acl->aces[1].who.sid = sid;
+    assert(chimera_acl_serialized_size(acl) ==
+           CHIMERA_ACL_SERIAL_HDR + 2 * CHIMERA_ACL_SERIAL_ACE + 1 + 1 + sid.len);
+    len = chimera_acl_serialize(acl, buf, sizeof(buf));
+    assert(len == (int) chimera_acl_serialized_size(acl));
+    assert(buf[0] == 2);
+    memset(back_storage, 0, sizeof(back_storage));
+    n = chimera_acl_deserialize(buf, len, back, 8);
+    assert(n == 2);
+    assert(!chimera_sid_present(&back->aces[0].who.sid));
+    assert(back->aces[0].who.id == 4000);
+    assert(chimera_sid_equal(&back->aces[1].who.sid, &sid));
+
+    TEST_PASS("an out-of-range SID length is encoded as absent");
+} /* test_serialize_bogus_sid_len */
 
 
 int
@@ -574,6 +655,7 @@ main(
     test_delete_allowed();
     test_sid_principal_never_matches();
     test_sid_survives_chmod_and_inherit();
+    test_serialize_bogus_sid_len();
 
     fprintf(stderr, "All ACL engine tests passed\n");
     return 0;

--- a/src/vfs/tests/vfs_idmap_test.c
+++ b/src/vfs/tests/vfs_idmap_test.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <grp.h>
 #undef NDEBUG
 #include <assert.h>
 
@@ -113,6 +114,114 @@ test_buffer_limits(void)
     TEST_PASS("too-small buffers are rejected");
 } /* test_buffer_limits */
 
+/* Every byte of the struct must be zero: the reserved byte, and the whole
+ * native SID including the bytes past its length. */
+static void
+assert_principal_defined(const struct chimera_principal *q)
+{
+    const uint8_t *b = (const uint8_t *) &q->sid;
+
+    assert(q->reserved == 0);
+    assert(!chimera_sid_present(&q->sid));
+    for (unsigned i = 0; i < sizeof(q->sid); i++) {
+        assert(b[i] == 0);
+    }
+} /* assert_principal_defined */
+
+/* The decoder fully defines a principal on every path.  The NFSv4 SETATTR
+ * decoder hands it space from a bump allocator that is never cleared, so a
+ * principal that only had type/special/id assigned carried whatever the
+ * previous RPC left in the native-SID tail -- and an ACE is stored and
+ * compared by value. */
+static void
+test_principal_fully_defined(void)
+{
+    struct chimera_principal q, want;
+    struct group            *gr = getgrgid(0);
+    char                     gname[CHIMERA_IDMAP_WHO_MAX];
+
+    /* Special who. */
+    memset(&q, 0xa5, sizeof(q));
+    assert(chimera_idmap_who_to_principal("OWNER@", 6, 0, NULL, &q) == 0);
+    assert_principal_defined(&q);
+    want = chimera_idmap_special_principal(CHIMERA_WHO_OWNER);
+    assert(memcmp(&q, &want, sizeof(q)) == 0);
+
+    /* Well-known SID string naming a special. */
+    memset(&q, 0xa5, sizeof(q));
+    assert(chimera_idmap_who_to_principal("S-1-3-0", 7, 0, NULL, &q) == 0);
+    assert_principal_defined(&q);
+    want = chimera_idmap_special_principal(CHIMERA_WHO_CREATOR_OWNER);
+    assert(memcmp(&q, &want, sizeof(q)) == 0);
+
+    /* Numeric user and group. */
+    memset(&q, 0xa5, sizeof(q));
+    assert(chimera_idmap_who_to_principal("1000", 4, 0, NULL, &q) == 0);
+    assert_principal_defined(&q);
+    want = chimera_idmap_uid_principal(1000);
+    assert(memcmp(&q, &want, sizeof(q)) == 0);
+
+    memset(&q, 0xa5, sizeof(q));
+    assert(chimera_idmap_who_to_principal("2000", 4, 1, NULL, &q) == 0);
+    assert_principal_defined(&q);
+    want = chimera_idmap_gid_principal(2000);
+    assert(memcmp(&q, &want, sizeof(q)) == 0);
+
+    /* name@domain through nsswitch: root is uid 0 everywhere; the group
+     * named for gid 0 is looked up so the test does not assume its name. */
+    memset(&q, 0xa5, sizeof(q));
+    assert(chimera_idmap_who_to_principal("root@example.com", 16, 0, NULL,
+                                          &q) == 0);
+    assert_principal_defined(&q);
+    want = chimera_idmap_uid_principal(0);
+    assert(memcmp(&q, &want, sizeof(q)) == 0);
+
+    if (gr) {
+        int n = snprintf(gname, sizeof(gname), "%s@example.com", gr->gr_name);
+
+        memset(&q, 0xa5, sizeof(q));
+        assert(chimera_idmap_who_to_principal(gname, n, 1, NULL, &q) == 0);
+        assert_principal_defined(&q);
+        want = chimera_idmap_gid_principal(0);
+        assert(memcmp(&q, &want, sizeof(q)) == 0);
+    }
+
+    /* Failure leaves nothing of the caller's storage either. */
+    memset(&q, 0xa5, sizeof(q));
+    assert(chimera_idmap_who_to_principal("nosuchuser_chimera@dom", 22, 0,
+                                          NULL, &q) == -1);
+    assert_principal_defined(&q);
+    assert(q.type == 0 && q.special == 0 && q.id == 0);
+
+    TEST_PASS("decoded principals are fully defined on every path");
+} /* test_principal_fully_defined */
+
+/* An opaque native-SID principal has no NFSv4 name and no algorithmic SID:
+ * both encoders refuse it, so the NFSv4 ACL emitter drops the ACE instead of
+ * naming uid 0 -- root -- and nothing invents an S-1-5-88-2-0 for it.  An
+ * unknown type (a corrupt on-disk blob) is nameless the same way. */
+static void
+test_sid_principal_unnamed(void)
+{
+    struct chimera_principal p;
+    char                     buf[CHIMERA_IDMAP_WHO_MAX];
+
+    memset(&p, 0, sizeof(p));
+    p.type = CHIMERA_PRINCIPAL_SID;
+    assert(chimera_sid_from_str(&p.sid, "S-1-5-21-1-2-3-4") == 0);
+
+    assert(chimera_idmap_principal_to_who(&p, NULL, buf, sizeof(buf)) == -1);
+    assert(chimera_idmap_principal_to_who(&p, "example.com", buf,
+                                          sizeof(buf)) == -1);
+    assert(chimera_idmap_principal_to_sid(&p, buf, sizeof(buf)) == -1);
+
+    p.type = 200;
+    assert(chimera_idmap_principal_to_who(&p, NULL, buf, sizeof(buf)) == -1);
+    assert(chimera_idmap_principal_to_sid(&p, buf, sizeof(buf)) == -1);
+
+    TEST_PASS("an opaque SID principal is nameless to NFSv4 and the idmap");
+} /* test_sid_principal_unnamed */
+
 int
 main(
     int    argc,
@@ -121,6 +230,8 @@ main(
     test_who_roundtrip();
     test_sid_roundtrip();
     test_buffer_limits();
+    test_principal_fully_defined();
+    test_sid_principal_unnamed();
 
     fprintf(stderr, "All idmap tests passed\n");
     return 0;

--- a/src/vfs/tests/vfs_sid_test.c
+++ b/src/vfs/tests/vfs_sid_test.c
@@ -36,6 +36,20 @@ test_str_roundtrip(void)
     assert(chimera_sid_to_str(&s, buf, sizeof(buf)) > 0);
     assert(strcmp(buf, "S-1-5-21-1-2-3-1001") == 0);
 
+    /* The struct is fully defined: every byte past the SID is zero, so a
+     * copy of it (e.g. inside an ACE) compares byte-for-byte with one that
+     * was deserialized into zeroed storage. */
+    for (unsigned i = s.len; i < CHIMERA_SID_MAX_LEN; i++) {
+        assert(s.data[i] == 0);
+    }
+    /* ... and a failed parse leaves nothing of the previous contents. */
+    memset(&s, 0xa5, sizeof(s));
+    assert(chimera_sid_from_str(&s, "S-1-5-abc") == -1);
+    assert(!chimera_sid_present(&s));
+    for (unsigned i = 0; i < CHIMERA_SID_MAX_LEN; i++) {
+        assert(s.data[i] == 0);
+    }
+
     /* A well-known SID with a single sub-authority. */
     assert(chimera_sid_from_str(&s, "S-1-1-0") == 0);
     assert(s.len == 12);

--- a/src/vfs/tests/vfs_sid_test.c
+++ b/src/vfs/tests/vfs_sid_test.c
@@ -170,6 +170,94 @@ test_absent_and_equal(void)
     TEST_PASS("len 0 is the absent state; equality compares bytes");
 } /* test_absent_and_equal */
 
+/* The owner/group pair record the native backends persist (cairn and diskfs
+ * share this codec): every case leaves both outputs fully defined. */
+static void
+test_pair_codec(void)
+{
+    struct chimera_sid owner, group, o2, g2, none;
+    uint8_t            rec[CHIMERA_SID_PAIR_MAX];
+    uint8_t            big[CHIMERA_SID_PAIR_MAX + 16];
+    int                len;
+
+    memset(&none, 0, sizeof(none));
+    assert(chimera_sid_from_str(&owner, "S-1-5-21-1-2-3-1001") == 0);
+    assert(chimera_sid_from_str(&group, "S-1-5-21-1-2-3-513") == 0);
+
+    /* Both present: round trip byte for byte. */
+    len = chimera_sid_pair_encode(&owner, &group, rec, sizeof(rec));
+    assert(len == 2 + (int) owner.len + (int) group.len);
+    memset(&o2, 0xa5, sizeof(o2));
+    memset(&g2, 0xa5, sizeof(g2));
+    assert(chimera_sid_pair_decode(rec, len, &o2, &g2) == 0);
+    assert(memcmp(&o2, &owner, sizeof(owner)) == 0);
+    assert(memcmp(&g2, &group, sizeof(group)) == 0);
+
+    /* Owner only: the record ends with a zero group length. */
+    len = chimera_sid_pair_encode(&owner, NULL, rec, sizeof(rec));
+    assert(len == 2 + (int) owner.len);
+    assert(rec[len - 1] == 0);
+    assert(chimera_sid_pair_decode(rec, len, &o2, &g2) == 0);
+    assert(memcmp(&o2, &owner, sizeof(owner)) == 0);
+    assert(memcmp(&g2, &none, sizeof(none)) == 0);
+
+    /* Owner only, record cut right after the owner (no group length byte). */
+    assert(chimera_sid_pair_decode(rec, len - 1, &o2, &g2) == 0);
+    assert(memcmp(&o2, &owner, sizeof(owner)) == 0);
+    assert(memcmp(&g2, &none, sizeof(none)) == 0);
+
+    /* Group only: a zero owner length, then the group. */
+    len = chimera_sid_pair_encode(&none, &group, rec, sizeof(rec));
+    assert(len == 2 + (int) group.len);
+    assert(rec[0] == 0);
+    assert(chimera_sid_pair_decode(rec, len, &o2, &g2) == 0);
+    assert(memcmp(&o2, &none, sizeof(none)) == 0);
+    assert(memcmp(&g2, &group, sizeof(group)) == 0);
+
+    /* Neither present: nothing to store.  Too small a buffer: refused. */
+    assert(chimera_sid_pair_encode(NULL, NULL, rec, sizeof(rec)) == 0);
+    assert(chimera_sid_pair_encode(&none, &none, rec, sizeof(rec)) == 0);
+    assert(chimera_sid_pair_encode(&owner, &group, rec, 1) == -1);
+    assert(chimera_sid_pair_encode(&owner, &group, rec,
+                                   1 + owner.len + group.len) == -1);
+
+    /* Absent record: both outputs absent, not an error. */
+    memset(&o2, 0xa5, sizeof(o2));
+    memset(&g2, 0xa5, sizeof(g2));
+    assert(chimera_sid_pair_decode(NULL, 0, &o2, &g2) == 0);
+    assert(memcmp(&o2, &none, sizeof(none)) == 0);
+    assert(memcmp(&g2, &none, sizeof(none)) == 0);
+    rec[0] = 0;
+    assert(chimera_sid_pair_decode(rec, 1, &o2, &g2) == 0);
+    assert(memcmp(&o2, &none, sizeof(none)) == 0);
+
+    /* Corrupt owner, valid group: the group is still reachable and comes
+    * back; the owner is absent, and the record is reported malformed. */
+    len    = chimera_sid_pair_encode(&owner, &group, rec, sizeof(rec));
+    rec[2] = CHIMERA_SID_MAX_SUB_AUTHS + 1; /* owner's sub-authority count */
+    memset(&o2, 0xa5, sizeof(o2));
+    assert(chimera_sid_pair_decode(rec, len, &o2, &g2) == -1);
+    assert(memcmp(&o2, &none, sizeof(none)) == 0);
+    assert(memcmp(&g2, &group, sizeof(group)) == 0);
+
+    /* Owner length past the end of the record: nothing is reachable. */
+    len    = chimera_sid_pair_encode(&owner, &group, rec, sizeof(rec));
+    rec[0] = (uint8_t) (len + 5);
+    memset(&g2, 0xa5, sizeof(g2));
+    assert(chimera_sid_pair_decode(rec, len, &o2, &g2) == -1);
+    assert(memcmp(&o2, &none, sizeof(none)) == 0);
+    assert(memcmp(&g2, &none, sizeof(none)) == 0);
+
+    /* Trailing bytes after the group are ignored. */
+    len = chimera_sid_pair_encode(&owner, &group, big, sizeof(big));
+    memset(big + len, 0xee, sizeof(big) - len);
+    assert(chimera_sid_pair_decode(big, (int) sizeof(big), &o2, &g2) == 0);
+    assert(memcmp(&o2, &owner, sizeof(owner)) == 0);
+    assert(memcmp(&g2, &group, sizeof(group)) == 0);
+
+    TEST_PASS("owner/group pair record round-trips and stays defined");
+} /* test_pair_codec */
+
 int
 main(
     int    argc,
@@ -180,6 +268,7 @@ main(
     test_max_sub_auths();
     test_bad_input();
     test_absent_and_equal();
+    test_pair_codec();
 
     fprintf(stderr, "All SID codec tests passed\n");
     return 0;

--- a/src/vfs/tests/vfs_sid_test.c
+++ b/src/vfs/tests/vfs_sid_test.c
@@ -170,6 +170,39 @@ test_absent_and_equal(void)
     TEST_PASS("len 0 is the absent state; equality compares bytes");
 } /* test_absent_and_equal */
 
+/* A length that cannot describe a SID is not a SID: the presence predicate,
+ * and everything built on it, treats it as absent.  That is what bounds every
+ * consumer that copies `len` bytes -- the serializer, the SMB emitter, the
+ * backends -- whoever built the struct and however badly. */
+static void
+test_len_invariant(void)
+{
+    struct chimera_sid   s, t;
+    char                 buf[CHIMERA_SID_STR_MAX];
+    static const uint8_t bad[] = { 1, 2, 3, 4, 5, 6, 7, 69, 100, 200, 255 };
+
+    assert(chimera_sid_from_str(&s, "S-1-5-21-1-2-3-1001") == 0);
+
+    for (unsigned i = 0; i < sizeof(bad); i++) {
+        t     = s;
+        t.len = bad[i];
+        assert(!chimera_sid_present(&t));
+        assert(!chimera_sid_equal(&t, &t));
+        assert(!chimera_sid_equal(&t, &s));
+        assert(chimera_sid_to_str(&t, buf, sizeof(buf)) == -1);
+    }
+
+    /* The bounds themselves are present: the 8-byte header alone (a SID with
+     * no sub-authorities) and the 15-sub-authority maximum. */
+    t     = s;
+    t.len = CHIMERA_SID_MIN_LEN;
+    assert(chimera_sid_present(&t));
+    t.len = CHIMERA_SID_MAX_LEN;
+    assert(chimera_sid_present(&t));
+
+    TEST_PASS("out-of-range lengths are absent; the bounds are present");
+} /* test_len_invariant */
+
 /* The owner/group pair record the native backends persist (cairn and diskfs
  * share this codec): every case leaves both outputs fully defined. */
 static void
@@ -268,6 +301,7 @@ main(
     test_max_sub_auths();
     test_bad_input();
     test_absent_and_equal();
+    test_len_invariant();
     test_pair_codec();
 
     fprintf(stderr, "All SID codec tests passed\n");

--- a/src/vfs/tests/vfs_sid_test.c
+++ b/src/vfs/tests/vfs_sid_test.c
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+/*
+ * chimera_sid: the native Windows SID value type carried on ACL principals
+ * and owner/group attrs.  Covers the binary <-> string codec, the struct
+ * helpers, and the malformed-input rejections the SMB security-descriptor
+ * parser relies on.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#undef NDEBUG
+#include <assert.h>
+
+#include "vfs/sdk/vfs_sid.h"
+
+#define TEST_PASS(name) fprintf(stderr, "  PASS: %s\n", name)
+
+/* A domain SID round-trips string -> binary -> string. */
+static void
+test_str_roundtrip(void)
+{
+    struct chimera_sid s;
+    char               buf[CHIMERA_SID_STR_MAX];
+
+    memset(&s, 0xa5, sizeof(s)); /* from_str must fully define the struct */
+
+    assert(chimera_sid_from_str(&s, "S-1-5-21-1-2-3-1001") == 0);
+    assert(chimera_sid_present(&s));
+    assert(s.len == 8 + 5 * 4);
+    assert(s.data[0] == 1);  /* revision */
+    assert(s.data[1] == 5);  /* sub-authority count */
+    assert(s.data[7] == 5);  /* NT authority, big-endian low byte */
+    assert(chimera_sid_to_str(&s, buf, sizeof(buf)) > 0);
+    assert(strcmp(buf, "S-1-5-21-1-2-3-1001") == 0);
+
+    /* A well-known SID with a single sub-authority. */
+    assert(chimera_sid_from_str(&s, "S-1-1-0") == 0);
+    assert(s.len == 12);
+    assert(chimera_sid_to_str(&s, buf, sizeof(buf)) == 7);
+    assert(strcmp(buf, "S-1-1-0") == 0);
+
+    TEST_PASS("SID string round-trips through binary form");
+} /* test_str_roundtrip */
+
+/* The struct copies out of (and back into) a raw wire buffer. */
+static void
+test_bin_roundtrip(void)
+{
+    struct chimera_sid a, b;
+    uint8_t            wire[CHIMERA_SID_MAX_LEN + 8];
+    char               str[CHIMERA_SID_STR_MAX];
+    int                n;
+
+    assert(chimera_sid_from_str(&a, "S-1-5-21-100-200-300-513") == 0);
+
+    /* Consume exactly the SID from a longer buffer. */
+    memset(wire, 0xee, sizeof(wire));
+    memcpy(wire, a.data, a.len);
+    n = chimera_sid_from_bin(&b, wire, sizeof(wire));
+    assert(n == (int) a.len);
+    assert(chimera_sid_equal(&a, &b));
+
+    /* Raw-buffer string codec agrees with the struct form. */
+    n = chimera_sid_bin_to_str(wire, sizeof(wire), str, sizeof(str));
+    assert(n == (int) a.len);
+    assert(strcmp(str, "S-1-5-21-100-200-300-513") == 0);
+    memset(wire, 0, sizeof(wire));
+    n = chimera_sid_str_to_bin(str, wire, sizeof(wire));
+    assert(n == (int) a.len);
+    assert(memcmp(wire, a.data, a.len) == 0);
+
+    /* Truncated: the buffer ends before the declared sub-authorities. */
+    assert(chimera_sid_from_bin(&b, a.data, a.len - 1) == -1);
+
+    /* Over-long sub-authority count is rejected, not overrun. */
+    memset(wire, 0, sizeof(wire));
+    wire[0] = 1;
+    wire[1] = CHIMERA_SID_MAX_SUB_AUTHS + 1;
+    assert(chimera_sid_from_bin(&b, wire, sizeof(wire)) == -1);
+    assert(chimera_sid_bin_to_str(wire, sizeof(wire), str, sizeof(str)) == -1);
+
+    /* Too short to even hold a header. */
+    assert(chimera_sid_from_bin(&b, wire, 7) == -1);
+
+    TEST_PASS("SID binary round-trips and rejects malformed input");
+} /* test_bin_roundtrip */
+
+/* The MS-DTYP maximum of 15 sub-authorities fits; 16 does not. */
+static void
+test_max_sub_auths(void)
+{
+    struct chimera_sid s;
+    char               buf[CHIMERA_SID_STR_MAX];
+    char               big[CHIMERA_SID_STR_MAX];
+    int                pos;
+
+    pos = snprintf(big, sizeof(big), "S-1-5");
+    for (int i = 0; i < CHIMERA_SID_MAX_SUB_AUTHS; i++) {
+        pos += snprintf(big + pos, sizeof(big) - pos, "-%u", 4000000000u + i);
+    }
+    assert(chimera_sid_from_str(&s, big) == 0);
+    assert(s.len == CHIMERA_SID_MAX_LEN);
+    assert(chimera_sid_to_str(&s, buf, sizeof(buf)) == (int) strlen(big));
+    assert(strcmp(buf, big) == 0);
+
+    /* One more sub-authority than the cap. */
+    snprintf(big + pos, sizeof(big) - pos, "-7");
+    assert(chimera_sid_from_str(&s, big) == -1);
+
+    TEST_PASS("15 sub-authorities round-trip, 16 are rejected");
+} /* test_max_sub_auths */
+
+/* Malformed strings and too-small output buffers are rejected. */
+static void
+test_bad_input(void)
+{
+    struct chimera_sid s;
+    char               tiny[4];
+    uint8_t            binsmall[8];
+
+    assert(chimera_sid_from_str(&s, "") == -1);
+    assert(chimera_sid_from_str(&s, "X-1-5-21") == -1);
+    assert(chimera_sid_from_str(&s, "S-1") == -1);
+    assert(chimera_sid_from_str(&s, "S-1-5-abc") == -1);
+    assert(chimera_sid_from_str(&s, "S-1-5-21-") == -1);
+
+    assert(chimera_sid_from_str(&s, "S-1-5-21-1-2-3-1001") == 0);
+    assert(chimera_sid_to_str(&s, tiny, sizeof(tiny)) == -1);
+    assert(chimera_sid_str_to_bin("S-1-5-21-1-2-3-1001", binsmall,
+                                  sizeof(binsmall)) == -1);
+
+    TEST_PASS("malformed strings and small buffers are rejected");
+} /* test_bad_input */
+
+/* Zero length is the absent state; equal compares length and bytes. */
+static void
+test_absent_and_equal(void)
+{
+    struct chimera_sid a, b, none;
+
+    memset(&none, 0, sizeof(none));
+    assert(!chimera_sid_present(&none));
+    assert(!chimera_sid_present(NULL));
+
+    assert(chimera_sid_from_str(&a, "S-1-5-21-1-2-3-1001") == 0);
+    assert(chimera_sid_from_str(&b, "S-1-5-21-1-2-3-1002") == 0);
+    assert(!chimera_sid_equal(&a, &b));
+    assert(chimera_sid_equal(&a, &a));
+    assert(!chimera_sid_equal(&a, &none));
+    assert(!chimera_sid_equal(&a, NULL));
+    assert(!chimera_sid_equal(NULL, NULL));
+
+    TEST_PASS("len 0 is the absent state; equality compares bytes");
+} /* test_absent_and_equal */
+
+int
+main(
+    int    argc,
+    char **argv)
+{
+    test_str_roundtrip();
+    test_bin_roundtrip();
+    test_max_sub_auths();
+    test_bad_input();
+    test_absent_and_equal();
+
+    fprintf(stderr, "All SID codec tests passed\n");
+    return 0;
+} /* main */

--- a/src/vfs/vfs_acl.c
+++ b/src/vfs/vfs_acl.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-2.1-only
 
 #include <sys/stat.h>
+#include <string.h>
 
 #include "sdk/vfs_acl.h"
 #include "sdk/vfs_cred.h"
@@ -115,6 +116,10 @@ ace_applies(
             return (uint64_t) cred->uid == who->id;
         case CHIMERA_PRINCIPAL_GROUP:
             return cred_in_group(cred, who->id);
+        case CHIMERA_PRINCIPAL_SID:
+            /* An opaque native SID with no unix identity: preserved for
+             * round-tripping, but it can never describe a Unix caller. */
+            return 0;
         default:
             return 0;
     } /* switch */
@@ -341,6 +346,7 @@ chimera_acl_from_mode(
 #define EMIT(t, m, sp) \
         do { \
             if (n >= max_aces) { return -1; } \
+            memset(&out->aces[n], 0, sizeof(out->aces[n])); \
             out->aces[n].type        = (t); \
             out->aces[n].flags       = 0; \
             out->aces[n].access_mask = (m); \
@@ -382,6 +388,7 @@ chimera_acl_default_acl(
 #define EMIT(t, m, sp) \
         do { \
             if (n >= max_aces) { return -1; } \
+            memset(&out->aces[n], 0, sizeof(out->aces[n])); \
             out->aces[n].type        = (t); \
             out->aces[n].flags       = 0; \
             out->aces[n].access_mask = (m); \
@@ -552,12 +559,13 @@ inherit_subst_creator(const struct chimera_principal *who)
 {
     struct chimera_principal p = *who;
 
-    if (p.type == CHIMERA_PRINCIPAL_SPECIAL) {
-        if (p.special == CHIMERA_WHO_CREATOR_OWNER) {
-            p.special = CHIMERA_WHO_OWNER;
-        } else if (p.special == CHIMERA_WHO_CREATOR_GROUP) {
-            p.special = CHIMERA_WHO_GROUP;
-        }
+    if (p.type == CHIMERA_PRINCIPAL_SPECIAL &&
+        (p.special == CHIMERA_WHO_CREATOR_OWNER ||
+         p.special == CHIMERA_WHO_CREATOR_GROUP)) {
+        p.special = (p.special == CHIMERA_WHO_CREATOR_OWNER) ?
+            CHIMERA_WHO_OWNER : CHIMERA_WHO_GROUP;
+        /* The whole SID, not just its length: an ACE is compared by value. */
+        memset(&p.sid, 0, sizeof(p.sid));
     }
     return p;
 } /* inherit_subst_creator */

--- a/src/vfs/vfs_acl_serialize.c
+++ b/src/vfs/vfs_acl_serialize.c
@@ -64,19 +64,55 @@ get_u32(const uint8_t **p)
     return v;
 } /* get_u32 */
 
+/* Non-zero if any ACE carries a native SID, which selects the v2 encoding. */
+static int
+acl_has_sid(const struct chimera_acl *acl)
+{
+    for (unsigned i = 0; i < acl->num_aces; i++) {
+        if (chimera_sid_present(&acl->aces[i].who.sid)) {
+            return 1;
+        }
+    }
+    return 0;
+} /* acl_has_sid */
+
+/* Length of the SID trailer an ACE contributes to a v2 encoding: the length
+ * byte, plus the SID bytes when one is present.  A SID whose length is out of
+ * range is encoded as absent rather than copied as declared. */
+static size_t
+ace_sid_trailer(const struct chimera_ace *ace)
+{
+    return 1 + (chimera_sid_present(&ace->who.sid) ? ace->who.sid.len : 0);
+} /* ace_sid_trailer */
+
+SYMBOL_EXPORT size_t
+chimera_acl_serialized_size(const struct chimera_acl *acl)
+{
+    size_t size = CHIMERA_ACL_SERIAL_HDR +
+        (size_t) acl->num_aces * CHIMERA_ACL_SERIAL_ACE;
+
+    if (acl_has_sid(acl)) {
+        for (unsigned i = 0; i < acl->num_aces; i++) {
+            size += ace_sid_trailer(&acl->aces[i]);
+        }
+    }
+    return size;
+} /* chimera_acl_serialized_size */
+
 SYMBOL_EXPORT int
 chimera_acl_serialize(
     const struct chimera_acl *acl,
     void                     *buf,
     size_t                    buflen)
 {
-    uint8_t *p = buf;
+    uint8_t *p  = buf;
+    int      v2 = acl_has_sid(acl);
 
     if (buflen < chimera_acl_serialized_size(acl)) {
         return -1;
     }
 
-    put_u8(&p, CHIMERA_ACL_SERIAL_VERSION);
+    put_u8(&p, v2 ? CHIMERA_ACL_SERIAL_VERSION : CHIMERA_ACL_SERIAL_V1);
     put_u16(&p, acl->ctrl_flags);
     put_u16(&p, acl->num_aces);
 
@@ -89,6 +125,16 @@ chimera_acl_serialize(
         put_u8(&p, ace->who.type);
         put_u8(&p, ace->who.special);
         put_u32(&p, ace->who.id);
+
+        if (v2) {
+            if (chimera_sid_present(&ace->who.sid)) {
+                put_u8(&p, ace->who.sid.len);
+                memcpy(p, ace->who.sid.data, ace->who.sid.len);
+                p += ace->who.sid.len;
+            } else {
+                put_u8(&p, 0);
+            }
+        }
     }
 
     return (int) (p - (uint8_t *) buf);
@@ -101,7 +147,8 @@ chimera_acl_deserialize(
     struct chimera_acl *out,
     unsigned            max_aces)
 {
-    const uint8_t *p = buf;
+    const uint8_t *p   = buf;
+    const uint8_t *end = p + buflen;
     uint8_t        version;
     uint16_t       num_aces;
 
@@ -110,7 +157,7 @@ chimera_acl_deserialize(
     }
 
     version = get_u8(&p);
-    if (version != CHIMERA_ACL_SERIAL_VERSION) {
+    if (version != CHIMERA_ACL_SERIAL_V1 && version != CHIMERA_ACL_SERIAL_VERSION) {
         return -1;
     }
 
@@ -121,6 +168,7 @@ chimera_acl_deserialize(
         return -1;
     }
 
+    /* Lower bound; the v2 SID trailers are checked per ACE below. */
     if (buflen < CHIMERA_ACL_SERIAL_HDR +
         (size_t) num_aces * CHIMERA_ACL_SERIAL_ACE) {
         return -1;
@@ -128,6 +176,10 @@ chimera_acl_deserialize(
 
     for (unsigned i = 0; i < num_aces; i++) {
         struct chimera_ace *ace = &out->aces[i];
+
+        if (p + CHIMERA_ACL_SERIAL_ACE > end) {
+            return -1;
+        }
 
         /* Zero interior struct padding so a deserialized ACL is byte-deterministic. */
         memset(ace, 0, sizeof(*ace));
@@ -138,6 +190,24 @@ chimera_acl_deserialize(
         ace->who.type    = get_u8(&p);
         ace->who.special = get_u8(&p);
         ace->who.id      = get_u32(&p);
+
+        if (version == CHIMERA_ACL_SERIAL_VERSION) {
+            uint8_t sid_len;
+
+            if (p + 1 > end) {
+                return -1;
+            }
+            sid_len = get_u8(&p);
+            if (sid_len) {
+                if (p + sid_len > end ||
+                    chimera_sid_bin_len(p, sid_len) != (int) sid_len) {
+                    return -1;
+                }
+                memcpy(ace->who.sid.data, p, sid_len);
+                ace->who.sid.len = sid_len;
+                p               += sid_len;
+            }
+        }
     }
 
     out->num_aces = num_aces;

--- a/src/vfs/vfs_attr_cache.h
+++ b/src/vfs/vfs_attr_cache.h
@@ -269,6 +269,18 @@ chimera_vfs_attr_cache_insert(
         entry->score = 0;
         entry->attr  = *attr;
 
+        /* The ACL and owner/group SID fields point at backend storage that is
+         * only valid for the completion callback that produced `attr`, and
+         * none of them is cacheable.  Drop the bits and the pointers on the
+         * cached copy so a later consumer can never dereference a stale
+         * per-thread scratch through a cache hit. */
+        entry->attr.va_set_mask &= ~(CHIMERA_VFS_ATTR_ACL |
+                                     CHIMERA_VFS_ATTR_OWNER_SID |
+                                     CHIMERA_VFS_ATTR_GROUP_SID);
+        entry->attr.va_acl       = NULL;
+        entry->attr.va_owner_sid = NULL;
+        entry->attr.va_group_sid = NULL;
+
         entry->expiration = chimera_vfs_now_ticks() +
             chimera_vfs_ns_to_ticks((uint64_t) cache->ttl * 1000000000ULL);
 

--- a/src/vfs/vfs_idmap.c
+++ b/src/vfs/vfs_idmap.c
@@ -107,6 +107,14 @@ chimera_idmap_principal_to_who(
         return len;
     }
 
+    /* An opaque native SID (and any type this build does not know) has no
+     * NFSv4 name: it maps to no uid or gid, and naming it by its zero id
+     * would present an ACE for root that the server never enforces.  Report
+     * it nameless; the NFSv4 ACL emitter drops nameless ACEs. */
+    if (p->type != CHIMERA_PRINCIPAL_USER && p->type != CHIMERA_PRINCIPAL_GROUP) {
+        return -1;
+    }
+
     /* Numeric user/group.  Resolve to name@domain when a domain is configured
      * and nsswitch knows the id; otherwise emit the numeric form, which is a
      * valid NFSv4 who string (RFC 8881 section 5.9). */
@@ -178,11 +186,15 @@ chimera_idmap_who_to_principal(
         return -1;
     }
 
+    /* Fully define the result on every path, success or failure: the
+     * reserved byte and the native-SID tail must be zero whatever the
+     * caller's storage held (the NFSv4 decoder hands us space from a bump
+     * allocator that is never cleared). */
+    memset(p, 0, sizeof(*p));
+
     special = who_string_to_special(who, len);
     if (special >= 0) {
-        p->type    = CHIMERA_PRINCIPAL_SPECIAL;
-        p->special = (uint8_t) special;
-        p->id      = 0;
+        *p = chimera_idmap_special_principal((uint8_t) special);
         return 0;
     }
 
@@ -204,9 +216,10 @@ chimera_idmap_who_to_principal(
 
     /* Pure numeric id. */
     if (all_digits(who, len)) {
-        p->type    = is_group ? CHIMERA_PRINCIPAL_GROUP : CHIMERA_PRINCIPAL_USER;
-        p->special = 0;
-        p->id      = (uint32_t) strtoul(who, NULL, 10);
+        uint32_t id = (uint32_t) strtoul(who, NULL, 10);
+
+        *p = is_group ? chimera_idmap_gid_principal(id)
+                      : chimera_idmap_uid_principal(id);
         return 0;
     }
 
@@ -229,9 +242,7 @@ chimera_idmap_who_to_principal(
 
             if (getgrnam_r(name, &gr, namebuf, sizeof(namebuf), &res) == 0 &&
                 res) {
-                p->type    = CHIMERA_PRINCIPAL_GROUP;
-                p->special = 0;
-                p->id      = gr.gr_gid;
+                *p = chimera_idmap_gid_principal(gr.gr_gid);
                 return 0;
             }
         } else {
@@ -239,9 +250,7 @@ chimera_idmap_who_to_principal(
 
             if (getpwnam_r(name, &pw, namebuf, sizeof(namebuf), &res) == 0 &&
                 res) {
-                p->type    = CHIMERA_PRINCIPAL_USER;
-                p->special = 0;
-                p->id      = pw.pw_uid;
+                *p = chimera_idmap_uid_principal(pw.pw_uid);
                 return 0;
             }
         }
@@ -285,6 +294,13 @@ chimera_idmap_principal_to_sid(
         }
         memcpy(buf, s, len + 1);
         return len;
+    }
+
+    /* An opaque native SID's identity is its stored bytes, which the SMB
+     * emitter copies verbatim; inventing an algorithmic S-1-5-88 form from
+     * its zero id would name a principal it never was. */
+    if (p->type != CHIMERA_PRINCIPAL_USER && p->type != CHIMERA_PRINCIPAL_GROUP) {
+        return -1;
     }
 
     /* Unix uid/gid SIDs in the modefromsid scheme (S-1-5-88-1/2-<id>), matching

--- a/src/vfs/vfs_idmap.h
+++ b/src/vfs/vfs_idmap.h
@@ -58,7 +58,9 @@ chimera_idmap_special_principal(uint8_t special)
 /*
  * Encode `p` as an NFSv4 owner/who string into `buf` (capacity `buflen`).
  * `domain` may be NULL (then numeric ids are emitted verbatim).  Returns the
- * string length, or -1 if the buffer is too small.
+ * string length, or -1 if the buffer is too small or the principal has no
+ * NFSv4 name -- a CHIMERA_PRINCIPAL_SID maps to no uid or gid and must not
+ * be presented as one; the caller drops such an ACE.
  */
 int chimera_idmap_principal_to_who(
     const struct chimera_principal *p,
@@ -70,6 +72,8 @@ int chimera_idmap_principal_to_who(
  * Decode an NFSv4 owner/who string (`who`, length `len`) into `p`.
  * `is_group` selects group vs user when the string names a principal.
  * `domain` may be NULL.  Returns 0 on success, -1 if it could not be resolved.
+ * `*p` is fully defined on return -- every byte, including the native-SID
+ * tail -- and zeroed on failure, whatever the caller's storage held.
  */
 int chimera_idmap_who_to_principal(
     const char               *who,

--- a/src/vfs/vfs_idmap.h
+++ b/src/vfs/vfs_idmap.h
@@ -84,10 +84,14 @@ int chimera_idmap_who_to_principal(
 
 /*
  * Encode `p` as a Windows SID string ("S-1-...") into `buf`.  Special-whos map
- * to well-known SIDs (EVERYONE@ -> S-1-1-0, OWNER@ -> S-1-3-0, GROUP@ ->
- * S-1-3-1); numeric ids map algorithmically (uid -> S-1-22-1-<uid>, gid ->
- * S-1-22-2-<gid>).  Returns the string length, or -1 if the buffer is too
- * small / the principal is not representable.
+ * to their well-known SIDs (EVERYONE@ -> S-1-1-0, CREATOR OWNER -> S-1-3-0,
+ * CREATOR GROUP -> S-1-3-1, ...); OWNER@ and GROUP@ have no standalone SID
+ * (the SD emitter substitutes the object's owner / group) and, like an opaque
+ * CHIMERA_PRINCIPAL_SID whose identity is its stored bytes, are not
+ * representable.  Numeric ids map algorithmically to the modefromsid forms
+ * (uid -> S-1-5-88-1-<uid>, gid -> S-1-5-88-2-<gid>); sid_to_principal still
+ * parses the Samba S-1-22 forms as well.  Returns the string length, or -1 if
+ * the buffer is too small / the principal is not representable.
  */
 int chimera_idmap_principal_to_sid(
     const struct chimera_principal *p,

--- a/src/vfs/vfs_proc_setattr.c
+++ b/src/vfs/vfs_proc_setattr.c
@@ -11,6 +11,7 @@
 #include "vfs_attr_cache.h"
 #include "sdk/vfs_access.h"
 #include "sdk/vfs_acl.h"
+#include "sdk/vfs_sid.h"
 #include "common/misc.h"
 #include "common/macros.h"
 
@@ -25,7 +26,9 @@
  * present, an owner/group field set to the value it already holds is not a
  * change and does not require WRITE_OWNER -- which matters because a SET_INFO
  * security descriptor commonly restates the existing owner alongside a DACL,
- * and the owner holds WRITE_ACL but not WRITE_OWNER implicitly.
+ * and the owner holds WRITE_ACL but not WRITE_OWNER implicitly.  The native
+ * owner/group SID companions follow the same rule: restating the SID the
+ * object already carries is not a chown.
  */
 static uint32_t
 chimera_vfs_setattr_required(
@@ -45,7 +48,13 @@ chimera_vfs_setattr_required(
                 cur->va_uid == set_attr->va_uid)) ||
         ((m & CHIMERA_VFS_ATTR_GID) &&
          !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_GID) &&
-           cur->va_gid == set_attr->va_gid));
+           cur->va_gid == set_attr->va_gid)) ||
+        ((m & CHIMERA_VFS_ATTR_OWNER_SID) &&
+         !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) &&
+           chimera_sid_equal(cur->va_owner_sid, set_attr->va_owner_sid))) ||
+        ((m & CHIMERA_VFS_ATTR_GROUP_SID) &&
+         !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) &&
+           chimera_sid_equal(cur->va_group_sid, set_attr->va_group_sid)));
 
     if (chowns) {
         required |= CHIMERA_ACE_WRITE_OWNER;
@@ -102,7 +111,11 @@ chimera_vfs_setattr_cred_in_group(
  * current owner/group.  Only the super-user may change the owner (uid); the
  * group (gid) may be changed only by the file's owner and only to a group in
  * the caller's group set.  A field left unset, or set to its current value, is
- * not a change.  Returns CHIMERA_VFS_OK when permitted, else CHIMERA_VFS_EPERM.
+ * not a change.  The native owner/group SID companions are governed as part
+ * of the identity they accompany: naming one is a chown for the ownership
+ * test, and the owner may attach, restate or clear its SID but not replace a
+ * stored owner SID with a different one.  Returns CHIMERA_VFS_OK when
+ * permitted, else CHIMERA_VFS_EPERM.
  */
 static enum chimera_vfs_error
 chimera_vfs_setattr_chown_check(
@@ -113,13 +126,16 @@ chimera_vfs_setattr_chown_check(
     uint64_t m  = set_attr->va_set_mask;
     int has_uid = (m & CHIMERA_VFS_ATTR_UID) != 0;
     int has_gid = (m & CHIMERA_VFS_ATTR_GID) != 0;
+    int has_sid = (m & (CHIMERA_VFS_ATTR_OWNER_SID |
+                        CHIMERA_VFS_ATTR_GROUP_SID)) != 0;
 
     if (cred->uid == 0) {
         return CHIMERA_VFS_OK;
     }
 
-    /* chown(path, -1, -1) names no owner or group and is always permitted. */
-    if (!has_uid && !has_gid) {
+    /* chown(path, -1, -1) names no owner, group or SID and is always
+     * permitted. */
+    if (!has_uid && !has_gid && !has_sid) {
         return CHIMERA_VFS_OK;
     }
 
@@ -136,7 +152,21 @@ chimera_vfs_setattr_chown_check(
         return CHIMERA_VFS_EPERM;
     }
 
-    /* The owner may change the group only to one it is a member of. */
+    /* Nor replace a native owner SID the object already carries with a
+    * different one: that names another Windows principal as owner, which is
+    * an ownership change (Windows demands WRITE_OWNER for it as well).
+    * Attaching a SID to an object that has none, restating it, or clearing
+    * it leaves the identity the uid names and is permitted -- a domain user
+    * saving a DACL on a file created over NFS relies on the attach. */
+    if ((m & CHIMERA_VFS_ATTR_OWNER_SID) &&
+        (cur->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) &&
+        chimera_sid_present(set_attr->va_owner_sid) &&
+        !chimera_sid_equal(cur->va_owner_sid, set_attr->va_owner_sid)) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    /* The owner may change the group only to one it is a member of.  The
+     * group SID follows the gid and needs no rule of its own. */
     if (has_gid &&
         (cur->va_set_mask & CHIMERA_VFS_ATTR_GID) &&
         set_attr->va_gid != cur->va_gid &&
@@ -154,7 +184,11 @@ chimera_vfs_setattr_chown_check(
  * but, following the BSD/Solaris NFSv4 implementations, only to its own identity
  * -- the new uid must equal the caller's uid, and the new gid must be a group
  * the caller is a member of.  A field left unset, or restated to its current
- * value, is not a change.  Returns CHIMERA_VFS_OK when permitted, else EPERM.
+ * value, is not a change.  A native owner/group SID is accepted only as a
+ * restatement of the stored one or as the companion of a uid (gid) the caller
+ * is taking to its own identity in the same call: the engine cannot compare a
+ * SID with the caller, so the numeric identity vouches for it.  Returns
+ * CHIMERA_VFS_OK when permitted, else EPERM.
  */
 static enum chimera_vfs_error
 chimera_vfs_setattr_write_owner_check(
@@ -178,6 +212,22 @@ chimera_vfs_setattr_write_owner_check(
         return CHIMERA_VFS_EPERM;
     }
 
+    if ((m & CHIMERA_VFS_ATTR_OWNER_SID) &&
+        !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_OWNER_SID) &&
+          chimera_sid_equal(cur->va_owner_sid, set_attr->va_owner_sid)) &&
+        !((m & CHIMERA_VFS_ATTR_UID) &&
+          set_attr->va_uid == (uint64_t) cred->uid)) {
+        return CHIMERA_VFS_EPERM;
+    }
+
+    if ((m & CHIMERA_VFS_ATTR_GROUP_SID) &&
+        !(cur && (cur->va_set_mask & CHIMERA_VFS_ATTR_GROUP_SID) &&
+          chimera_sid_equal(cur->va_group_sid, set_attr->va_group_sid)) &&
+        !((m & CHIMERA_VFS_ATTR_GID) &&
+          chimera_vfs_setattr_cred_in_group(cred, set_attr->va_gid))) {
+        return CHIMERA_VFS_EPERM;
+    }
+
     return CHIMERA_VFS_OK;
 } /* chimera_vfs_setattr_write_owner_check */
 
@@ -189,7 +239,8 @@ chimera_vfs_setattr_denied_error(
     uint64_t m = set_attr->va_set_mask;
 
     if (m & (CHIMERA_VFS_ATTR_MODE | CHIMERA_VFS_ATTR_ACL |
-             CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+             CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID |
+             CHIMERA_VFS_ATTR_OWNER_SID | CHIMERA_VFS_ATTR_GROUP_SID)) {
         return CHIMERA_VFS_EPERM;
     }
 
@@ -424,8 +475,13 @@ chimera_vfs_setattr_gate_complete(
      * signal, since Windows withholds the owner's implicit WRITE_OWNER) or an
      * explicit WRITE_OWNER ACE grants it.  This keeps the synthesised-ACL and
      * mode-only (e.g. NFSv3) representations consistent: an owner's POSIX-legal
-     * chgrp is permitted in both, while a uid change still demands privilege. */
-    if (gate->set_attr->va_set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID)) {
+     * chgrp is permitted in both, while a uid change still demands privilege.
+     * The native owner/group SID companions enter the same block, so a
+     * SID-only set faces these rules rather than a WRITE_OWNER requirement
+     * that nothing else checks. */
+    if (gate->set_attr->va_set_mask & (CHIMERA_VFS_ATTR_UID | CHIMERA_VFS_ATTR_GID |
+                                       CHIMERA_VFS_ATTR_OWNER_SID |
+                                       CHIMERA_VFS_ATTR_GROUP_SID)) {
         int is_owner = (attr->va_set_mask & CHIMERA_VFS_ATTR_UID) &&
             (uint64_t) gate->cred->uid == attr->va_uid;
 
@@ -560,7 +616,9 @@ chimera_vfs_setattr_common(
             gate->private_data   = private_data;
 
             chimera_vfs_getattr(thread, cred, handle,
-                                CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL,
+                                CHIMERA_VFS_ATTR_MASK_STAT | CHIMERA_VFS_ATTR_ACL |
+                                CHIMERA_VFS_ATTR_OWNER_SID |
+                                CHIMERA_VFS_ATTR_GROUP_SID,
                                 chimera_vfs_setattr_gate_complete, gate);
             return;
         }

--- a/src/vfs/vfs_sid.c
+++ b/src/vfs/vfs_sid.c
@@ -181,8 +181,11 @@ chimera_sid_from_bin(
 {
     int len = chimera_sid_bin_len(buf, avail);
 
+    /* Fully define the struct on every path -- the pad, and the tail past the
+     * SID -- so a chimera_sid (and any ACE carrying one) is byte-deterministic
+     * and safe to memcmp. */
+    memset(sid, 0, sizeof(*sid));
     if (len < 0) {
-        sid->len = 0;
         return -1;
     }
     memcpy(sid->data, buf, len);
@@ -210,10 +213,14 @@ chimera_sid_from_str(
     struct chimera_sid *sid,
     const char         *str)
 {
-    int len = chimera_sid_str_to_bin(str, sid->data, CHIMERA_SID_MAX_LEN);
+    int len;
 
+    /* Zero first, then parse into data[]: the pad and the tail past the SID
+     * are defined whether the parse succeeds or not. */
+    memset(sid, 0, sizeof(*sid));
+    len = chimera_sid_str_to_bin(str, sid->data, CHIMERA_SID_MAX_LEN);
     if (len < 0) {
-        sid->len = 0;
+        memset(sid, 0, sizeof(*sid));
         return -1;
     }
     sid->len = (uint8_t) len;

--- a/src/vfs/vfs_sid.c
+++ b/src/vfs/vfs_sid.c
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2026 Chimera-NAS Project Contributors
+//
+// SPDX-License-Identifier: LGPL-2.1-only
+
+#include <stdio.h>
+#include <string.h>
+
+#include "sdk/vfs_sid.h"
+#include "common/macros.h"
+
+static inline uint32_t
+sid_get_u32(const uint8_t *p)
+{
+    return (uint32_t) p[0] | ((uint32_t) p[1] << 8) |
+           ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 24);
+} /* sid_get_u32 */
+
+static inline void
+sid_put_u32(
+    uint8_t *p,
+    uint32_t v)
+{
+    p[0] = (uint8_t) (v & 0xff);
+    p[1] = (uint8_t) ((v >> 8) & 0xff);
+    p[2] = (uint8_t) ((v >> 16) & 0xff);
+    p[3] = (uint8_t) ((v >> 24) & 0xff);
+} /* sid_put_u32 */
+
+/*
+ * Parse a run of decimal digits at *pp into *out (up to `max`), advancing
+ * *pp past them.  Requires at least one digit and rejects overflow.  Returns
+ * 0 on success, -1 otherwise.
+ */
+static int
+sid_parse_dec(
+    const char **pp,
+    uint64_t     max,
+    uint64_t    *out)
+{
+    const char *p = *pp;
+    uint64_t    v = 0;
+
+    if (*p < '0' || *p > '9') {
+        return -1;
+    }
+    while (*p >= '0' && *p <= '9') {
+        uint64_t d = (uint64_t) (*p - '0');
+
+        if (v > (max - d) / 10) {
+            return -1;
+        }
+        v = v * 10 + d;
+        p++;
+    }
+    *out = v;
+    *pp  = p;
+    return 0;
+} /* sid_parse_dec */
+
+SYMBOL_EXPORT int
+chimera_sid_bin_len(
+    const uint8_t *buf,
+    uint32_t       avail)
+{
+    uint32_t count;
+
+    if (!buf || avail < CHIMERA_SID_MIN_LEN) {
+        return -1;
+    }
+    count = buf[1];
+    if (count > CHIMERA_SID_MAX_SUB_AUTHS) {
+        return -1;
+    }
+    if (CHIMERA_SID_MIN_LEN + count * 4 > avail) {
+        return -1;
+    }
+    return (int) (CHIMERA_SID_MIN_LEN + count * 4);
+} /* chimera_sid_bin_len */
+
+SYMBOL_EXPORT int
+chimera_sid_bin_to_str(
+    const uint8_t *buf,
+    uint32_t       len,
+    char          *out,
+    int            outlen)
+{
+    uint64_t authority = 0;
+    int      binlen, count, pos;
+
+    binlen = chimera_sid_bin_len(buf, len);
+    if (binlen < 0 || !out || outlen <= 0) {
+        return -1;
+    }
+    count = buf[1];
+
+    for (int i = 0; i < 6; i++) {
+        authority = (authority << 8) | buf[2 + i];
+    }
+
+    pos = snprintf(out, outlen, "S-%u-%llu", buf[0], (unsigned long long) authority);
+    if (pos < 0 || pos >= outlen) {
+        return -1;
+    }
+    for (int i = 0; i < count; i++) {
+        int n = snprintf(out + pos, outlen - pos, "-%u",
+                         sid_get_u32(buf + CHIMERA_SID_MIN_LEN + i * 4));
+
+        if (n < 0 || pos + n >= outlen) {
+            return -1;
+        }
+        pos += n;
+    }
+    return binlen;
+} /* chimera_sid_bin_to_str */
+
+SYMBOL_EXPORT int
+chimera_sid_str_to_bin(
+    const char *str,
+    uint8_t    *out,
+    int         outcap)
+{
+    const char *p = str;
+    uint64_t    v;
+    int         count = 0;
+
+    if (!str || !out || outcap < CHIMERA_SID_MIN_LEN) {
+        return -1;
+    }
+    if (str[0] != 'S' && str[0] != 's') {
+        return -1;
+    }
+    p++;
+    if (*p != '-') {
+        return -1;
+    }
+    p++;
+
+    /* revision */
+    if (sid_parse_dec(&p, 255, &v) < 0 || *p != '-') {
+        return -1;
+    }
+    out[0] = (uint8_t) v;
+    p++;
+
+    /* 48-bit identifier authority, stored big-endian */
+    if (sid_parse_dec(&p, 0xffffffffffffULL, &v) < 0) {
+        return -1;
+    }
+    for (int i = 0; i < 6; i++) {
+        out[2 + i] = (uint8_t) ((v >> (8 * (5 - i))) & 0xff);
+    }
+
+    while (*p == '-') {
+        p++;
+        if (count >= CHIMERA_SID_MAX_SUB_AUTHS) {
+            return -1;
+        }
+        if (sid_parse_dec(&p, 0xffffffffULL, &v) < 0) {
+            return -1;
+        }
+        if (CHIMERA_SID_MIN_LEN + (count + 1) * 4 > outcap) {
+            return -1;
+        }
+        sid_put_u32(out + CHIMERA_SID_MIN_LEN + count * 4, (uint32_t) v);
+        count++;
+    }
+
+    if (*p != '\0') {
+        return -1; /* trailing text is not part of a SID */
+    }
+
+    out[1] = (uint8_t) count;
+    return CHIMERA_SID_MIN_LEN + count * 4;
+} /* chimera_sid_str_to_bin */
+
+SYMBOL_EXPORT int
+chimera_sid_from_bin(
+    struct chimera_sid *sid,
+    const uint8_t      *buf,
+    uint32_t            avail)
+{
+    int len = chimera_sid_bin_len(buf, avail);
+
+    if (len < 0) {
+        sid->len = 0;
+        return -1;
+    }
+    memcpy(sid->data, buf, len);
+    sid->len = (uint8_t) len;
+    return len;
+} /* chimera_sid_from_bin */
+
+SYMBOL_EXPORT int
+chimera_sid_to_str(
+    const struct chimera_sid *sid,
+    char                     *out,
+    int                       outlen)
+{
+    if (!chimera_sid_present(sid)) {
+        return -1;
+    }
+    if (chimera_sid_bin_to_str(sid->data, sid->len, out, outlen) < 0) {
+        return -1;
+    }
+    return (int) strlen(out);
+} /* chimera_sid_to_str */
+
+SYMBOL_EXPORT int
+chimera_sid_from_str(
+    struct chimera_sid *sid,
+    const char         *str)
+{
+    int len = chimera_sid_str_to_bin(str, sid->data, CHIMERA_SID_MAX_LEN);
+
+    if (len < 0) {
+        sid->len = 0;
+        return -1;
+    }
+    sid->len = (uint8_t) len;
+    return 0;
+} /* chimera_sid_from_str */

--- a/src/vfs/vfs_sid.c
+++ b/src/vfs/vfs_sid.c
@@ -226,3 +226,88 @@ chimera_sid_from_str(
     sid->len = (uint8_t) len;
     return 0;
 } /* chimera_sid_from_str */
+
+SYMBOL_EXPORT int
+chimera_sid_pair_encode(
+    const struct chimera_sid *owner,
+    const struct chimera_sid *group,
+    uint8_t                  *out,
+    int                       outcap)
+{
+    int have_owner = chimera_sid_present(owner);
+    int have_group = chimera_sid_present(group);
+    int need       = 2 + (have_owner ? owner->len : 0) +
+        (have_group ? group->len : 0);
+    int pos = 0;
+
+    if (!have_owner && !have_group) {
+        return 0;
+    }
+    if (outcap < need) {
+        return -1;
+    }
+
+    out[pos++] = have_owner ? owner->len : 0;
+    if (have_owner) {
+        memcpy(out + pos, owner->data, owner->len);
+        pos += owner->len;
+    }
+    out[pos++] = have_group ? group->len : 0;
+    if (have_group) {
+        memcpy(out + pos, group->data, group->len);
+        pos += group->len;
+    }
+    return pos;
+} /* chimera_sid_pair_encode */
+
+SYMBOL_EXPORT int
+chimera_sid_pair_decode(
+    const uint8_t      *buf,
+    int                 len,
+    struct chimera_sid *owner,
+    struct chimera_sid *group)
+{
+    int     pos = 0;
+    int     rc  = 0;
+    uint8_t olen, glen;
+
+    memset(owner, 0, sizeof(*owner));
+    memset(group, 0, sizeof(*group));
+
+    if (!buf || len < 2) {
+        return 0;
+    }
+
+    olen = buf[pos++];
+    if (olen) {
+        if (pos + olen > len) {
+            /* The owner length runs past the record: the group SID cannot
+             * be located either. */
+            return -1;
+        }
+        /* from_bin returns the SID's own length; a stored length that does
+         * not agree with it is a malformed record, not a shorter SID. */
+        if (chimera_sid_from_bin(owner, buf + pos, olen) != (int) olen) {
+            memset(owner, 0, sizeof(*owner));
+            rc = -1;
+        }
+        pos += olen;
+    }
+
+    if (pos >= len) {
+        /* Owner only (or the record ends right after the owner). */
+        return rc;
+    }
+
+    glen = buf[pos++];
+    if (glen) {
+        if (pos + glen > len) {
+            return -1;
+        }
+        if (chimera_sid_from_bin(group, buf + pos, glen) != (int) glen) {
+            memset(group, 0, sizeof(*group));
+            rc = -1;
+        }
+    }
+    return rc;
+} /* chimera_sid_pair_decode */


### PR DESCRIPTION
A principal was a uid/gid, so a SID the identity layer could not map had no
uid and was dropped on the way in.  A Windows client that set a DACL naming a
domain user this server has never heard of read the descriptor back with that
ACE missing -- including DENY aces, whose disappearance grants access rather
than denying it.  The same was true of the owner and group fields, which were
always re-derived from uid/gid on the way out.

**This is the storage half of the fix: the VFS can carry and persist a native
SID alongside the numeric identity.**  No SID reaches a client yet -- the SMB
server neither produces nor consumes one until the follow-up PR.  Splitting it
this way keeps the on-disk format and the authorization gate in one review,
and the protocol behaviour in another.

This is self-contained and touches no SMB file, so it is independent of #1675
(the wrapping-offset fix in the security-descriptor decoders) and the two can
land in either order.  The SMB half needs both.

Two diskfs changes here are visible without that half, both over NFSv4: an
ACL too large for one record is refused with `EFBIG` (NFS4ERR_FBIG) instead
of being silently dropped, and a SETATTR carrying a pNFS layout alongside an
ACL no longer loses the ACL, because every setattr path now converges on the
same record tail.  diskfs also starts advertising
`CHIMERA_VFS_CAP_ACL_NATIVE`, which it has always satisfied but never
claimed; nothing in tree reads that bit today, so it is a declaration rather
than a behaviour change.

Access evaluation is deliberately untouched, here and in the SMB half: it
still runs purely on the numeric identity.  A SID that resolves to nobody
matches no caller, which is the same thing NTFS does with a departed user's
ACE.

### The value type and the SDK

`struct chimera_sid` (`src/vfs/sdk/vfs_sid.h`, `vfs_sid.c`) holds a SID in its
MS-DTYP binary form with the 15 sub-authority cap, and owns the binary/string
codec that `smb_proc_security.c` previously kept as file-local statics.  The
string parser is strict -- digits only, no trailing text -- so a malformed wire
SID is rejected rather than overrunning a buffer.  `chimera_sid_present()`
enforces the length invariant (8 <= len <= 68), and every consumer that copies
`len` bytes -- the serializer, the SMB emitter, the backends -- goes through
it, so a producer that never initialised the struct, or an out-of-tree module
returning a bogus owner SID, cannot put those bytes on disk or on the wire.
The struct carries an explicit 3-byte pad: a principal is exactly 80 bytes and
an ACE 88 with no compiler padding (static-asserted), so the by-value memcmp
contract the tests rely on follows from the language.  The owner/group SID
pair record codec the native backends share lives in the SDK too
(`chimera_sid_pair_encode/decode`).

`struct chimera_principal` gains an inline SID.  It is populated only on USER
and GROUP principals that resolved through the identity layer, and on the new
`CHIMERA_PRINCIPAL_SID` for a SID that resolved to nothing at all; SPECIAL
principals never carry one, since `OWNER@` and friends re-derive on emit.
`chimera_idmap_who_to_principal` fully defines the principal it decodes (the
NFSv4 SETATTR decoder hands it never-cleared bump-allocated space), and both
idmap encoders refuse `CHIMERA_PRINCIPAL_SID`, so an opaque SID is never
presented to an NFSv4 client as uid 0.

The principal is a published SDK type that out-of-tree modules consume, so
`CHIMERA_VFS_SDK_VERSION` moves to 2 and a module built against 1 must be
rebuilt.

On-disk ACL encoding gains a v2 that appends a length-prefixed SID to each ACE.
The serializer picks v2 only when some ACE actually carries a SID and otherwise
still writes v1, so a volume stays readable by an older binary until a real
domain SID is stored; the deserializer accepts both.
`chimera_acl_serialized_size` becomes a walk, since the encoding is now
variable-length.

### Attributes and the chown gate

`CHIMERA_VFS_ATTR_OWNER_SID` / `GROUP_SID` and the pointer-valued
`va_owner_sid` / `va_group_sid` are the SID companions to `va_uid` / `va_gid`,
with `va_acl`'s callback-lifetime contract and deliberately outside `MASK_STAT`
and `MASK_CACHEABLE`.

The setattr gate folds the SIDs into its "is this really a chown" test the
same way it already treats a restated uid, so a SET_INFO security descriptor
that restates the owner SID the object already carries alongside a new DACL
keeps requiring only `WRITE_ACL`, which the owner holds implicitly.  The chown
authorization itself is keyed on `OWNER_SID`/`GROUP_SID` as well as
`UID`/`GID`, treating the SID as the companion of its numeric identity: a
non-owner naming a SID needs WRITE_OWNER and may attach one only alongside a
uid/gid it is taking to itself; the owner may attach, restate or clear its SID
but not replace a stored owner SID with a different one (an ownership change,
as on Windows).  The attr cache copies the whole attrs struct by value, while
the ACL and SID pointers in that copy reference per-thread backend scratch that
is dead once the producing callback returns -- so the cache clears those bits
and NULLs those pointers on insert.

### Backends

memfs, cairn and diskfs all keep the owner/group SIDs in a record *separate*
from the ACL, so "no ACL record" keeps meaning "mode-derived DACL" and a chown
never has to touch the DACL record.  cairn adds `CAIRN_KEY_SID`, diskfs adds
`DISKFS_REC_SID` with the same mirror discipline as its ACL record, and memfs
stores them on the inode.

All three keep the SIDs coherent with uid/gid: an explicit `OWNER_SID` /
`GROUP_SID` set stores or clears, while a bare chown drops the stale one that
would no longer describe the new owner.

Every diskfs setattr path converges on one record tail (SID mirror, then
pNFS -> ACL -> SID replay, then commit): a shrinking truncate and a
layout-carrying setattr used to finish on chains that bypassed the record
steps, the latter after mutating the SID mirror, so a skipped REMOVE could
later abort on a duplicate-key insert.  The SID chain completions fail the
request on a b+tree error.  Because a v2 ACE is variable-length, whether an ACL
fits one diskfs record is decided by `chimera_acl_serialized_size` rather than
an ACE count, and one that does not fit is refused with `EFBIG` (NFS4ERR_FBIG,
as Linux nfsd does) before anything is mutated instead of re-deriving the mode
from it and silently dropping the record.  diskfs has always persisted the
canonical ACL but never advertised `CHIMERA_VFS_CAP_ACL_NATIVE`; it does now,
like the other two.

### Coverage

`vfs/sid_test`, `vfs/acl_test`, `vfs/idmap_test` and `vfs/acl_sid_*` across
memfs/cairn/diskfs are all extended-tier, and the merge gate runs the quick
tier -- so on their own they would not catch a regression here until the next
Extended run.  The quick-tier coverage arrives with the SMB half, where the
behaviour becomes observable over the wire.

What the unit tests pin: fully-defined principals and nameless SID
principals; the length invariant and the serializer's use of it; the pair
codec; the v1/v2 encoding round trip and the v1 fallback; a non-root
chown-gate leg over the whole matrix (owner attach / restate / clear / replace,
non-owner with and without WRITE_OWNER); a shrink-and-chown leg; and a **cold
restart** on cairn and diskfs -- the in-memory mirrors are gone across it, so
this proves the on-disk replay and the fault-in, which an in-process
umount/mount would not.

### Notes for review

- Owner/group SID companions are not seeded at create.
- A stored `PRINCIPAL_SID` never upgrades if the SID later becomes resolvable.
- NFSv4 who-strings are unchanged; the protocol side is SMB-only and lands in
  the follow-up PR.
