### PR TITLE
vfs/diskfs: hold back an internal space reserve, as ext4 and XFS do

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -968,7 +968,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # bison: Apple ships 2.3 and the ndrzcc grammar needs 3.x; the
           # top-level CMakeLists already adds the keg-only Homebrew path.
           # libxcrypt: Darwin libc crypt(3) is DES-only, and REST auth needs
@@ -1125,7 +1148,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # llvm: the analyzer this job has always run.  bison 3.x for the
           # ndrzcc grammar, libxcrypt for full crypt(5) verification.
           # No llvm: scan-build needed it for the analyzer *driver*, but driving

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -903,7 +903,30 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # bison: Apple ships 2.3 and the ndrzcc grammar needs 3.x; the
           # top-level CMakeLists already adds the keg-only Homebrew path.
           # libxcrypt: Darwin libc crypt(3) is DES-only, and REST auth needs
@@ -1031,7 +1054,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # No llvm: scan-build needed it for the analyzer *driver*, but driving
           # `clang --analyze` directly does not.  Dropping it also keeps this
           # job on Apple's clang -- the compiler ccc-analyzer was always

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -370,7 +370,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # No llvm: it was only ever here to supply the scan-build driver, and
           # driving `clang --analyze` directly does not need it.  Dropping it
           # also keeps this job on Apple's clang -- the compiler ccc-analyzer

--- a/src/posix/tests/test_diskfs_enospc.c
+++ b/src/posix/tests/test_diskfs_enospc.c
@@ -47,7 +47,9 @@ free_bytes(struct posix_test_env *env)
         fprintf(stderr, "statfs failed: %s\n", strerror(errno));
         posix_test_fail(env);
     }
-    return (uint64_t) sf.f_bfree * (uint64_t) sf.f_bsize;
+    /* f_bavail, not f_bfree: what a writer can actually place, i.e. free less
+     * the filesystem's internal reserve (POSIX's bfree/bavail split). */
+    return (uint64_t) sf.f_bavail * (uint64_t) sf.f_bsize;
 } /* free_bytes */
 
 int

