### PR TITLE
smb: resolve an undeliverable break only while the holder is still reachable

### DIFF
--- a/src/server/smb/smb_internal.h
+++ b/src/server/smb/smb_internal.h
@@ -2670,10 +2670,17 @@ chimera_smb_conn_free(
     {
         struct chimera_smb_session *s = session_handle->session;
         int                         i;
+        int                         sibling_channel;
 
         if (!s) {
             continue;
         }
+
+        /* num_channels still counts this channel here -- conn_free does not
+         * release the session handles (and decrement it) until below. */
+        pthread_mutex_lock(&thread->shared->sessions_lock);
+        sibling_channel = s->num_channels > 1;
+        pthread_mutex_unlock(&thread->shared->sessions_lock);
 
         /* Walk the session's trees under session->lock, matching
          * chimera_smb_session_park_durables / _flush_notifies: a concurrent
@@ -2697,7 +2704,16 @@ chimera_smb_conn_free(
                 {
                     if (of->create_conn == conn) {
                         of->create_conn = NULL;
-                        if (of->handle && of->handle->fh_len &&
+                        /* Only when the client is still reachable: a session
+                         * with another bound channel is one whose holder is
+                         * merely unreachable on THIS transport, so the break it
+                         * never acked is ours to resolve.  A session losing its
+                         * last channel is a holder that has genuinely gone away
+                         * -- its durable handle is preserved for reconnect and
+                         * must come back with the full lease it never gave up
+                         * (smb2.durable-open.lease-disconnect-race), so leave
+                         * that break exactly as it is. */
+                        if (sibling_channel && of->handle && of->handle->fh_len &&
                             brk_n < CHIMERA_SMB_CONN_BREAK_FIXUP_MAX) {
                             memcpy(brk_fh[brk_n], of->handle->fh,
                                    of->handle->fh_len);


### PR DESCRIPTION
Fixes the regression a9a50dd9 (#1673) introduced, without reverting the fix it carried. One file, one condition.

## The regression

#1673 made `conn_free` resolve a break the dying channel could no longer deliver, gated on *"is an opener parked on this break"* — reasoning that nothing is parked in `smb2.durable-open.lease-disconnect-race`, because the holder disconnects before any opener exists.

Under the parallelism that suite actually runs at, that's false often enough to matter. The opener's CREATE and the holder's disconnect interleave, the guard fires, and the break is applied to a holder entitled to keep its lease:

```
durable_open.c:2262: io2.out.lease_response.lease_state was 3 (0x3), expected 7 (0x7)
```

**10 of 36 concurrent runs**, and three extended-run jobs a night. Serially it passes 20/20 — which is exactly how it got through review.

## The corrected gate

Not *who is waiting*, but whether the holder is still **reachable**:

| | meaning | action |
|---|---|---|
| session has another bound channel | holder is alive, merely unreachable on *this* transport; it never got the break and can't be told on the dead channel | resolve it |
| session lost its **last** channel | holder has genuinely gone away; its durable handle is preserved for reconnect and must return with the full lease it never gave up | leave it — the deadline still bounds it |

`num_channels` already carries this, and `conn_free` reads it *before* releasing the session handles that decrement it, so the dying channel is still counted — a sibling exists iff `num_channels > 1`.

## Measurements

Regression removed:

| | a9a50dd9 as merged | this change |
|---|---|---|
| `durable-open.{lease,oplock}-disconnect-race`, 6 concurrent × 6 rounds | **10 / 36** | **0 / 36** |
| `smbtorture_smb2_{durable,lease,oplock,dirlease}_*_memfs` | — | **143 / 143** |

WPTS, five 50-case shards concurrently, measured on this base:

| arm | failing shards |
|---|---|
| no fixup at all (what a revert restores) | **4 / 50** |
| this change | **1 / 65** |

## This is not a complete fix, and I want that on the record

It is strictly better than both alternatives — better than the merged version, which regresses the durable tests nightly, and better than a revert, which restores the higher WPTS rate. But a residual remains, and it's structural.

When a client drops *every* channel momentarily and re-binds, no sibling survives the instant `conn_free` runs, so the break is left alone and that occurrence still strands its opener. Resolving at `conn_free` fundamentally cannot distinguish *"will re-bind channels to this session"* from *"will reclaim this durable handle on a new session"* — the two demand opposite handling and are only distinguishable afterwards.

The complete fix is to defer the decision: keep the break pending and re-deliver it when a channel next binds to the session. That's the follow-up, and it needs the session→channel reverse index that doesn't exist today.

Supersedes #1679 (revert) and #1680 (stacked re-land), both closed.
