### PR TITLE
vfs: read the origin before publishing an identity job to it

### DIFF
--- a/src/vfs/vfs_identity.c
+++ b/src/vfs/vfs_identity.c
@@ -223,6 +223,7 @@ chimera_vfs_identity_worker(void *arg)
 {
     struct chimera_vfs_identity         *identity = arg;
     struct chimera_vfs_identity_request *req;
+    struct chimera_vfs_thread           *origin;
 
     /* Pure writer: this worker only runs miss handlers and populates the cache
      * (call_rcu + rcu_assign), never taking an RCU read lock -- the read-side
@@ -271,12 +272,22 @@ chimera_vfs_identity_worker(void *arg)
             req->found = 0;
         }
 
-        /* Hand the completed job back to the originating evpl thread. */
-        pthread_mutex_lock(&req->origin->lock);
-        DL_APPEND(req->origin->pending_identity, req);
-        pthread_mutex_unlock(&req->origin->lock);
+        /* Hand the completed job back to the originating evpl thread.
+         *
+         * Read the origin out of the job FIRST.  Appending it publishes it:
+         * from the moment the origin's lock is dropped that thread may drain
+         * the list, run the callback and free the job, so any later reach
+         * through `req` -- including for the doorbell to wake it with -- is a
+         * use-after-free.  The window is one instruction wide and the
+         * identity path is a cache miss, so it takes an unlucky Debug run to
+         * catch it, which is how it survived. */
+        origin = req->origin;
 
-        evpl_ring_doorbell(&req->origin->doorbell);
+        pthread_mutex_lock(&origin->lock);
+        DL_APPEND(origin->pending_identity, req);
+        pthread_mutex_unlock(&origin->lock);
+
+        evpl_ring_doorbell(&origin->doorbell);
 
         pthread_mutex_lock(&identity->lock);
     }


### PR DESCRIPTION
## The bug

`chimera_vfs_identity_worker` hands a finished job back to the thread that asked for it by appending it to that thread's list and then ringing its doorbell. Both reached the thread *through the job*:

```c
pthread_mutex_lock(&req->origin->lock);
DL_APPEND(req->origin->pending_identity, req);
pthread_mutex_unlock(&req->origin->lock);

evpl_ring_doorbell(&req->origin->doorbell);   /* req may already be freed */
```

Appending is publishing. From the moment the origin's lock is dropped, that thread may drain the list, run the callback and `free(req)` — so the doorbell's reach through `req` is a use-after-free across cores.

## The fix

Read the origin into a local before publishing. The list still needs the lock; the doorbell needs only a pointer that is still alive, and the originating thread outlives the job by construction.

`nfs4_cb_resume_bounce` already does exactly this, and every other doorbell in the tree rings on an object it did not just hand away. This was the only site that didn't.

## How it was found, and how it's confirmed

It surfaced as a merge-queue ASAN failure on `rocky9 amd64 Debug` — `chimera/posix/smb/loopback_wire_all_features`, an SMB QUERY_INFO security request resolving an owner:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 at ... thread T8
    #0 chimera_vfs_identity_worker        src/vfs/vfs_identity.c:279
freed by thread T21 here:
    #1 chimera_vfs_identity_thread_complete  src/vfs/vfs_identity.c:541
```

The window is one instruction wide and the identity path is only reached on a cache miss, so it is rare rather than benign. Widening it with a 2 ms sleep between the unlock and the doorbell reproduces it on demand; with this change the same widened window is clean, and the sleep was then removed.

Quick tier is green locally apart from the four `linux`/`io_uring` passthrough cells, which fail on this machine because the container's `/tmp` is overlayfs and `name_to_handle_at` handles go stale there. This branch is `main` plus one local variable, so those are environmental.