### PR TITLE
vfs/diskfs: scale the block-cache shard count to the pool

### DIFF
--- a/src/vfs/diskfs/diskfs_block.c
+++ b/src/vfs/diskfs/diskfs_block.c
@@ -667,10 +667,22 @@ diskfs_block_cache_create(struct diskfs_shared *shared)
         total = min;
     }
 
-    cache->shard_cap = total / DISKFS_BLOCK_CACHE_SHARDS;
+    /* Largest power of two no greater than MAX_SHARDS that still leaves every
+     * shard MIN_SHARD_BLOCKS, and at least one shard however small the pool. */
+    cache->num_shards = 1;
+    while (cache->num_shards * 2 <= DISKFS_BLOCK_CACHE_MAX_SHARDS &&
+           total / (cache->num_shards * 2) >= DISKFS_BLOCK_CACHE_MIN_SHARD_BLOCKS) {
+        cache->num_shards *= 2;
+    }
+    cache->shard_mask = cache->num_shards - 1;
+
+    cache->shard_cap = total / cache->num_shards;
     if (cache->shard_cap == 0) {
         cache->shard_cap = 1;
     }
+
+    chimera_diskfs_info("Block cache: %u blocks in %u shards (%u blocks/shard)",
+                        total, cache->num_shards, cache->shard_cap);
 
     /* No dedicated CoW slush: a fork draws its buffer from the regular LRU
      * (diskfs_block_buf_reclaim_locked) and parks if the shard is fully pinned,
@@ -679,7 +691,7 @@ diskfs_block_cache_create(struct diskfs_shared *shared)
     cache->buffer_extra_per_shard = extra;
     pthread_mutex_init(&cache->prealloc_lock, NULL);
 
-    for (i = 0; i < DISKFS_BLOCK_CACHE_SHARDS; i++) {
+    for (i = 0; i < (int) cache->num_shards; i++) {
         struct diskfs_block_shard *shard = &cache->shards[i];
 
         pthread_mutex_init(&shard->lock, NULL);
@@ -716,7 +728,7 @@ diskfs_block_cache_prealloc(
         return;
     }
 
-    for (i = 0; i < DISKFS_BLOCK_CACHE_SHARDS; i++) {
+    for (i = 0; i < (int) cache->num_shards; i++) {
         struct diskfs_block_shard *shard = &cache->shards[i];
         uint32_t                   total = shard->nblocks + cache->buffer_extra_per_shard;
 
@@ -805,7 +817,7 @@ diskfs_block_cache_destroy(struct diskfs_shared *shared)
         return;
     }
 
-    for (i = 0; i < DISKFS_BLOCK_CACHE_SHARDS; i++) {
+    for (i = 0; i < (int) cache->num_shards; i++) {
         struct diskfs_block_shard *shard = &cache->shards[i];
         uint32_t                   j;
 
@@ -905,7 +917,7 @@ diskfs_block_claim(
 {
     struct diskfs_block_cache *cache  = thread->shared->block_cache;
     uint64_t                   hash   = diskfs_block_hash(device_id, device_offset);
-    uint32_t                   sidx   = hash & DISKFS_BLOCK_CACHE_SHARD_MASK;
+    uint32_t                   sidx   = hash & cache->shard_mask;
     uint32_t                   bucket = (hash >> 8) & DISKFS_BLOCK_CACHE_BUCKET_MASK;
     struct diskfs_block_shard *shard  = &cache->shards[sidx];
     struct diskfs_block       *blk;
@@ -1506,7 +1518,7 @@ diskfs_block_claim_async(
 {
     struct diskfs_block_cache  *cache  = thread->shared->block_cache;
     uint64_t                    hash   = diskfs_block_hash(device_id, device_offset);
-    uint32_t                    sidx   = hash & DISKFS_BLOCK_CACHE_SHARD_MASK;
+    uint32_t                    sidx   = hash & cache->shard_mask;
     uint32_t                    bucket = (hash >> 8) & DISKFS_BLOCK_CACHE_BUCKET_MASK;
     struct diskfs_block_shard  *shard  = &cache->shards[sidx];
     struct diskfs_block        *blk;

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -761,9 +761,30 @@ struct diskfs_inode_cache {
 
 #define DISKFS_BLOCK_SIZE                    SM_BLOCK_SIZE   /* 4096 */
 
-#define DISKFS_BLOCK_CACHE_SHARDS            256
+/*
+ * Shards exist to spread block-cache lock contention, but the pool is divided
+ * evenly between them (shard_cap = total / num_shards) and a block's shard is
+ * fixed by its address -- so the shard count is also the divisor on how much
+ * cache any single address may occupy.  A hot block holds one live CoW
+ * generation per un-pushed record that snapshotted it, a count bounded by the
+ * intent log's depth, and every generation shares its address and therefore its
+ * shard.  Fixing the count at 256 made that ceiling total/256 regardless of how
+ * small the pool was: with a 4 MiB journal the default pool is 2048 blocks, or
+ * 8 per shard, and one block could exhaust its shard while 99% of the cache sat
+ * idle (the synchronous claim then aborts -- it cannot park).
+ *
+ * So treat 256 as a MAXIMUM and scale down to the pool: the largest power of
+ * two no greater than it that still leaves each shard MIN_SHARD_BLOCKS.  Small
+ * caches get fewer, fatter shards (less lock spreading, but they are small
+ * enough that contention is not the binding concern); large caches are
+ * unchanged at 256.
+ */
+#define DISKFS_BLOCK_CACHE_MAX_SHARDS        256
 
