### PR TITLE
vfs: stop requiring a real path open on diskfs and the nfs proxy

### DIFF
--- a/src/vfs/diskfs/diskfs.c
+++ b/src/vfs/diskfs/diskfs.c
@@ -194,10 +194,6 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_diskfs = {
     .fh_magic     = CHIMERA_VFS_FH_MAGIC_DISKFS,
     .capabilities = CHIMERA_VFS_CAP_CREATE_UNLINKED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_KV |
         CHIMERA_VFS_CAP_FS_RELATIVE_OP | CHIMERA_VFS_CAP_XATTR | CHIMERA_VFS_CAP_LAYOUT |
-        /* Require a real open so every file op carries a pinned inode in
-         * handle->vfs_private (diskfs_open_fh_inode_cb), which read/write reuse
-         * to skip per-I/O inode resolution. */
-        CHIMERA_VFS_CAP_OPEN_PATH_REQUIRED |
         CHIMERA_VFS_CAP_CHANGE | CHIMERA_VFS_CAP_MKFS |
         CHIMERA_VFS_CAP_READ_PLUS | CHIMERA_VFS_CAP_WRITE_SAME |
         CHIMERA_VFS_CAP_CLONE_RANGE |

--- a/src/vfs/nfs/nfs.c
+++ b/src/vfs/nfs/nfs.c
@@ -423,7 +423,7 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_nfs = {
      * conflict with another client of that server visible to the claim core.
      * CAP_CLAIM_AGGREGATE is deliberately absent: nothing here holds a
      * revocable per-node cache token upstream. */
-    .capabilities   = CHIMERA_VFS_CAP_OPEN_PATH_REQUIRED | CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_RELATIVE_OP |
+    .capabilities   = CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_RELATIVE_OP |
         CHIMERA_VFS_CAP_CLAIM_RANGE | CHIMERA_VFS_CAP_READ_PROVIDES_BUFFERS | CHIMERA_VFS_CAP_DELEGATES_DAC |
         CHIMERA_VFS_CAP_REMOTE_DAC,
     .init           = chimera_nfs_init,

--- a/src/vfs/sdk/vfs_module.h
+++ b/src/vfs/sdk/vfs_module.h
@@ -37,6 +37,17 @@ struct chimera_vfs_request;
  * If not set, VFS may create synthetic open handles that
  * only contain the file handle w/o an explicit open callout
  * to the module for stateless operation (ie NFS3).
+ *
+ * SET THIS ONLY IF THE HANDLE CARRIES THE ADDRESSING.  The question is not
+ * whether the module has something useful to do at open time -- it is whether
+ * a later operation can still find the object without having opened it.  A
+ * module whose ops work from the file handle can always find it and does not
+ * need this, however much per-open state it would like to keep; state that
+ * only data operations consume is what a data open (always real) is for.
+ * The modules that do need it are the ones where the open produces the only
+ * thing that names the object afterwards: an O_PATH descriptor for the *at()
+ * families (linux, io_uring), or the interning of a path id against the path
+ * it resolved from (smb, which has no fh-relative ops at all).
  */
 #define CHIMERA_VFS_CAP_OPEN_PATH_REQUIRED (1U << 0)
 

--- a/src/vfs/smb/smb.c
+++ b/src/vfs/smb/smb.c
@@ -1335,7 +1335,13 @@ SYMBOL_EXPORT struct chimera_vfs_module vfs_smb = {
     .name        = "smb",
     .fh_magic    = CHIMERA_VFS_FH_MAGIC_SMB,
     /* Path-only backend: full mount-relative paths, opaque per-open handle
-     * tokens, no FH-relative ops (no CAP_FS_RELATIVE_OP). */
+     * tokens, no FH-relative ops (no CAP_FS_RELATIVE_OP).
+     *
+     * OPEN_PATH_REQUIRED is structural here, not an optimization: a file
+     * handle is only a path id, and it is the open that interns the id
+     * against the path it was resolved from.  With no fh-relative addressing
+     * to fall back on, a synthesized path handle names nothing a later
+     * operation can re-derive a path from. */
     .capabilities   = CHIMERA_VFS_CAP_FS | CHIMERA_VFS_CAP_FS_PATH_OP |
         CHIMERA_VFS_CAP_OPEN_PATH_REQUIRED,
     .init           = chimera_smb_client_init,


### PR DESCRIPTION
`CHIMERA_VFS_CAP_OPEN_PATH_REQUIRED` says the module must be called to open an object for a path operation, rather than the core synthesizing a handle that carries only the file handle.

diskfs, nfs and smb were given it when the single `CAP_OPEN_FILE_REQUIRED` gate was split. That gate had read `(caps & FILE_REQUIRED) || !INFERRED`, so declaring `FILE_REQUIRED` had made *every* open real, path opens included; granting all three the new flag preserved that behaviour. But it preserved a side effect rather than an intent — none of the three had ever declared the path flag, which already existed alongside it.

### What the flag is actually for

The question is not whether a module has something useful to do at open time. It is whether a later operation can still find the object without having opened it. That test now appears in the comment on the flag, so the next module to consider it does not have to infer the rule from who else sets it.

| module | what a path open costs | reads a path handle's `vfs_private`? | needs it |
|---|---|---|---|
| linux, io_uring | an `O_PATH` descriptor | yes — the descriptor is how the `*at()` families address the object | **yes** |
| smb | an SMB2 CREATE round trip and a later CLOSE | only `close` | **yes**, for a different reason (below) |
| diskfs | an inode resolve, a reference, a type check | no | no |
| nfs proxy | a state allocation; notably no RPC at all | no | no |

### diskfs and the nfs proxy

Neither reads a path handle's `vfs_private`. diskfs resolves by file handle, and its read/write paths already fall back to that when a handle carries no pinned inode. The proxy's open state is consumed only by write, commit, allocate and close — data operations, which still get a real open, since a data open is unconditionally real.

What diskfs gives up is an early type check in `open_fh`: a directory open of a symlink now reports `ESYMLINK` from `lookup_at` rather than from the open. That is already how memfs and cairn behave.

### smb keeps it

smb looked like the best candidate by cost and turned out to be the one that structurally cannot lose it. Its file handles are path ids, and it is the open that interns the id against the path it resolved from; with no fh-relative operations at all (`CAP_FS_PATH_OP`, no `CAP_FS_RELATIVE_OP`), a synthesized path handle names nothing later work can re-derive a path from. Dropping it there fails immediately at export-root normalization. The reasoning is recorded next to the flag.

### Verification

Quick tier (`ctest -R '/mbt'`, 79 tests) green. One run showed `chimera/vfs/diskfs/mbt/batch` failing at 145s on a machine at load average 24 with another full suite running concurrently; it passes in isolation at ~300s and passed in two other full runs of the same tree, so it reads as load-induced rather than related.