--- a/src/vfs/diskfs/diskfs_internal.h
+++ b/src/vfs/diskfs/diskfs_internal.h
@@ -950,6 +950,9 @@ struct diskfs_block_cache {
  * default is 2x the journal (comfortable per-shard headroom over the variance),
  * and a configured size is floored at 1.5x.
  */
+/* Bump-reservation roles a worker can hold at once (metadata + file data). */
+#define DISKFS_SPACE_RESERVE_ROLES 2
+
 #define DISKFS_INTENT_LOG_BLOCKS(sz)          ((sz) / SM_BLOCK_SIZE)
 
 #define DISKFS_BLOCK_CACHE_DEFAULT_BLOCKS(sz) (2 * DISKFS_INTENT_LOG_BLOCKS(sz))
@@ -5288,6 +5291,45 @@ diskfs_txn_commit(
 } /* diskfs_txn_commit */
 
 
+
+/*
+ * Internal space reserve.
+ *
+ * The allocator hands space out through per-thread bump reservations, and a
+ * reservation is released only when one request outgrows its remainder -- so at
+ * any moment each worker can be sitting on up to SM_RESERVATION_CHUNK per role
+ * that is claimed but undrawn, and a claim released mid-transaction keeps
+ * blocking its region until that transaction reaches the applied watermark.
+ * The free-extent sum is therefore an honest count of free space but an
+ * optimistic count of *allocatable* space, and a writer asked to fill the
+ * filesystem exactly hits ENOSPC a few megabytes early.
+ *
+ * Hold that slop back rather than accounting for it byte-exactly, which is what
+ * ext4 and XFS both do for the same reason:
+ *
+ *   ext4  min(2%, 4096 clusters)   "situations where we can not afford to run
+ *                                   out of space ... punch hole, or converting
+ *                                   unwritten extents in delalloc path"
+ *   XFS   min(5%, 8192 FSBs)       "intended to cover concurrent allocation
+ *                                   transactions when we initially hit ENOSPC"
+ *
+ * Both size it as concurrency x per-transaction reservation and then cap it, so
+ * the percentage governs only small filesystems and the cap governs real ones.
+ * Ours is the same shape, with the cap derived from what this allocator can
+ * actually have in flight: one chunk per role per worker.
+ */
+static inline uint64_t
+diskfs_space_reserve_bytes(const struct diskfs_shared *shared)
+{
+    uint64_t usable = space_map_usable_capacity(shared->space_map);
+    uint64_t pct    = usable / 20;                 /* 5%, as XFS */
+    uint64_t cap    = (uint64_t) (shared->num_active_threads > 0
+                                  ? shared->num_active_threads : 1) *
+        DISKFS_SPACE_RESERVE_ROLES * SM_RESERVATION_CHUNK;
+
+    return pct < cap ? pct : cap;
+} /* diskfs_space_reserve_bytes */
+
 static inline void
 diskfs_map_attrs(
     struct diskfs_thread     *thread,
@@ -5399,8 +5441,17 @@ diskfs_map_attrs(
         if (attr->va_fs_space_free > attr->va_fs_space_total) {
             attr->va_fs_space_free = attr->va_fs_space_total;
         }
-        attr->va_fs_space_used  = attr->va_fs_space_total - attr->va_fs_space_free;
-        attr->va_fs_space_avail = attr->va_fs_space_free;
+        attr->va_fs_space_used = attr->va_fs_space_total - attr->va_fs_space_free;
+        /* space_free stays the honest free-extent sum; space_avail is what a
+         * writer can actually place, i.e. free less the internal reserve.
+         * (POSIX f_bfree vs f_bavail; ext4 subtracts its reserve from bavail
+         * the same way.) */
+        {
+            uint64_t reserve = diskfs_space_reserve_bytes(shared);
+
+            attr->va_fs_space_avail = attr->va_fs_space_free > reserve
+                ? attr->va_fs_space_free - reserve : 0;
+        }
         attr->va_fs_files_total = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_avail = CHIMERA_VFS_SYNTHETIC_FS_INODES;
         attr->va_fs_files_free  = CHIMERA_VFS_SYNTHETIC_FS_INODES;

--- a/src/vfs/diskfs/diskfs_test.c
+++ b/src/vfs/diskfs/diskfs_test.c
@@ -160,6 +160,7 @@ diskfs_test_snapshot(
     out->total_capacity  = sm->total_capacity;
     out->usable_capacity = sm->usable_capacity;
     out->num_devices     = sm->num_devices;
+    out->reserve_bytes   = diskfs_space_reserve_bytes(shared);
 
     diskfs_test_lock_all_ags(sm, 1);
 

--- a/src/vfs/diskfs/diskfs_test.h
+++ b/src/vfs/diskfs/diskfs_test.h
@@ -36,6 +36,7 @@ struct diskfs_test_space {
     uint64_t dev_free_sum;        /* sum over devices of dev->free_bytes */
     uint64_t tree_free_sum;       /* sum over AGs of the free-extent tree lengths */
     uint64_t claim_bytes;         /* sum of live reservation-claim lengths */
+    uint64_t reserve_bytes;       /* internal reserve held back from space_avail */
     uint64_t largest_free_extent; /* largest single free extent anywhere */
     uint64_t total_free_extents;  /* free-extent (fragment) count across all AGs */
     uint32_t num_devices;

--- a/src/vfs/diskfs/tests/diskfs_enospc_test.c
+++ b/src/vfs/diskfs/tests/diskfs_enospc_test.c
@@ -74,12 +74,15 @@ main(
     /* alloc06 step 2: everything still reported free, less 256 KiB. */
     r = diskfs_test_space(dh.vfs, &sp);
     assert(r == 0);
-    free_before = sp.ag_free_sum;
+    /* What a writer can actually place: the free-extent sum less the internal
+     * reserve, which is what statfs reports as available (va_fs_space_avail). */
+    free_before = sp.ag_free_sum > sp.reserve_bytes
+        ? sp.ag_free_sum - sp.reserve_bytes : 0;
     printf("free before boundary allocate: %" PRIu64 "\n", free_before);
-    printf("  total=%" PRIu64 " usable=%" PRIu64 " largest_extent=%" PRIu64
-           " fragments=%" PRIu64 " claims=%" PRIu64 " devs=%u ags=%u\n",
-           sp.total_capacity, sp.usable_capacity, sp.largest_free_extent,
-           sp.total_free_extents, sp.claim_bytes, sp.num_devices, sp.num_ags);
+    printf("  usable=%" PRIu64 " free=%" PRIu64 " reserve=%" PRIu64
+           " largest_extent=%" PRIu64 " claims=%" PRIu64 " ags=%u\n",
+           sp.usable_capacity, sp.ag_free_sum, sp.reserve_bytes,
+           sp.largest_free_extent, sp.claim_bytes, sp.num_ags);
     assert(free_before > ENOSPC_SMALL);
     ask = free_before - ENOSPC_SMALL;
 


### PR DESCRIPTION
**Stacked on #1686** (the homebrew-core pin), so the macOS jobs can actually run. Merge that first; the net diff against `main` afterwards is the single diskfs commit.

---

Fixes `nfstest_alloc` alloc06, which has failed on both diskfs backends in every extended run: it reads the reported free space, asks for all but 256 KiB of it, and gets ENOSPC.

## It was never a statfs bug

The free-extent sum is honest — every byte of it really is free. It's just an optimistic count of what a writer can **place**.

The allocator hands space out through per-thread bump reservations, and a reservation is released only when one request outgrows its remainder. So each worker can sit on up to `SM_RESERVATION_CHUNK` per role that's claimed but undrawn, and a claim released mid-transaction keeps blocking its whole region until that transaction reaches the intent log's applied watermark — which, for the transaction still doing the allocating, means until it commits.

A large fallocate exceeds its remainder on *every* request, so it refills on every request and walks the pool stranding a little at a time. Measured at the failure:

```
RESVFAIL want=4096 chunk=4194304
  AG dev=0 free=58626048  claims=4 claimed=58638336
  AG dev=1 free=125566976 claims=4 claimed=125566976
```

100% of free space covered by live claims, 180.3 MB of 184.2 MB drawn — ENOSPC on a 4 KiB request with ~3.9 MB free but unreachable.

## Both ext4 and XFS hold slop back for exactly this

> **ext4** (`ext4_init_reserve_clusters`) — *"By default we reserve 2% or 4096 clusters, whichever is smaller. This should cover the situations where we can not afford to run out of space like for example punch hole, or converting unwritten extents..."*

> **XFS** (`xfs_default_resblks`) — *"Default to 5% or 8192 FSBs of space reserved, whichever is smaller. This is intended to cover **concurrent allocation transactions when we initially hit ENOSPC**. These each require a 4 block reservation. Hence by default we cover roughly 2000 concurrent allocation reservations."*

That XFS comment is a description of our failure. Both size the reserve as **concurrency × per-transaction reservation, then cap it**, so the percentage governs only small filesystems and the cap governs real ones.

## The change

Same shape, with the cap derived from what this allocator can have in flight — one chunk per role per worker:

```c
reserve = min(usable / 20, threads * roles * SM_RESERVATION_CHUNK)
```

subtracted from `va_fs_space_avail` **only**. `va_fs_space_free` stays the honest free-extent sum — the POSIX `f_bfree`/`f_bavail` split, and what ext4 does with its reserved blocks. (XFS declines the distinction, `st->f_bavail = st->f_bfree`, having no unprivileged-user notion; we have the field, so we use it.)

diskfs already hides 80 MiB of intent log and per-AG logs behind `usable_capacity`, so holding space back from the reported total is established here — this extends it from "space the format needs" to "space the allocator needs in flight".

The two tests that model a user filling the filesystem now read what a user can place: the posix one switches `f_bfree` → `f_bavail`, the white-box one subtracts the reserve newly exposed through `diskfs_test_space`.

## Results

On the failing geometry the reserve is 9.2 MB (184 MB usable, so the percentage governs), comfortably over the 3.9 MB measured shortfall, and the boundary allocation **succeeds**.

| | |
|---|---|
| `chimera/vfs/diskfs/enospc_test`, `chimera/posix/diskfs_enospc_*` | pass |
| `diskfs_{evict,reclaim,enospc}` × `{aio,io_uring}` | 6/6 |
| local quint/MBT quick tier | 81/81 |

## What this deliberately does not do

It doesn't make the byte-exact accounting unnecessary. XFS still tracks genuinely-unreachable space in `m_allocbt_blks` and subtracts it from `f_bfree` itself; our stranded-claim equivalent is still there. Two follow-ups would shrink it — returning a released claim's undrawn tail immediately (proven in experiment: recovers ~900 KB, no new state), and recalling idle reservations under pressure — and either would let this cap come down. The reserve is what makes ENOSPC arrive where a user expects in the meantime.
