### PR TITLE
ci: pin homebrew-core on the macOS runners

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -968,7 +968,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # bison: Apple ships 2.3 and the ndrzcc grammar needs 3.x; the
           # top-level CMakeLists already adds the keg-only Homebrew path.
           # libxcrypt: Darwin libc crypt(3) is DES-only, and REST auth needs
@@ -1125,7 +1148,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # llvm: the analyzer this job has always run.  bison 3.x for the
           # ndrzcc grammar, libxcrypt for full crypt(5) verification.
           # No llvm: scan-build needed it for the analyzer *driver*, but driving

--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -903,7 +903,30 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # bison: Apple ships 2.3 and the ndrzcc grammar needs 3.x; the
           # top-level CMakeLists already adds the keg-only Homebrew path.
           # libxcrypt: Darwin libc crypt(3) is DES-only, and REST auth needs
@@ -1031,7 +1054,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # No llvm: scan-build needed it for the analyzer *driver*, but driving
           # `clang --analyze` directly does not.  Dropping it also keeps this
           # job on Apple's clang -- the compiler ccc-analyzer was always

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -370,7 +370,30 @@ jobs:
         env:
           CCACHE_REF: ghcr.io/chimera-nas/ccache:4.14-darwin
         run: |
-          brew update
+          # Pin homebrew-core rather than installing whatever was published
+          # overnight.  userspace-rcu 0.15.7 (2026-09-11) is bottled from
+          # arm64_sequoia onward only -- no arm64_sonoma -- and these jobs run
+          # on macos-14, so the install fails outright with "no bottle
+          # available!".  The revision below is the last with a Sonoma bottle
+          # (a 0.15.6 rebottle, 2026-09-10); old bottles are content-addressed
+          # in GHCR and stay pullable, so this installs a binary, not a source
+          # build.
+          #
+          # This pins the whole index, which is the point: every formula here
+          # gets a no-Sonoma bottle set at its next version bump, so without a
+          # pin this breaks again on someone else's schedule.  Bumping it is
+          # then a reviewed change.  HOMEBREW_NO_INSTALL_FROM_API makes brew
+          # resolve from the tap instead of the live API; the fetch is depth-1
+          # at that commit rather than a full 1.4 GB tap clone.
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          CORE="$(brew --repo)/Library/Taps/homebrew/homebrew-core"
+          rm -rf "$CORE" && mkdir -p "$CORE"
+          git -C "$CORE" init -q
+          git -C "$CORE" remote add origin \
+            https://github.com/Homebrew/homebrew-core.git
+          git -C "$CORE" fetch -q --depth 1 origin 6d80bc690123b975991058ef769b80a925199c7b
+          git -C "$CORE" checkout -q FETCH_HEAD
           # No llvm: it was only ever here to supply the scan-build driver, and
           # driving `clang --analyze` directly does not need it.  Dropping it
           # also keeps this job on Apple's clang -- the compiler ccc-analyzer


### PR DESCRIPTION
All three macOS jobs have failed at **"Install dependencies"** since the 2026-09-12 05:24 extended run — four clean runs immediately before it:

```
##[error]userspace-rcu: no bottle available!
```

## What actually happened

Not a network flake, which is why it's sticky rather than intermittent. `homebrew-core`'s own history says it plainly:

| commit | date | bottles |
|---|---|---|
| `a6ed4ed1` | 2026-09-11 | golden_gate, tahoe, sequoia, linux — **no sonoma** |
| `6d80bc69` | 2026-09-10 | golden_gate, tahoe, sequoia, **sonoma**, linux |
| `875dc337` | 2026-01-26 | tahoe, sequoia, **sonoma**, linux |

The formula wasn't withdrawn for Sonoma. `0.15.7` was bottled on 2026-09-11 for the macOS versions Homebrew still bottles, and `macos-14` (Sonoma) has aged out of that window. The revision **one day earlier** still has an `arm64_sonoma` bottle.

## The change

Pin the index to that revision instead of installing whatever was published overnight. Old bottles are content-addressed in GHCR and stay pullable, so this installs a **binary**, not a source build.

Pinning the *whole* index is the point rather than a side effect. Checked the rest of the list against the Homebrew API — `jansson`, `rocksdb`, `krb5`, `xxhash`, `libxcrypt`, `openssl@3`, `libnghttp2`, `bison` all still publish `arm64_sonoma` today, and `uthash` is an `all` bottle. But each loses Sonoma at its *next* version bump, exactly as `userspace-rcu` just did. Unpinned, this breaks again on someone else's schedule; pinned, moving forward is a reviewed change.

Mechanics: `HOMEBREW_NO_INSTALL_FROM_API` makes brew resolve from the tap rather than the live API, and the tap is fetched **depth-1 at the pinned commit** — a full tap clone is 1.4 GB, which would be a poor trade for a change meant to reduce fragility. `brew update` is dropped for the same reason: it's what moved these jobs onto 0.15.7 in the first place.

## Scope

Checked, since this could have been wider:

- **libevpl** — different dep set (`cmake ninja openssl@3 nghttp2 uthash protobuf-c oras`), all still Sonoma-bottled, runs green. Unaffected.
- **ext/specs** — `ubuntu-24.04` throughout, no macOS jobs. Unaffected.
- **chimera** — five sites: `build-test.yml` ×2, `extended.yml` ×2, and `analyze-macos` in `pr-checks.yml`, which is what validates this pre-merge.

## What this doesn't do

It unblocks the runners and makes the toolchain reproducible; it doesn't stop Sonoma ageing out. Moving these jobs to **`macos-15`**, where 0.15.7 *is* bottled, is the durable fix — and it wants its own run to judge the build and tests on a new platform rather than being smuggled in as a CI repair.