-#define DISKFS_BLOCK_CACHE_SHARD_MASK        (DISKFS_BLOCK_CACHE_SHARDS - 1)
+/* Floor on shard_cap.  Must comfortably exceed the live CoW generations one hot
+ * block can accumulate: measured peak on an idle box is ~22, and the abort was
+ * reached in CI at 64. */
+#define DISKFS_BLOCK_CACHE_MIN_SHARD_BLOCKS  256
 
 #define DISKFS_BLOCK_CACHE_BUCKETS_PER_SHARD 1024
 
@@ -886,10 +907,13 @@ struct diskfs_block_shard {
 
 struct diskfs_block_cache {
     uint32_t                  shard_cap;   /* max resident buffers per shard */
+    uint32_t                  num_shards;  /* power of two, <= MAX_SHARDS */
+    uint32_t                  shard_mask;  /* num_shards - 1 */
     uint32_t                  buffer_extra_per_shard;
     int                       buffers_ready;
     pthread_mutex_t           prealloc_lock;
-    struct diskfs_block_shard shards[DISKFS_BLOCK_CACHE_SHARDS];
+    /* Sized for the maximum; only the first num_shards are initialised/used. */
+    struct diskfs_block_shard shards[DISKFS_BLOCK_CACHE_MAX_SHARDS];
 };
 
 
@@ -4341,7 +4365,7 @@ diskfs_block_shard(
 {
     uint64_t hash = diskfs_block_hash(device_id, device_offset);
 
-    return &cache->shards[hash & DISKFS_BLOCK_CACHE_SHARD_MASK];
+    return &cache->shards[hash & cache->shard_mask];
 } /* diskfs_block_shard */
 
 


### PR DESCRIPTION
`chimera/vfs/diskfs/mbt/batch` aborts intermittently in CI — in the merge queue (it ejected #1674) and in the extended run, on the slower images:

```
synchronous CoW: shard full (LRU head still pinned) off=63832064   level=fatal
```

## The message is misleading twice over

The shard isn't "full" in any useful sense, and the LRU head isn't the problem. Instrumenting the moment of failure:

```
LRUSTATE lru=24 pinned=24 states[LOADING=0 CLEAN=24 DIRTY=0 LOGGED=0]
LRUTRACE shard_pinned=24/24 | global_pinned=72/6144 shards_with_pins=39 max_shard=24
```

Every block in the shard is pinned — while the cache as a whole is ~1% pinned, and one shard holds a third of every pin in it. Dumping the addresses:

```
LRUPIN dev=0 off=14008320 blk=3420 pin=1     <- x15, all the SAME offset
LRUPIN dev=0 off=14008320 blk=3420 pin=2
```

Not distinct blocks colliding in the hash. Successive **CoW generations of one block**: a fork retires the old struct still pinned by the record that snapshotted its buffer, so a block written repeatedly while its records are un-pushed accumulates one struct per in-flight record. They all share an address, therefore a shard, by construction. 71 distinct structs existed at that single offset over one run.

## Root cause

Nothing bounds generations against the shard. A block's live generations are bounded by **intent-log depth** (1024 blocks for the 4 MiB journal this test uses); its shard held `total/256` = **64**. The two limits are dimensionally unrelated, so the pigeonhole argument the cache is provisioned on — *"larger than the maximum pinnable set, so the LRU is never empty"* — is made globally and enforced per shard.

Growing the cache doesn't close the gap: `shard_cap` scales with it and the generation bound doesn't. A 4 MiB journal would need a **1 GiB** cache for the argument to hold per shard. (This is why the MBT harness's existing "just raise `DFS_BCACHE`" comment buys headroom but can't be a fix.)

Measured on a *passing* run at the shipped geometry, on an idle machine: one block reached **22 of its shard's 64 slots** and was still climbing at the end of the run. Under CI's slower images, with the tail-pusher lagging, it crosses.

## The change

Shards exist to spread lock contention; the count was a bare `256` with no rationale, not derived from anything and not tunable. Because the pool is divided evenly between them, that constant silently doubled as the divisor on how much cache any single address may occupy.

Treat it as a **maximum** and scale to the pool — the largest power of two no greater than it that still leaves each shard `DISKFS_BLOCK_CACHE_MIN_SHARD_BLOCKS` (256). Small caches get fewer, fatter shards; large caches are unchanged.

| config | before | after |
|---|---|---|
| `mbt/batch` (16384 blocks) | 256 × 64 | **64 × 256** |
| posix / kvm (32768 blocks) | 256 × 128 | **128 × 256** |
| default, 4 MiB journal (2048) | 256 × 8 | **8 × 256** |

That last row is the one that mattered: with a small journal the default pool is 2048 blocks — eight per shard — and a single hot block could exhaust its shard while 99% of the cache sat idle.

## Verification

The abort reproduces deterministically once the pool is shrunk far enough to lower the ceiling to the value CI hits:

| ceiling | before | after |
|---|---|---|
| `shard_cap` 16 | 6/6 runs aborted | **0/6** |
| `shard_cap` 8 | 3/3 runs aborted | **0/3** |

At the shipped geometry: `diskfs/mbt/batch` 3/3, local quint/MBT quick tier 79/79, `diskfs_{evict,reclaim,enospc}` × `{aio,io_uring}` 6/6. Built clean on macOS Debug/ASan and Linux Release; uncrustify 0.78.1 and copyright check clean.

## What this does not do

It raises the ceiling; it does not bound the generations. One hot block can still in principle out-run any per-shard capacity, because **nothing gates on how much of a shard is pinned** — `shard->pinned` is maintained in six places and never read. The comment on `diskfs_inode_finish_write_pin` describes exactly that gate:

> *the pin honors the per-shard pin threshold ... this is the backpressure that bounds the in-memory record/pin backlog under a create flood*

No such check exists. The async path parks only reactively, once `diskfs_block_recycle` has already failed, and the synchronous path cannot park at all. Bounding at the source is the follow-up.
